### PR TITLE
graft viz: interactive context-graph visualizer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
-# Context Graph Engine — configuration
+# Graft — configuration
 #
-# The engine calls OpenRouter for extraction and summaries, so an API key is
+# Graft calls OpenRouter for extraction and summaries, so an API key is
 # required for any LLM-backed step (`init`, `graph --llm`). Get one at:
 #   https://openrouter.ai/keys
 #
@@ -10,10 +10,10 @@
 # --- OpenRouter (required for LLM steps) --------------------------------------
 # OPENROUTER_API_KEY=sk-or-...
 # Optional: override the model (default: openai/gpt-4o-mini)
-# CONTEXT_GRAPH_OPENROUTER_MODEL=openai/gpt-4o-mini
+# GRAFT_OPENROUTER_MODEL=openai/gpt-4o-mini
 # Optional: override the API base URL (default: https://openrouter.ai/api/v1)
 # OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 
 # --- Graph location -----------------------------------------------------------
 # Where the graph lives (default: <repo>/.context)
-# CONTEXT_GRAPH_DIR=.context
+# GRAFT_DIR=.context

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 **Graft gives it the map it should have read first.**
 
 <p>
-  <a href="https://www.npmjs.com/package/graft"><img src="https://img.shields.io/npm/v/graft?style=for-the-badge&logo=npm&logoColor=white&label=npm" /></a>
-  <a href="https://www.npmjs.com/package/graft"><img src="https://img.shields.io/npm/dm/graft?style=for-the-badge&logo=npm&logoColor=white&label=downloads" /></a>
-  <a href="https://nodejs.org"><img src="https://img.shields.io/node/v/graft?style=for-the-badge&logo=nodedotjs&logoColor=white" /></a>
+  <a href="https://www.npmjs.com/package/@nanonets/graft"><img src="https://img.shields.io/npm/v/%40nanonets%2Fgraft?style=for-the-badge&logo=npm&logoColor=white&label=npm" /></a>
+  <a href="https://www.npmjs.com/package/@nanonets/graft"><img src="https://img.shields.io/npm/dm/%40nanonets%2Fgraft?style=for-the-badge&logo=npm&logoColor=white&label=downloads" /></a>
+  <a href="https://nodejs.org"><img src="https://img.shields.io/node/v/%40nanonets%2Fgraft?style=for-the-badge&logo=nodedotjs&logoColor=white" /></a>
   <img src="https://img.shields.io/badge/TypeScript-strict-3178C6?style=for-the-badge&logo=typescript&logoColor=white" />
   <img src="https://img.shields.io/badge/License-MIT-20C997?style=for-the-badge" />
   <img src="https://img.shields.io/badge/runs-100%25%20local-546FFF?style=for-the-badge&logo=ollama&logoColor=white" />
@@ -37,14 +37,19 @@ flowchart LR
 ## Quick start
 
 ```bash
-npx graft init
+npx @nanonets/graft init
 # builds .context/ from your code, one node per system, API, or concept
 
 git add .context && git commit -m "add context graph"
 # commit it so everyone who clones the repo (and their agents) gets the graph
 ```
 
-<!-- placeholder: package publish + `graft` rename pending; until then the bin is `context-graph` -->
+Or install it once and get the `graft` command everywhere:
+
+```bash
+npm install -g @nanonets/graft
+graft init
+```
 
 That is it. Point your agent at `.context/` and it reads the graph before it starts working.
 

--- a/README.md
+++ b/README.md
@@ -135,8 +135,6 @@ See [`.env.example`](.env.example) for the full list of settings (model names, b
 
 ## CLI
 
-Two commands. That is the whole surface.
-
 ```bash
 graft init [dir]                     # build .context/ from the code at [dir] (default: .)
 graft init --extensions .ts .py      # only include these code extensions
@@ -145,9 +143,41 @@ graft init --local                   # force local Ollama even if OPENROUTER_API
 graft check [dir]                    # fail (exit 1) if .context/ has drifted from the code
 graft check --json                   # print the drift report as JSON
 
+graft viz [dir]                      # see the graph: serves an interactive viewer on localhost
+graft viz --port 5000 --no-open      # pick a port; don't auto-open the browser
+
 # global
 graft --dir <path>                   # use a context dir other than <repo>/.context
 ```
+
+## Visualize it (`graft viz`)
+
+`graft viz` opens a local, interactive view of both graphs — no install, no dev
+server; the viewer ships prebuilt inside the package.
+
+- **Context** tab — the architecture graph from `.context/*.md`. Nodes colored by
+  type, sized by connectedness.
+- **Code** tab — the per-symbol graph from `graph.json` (run `graft graph` first).
+- **Outline** tab — the file → class → method hierarchy as a collapsible tree.
+
+Edges speak the code's language. Every link is one of a closed set of verbs, each
+answering a question someone building or reviewing code actually asks:
+
+| Verb | The question it answers |
+|---|---|
+| `part_of` / `contains` | where does this live? |
+| `uses` / `calls` / `imports` / `depends_on` | what breaks if I change this? |
+| `produces` | where does this output come from? |
+| `configures` | what changes its behavior without a code change? |
+| `validates` | what checks or judges this? (tests, drift checks, scoring) |
+| `extends` / `implements` | what contract must this honor? |
+
+Select a node and its edges take on direction: **amber = what it depends on,
+teal = what depends on it**, with the verb written on each highlighted edge.
+Chips above the canvas filter by verb; tree-sitter-extracted edges draw solid
+while LLM-inferred ones draw dashed. The viewer live-reloads when `.context/`
+changes on disk. Older graphs with vague verbs (`influences`, `supports`) are
+normalized on load — no regeneration needed.
 
 ---
 
@@ -178,15 +208,13 @@ See [`bench/README.md`](bench/README.md) for the method and how to add your own 
 ## Development
 
 ```bash
-git clone https://github.com/nanonets/graft.git && cd graft
+git clone https://github.com/NanoNets/context-graph-engine.git && cd context-graph-engine
 npm install
 npm run build
 npm test
 
 npm run cli -- init .      # run the CLI from source
 ```
-
-<!-- placeholder: confirm repo URL once published -->
 
 ---
 

--- a/bench/run.ts
+++ b/bench/run.ts
@@ -15,7 +15,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, copyFileSync, readdirSync, rmSyn
 import { tmpdir } from "node:os";
 import { join, dirname, resolve, basename } from "node:path";
 import { fileURLToPath } from "node:url";
-import { ContextGraphEngine } from "../src/index.js";
+import { Graft } from "../src/index.js";
 import { DOC_EXTENSIONS } from "../src/ingest/fs.js";
 import { extractPdfText, isPdfPath } from "../src/ingest/pdf.js";
 import { CORPORA, type Corpus } from "./tasks.js";
@@ -105,7 +105,7 @@ async function main() {
     // Fresh temp-backed engine; ingest once and reuse for the whole corpus.
     const dbDir = mkdtempSync(join(tmpdir(), "cge-bench-db-"));
     tmpDbDirs.push(dbDir);
-    const engine = new ContextGraphEngine({ dbPath: join(dbDir, "graph.db") });
+    const engine = new Graft({ dbPath: join(dbDir, "graph.db") });
 
     let agentRoot = corpus.path;
     let docsWorkdir: string | undefined;

--- a/docs/superpowers/plans/2026-07-15-graft-viz.md
+++ b/docs/superpowers/plans/2026-07-15-graft-viz.md
@@ -1,0 +1,110 @@
+# graft viz Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `graft viz` — a local interactive visualizer for both Graft graphs, with semantic edges per the approved spec.
+
+**Architecture:** A zero-runtime-dep `node:http` server (`src/viz/serve.ts`) exposes the assembled context graph (`src/viz/assemble.ts`), the raw `graph.json`, and an SSE reload channel; a prebuilt vanilla-TS viewer (`viewer/` → `dist/viewer/` via esbuild) renders tabs (Context/Code/Outline), a d3-force graph with the semantic edge grammar, detail panel, search, and themes. Spec: `docs/superpowers/specs/2026-07-15-graft-viz-design.md`. Visual reference of record: the approved mockup (artifact "graft viz — design & mockup").
+
+**Tech Stack:** TypeScript ESM (Node ≥ 20), commander, gray-matter (already deps); new devDeps: `esbuild`, `d3-force` (+ `@types/d3-force`) — bundled into the viewer, never a runtime dep.
+
+## Global Constraints
+
+- Node >= 20, ESM (`"type": "module"`), strict TS — match existing `tsconfig.json`
+- No new **runtime** dependencies (server uses `node:http`, `node:fs`, `node:path`, `node:child_process` only)
+- Relation enum (engine + viewer normalization): `part_of, uses, depends_on, produces, configures, validates, implements` — legacy mapping `influences→configures`; `supports|defines|measures→validates`
+- Tests: node built-in runner via `npm test` (`node --import tsx --test test/*.test.ts`)
+- Byte-stable outputs where applicable; no timestamps in generated JSON
+- Commit after each task; branch `feat/graft-viz`
+
+---
+
+### Task 1: Graph assembly (`assemble.ts`) — TDD
+
+**Files:**
+- Create: `src/viz/assemble.ts`
+- Create: `test/viz-assemble.test.ts`
+- Create: `test/fixtures/viz-context/{alpha.md, beta.md, broken.md, manifest.json}`
+
+**Interfaces:**
+- Produces: `assembleContextGraph(contextDir: string): VizGraph` where
+  `VizGraph = { meta: { nodeCount: number; edgeCount: number; skippedFiles: number; droppedEdges: number }, nodes: VizNode[], edges: VizEdge[] }`,
+  `VizNode = { id: string; name: string; type: string; summary: string; sources: string[] }`,
+  `VizEdge = { source: string; target: string; relation: string; description?: string }`
+- Also exports `NORMALIZE_RELATION: Record<string,string>` and `normalizeRelation(rel: string): string`
+
+- [ ] **Step 1: Write fixtures + failing tests** — fixture `alpha.md` links to `beta` (`relation: influences`) and to missing `gamma`; `broken.md` has invalid YAML. Tests assert: 2 nodes; 1 edge normalized to `configures`; `droppedEdges === 1`; `skippedFiles === 1`; summary extracted from generated block.
+- [ ] **Step 2: Run** `npm test -- test/viz-assemble.test.ts` → FAIL (module not found)
+- [ ] **Step 3: Implement** — read `*.md` (excluding non-node files) with gray-matter; node id = slug (fallback: filename); summary = body text inside `<!-- context:generated:start/end -->` stripped of `## Summary`/`## Related` headings, first 500 chars; edges from `links[]`; drop dangling; normalize relations.
+- [ ] **Step 4: Run tests** → PASS
+- [ ] **Step 5: Commit** `feat(viz): assemble context graph JSON from .context markdown`
+
+### Task 2: Server (`serve.ts`) — TDD
+
+**Files:**
+- Create: `src/viz/serve.ts`
+- Create: `test/viz-serve.test.ts`
+
+**Interfaces:**
+- Consumes: `assembleContextGraph`
+- Produces: `startVizServer(opts: { contextDir: string; viewerDir: string; port: number; repoName: string }): Promise<{ url: string; close(): Promise<void> }>` — tries `port..port+10`; routes: `GET /` `/app.js` `/style.css` (static from viewerDir), `GET /api/context-graph` (assembled JSON + `repoName` in meta), `GET /api/code-graph` (`graph.json` passthrough if `meta.version === 1`, else 404 `{error}`), `GET /events` (SSE, `fs.watch` on contextDir debounced 300 ms → `data: change\n\n`)
+
+- [ ] **Step 1: Failing tests** — start on port 0-ish random base against fixtures dir + temp viewer dir with stub `index.html`; assert context-graph shape, code-graph 404 without file and 200 with valid fixture `graph.json`, port fallback (occupy base port first), SSE emits on file touch.
+- [ ] **Step 2: Run** → FAIL
+- [ ] **Step 3: Implement** (no runtime deps; content-types html/js/css/json; SSE keeps sockets, closes cleanly)
+- [ ] **Step 4: Run tests** → PASS
+- [ ] **Step 5: Commit** `feat(viz): local http server with SSE live reload`
+
+### Task 3: Viewer
+
+**Files:**
+- Create: `viewer/index.html`, `viewer/style.css`, `viewer/main.ts`, `viewer/graph.ts`, `viewer/tree.ts`, `viewer/detail.ts`, `viewer/data.ts`
+- Create: `scripts/build-viewer.mjs` (esbuild: bundle `main.ts` → `dist/viewer/app.js`, copy html/css)
+- Modify: `package.json` (devDeps `esbuild`, `d3-force`, `@types/d3-force`; `"build": "tsc -p tsconfig.json && node scripts/build-viewer.mjs"`; add `dist/viewer` to published files if a `files` field exists)
+
+**Interfaces:**
+- Consumes: `/api/context-graph`, `/api/code-graph`, `/events` from Task 2
+- Produces: `dist/viewer/{index.html, app.js, style.css}`
+
+- [ ] **Step 1: Port the approved mockup** (visual reference of record; local working copy at the session scratchpad `graft-viz-design.html`) into modules, replacing the hand-rolled sim with `d3-force` (`forceSimulation`, `forceManyBody`, `forceLink` with per-family `distance` [part_of 85 / uses-family 145 / contract 150 / association 185], `forceCenter`, `forceCollide`) and persistent SVG elements (create once, update `transform`/`d` per tick — no rebuild). Keep verbatim: token palette & both themes, tabs, semantic edge grammar (form per family, chevron/hollow/filled markers), verb chips with counts + hints, focus mode (amber out / teal in + labels only on focused edges), detail panel (Depends on / Depended on by), outline tree, search (Enter zooms), theme toggle, zoom/pan/drag. Add: SSE refetch that preserves positions by node id; empty states ("run `graft init`" / "run `graft graph`"); `references` chip hint "mentioned but never called"; inferred-confidence edges render dashed.
+- [ ] **Step 2: Build** `node scripts/build-viewer.mjs` → `dist/viewer/*` exists, `app.js` < 150 kB
+- [ ] **Step 3: Manual smoke** — serve fixtures via Task 2 server, check tabs/selection/chips in browser
+- [ ] **Step 4: Commit** `feat(viz): viewer app (semantic edges, focus mode, outline, themes)`
+
+### Task 4: CLI wiring
+
+**Files:**
+- Modify: `src/cli.ts` (add `viz` command), `src/index.ts` (export viz types)
+
+**Interfaces:**
+- Consumes: `startVizServer`
+- Produces: `graft viz [dir] --port <n> --no-open`; viewerDir resolved relative to compiled module (`new URL("../viewer/", import.meta.url)` from `dist/`); browser open via `open`/`xdg-open`/`start` spawn, skipped with `--no-open`; exit 1 + guidance when context dir missing
+
+- [ ] **Step 1: Implement command** (commander, matching existing `init`/`graph`/`check` style and `--dir` global)
+- [ ] **Step 2: Verify** `npm run cli -- viz . --no-open` prints URL; curl endpoints respond
+- [ ] **Step 3: Commit** `feat(cli): graft viz command`
+
+### Task 5: Engine — closed relation enum
+
+**Files:**
+- Modify: `src/ai/synthesize.ts` (tool schema `relation` → `enum: ["part_of","uses","depends_on","produces","configures","validates","implements"]`; prompt text lists the verbs with their reviewer-questions)
+- Test: extend `test/viz-assemble.test.ts` with normalization table cases
+
+- [ ] **Step 1: Failing test** for `normalizeRelation` full table (influences→configures; supports/defines/measures→validates; known verbs pass through)
+- [ ] **Step 2: Run** → FAIL, **Step 3: implement enum + prompt edit**, **Step 4: tests PASS**
+- [ ] **Step 5: Commit** `feat(engine): closed relation vocabulary for synthesized links`
+
+### Task 6: End-to-end + docs
+
+**Files:**
+- Modify: `README.md` (viz section: command, screenshot placeholder-free description, verb vocabulary table)
+
+- [ ] **Step 1:** `npm run build && npm test` → all green
+- [ ] **Step 2:** `node dist/cli.js viz . --no-open` against this repo's real `.context/`; browser-verify against the design reference (chips: part of 2 · uses 2 · configures 1 · produces 1 · validates 2 after normalization)
+- [ ] **Step 3:** Commit `docs: README section for graft viz`
+
+## Self-Review
+
+- Spec coverage: tabs/delivery/interactions (T3–T4), semantic edges + vocabulary (T1, T3, T5), scale items 3–5 (T3; 1–2 explicitly v2 in spec), error handling (T1, T2, T4), testing (T1, T2, T6). ✔
+- No placeholders: viewer task consumes an existing concrete source file (the approved mockup) rather than pseudo-code. ✔
+- Type consistency: `VizGraph/VizNode/VizEdge` defined once in Task 1 and consumed by name in Tasks 2–3. ✔

--- a/docs/superpowers/specs/2026-07-15-graft-viz-design.md
+++ b/docs/superpowers/specs/2026-07-15-graft-viz-design.md
@@ -1,0 +1,110 @@
+# graft viz — Context Graph Visualizer
+
+**Date:** 2026-07-15
+**Status:** Approved (interactive design reference: claude.ai artifact "graft viz — design & mockup")
+
+## Purpose
+
+Graft builds two graph artifacts (`.context/*.md` context graph, `.context/graph.json` code graph) but has no way to see them. `graft viz` serves a local, interactive, nanoindex-style visualization of both. Design priorities, in order: (1) edges must mean something to someone building or reviewing code, (2) modern minimal look, (3) scales to large codebases.
+
+## Decisions made during design (with user)
+
+| Question | Decision |
+|---|---|
+| What to visualize | Both graphs, as tabs — Context (architecture) and Code (symbols) + Outline (tree) |
+| Delivery | New `graft viz` CLI command; serves a prebuilt single-page viewer on localhost; auto-opens browser; no npm install/dev-server at runtime |
+| MVP interactions | Force graph with zoom/pan/drag, legend filters, detail panel, tree outline, search, dark/light mode, live reload |
+| Viewer tech | Vanilla TS, bundled once with esbuild, shipped in the npm package. d3-force for simulation only (Barnes–Hut perf at scale); rendering is hand-rolled SVG |
+| Edge design | Semantic: verbs from the code, not invented taxonomy (below) |
+
+## Edge semantics (the core of the design)
+
+### Verb vocabulary — one test, six verbs
+
+Every relation verb must answer a question someone building or reviewing code actually asks. Vague LLM softeners are banned.
+
+| Verb | Question it answers |
+|---|---|
+| `part_of` / `contains` | where does this live? |
+| `uses` / `calls` / `imports` / `depends_on` | what breaks if I change this? |
+| `produces` | where does this output come from? |
+| `configures` | what changes its behavior without a code change? |
+| `validates` | what checks or judges this? (tests, drift checks, scoring) |
+| `extends` / `implements` | what contract must this honor? |
+
+**Enforcement:**
+1. Engine: the synthesize tool schema (`src/ai/synthesize.ts`) constrains `relation` to a closed enum: `part_of, uses, produces, configures, validates, implements, depends_on`. The LLM must pick one or drop the link.
+2. Viewer: legacy graphs are normalized on load — `influences → configures`; `supports`, `defines`, `measures → validates`. Existing `.context/` folders read cleanly without regeneration.
+
+### Chips (legend + filter)
+
+Shown top-left of the canvas: the verbs **actually present in the repo**, with counts. `part_of`/`contains` group under the chip **"part of"**; `calls`/`uses`/`depends_on`/`imports` group under **"uses"** (user-approved names). Every other verb gets its own chip. Clicking toggles that verb's edges. Hover shows the question the verb answers.
+
+### Form encodes reading priority
+
+- **part of** — thick, muted, no arrowhead, shorter force-spring length (hierarchy pulls clusters together; layout, not clutter)
+- **uses / produces / configures / validates** — solid, small open-chevron arrowhead
+- **extends / implements** — hollow UML-style arrowhead
+- **references** (code graph only) — faint dotted, no arrowhead ("mentioned but never called")
+- Arrowheads are deliberately subtle: open chevrons at rest, compact filled heads only on focused edges
+
+### Meaning on demand (focus mode)
+
+At rest the graph is quiet (edges ~0.3–0.55 opacity). Selecting a node:
+- outgoing edges turn **amber** (`--fil`) = what it depends on
+- incoming edges turn **teal** (`--accent`) = what depends on it
+- relation verbs are written only on those focused edges
+- non-neighbor nodes and edges fade (~0.06–0.2 opacity)
+- detail panel mirrors the colors: "Depends on ·" (amber dot) / "Depended on by ·" (teal dot), each entry showing verb + Graft's per-edge description sentence
+
+### Scale strategy (large codebases)
+
+1. **Containment becomes geometry**: past ~200 visible nodes, `contains` edges stop rendering; files collapse into compound nodes with symbol counts, expandable on click (removes ~40–50% of edges).
+2. **Level-of-detail by zoom**: zoomed out, only aggregated file↔file dependency edges, width ∝ bundled edge count; zoom reveals individual edges, then labels on focused ones.
+3. **Focus is the primary reading mode** at density; ambient edges just show shape.
+4. **Trust is visible**: `confidence: "extracted"` edges solid; `"inferred"` dashed.
+5. Faint-dotted verbs (`references`) hidden by default past ~500 edges.
+
+(v1 implements 3, 4, 5 fully; 1 and 2 are v2 — v1 must stay usable to ~1,500 nodes via d3-force + persistent-element SVG updates.)
+
+## Architecture
+
+```
+src/
+├── cli.ts               + viz command: graft viz [dir] [--port 4400] [--no-open]
+└── viz/
+    ├── assemble.ts        .context/*.md frontmatter → {meta, nodes[], edges[]}
+    └── serve.ts           node:http server, SSE live reload, port fallback, open browser
+viewer/                    frontend source (vanilla TS + tokens.css), esbuild → dist/viewer/
+dist/viewer/               prebuilt bundle shipped in the npm package
+```
+
+- **Server** (`node:http`, zero new runtime deps):
+  - `GET /` , `/app.js`, `/style.css` — static viewer from `dist/viewer/`
+  - `GET /api/context-graph` — parse every `.context/*.md` with gray-matter; nodes from frontmatter, edges from `links`; relation normalization; dangling edges dropped and counted in `meta.droppedEdges`; malformed files skipped and counted in `meta.skippedFiles`
+  - `GET /api/code-graph` — streams `graph.json` if present and `meta.version === 1`, else 404 with `{error}`
+  - `GET /events` — SSE; `fs.watch` on the context dir, 300 ms debounce → `data: change`
+- **Viewer**: tabs Context / Code / Outline; d3-force simulation; SVG with persistent elements (positions updated per tick, not rebuilt); semantic edge rendering per this spec; detail panel (summary, sources, links); search (Enter zooms to best match); theme toggle (localStorage + `prefers-color-scheme`); SSE-driven refetch that morphs the sim in place (matching ids keep positions).
+- **CLI**: errors with guidance if the context dir is missing ("run `graft init` first"); Code/Outline tabs show an instructive empty state if `graph.json` absent ("run `graft graph`").
+
+## Visual design
+
+Token-driven, both themes (light default follows OS, toggle persisted). Palette: cool neutrals; accent deep teal `#0B7A69` (light) / `#2FBFA4` (dark); amber `#D98E2B`/`#E0A04A` reserved for "depends on" focus; node categories — system/class blue, concept/interface violet, file amber, function teal, method cyan, type pink, enum green. System font stack (Avenir Next/Segoe UI fallbacks), `ui-monospace` for paths/signatures. Node radius by degree (11 + 2.6·deg, capped). The approved mockup is the visual reference of record.
+
+## Error handling
+
+- No `.context/` → CLI exit 1 with guidance
+- Malformed frontmatter → skip node, warn once, count in `meta.skippedFiles`
+- Dangling link target → drop edge, count in `meta.droppedEdges`
+- Port busy → try next port (up to +10), print final URL
+- `graph.json` missing/wrong version → Code & Outline tabs render empty state; Context unaffected
+
+## Testing
+
+- Unit (node test runner, existing style): assembly from fixture `.context/` (frontmatter → edges, normalization, dangling-drop, malformed-skip); code-graph version gate
+- Server: endpoint shapes on a random port; SSE fires on file change; port fallback
+- End-to-end: run against this repo's own `.context/` and a generated `graph.json`; screenshot check against the design reference
+
+## Out of scope (v1)
+
+Compound-node collapse & zoom LOD (v2), canvas renderer, multi-repo dashboard, editing the graph from the UI, `Ask` (chat) feature from nanoindex.

--- a/install.sh
+++ b/install.sh
@@ -1,22 +1,22 @@
 #!/usr/bin/env sh
-# Context Graph Engine — one-line installer.
+# Graft — one-line installer.
 #
 # Two ways to use it:
 #   1. From a checkout:  ./install.sh          (builds THIS directory — no re-clone)
 #   2. Over the network: curl -fsSL https://raw.githubusercontent.com/NanoNets/context-graph-engine/main/install.sh | sh
 #
-# Either way it builds the project and puts the `context-graph` command on your
+# Either way it builds the project and puts the `graft` command on your
 # PATH. Requires git, Node >= 20, and npm.
 #
 # Environment overrides:
-#   CGE_REPO   git URL to clone from      (default: the NanoNets repo below)
-#   CGE_REF    branch/tag/commit to fetch (default: main)
-#   CGE_HOME   where to clone into        (default: ~/.context-graph-engine)
+#   GRAFT_REPO   git URL to clone from      (default: the NanoNets repo below)
+#   GRAFT_REF    branch/tag/commit to fetch (default: main)
+#   GRAFT_HOME   where to clone into        (default: ~/.graft)
 set -eu
 
-REPO_URL="${CGE_REPO:-https://github.com/NanoNets/context-graph-engine.git}"
-REF="${CGE_REF:-main}"
-INSTALL_DIR="${CGE_HOME:-$HOME/.context-graph-engine}"
+REPO_URL="${GRAFT_REPO:-https://github.com/NanoNets/context-graph-engine.git}"
+REF="${GRAFT_REF:-main}"
+INSTALL_DIR="${GRAFT_HOME:-$HOME/.graft}"
 
 info() { printf '\033[1;36m›\033[0m %s\n' "$1"; }
 err()  { printf '\033[1;31m✗ %s\033[0m\n' "$1" >&2; }
@@ -44,7 +44,7 @@ case "${0:-}" in
   */*) SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" 2>/dev/null && pwd) || SCRIPT_DIR="" ;;
 esac
 
-if [ -n "$SCRIPT_DIR" ] && grep -q '"context-graph-engine"' "$SCRIPT_DIR/package.json" 2>/dev/null; then
+if [ -n "$SCRIPT_DIR" ] && grep -q '"@nanonets/graft"' "$SCRIPT_DIR/package.json" 2>/dev/null; then
   INSTALL_DIR="$SCRIPT_DIR"
   info "Installing from local checkout at $INSTALL_DIR"
 else
@@ -66,7 +66,7 @@ info "Installing dependencies"
 info "Building"
 ( cd "$INSTALL_DIR" && npm run build --silent )
 
-info "Linking the 'context-graph' command"
+info "Linking the 'graft' command"
 ( cd "$INSTALL_DIR" && npm link >/dev/null 2>&1 )
 
 echo
@@ -75,11 +75,11 @@ cat <<'NEXT'
 
   Build the graph, then commit it:
           cd your-repo
-          context-graph init          # writes .context/*.md from your code
+          graft init          # writes .context/*.md from your code
           git add .context && git commit -m "add context graph"
 
   Keep it honest in CI:
-          context-graph check         # exits non-zero if the graph is stale
+          graft check         # exits non-zero if the graph is stale
 
   Runs locally out of the box:
     • Extraction/summaries default to a local Ollama model. Install Ollama and

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "context-graph-engine",
+  "name": "@nanonets/graft",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "context-graph-engine",
+      "name": "@nanonets/graft",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -18,10 +18,13 @@
         "tree-sitter-typescript": "^0.23.2"
       },
       "bin": {
-        "context-graph": "dist/cli.js"
+        "graft": "dist/cli.js"
       },
       "devDependencies": {
+        "@types/d3-force": "^3.0.10",
         "@types/node": "^26.1.0",
+        "d3-force": "^3.0.0",
+        "esbuild": "^0.28.1",
         "tsx": "^4.22.4",
         "typescript": "^6.0.3"
       },
@@ -471,6 +474,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "26.1.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
@@ -503,6 +513,51 @@
       "license": "MIT",
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/dotenv": {
@@ -831,40 +886,6 @@
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "context-graph-engine",
+  "name": "@nanonets/graft",
   "version": "0.1.0",
   "description": "Build a repo's context graph as a folder of linked markdown files that live in the repo and stay in sync with the code through git.",
   "keywords": [
@@ -8,9 +8,21 @@
     "knowledge-graph",
     "context",
     "codebase",
-    "llm"
+    "llm",
+    "graft"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/NanoNets/context-graph-engine.git"
+  },
+  "homepage": "https://github.com/NanoNets/context-graph-engine#readme",
+  "bugs": {
+    "url": "https://github.com/NanoNets/context-graph-engine/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -21,7 +33,7 @@
     }
   },
   "bin": {
-    "context-graph": "./dist/cli.js"
+    "graft": "./dist/cli.js"
   },
   "files": [
     "dist",
@@ -29,7 +41,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.json && tsc -p viewer/tsconfig.json && node scripts/build-viewer.mjs",
     "dev": "tsc -p tsconfig.json --watch",
     "cli": "tsx src/cli.ts",
     "bench": "tsx bench/run.ts",
@@ -50,7 +62,10 @@
     "tree-sitter-typescript": "^0.23.2"
   },
   "devDependencies": {
+    "@types/d3-force": "^3.0.10",
     "@types/node": "^26.1.0",
+    "d3-force": "^3.0.0",
+    "esbuild": "^0.28.1",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3"
   }

--- a/scripts/build-viewer.mjs
+++ b/scripts/build-viewer.mjs
@@ -1,0 +1,28 @@
+/**
+ * Bundles the viewer into dist/viewer/ (app.js via esbuild + copied static
+ * assets). Runs as part of `npm run build`; the bundle ships in the package
+ * so `graft viz` needs no install or build step at runtime.
+ */
+import { build } from "esbuild";
+import { mkdirSync, copyFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const outDir = join(root, "dist", "viewer");
+mkdirSync(outDir, { recursive: true });
+
+await build({
+  entryPoints: [join(root, "viewer", "main.ts")],
+  bundle: true,
+  minify: true,
+  format: "esm",
+  target: "es2022",
+  outfile: join(outDir, "app.js"),
+});
+
+for (const asset of ["index.html", "style.css"]) {
+  copyFileSync(join(root, "viewer", asset), join(outDir, asset));
+}
+
+console.log("viewer bundle → dist/viewer/");

--- a/src/ai/providers.ts
+++ b/src/ai/providers.ts
@@ -7,12 +7,12 @@ import type { Synthesizer } from "./synthesize.js";
  * API key is required for any LLM-backed operation.
  */
 export interface EngineConfig {
-  /** Where the graph lives. Env: CONTEXT_GRAPH_DIR. Default: `<repo>/.context`. */
+  /** Where the graph lives. Env: GRAFT_DIR. Default: `<repo>/.context`. */
   contextDir?: string;
 
   /** OpenRouter key for extraction + summarization. Env: OPENROUTER_API_KEY. */
   openrouterApiKey?: string;
-  /** OpenRouter model id. Env: CONTEXT_GRAPH_OPENROUTER_MODEL. Default: openai/gpt-4o-mini */
+  /** OpenRouter model id. Env: GRAFT_OPENROUTER_MODEL. Default: openai/gpt-4o-mini */
   openrouterModel?: string;
   /** OpenRouter API base URL. Env: OPENROUTER_BASE_URL. Default: https://openrouter.ai/api/v1 */
   openrouterBaseUrl?: string;
@@ -43,10 +43,10 @@ export const DEFAULTS = {
 export function resolveConfig(config: EngineConfig = {}): ResolvedConfig {
   const env = process.env;
   return {
-    contextDir: config.contextDir ?? env.CONTEXT_GRAPH_DIR,
+    contextDir: config.contextDir ?? env.GRAFT_DIR,
     openrouterApiKey: config.openrouterApiKey ?? env.OPENROUTER_API_KEY,
     openrouterModel:
-      config.openrouterModel ?? env.CONTEXT_GRAPH_OPENROUTER_MODEL ?? DEFAULTS.openrouterModel,
+      config.openrouterModel ?? env.GRAFT_OPENROUTER_MODEL ?? DEFAULTS.openrouterModel,
     openrouterBaseUrl:
       config.openrouterBaseUrl ?? env.OPENROUTER_BASE_URL ?? DEFAULTS.openrouterBaseUrl,
     synthesizer: config.synthesizer,

--- a/src/ai/synthesize.ts
+++ b/src/ai/synthesize.ts
@@ -46,7 +46,8 @@ Produce a CURATED set of nodes of mixed granularity:
 Rules:
 - Strongly prefer FEWER, larger, meaningful nodes. For a repo of N files, aim for well under N nodes. Do NOT emit one node per file, and never a node per incidental identifier (a local interface, helper, or third-party symbol).
 - Merge duplicates and surface-form variants into one node.
-- For each node give: a canonical human-readable name; a type ("system" | "file" | "concept"); a 1-3 sentence summary of its ROLE in the system; "sources" = the exact file paths (from the input) it is grounded in (a system lists all its files; a concept lists the files that motivate it); and "links" to other nodes you define, each with a snake_case relation (depends_on, part_of, uses, implements, produces) and a short description.
+- For each node give: a canonical human-readable name; a type ("system" | "file" | "concept"); a 1-3 sentence summary of its ROLE in the system; "sources" = the exact file paths (from the input) it is grounded in (a system lists all its files; a concept lists the files that motivate it); and "links" to other nodes you define, each with a relation and a short description of what concretely happens in the code.
+- The relation MUST be one of exactly these verbs (each answers a question a code reviewer asks): "part_of" (where does this live?), "uses" (what breaks if the target changes?), "depends_on" (same, for non-call dependencies), "produces" (where does this output come from?), "configures" (what changes its behavior without a code change?), "validates" (what checks or judges this? tests, drift checks, scoring), "implements" (what contract must this honor?). Never invent vague relations like "influences", "supports", or "relates_to" — if none of the verbs fit, drop the link.
 - Only link to nodes you actually define in this response.
 Respond only via the record_graph tool / JSON schema.`;
 
@@ -68,7 +69,10 @@ const NODES_SCHEMA = {
               type: "object",
               properties: {
                 to: { type: "string" },
-                relation: { type: "string" },
+                relation: {
+                  type: "string",
+                  enum: ["part_of", "uses", "depends_on", "produces", "configures", "validates", "implements"],
+                },
                 description: { type: "string" },
               },
               required: ["to", "relation"],

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * `context-graph` CLI. Two commands:
+ * `graft` CLI. Two commands:
  *
  *   init    build .context/ from your code (one markdown node per system,
  *           API, or concept; linked to each other; committed to the repo).
@@ -12,20 +12,20 @@
 import "dotenv/config";
 import { Command } from "commander";
 import { relative } from "node:path";
-import { ContextGraphEngine } from "./engine.js";
+import { Graft } from "./engine.js";
 import { formatCheckReport } from "./context/check.js";
 import { formatGraphCheckReport } from "./graph/check.js";
 
 const program = new Command();
 
 program
-  .name("context-graph")
+  .name("graft")
   .description("Build a repo's context graph as linked markdown, and keep it in sync with the code.")
   .option("--dir <path>", "context graph directory (default: <repo>/.context)");
 
-function engineFrom(): ContextGraphEngine {
+function engineFrom(): Graft {
   const opts = program.opts<{ dir?: string }>();
-  return new ContextGraphEngine({ contextDir: opts.dir });
+  return new Graft({ contextDir: opts.dir });
 }
 
 program
@@ -103,6 +103,42 @@ program
 
     // A missing graph.json is not a failure — the markdown graph stands alone.
     if (!r.ok || (!g.missing && !g.ok)) process.exit(1);
+  });
+
+program
+  .command("viz")
+  .description("Serve an interactive visualization of the context graph (and graph.json when present)")
+  .argument("[dir]", "repository root", ".")
+  .option("-p, --port <port>", "port to serve on", "4400")
+  .option("--no-open", "don't open the browser")
+  .action(async (dir: string, opts: { port: string; open: boolean }) => {
+    const { existsSync } = await import("node:fs");
+    const { resolve, basename } = await import("node:path");
+    const { spawn } = await import("node:child_process");
+    const { fileURLToPath } = await import("node:url");
+    const { contextDirFor } = await import("./context/node-file.js");
+    const { startVizServer } = await import("./viz/serve.js");
+
+    const root = resolve(dir);
+    const globalOpts = program.opts<{ dir?: string }>();
+    const contextDir = contextDirFor(root, globalOpts.dir);
+    if (!existsSync(contextDir)) {
+      console.error(`✗ no context graph at ${contextDir} — run \`graft init\` first`);
+      process.exit(1);
+    }
+    // dist/cli.js → dist/viewer/ (prebuilt at package build time)
+    const viewerDir = fileURLToPath(new URL("./viewer/", import.meta.url));
+    const srv = await startVizServer({
+      contextDir,
+      viewerDir,
+      port: Number(opts.port),
+      repoName: basename(root),
+    });
+    console.log(`graft viz → ${srv.url}  (ctrl-c to stop)`);
+    if (opts.open) {
+      const opener = process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open";
+      spawn(opener, [srv.url], { stdio: "ignore", detached: true, shell: process.platform === "win32" }).unref();
+    }
   });
 
 program.parseAsync().catch((err) => {

--- a/src/context/check.ts
+++ b/src/context/check.ts
@@ -4,7 +4,7 @@
  * Pure I/O + hashing: no LLM, no network, milliseconds. It re-hashes the source
  * files the manifest recorded and compares. Meant to run in CI: exit 0 when the
  * graph is fresh, 1 when it has drifted (so a PR that changed code but not the
- * graph fails until `context-graph init` is re-run and committed).
+ * graph fails until `graft init` is re-run and committed).
  *
  * Drift categories:
  *   content     a recorded source file's bytes changed
@@ -109,11 +109,11 @@ export function checkContext(dir: string, opts: CheckOptions = {}): CheckResult 
 /** Render a check result as a human-readable report. */
 export function formatCheckReport(r: CheckResult): string {
   if (r.missing) {
-    return "context-graph check: NO GRAPH\n\nNo .context/manifest.json found. Run `context-graph init` first.";
+    return "graft check: NO GRAPH\n\nNo .context/manifest.json found. Run `graft init` first.";
   }
-  if (r.ok) return "context-graph check: OK — the graph is in sync with the code.";
+  if (r.ok) return "graft check: OK — the graph is in sync with the code.";
 
-  const lines: string[] = ["context-graph check: STALE", ""];
+  const lines: string[] = ["graft check: STALE", ""];
   if (r.contentDrift.length) {
     lines.push(`changed (${r.contentDrift.length}):`);
     for (const c of r.contentDrift) lines.push(`  ~ ${c.path}  (${c.from} → ${c.to})`);
@@ -130,7 +130,7 @@ export function formatCheckReport(r: CheckResult): string {
     lines.push(`index mismatch (${r.indexDrift.length}):`);
     for (const s of r.indexDrift) lines.push(`  ! ${s}`);
   }
-  lines.push("", "Run `context-graph init` to regenerate, then commit .context/.");
+  lines.push("", "Run `graft init` to regenerate, then commit .context/.");
   return lines.join("\n");
 }
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2,8 +2,8 @@
  * The Context Graph Engine.
  *
  * Two operations, no database:
- *   - {@link ContextGraphEngine.init}  build `.context/` from a code repo.
- *   - {@link ContextGraphEngine.check} report whether `.context/` is still in
+ *   - {@link Graft.init}  build `.context/` from a code repo.
+ *   - {@link Graft.check} report whether `.context/` is still in
  *     sync with the code (for CI).
  *
  * The graph is a folder of linked markdown files committed to the repo; git is
@@ -39,7 +39,7 @@ export interface GraphRunOptions {
   onProgress?: GraphBuildOptions["onProgress"];
 }
 
-export class ContextGraphEngine {
+export class Graft {
   private cfg: ResolvedConfig;
 
   constructor(config: EngineConfig = {}) {

--- a/src/graph/check.ts
+++ b/src/graph/check.ts
@@ -103,7 +103,7 @@ export function checkGraph(dir: string, opts: GraphCheckOptions = {}): GraphChec
 /** Render a graph-check result as a human-readable report. */
 export function formatGraphCheckReport(r: GraphCheckResult): string {
   if (r.missing) {
-    return "graph check: NO GRAPH\n\nNo .context/graph.json found. Run `context-graph graph` first.";
+    return "graph check: NO GRAPH\n\nNo .context/graph.json found. Run `graft graph` first.";
   }
   if (r.ok) {
     const note = r.pending ? ` (${r.pending} node(s) not yet summarized — run \`graph --llm\`)` : "";
@@ -129,7 +129,7 @@ export function formatGraphCheckReport(r: GraphCheckResult): string {
     for (const id of r.stale) lines.push(`  ! ${id}`);
   }
   lines.push("");
-  if (structural) lines.push("Run `context-graph graph` to rebuild the structure, then commit .context/.");
-  if (r.stale.length) lines.push("Run `context-graph graph --llm` to refresh stale summaries.");
+  if (structural) lines.push("Run `graft graph` to rebuild the structure, then commit .context/.");
+  if (r.stale.length) lines.push("Run `graft graph --llm` to refresh stale summaries.");
   return lines.join("\n");
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,21 @@
 /**
- * Context Graph Engine — public API.
+ * Graft — public API.
  *
  * The graph is a folder of linked markdown files (`.context/`) committed to the
  * repo. Build it from code, then check it stays in sync.
  *
  * @example
  * ```ts
- * import { ContextGraphEngine } from "context-graph-engine";
+ * import { Graft } from "@nanonets/graft";
  *
- * const engine = new ContextGraphEngine();
+ * const engine = new Graft();
  * await engine.init(".");             // writes .context/*.md + manifest.json
  *
  * const result = engine.check(".");   // { ok: boolean, ...drift }
  * if (!result.ok) process.exitCode = 1;
  * ```
  */
-export { ContextGraphEngine, CODE_EXTENSIONS } from "./engine.js";
+export { Graft, CODE_EXTENSIONS } from "./engine.js";
 export type { InitOptions, CheckRunOptions, BuildResult, BuildProgress, CheckResult } from "./engine.js";
 
 export { buildContext } from "./context/build.js";

--- a/src/viz/assemble.ts
+++ b/src/viz/assemble.ts
@@ -1,0 +1,130 @@
+/**
+ * Assembles the viz-facing JSON for the context graph: reads every `.md` node
+ * file in a context dir (frontmatter = node + edges) and produces a single
+ * `{meta, nodes, edges}` document the viewer can render directly.
+ *
+ * Design rules (see docs/superpowers/specs/2026-07-15-graft-viz-design.md):
+ *  - relations are normalized into the closed verb vocabulary — vague LLM
+ *    softeners map to the concrete verb they usually mean
+ *  - edges whose target slug doesn't exist are dropped (LLM output can dangle)
+ *  - a node file with unparseable frontmatter is skipped, never fatal
+ *  - both drop counts are reported in `meta` so the UI can say so
+ */
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import matter from "gray-matter";
+import type { NodeLink, SourceRef } from "../context/node-file.js";
+
+export interface VizNode {
+  id: string;
+  name: string;
+  type: string;
+  summary: string;
+  sources: string[];
+}
+
+export interface VizEdge {
+  source: string;
+  target: string;
+  relation: string;
+  description?: string;
+}
+
+export interface VizGraph {
+  meta: {
+    nodeCount: number;
+    edgeCount: number;
+    skippedFiles: number;
+    droppedEdges: number;
+  };
+  nodes: VizNode[];
+  edges: VizEdge[];
+}
+
+/**
+ * Legacy vague verbs → the concrete verb they usually mean. Keeps old
+ * `.context/` folders readable without regeneration; the synthesizer itself
+ * is constrained to the closed vocabulary going forward.
+ */
+export const NORMALIZE_RELATION: Record<string, string> = {
+  influences: "configures",
+  supports: "validates",
+  defines: "validates",
+  measures: "validates",
+};
+
+export function normalizeRelation(rel: string): string {
+  return NORMALIZE_RELATION[rel] ?? rel;
+}
+
+const GEN_START = "<!-- context:generated:start -->";
+const GEN_END = "<!-- context:generated:end -->";
+const SUMMARY_MAX = 500;
+
+/** Pull the prose summary out of a node body's generated block. */
+function extractSummary(body: string): string {
+  let text = body;
+  const start = text.indexOf(GEN_START);
+  const end = text.indexOf(GEN_END);
+  if (start >= 0 && end > start) text = text.slice(start + GEN_START.length, end);
+  // Keep only the Summary section if headings are present.
+  const related = text.indexOf("## Related");
+  if (related >= 0) text = text.slice(0, related);
+  text = text.replace(/^##\s+Summary\s*$/m, "");
+  text = text.trim();
+  return text.length > SUMMARY_MAX ? text.slice(0, SUMMARY_MAX).trimEnd() + "…" : text;
+}
+
+/** Read a context dir and assemble the render-ready graph document. */
+export function assembleContextGraph(contextDir: string): VizGraph {
+  const nodes: VizNode[] = [];
+  const rawEdges: VizEdge[] = [];
+  let skippedFiles = 0;
+
+  if (existsSync(contextDir)) {
+    for (const entry of readdirSync(contextDir).sort()) {
+      if (!entry.endsWith(".md")) continue;
+      let parsed: matter.GrayMatterFile<string>;
+      try {
+        parsed = matter(readFileSync(join(contextDir, entry), "utf8"));
+      } catch {
+        skippedFiles++;
+        continue;
+      }
+      const fm = parsed.data as Record<string, unknown>;
+      const id = String(fm.slug ?? entry.replace(/\.md$/, ""));
+      const sources = Array.isArray(fm.sources) ? (fm.sources as SourceRef[]) : [];
+      const links = Array.isArray(fm.links) ? (fm.links as NodeLink[]) : [];
+      nodes.push({
+        id,
+        name: String(fm.name ?? id),
+        type: String(fm.type ?? "concept"),
+        summary: extractSummary(parsed.content),
+        sources: sources.map((s) => s.path),
+      });
+      for (const link of links) {
+        if (!link || typeof link.to !== "string") continue;
+        rawEdges.push({
+          source: id,
+          target: link.to,
+          relation: normalizeRelation(String(link.relation ?? "uses")),
+          ...(link.description ? { description: link.description } : {}),
+        });
+      }
+    }
+  }
+
+  const known = new Set(nodes.map((n) => n.id));
+  const edges = rawEdges.filter((e) => known.has(e.source) && known.has(e.target));
+
+  return {
+    meta: {
+      nodeCount: nodes.length,
+      edgeCount: edges.length,
+      skippedFiles,
+      droppedEdges: rawEdges.length - edges.length,
+    },
+    nodes,
+    edges,
+  };
+}

--- a/src/viz/serve.ts
+++ b/src/viz/serve.ts
@@ -1,0 +1,148 @@
+/**
+ * The `graft viz` local server. Zero runtime dependencies: node:http serves
+ * the prebuilt viewer bundle, two JSON endpoints, and an SSE channel that
+ * pings the browser whenever the context dir changes on disk.
+ *
+ *   GET /                  viewer (index.html, app.js, style.css from viewerDir)
+ *   GET /api/context-graph assembled from .context/*.md on every request
+ *   GET /api/code-graph    .context/graph.json passthrough (404 until generated)
+ *   GET /events            SSE; fs.watch on the context dir, debounced 300ms
+ */
+import { createServer, type Server, type ServerResponse } from "node:http";
+import { readFileSync, existsSync, watch, type FSWatcher } from "node:fs";
+import { join } from "node:path";
+import { assembleContextGraph } from "./assemble.js";
+
+export interface VizServerOptions {
+  contextDir: string;
+  viewerDir: string;
+  port: number;
+  repoName: string;
+}
+
+export interface VizServer {
+  url: string;
+  close(): Promise<void>;
+}
+
+const PORT_ATTEMPTS = 10;
+const WATCH_DEBOUNCE_MS = 300;
+
+const STATIC_FILES: Record<string, { file: string; type: string }> = {
+  "/": { file: "index.html", type: "text/html; charset=utf-8" },
+  "/index.html": { file: "index.html", type: "text/html; charset=utf-8" },
+  "/app.js": { file: "app.js", type: "text/javascript; charset=utf-8" },
+  "/style.css": { file: "style.css", type: "text/css; charset=utf-8" },
+};
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { "content-type": "application/json; charset=utf-8" });
+  res.end(JSON.stringify(body));
+}
+
+function listen(server: Server, port: number): Promise<boolean> {
+  return new Promise((resolve, reject) => {
+    const onError = (err: NodeJS.ErrnoException) => {
+      if (err.code === "EADDRINUSE") resolve(false);
+      else reject(err);
+    };
+    server.once("error", onError);
+    server.listen(port, "127.0.0.1", () => {
+      server.removeListener("error", onError);
+      resolve(true);
+    });
+  });
+}
+
+export async function startVizServer(opts: VizServerOptions): Promise<VizServer> {
+  const sseClients = new Set<ServerResponse>();
+
+  const server = createServer((req, res) => {
+    const path = (req.url ?? "/").split("?")[0];
+
+    const asset = STATIC_FILES[path];
+    if (asset) {
+      const file = join(opts.viewerDir, asset.file);
+      if (!existsSync(file)) {
+        res.writeHead(404, { "content-type": "text/plain" });
+        res.end("viewer bundle missing — run the package build");
+        return;
+      }
+      res.writeHead(200, { "content-type": asset.type });
+      res.end(readFileSync(file));
+      return;
+    }
+
+    if (path === "/api/context-graph") {
+      const graph = assembleContextGraph(opts.contextDir);
+      sendJson(res, 200, { ...graph, meta: { ...graph.meta, repoName: opts.repoName } });
+      return;
+    }
+
+    if (path === "/api/code-graph") {
+      const file = join(opts.contextDir, "graph.json");
+      if (!existsSync(file)) {
+        sendJson(res, 404, { error: "no graph.json in this context dir — run `graft graph` first" });
+        return;
+      }
+      try {
+        const parsed = JSON.parse(readFileSync(file, "utf8"));
+        if (parsed?.meta?.version !== 1) {
+          sendJson(res, 404, { error: "graph.json has an unsupported version — regenerate with `graft graph`" });
+          return;
+        }
+        sendJson(res, 200, parsed);
+      } catch {
+        sendJson(res, 404, { error: "graph.json is unreadable — regenerate with `graft graph`" });
+      }
+      return;
+    }
+
+    if (path === "/events") {
+      res.writeHead(200, {
+        "content-type": "text/event-stream",
+        "cache-control": "no-cache",
+        connection: "keep-alive",
+      });
+      res.write(": connected\n\n");
+      sseClients.add(res);
+      req.on("close", () => sseClients.delete(res));
+      return;
+    }
+
+    res.writeHead(404, { "content-type": "text/plain" });
+    res.end("not found");
+  });
+
+  let port = opts.port;
+  let bound = false;
+  for (let i = 0; i < PORT_ATTEMPTS && !bound; i++) {
+    port = opts.port + i;
+    bound = await listen(server, port);
+  }
+  if (!bound) {
+    throw new Error(`no free port in ${opts.port}–${opts.port + PORT_ATTEMPTS - 1}`);
+  }
+
+  let watcher: FSWatcher | undefined;
+  let debounce: NodeJS.Timeout | undefined;
+  if (existsSync(opts.contextDir)) {
+    watcher = watch(opts.contextDir, () => {
+      clearTimeout(debounce);
+      debounce = setTimeout(() => {
+        for (const client of sseClients) client.write("data: change\n\n");
+      }, WATCH_DEBOUNCE_MS);
+    });
+  }
+
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close(): Promise<void> {
+      clearTimeout(debounce);
+      watcher?.close();
+      for (const client of sseClients) client.end();
+      sseClients.clear();
+      return new Promise((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+    },
+  };
+}

--- a/test/viz-assemble.test.ts
+++ b/test/viz-assemble.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for the viz graph assembly: .context/*.md frontmatter → {meta, nodes, edges}
+ * with relation normalization, dangling-edge dropping, and malformed-file skipping.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { assembleContextGraph, normalizeRelation } from "../src/viz/assemble.js";
+
+function makeContextDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graftviz-"));
+  writeFileSync(
+    join(dir, "alpha.md"),
+    `---
+name: Alpha
+slug: alpha
+type: system
+sources:
+  - path: src/a.ts
+    hash: abc123
+links:
+  - to: beta
+    relation: influences
+    description: Affects beta somehow.
+  - to: gamma
+    relation: uses
+---
+<!-- context:generated:start -->
+## Summary
+Alpha coordinates the whole show.
+
+## Related
+- uses [[beta]]
+<!-- context:generated:end -->
+## Notes
+_preserved_
+`,
+  );
+  writeFileSync(
+    join(dir, "beta.md"),
+    `---
+name: Beta
+slug: beta
+type: concept
+sources: []
+links: []
+---
+<!-- context:generated:start -->
+## Summary
+Beta holds shared state.
+<!-- context:generated:end -->
+`,
+  );
+  // Invalid YAML frontmatter — must be skipped, not fatal.
+  writeFileSync(join(dir, "broken.md"), `---\nname: [unclosed\n---\nbody\n`);
+  writeFileSync(join(dir, "manifest.json"), "{}\n");
+  return dir;
+}
+
+test("assembleContextGraph builds nodes and edges from frontmatter", () => {
+  const dir = makeContextDir();
+  try {
+    const g = assembleContextGraph(dir);
+
+    assert.equal(g.nodes.length, 2);
+    assert.deepEqual(g.nodes.map((n) => n.id).sort(), ["alpha", "beta"]);
+
+    const alpha = g.nodes.find((n) => n.id === "alpha")!;
+    assert.equal(alpha.name, "Alpha");
+    assert.equal(alpha.type, "system");
+    assert.deepEqual(alpha.sources, ["src/a.ts"]);
+    assert.equal(alpha.summary, "Alpha coordinates the whole show.");
+
+    // influences → configures; dangling gamma edge dropped
+    assert.equal(g.edges.length, 1);
+    assert.deepEqual(g.edges[0], {
+      source: "alpha",
+      target: "beta",
+      relation: "configures",
+      description: "Affects beta somehow.",
+    });
+
+    assert.equal(g.meta.nodeCount, 2);
+    assert.equal(g.meta.edgeCount, 1);
+    assert.equal(g.meta.droppedEdges, 1);
+    assert.equal(g.meta.skippedFiles, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("normalizeRelation maps vague verbs to the closed vocabulary", () => {
+  assert.equal(normalizeRelation("influences"), "configures");
+  assert.equal(normalizeRelation("supports"), "validates");
+  assert.equal(normalizeRelation("defines"), "validates");
+  assert.equal(normalizeRelation("measures"), "validates");
+  // members of the vocabulary pass through untouched
+  for (const rel of ["part_of", "uses", "depends_on", "produces", "configures", "validates", "implements"]) {
+    assert.equal(normalizeRelation(rel), rel);
+  }
+  // unknown verbs are kept verbatim (viewer renders them as their own chip)
+  assert.equal(normalizeRelation("orchestrates"), "orchestrates");
+});

--- a/test/viz-serve.test.ts
+++ b/test/viz-serve.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Tests for the viz server: endpoint shapes, code-graph gating, port fallback,
+ * and SSE live-reload on context-dir changes.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createServer } from "node:http";
+import { startVizServer } from "../src/viz/serve.js";
+
+function makeDirs(): { contextDir: string; viewerDir: string; root: string } {
+  const root = mkdtempSync(join(tmpdir(), "graftviz-srv-"));
+  const contextDir = join(root, ".context");
+  const viewerDir = join(root, "viewer");
+  mkdirSync(contextDir);
+  mkdirSync(viewerDir);
+  writeFileSync(join(viewerDir, "index.html"), "<title>stub</title>\n");
+  writeFileSync(join(viewerDir, "app.js"), "// stub\n");
+  writeFileSync(join(viewerDir, "style.css"), "/* stub */\n");
+  writeFileSync(
+    join(contextDir, "alpha.md"),
+    `---\nname: Alpha\nslug: alpha\ntype: system\nsources: []\nlinks: []\n---\nbody\n`,
+  );
+  return { contextDir, viewerDir, root };
+}
+
+test("viz server serves viewer, context graph, and gates code graph", async () => {
+  const { contextDir, viewerDir, root } = makeDirs();
+  const srv = await startVizServer({ contextDir, viewerDir, port: 4831, repoName: "fixture" });
+  try {
+    const html = await fetch(`${srv.url}/`).then((r) => r.text());
+    assert.match(html, /stub/);
+
+    const graph = await fetch(`${srv.url}/api/context-graph`).then((r) => r.json());
+    assert.equal(graph.meta.nodeCount, 1);
+    assert.equal(graph.meta.repoName, "fixture");
+    assert.equal(graph.nodes[0].id, "alpha");
+
+    // no graph.json yet → 404 with an explanatory error
+    const missing = await fetch(`${srv.url}/api/code-graph`);
+    assert.equal(missing.status, 404);
+    const body = await missing.json();
+    assert.match(body.error, /graft graph/);
+
+    // valid graph.json → passthrough
+    writeFileSync(
+      join(contextDir, "graph.json"),
+      JSON.stringify({ meta: { version: 1, nodeCount: 0, edgeCount: 0, languages: [] }, nodes: [], edges: [] }),
+    );
+    const code = await fetch(`${srv.url}/api/code-graph`).then((r) => r.json());
+    assert.equal(code.meta.version, 1);
+  } finally {
+    await srv.close();
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("viz server falls back to the next free port", async () => {
+  const { contextDir, viewerDir, root } = makeDirs();
+  const blocker = createServer(() => {});
+  await new Promise<void>((res) => blocker.listen(4841, "127.0.0.1", res));
+  const srv = await startVizServer({ contextDir, viewerDir, port: 4841, repoName: "fixture" });
+  try {
+    assert.match(srv.url, /:4842$/);
+  } finally {
+    await srv.close();
+    await new Promise((res) => blocker.close(res));
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("viz server emits an SSE event when the context dir changes", async () => {
+  const { contextDir, viewerDir, root } = makeDirs();
+  const srv = await startVizServer({ contextDir, viewerDir, port: 4851, repoName: "fixture" });
+  try {
+    const controller = new AbortController();
+    const res = await fetch(`${srv.url}/events`, {
+      headers: { accept: "text/event-stream" },
+      signal: controller.signal,
+    });
+    const reader = res.body!.getReader();
+    // trigger a change after the stream is open
+    setTimeout(() => writeFileSync(join(contextDir, "alpha.md"), "---\nname: Alpha2\nslug: alpha\n---\n"), 150);
+    const deadline = Date.now() + 5000;
+    let seen = "";
+    while (Date.now() < deadline && !seen.includes("data: change")) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      seen += new TextDecoder().decode(value);
+    }
+    controller.abort();
+    assert.match(seen, /data: change/);
+  } finally {
+    await srv.close();
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/viewer/data.ts
+++ b/viewer/data.ts
@@ -1,0 +1,121 @@
+/**
+ * Data layer: fetches both graphs from the graft viz server and carries the
+ * edge semantics (verb → family → form) defined in the design spec.
+ */
+
+export interface VizNode {
+  id: string;
+  name: string;
+  type: string;
+  summary: string;
+  sources: string[];
+}
+
+export interface VizEdge {
+  source: string;
+  target: string;
+  relation: string;
+  description?: string;
+  confidence?: "extracted" | "inferred";
+}
+
+export interface VizGraph {
+  meta: { repoName?: string; nodeCount: number; edgeCount: number; skippedFiles?: number; droppedEdges?: number };
+  nodes: VizNode[];
+  edges: VizEdge[];
+}
+
+/** Every relation verb belongs to one family; form follows family. */
+export type Family = "structure" | "dependency" | "contract" | "association";
+
+const FAMILY: Record<string, Family> = {
+  part_of: "structure", contains: "structure",
+  uses: "dependency", depends_on: "dependency", calls: "dependency", imports: "dependency",
+  produces: "dependency", configures: "dependency", validates: "dependency",
+  extends: "contract", implements: "contract",
+  references: "association",
+};
+
+export function famOf(rel: string): Family {
+  return FAMILY[rel] ?? "association";
+}
+
+/** Force-spring rest length per family: hierarchy pulls tight. */
+export const REST: Record<Family, number> = { structure: 85, dependency: 145, contract: 150, association: 185 };
+
+/** Chip grouping: "part of" and "uses" are clear as groups; other verbs stand alone. */
+export function chipKey(rel: string): string {
+  if (famOf(rel) === "structure") return "part of";
+  if (rel === "calls" || rel === "uses" || rel === "depends_on" || rel === "imports") return "uses";
+  return rel.replace(/_/g, " ");
+}
+
+/** Hover hint: the question the verb answers for someone building or reviewing code. */
+export const CHIP_HINT: Record<string, string> = {
+  "part of": "where does this live? (contains, part of)",
+  "uses": "what breaks if the target changes? (calls, uses, depends on, imports)",
+  "produces": "where does this output come from?",
+  "configures": "what changes its behavior without a code change?",
+  "validates": "what checks or judges this? (tests, drift checks, scoring)",
+  "extends": "what contract must this honor? (inheritance)",
+  "implements": "what contract must this honor? (interface)",
+  "references": "mentioned but never called — possible dead coupling",
+};
+
+/** Node-type → CSS custom property, per tab. */
+const CONTEXT_COLORS: Record<string, string> = { system: "--sys", concept: "--con", file: "--fil", api: "--api" };
+const CODE_COLORS: Record<string, string> = {
+  file: "--k-file", class: "--k-class", function: "--k-fn", method: "--k-method",
+  interface: "--k-iface", type: "--k-type", enum: "--k-enum",
+};
+
+export function colorToken(tab: "context" | "code", type: string): string {
+  const m = tab === "code" ? CODE_COLORS : CONTEXT_COLORS;
+  return m[type] ?? "--edge";
+}
+
+export function cvar(name: string): string {
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+}
+
+export async function loadContextGraph(): Promise<VizGraph> {
+  const res = await fetch("/api/context-graph");
+  return (await res.json()) as VizGraph;
+}
+
+interface CodeGraphV1 {
+  meta: { version: number; nodeCount: number; edgeCount: number };
+  nodes: Array<{
+    id: string; name: string; kind: string; path: string; span: string;
+    signature: string | null; summary: string | null; crux: { code: string; span: string } | null;
+  }>;
+  edges: Array<{ source: string; target: string; relation: string; confidence: "extracted" | "inferred" }>;
+}
+
+/** Fetch graph.json and reshape it into the viewer's graph form (null if absent). */
+export async function loadCodeGraph(): Promise<VizGraph | null> {
+  const res = await fetch("/api/code-graph");
+  if (!res.ok) return null;
+  const raw = (await res.json()) as CodeGraphV1;
+  const nodes: VizNode[] = raw.nodes.map((n) => ({
+    id: n.id,
+    name: n.name,
+    type: n.kind,
+    summary: n.summary ?? n.signature ?? "",
+    sources: [`${n.path} · ${n.span}`],
+  }));
+  const known = new Set(nodes.map((n) => n.id));
+  // imports edges may point at unresolved module strings — drop those for rendering
+  const edges: VizEdge[] = raw.edges
+    .filter((e) => known.has(e.source) && known.has(e.target))
+    .map((e) => ({ source: e.source, target: e.target, relation: e.relation, confidence: e.confidence }));
+  return { meta: { nodeCount: nodes.length, edgeCount: edges.length }, nodes, edges };
+}
+
+/** Subscribe to the server's live-reload channel. */
+export function onServerChange(handler: () => void): void {
+  const source = new EventSource("/events");
+  source.onmessage = (ev) => {
+    if (ev.data === "change") handler();
+  };
+}

--- a/viewer/detail.ts
+++ b/viewer/detail.ts
@@ -1,0 +1,58 @@
+/**
+ * Detail panel: the selected node's type, summary, sources, and its links in
+ * both directions — amber "Depends on" (outgoing) and teal "Depended on by"
+ * (incoming), mirroring the focus-mode edge colors.
+ */
+import { type VizGraph, colorToken, cvar } from "./data.js";
+
+function esc(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;");
+}
+
+export function renderDetail(
+  host: HTMLElement,
+  graph: VizGraph | null,
+  tab: "context" | "code",
+  id: string | null,
+  onNavigate: (id: string) => void,
+): void {
+  if (!id || !graph) {
+    host.innerHTML = '<div class="empty">Select a node to view details</div>';
+    return;
+  }
+  const node = graph.nodes.find((n) => n.id === id);
+  if (!node) {
+    host.innerHTML = '<div class="empty">Select a node to view details</div>';
+    return;
+  }
+  const color = cvar(colorToken(tab, node.type));
+  const name = (nid: string) => graph.nodes.find((n) => n.id === nid)?.name ?? nid;
+  const out = graph.edges.filter((e) => e.source === id);
+  const inn = graph.edges.filter((e) => e.target === id);
+
+  let html = `<span class="d-type"><span class="sw" style="background:${color}"></span>${esc(node.type)}</span>`;
+  html += `<h3>${esc(node.name)}</h3>`;
+  if (node.summary) html += `<p class="summary">${esc(node.summary)}</p>`;
+  if (node.sources.length) {
+    html += `<div class="d-label">Sources · ${node.sources.length}</div>`;
+    for (const s of node.sources) html += `<div class="src mono">${esc(s)}</div>`;
+  }
+  const linkList = (edges: typeof out, dotColor: string, title: string, other: (e: (typeof out)[number]) => string) => {
+    if (!edges.length) return;
+    html += `<div class="d-label"><span class="dot" style="background:${dotColor}"></span>${title} · ${edges.length}</div>`;
+    for (const e of edges) {
+      html += `<button class="lnk" data-go="${esc(other(e))}">` +
+        `<span class="rel">${esc(e.relation.replace(/_/g, " "))}</span> ` +
+        `<span class="to">${esc(name(other(e)))}</span>` +
+        (e.description ? `<div class="desc">${esc(e.description)}</div>` : "") +
+        `</button>`;
+    }
+  };
+  linkList(out, cvar("--fil"), "Depends on", (e) => e.target);
+  linkList(inn, cvar("--accent"), "Depended on by", (e) => e.source);
+
+  host.innerHTML = html;
+  host.querySelectorAll<HTMLButtonElement>("[data-go]").forEach((b) => {
+    b.addEventListener("click", () => onNavigate(b.dataset.go!));
+  });
+}

--- a/viewer/graph.ts
+++ b/viewer/graph.ts
@@ -1,0 +1,334 @@
+/**
+ * Force-directed graph view. d3-force drives the simulation (Barnes–Hut, so
+ * large graphs stay interactive); rendering is persistent SVG — elements are
+ * created when data changes and only attributes are updated per tick.
+ *
+ * Edge grammar (per the design spec):
+ *   part of            thick · muted · no arrowhead · short spring
+ *   uses-family        solid · open-chevron arrowhead
+ *   extends/implements hollow arrowhead
+ *   references         faint dots · no arrowhead
+ *   inferred edges     dashed (trust is visible)
+ * Focus mode: selecting a node paints outgoing edges amber ("depends on"),
+ * incoming teal ("depended on by"), labels the verbs on just those edges,
+ * and fades the rest of the graph.
+ */
+import {
+  forceSimulation, forceManyBody, forceLink, forceCenter, forceCollide,
+  type Simulation, type SimulationNodeDatum,
+} from "d3-force";
+import { type VizGraph, type VizEdge, famOf, REST, chipKey, colorToken, cvar } from "./data.js";
+
+interface SimNode extends SimulationNodeDatum {
+  id: string;
+  name: string;
+  type: string;
+  deg: number;
+  r: number;
+  fx?: number | null;
+  fy?: number | null;
+}
+
+interface SimEdge {
+  source: SimNode;
+  target: SimNode;
+  relation: string;
+  description?: string;
+  confidence?: string;
+}
+
+const NS = "http://www.w3.org/2000/svg";
+
+function el<K extends keyof SVGElementTagNameMap>(tag: K, attrs: Record<string, string | number>): SVGElementTagNameMap[K] {
+  const node = document.createElementNS(NS, tag);
+  for (const [k, v] of Object.entries(attrs)) node.setAttribute(k, String(v));
+  return node;
+}
+
+export class GraphView {
+  private svg: SVGSVGElement;
+  private defs!: SVGDefsElement;
+  private viewport!: SVGGElement;
+  private sim: Simulation<SimNode, undefined> | null = null;
+  private nodes: SimNode[] = [];
+  private edges: SimEdge[] = [];
+  private edgeEls: { path: SVGPathElement; label: SVGTextElement; edge: SimEdge }[] = [];
+  private nodeEls: { group: SVGGElement; circle: SVGCircleElement; ring: SVGCircleElement; label: SVGTextElement; node: SimNode }[] = [];
+  private view = { x: 0, y: 0, k: 1 };
+  private tab: "context" | "code" = "context";
+  selected: string | null = null;
+  query = "";
+  hiddenRels: Record<string, boolean> = {};
+  hiddenTypes: Record<string, boolean> = {};
+  onSelect: (id: string | null) => void = () => {};
+
+  constructor(svg: SVGSVGElement) {
+    this.svg = svg;
+    this.buildChrome();
+    this.bindPanZoom();
+  }
+
+  private buildChrome(): void {
+    this.svg.textContent = "";
+    this.defs = el("defs", {});
+    this.svg.appendChild(this.defs);
+    this.viewport = el("g", {});
+    this.svg.appendChild(this.viewport);
+    this.svg.addEventListener("click", () => this.select(null));
+  }
+
+  private ensureMarkers(): void {
+    this.defs.textContent = "";
+    const chevron = el("marker", { id: "arr", viewBox: "0 0 10 10", refX: 8, refY: 5, markerWidth: 4.5, markerHeight: 4.5, orient: "auto-start-reverse" });
+    chevron.appendChild(el("path", { d: "M2,1.5L8.5,5L2,8.5", fill: "none", stroke: cvar("--edge"), "stroke-width": 1.8, "stroke-linecap": "round", "stroke-linejoin": "round", opacity: 0.75 }));
+    const hollow = el("marker", { id: "arrH", viewBox: "0 0 12 12", refX: 10, refY: 6, markerWidth: 6.5, markerHeight: 6.5, orient: "auto-start-reverse" });
+    hollow.appendChild(el("path", { d: "M1.5,1.5L10.5,6L1.5,10.5z", fill: cvar("--canvas"), stroke: cvar("--edge"), "stroke-width": 1.4 }));
+    const out = el("marker", { id: "arrOut", viewBox: "0 0 10 10", refX: 8, refY: 5, markerWidth: 5, markerHeight: 5, orient: "auto-start-reverse" });
+    out.appendChild(el("path", { d: "M1,1L9,5L1,9z", fill: cvar("--fil") }));
+    const inn = el("marker", { id: "arrIn", viewBox: "0 0 10 10", refX: 8, refY: 5, markerWidth: 5, markerHeight: 5, orient: "auto-start-reverse" });
+    inn.appendChild(el("path", { d: "M1,1L9,5L1,9z", fill: cvar("--accent") }));
+    for (const m of [chevron, hollow, out, inn]) this.defs.appendChild(m);
+  }
+
+  /** Load (or morph into) a new dataset. Nodes keep their positions by id. */
+  setData(graph: VizGraph, tab: "context" | "code"): void {
+    this.tab = tab;
+    const prev = new Map(this.nodes.map((n) => [n.id, n]));
+    const deg: Record<string, number> = {};
+    for (const e of graph.edges) {
+      deg[e.source] = (deg[e.source] ?? 0) + 1;
+      deg[e.target] = (deg[e.target] ?? 0) + 1;
+    }
+    const W = this.svg.clientWidth || 800;
+    const H = this.svg.clientHeight || 600;
+    this.nodes = graph.nodes.map((n, i) => {
+      const p = prev.get(n.id);
+      const angle = (i / Math.max(1, graph.nodes.length)) * Math.PI * 2;
+      const d = deg[n.id] ?? 0;
+      return {
+        id: n.id, name: n.name, type: n.type,
+        deg: d, r: 11 + Math.min(13, d * 2.6),
+        x: p?.x ?? W / 2 + Math.cos(angle) * Math.min(W, H) / 4,
+        y: p?.y ?? H / 2 + Math.sin(angle) * Math.min(W, H) / 4,
+        vx: p?.vx ?? 0, vy: p?.vy ?? 0,
+      };
+    });
+    const byId = new Map(this.nodes.map((n) => [n.id, n]));
+    this.edges = graph.edges
+      .map((e: VizEdge) => ({
+        source: byId.get(e.source)!, target: byId.get(e.target)!,
+        relation: e.relation, description: e.description, confidence: e.confidence,
+      }))
+      .filter((e) => e.source && e.target);
+
+    this.sim?.stop();
+    this.sim = forceSimulation(this.nodes)
+      .force("charge", forceManyBody().strength(-220))
+      .force("link", forceLink(this.edges as unknown as { source: SimNode; target: SimNode }[])
+        .distance((l) => REST[famOf((l as unknown as SimEdge).relation)])
+        .strength(0.5))
+      .force("center", forceCenter(W / 2, H / 2))
+      .force("collide", forceCollide<SimNode>().radius((n) => n.r + 6))
+      .on("tick", () => this.tick());
+
+    this.buildElements();
+    this.restyle();
+  }
+
+  private buildElements(): void {
+    this.ensureMarkers();
+    this.viewport.textContent = "";
+    this.edgeEls = this.edges.map((edge) => {
+      const path = el("path", { fill: "none", "stroke-linecap": "round" });
+      const title = el("title", {});
+      title.textContent = edge.relation.replace(/_/g, " ") + (edge.description ? ` — ${edge.description}` : "");
+      path.appendChild(title);
+      const label = el("text", { "text-anchor": "middle", "font-size": 9.5, "font-weight": 700, "stroke-width": 3, "paint-order": "stroke", display: "none" });
+      label.textContent = edge.relation.replace(/_/g, " ");
+      this.viewport.appendChild(path);
+      this.viewport.appendChild(label);
+      return { path, label, edge };
+    });
+    this.nodeEls = this.nodes.map((node) => {
+      const group = el("g", { cursor: "pointer" });
+      const ring = el("circle", { fill: "none", "stroke-width": 1.6, opacity: 0, r: node.r + 5 });
+      const circle = el("circle", { r: node.r, opacity: 0.92 });
+      const label = el("text", { y: node.r + 15, "text-anchor": "middle", "font-size": 11.5, "font-weight": 600 });
+      label.textContent = node.name;
+      group.append(ring, circle, label);
+      group.addEventListener("click", (ev) => { ev.stopPropagation(); this.select(node.id); });
+      this.bindDrag(group, node);
+      this.viewport.appendChild(group);
+      return { group, circle, ring, label, node };
+    });
+  }
+
+  private tick(): void {
+    for (const { path, label, edge } of this.edgeEls) {
+      const a = edge.source, b = edge.target;
+      const dx = (b.x ?? 0) - (a.x ?? 0), dy = (b.y ?? 0) - (a.y ?? 0);
+      const d = Math.sqrt(dx * dx + dy * dy) || 1;
+      const ux = dx / d, uy = dy / d;
+      const sx = (a.x ?? 0) + ux * (a.r + 2), sy = (a.y ?? 0) + uy * (a.r + 2);
+      const tx = (b.x ?? 0) - ux * (b.r + 6), ty = (b.y ?? 0) - uy * (b.r + 6);
+      const mx = (sx + tx) / 2 - uy * 10, my = (sy + ty) / 2 + ux * 10;
+      path.setAttribute("d", `M${sx},${sy} Q${mx},${my} ${tx},${ty}`);
+      label.setAttribute("x", String((sx + tx) / 2 - uy * 14));
+      label.setAttribute("y", String((sy + ty) / 2 + ux * 14));
+    }
+    for (const { group, node } of this.nodeEls) {
+      group.setAttribute("transform", `translate(${node.x ?? 0},${node.y ?? 0})`);
+    }
+  }
+
+  /** Re-apply all style attributes (theme, filters, focus, search). */
+  restyle(): void {
+    this.ensureMarkers();
+    const neighbors = new Set<string>();
+    if (this.selected) {
+      for (const e of this.edges) {
+        if (e.source.id === this.selected) neighbors.add(e.target.id);
+        if (e.target.id === this.selected) neighbors.add(e.source.id);
+      }
+    }
+    const q = this.query.toLowerCase();
+    const nodeShown = (n: SimNode) => !this.hiddenTypes[n.type];
+
+    for (const { path, label, edge } of this.edgeEls) {
+      const visible = nodeShown(edge.source) && nodeShown(edge.target) && !this.hiddenRels[chipKey(edge.relation)];
+      path.style.display = visible ? "" : "none";
+      label.setAttribute("display", "none");
+      if (!visible) continue;
+      const fam = famOf(edge.relation);
+      let stroke = cvar("--edge"), width = 1.3, dash = "none", opacity = 0.5, marker = "url(#arr)";
+      if (fam === "structure") { width = 2.4; opacity = 0.32; marker = "none"; }
+      else if (fam === "dependency") { width = 1.5; opacity = 0.55; }
+      else if (fam === "contract") { opacity = 0.55; marker = "url(#arrH)"; }
+      else { dash = "2 5"; width = 1.2; opacity = 0.28; marker = "none"; }
+      if (edge.confidence === "inferred") dash = "5 4";
+      if (q) opacity = 0.12;
+      const role = this.selected
+        ? (edge.source.id === this.selected ? "out" : edge.target.id === this.selected ? "in" : "far")
+        : "none";
+      if (role === "out") { stroke = cvar("--fil"); opacity = 0.95; width += 0.7; marker = "url(#arrOut)"; }
+      else if (role === "in") { stroke = cvar("--accent"); opacity = 0.95; width += 0.7; marker = "url(#arrIn)"; }
+      else if (role === "far") { opacity = 0.06; }
+      path.setAttribute("stroke", stroke);
+      path.setAttribute("stroke-width", String(width));
+      path.setAttribute("stroke-dasharray", dash);
+      path.setAttribute("opacity", String(opacity));
+      if (marker === "none") path.removeAttribute("marker-end");
+      else path.setAttribute("marker-end", marker);
+      if (role === "out" || role === "in") {
+        label.removeAttribute("display");
+        label.setAttribute("fill", stroke);
+        label.setAttribute("stroke", cvar("--canvas"));
+      }
+    }
+
+    for (const { group, circle, ring, label, node } of this.nodeEls) {
+      const shown = nodeShown(node);
+      group.style.display = shown ? "" : "none";
+      if (!shown) continue;
+      const match = !q || node.name.toLowerCase().includes(q);
+      let opacity = match ? 1 : 0.22;
+      if (this.selected && node.id !== this.selected && !neighbors.has(node.id)) opacity = Math.min(opacity, 0.2);
+      group.setAttribute("opacity", String(opacity));
+      const color = cvar(colorToken(this.tab, node.type));
+      circle.setAttribute("fill", color);
+      ring.setAttribute("stroke", color);
+      ring.setAttribute("opacity", node.id === this.selected ? "0.55" : "0");
+      label.setAttribute("fill", cvar("--ink"));
+    }
+  }
+
+  select(id: string | null): void {
+    this.selected = id;
+    this.restyle();
+    this.onSelect(id);
+  }
+
+  /** Center the view on a node and select it (used by search). */
+  focus(id: string): void {
+    const node = this.nodes.find((n) => n.id === id);
+    if (!node) return;
+    const W = this.svg.clientWidth, H = this.svg.clientHeight;
+    this.view.k = Math.max(this.view.k, 1.4);
+    this.view.x = W / 2 - (node.x ?? 0) * this.view.k;
+    this.view.y = H / 2 - (node.y ?? 0) * this.view.k;
+    this.applyView();
+    this.select(id);
+  }
+
+  firstMatch(): SimNode | undefined {
+    const q = this.query.toLowerCase();
+    return this.nodes.find((n) => !this.hiddenTypes[n.type] && n.name.toLowerCase().includes(q));
+  }
+
+  private applyView(): void {
+    this.viewport.setAttribute("transform", `translate(${this.view.x},${this.view.y}) scale(${this.view.k})`);
+  }
+
+  zoomBy(factor: number): void {
+    const W = this.svg.clientWidth / 2, H = this.svg.clientHeight / 2;
+    const k = Math.max(0.35, Math.min(3, this.view.k * factor));
+    this.view.x = W - (W - this.view.x) * (k / this.view.k);
+    this.view.y = H - (H - this.view.y) * (k / this.view.k);
+    this.view.k = k;
+    this.applyView();
+  }
+
+  resetView(): void {
+    this.view = { x: 0, y: 0, k: 1 };
+    this.applyView();
+  }
+
+  reheat(): void {
+    this.sim?.alpha(0.6).restart();
+  }
+
+  private bindDrag(group: SVGGElement, node: SimNode): void {
+    group.addEventListener("pointerdown", (ev) => {
+      ev.stopPropagation();
+      group.setPointerCapture(ev.pointerId);
+      const move = (mv: PointerEvent) => {
+        const rect = this.svg.getBoundingClientRect();
+        node.fx = (mv.clientX - rect.left - this.view.x) / this.view.k;
+        node.fy = (mv.clientY - rect.top - this.view.y) / this.view.k;
+        this.sim?.alphaTarget(0.25).restart();
+      };
+      const up = () => {
+        node.fx = null; node.fy = null;
+        this.sim?.alphaTarget(0);
+        group.removeEventListener("pointermove", move);
+        group.removeEventListener("pointerup", up);
+      };
+      group.addEventListener("pointermove", move);
+      group.addEventListener("pointerup", up);
+    });
+  }
+
+  private bindPanZoom(): void {
+    let panStart: { x: number; y: number } | null = null;
+    this.svg.addEventListener("pointerdown", (ev) => {
+      panStart = { x: ev.clientX - this.view.x, y: ev.clientY - this.view.y };
+    });
+    this.svg.addEventListener("pointermove", (ev) => {
+      if (!panStart) return;
+      this.view.x = ev.clientX - panStart.x;
+      this.view.y = ev.clientY - panStart.y;
+      this.applyView();
+    });
+    window.addEventListener("pointerup", () => { panStart = null; });
+    this.svg.addEventListener("wheel", (ev) => {
+      ev.preventDefault();
+      const rect = this.svg.getBoundingClientRect();
+      const px = ev.clientX - rect.left, py = ev.clientY - rect.top;
+      const k = Math.max(0.35, Math.min(3, this.view.k * Math.exp(-ev.deltaY * 0.0016)));
+      this.view.x = px - (px - this.view.x) * (k / this.view.k);
+      this.view.y = py - (py - this.view.y) * (k / this.view.k);
+      this.view.k = k;
+      this.applyView();
+    }, { passive: false });
+  }
+}

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>graft viz</title>
+<link rel="stylesheet" href="/style.css">
+</head>
+<body>
+<header class="appbar">
+  <div class="brand"><b>graft</b><span id="repoName"></span></div>
+  <div class="counts" id="counts"></div>
+  <nav class="tabs" role="tablist" id="tabs">
+    <button class="tab" role="tab" aria-selected="true" data-tab="context">Context</button>
+    <button class="tab" role="tab" aria-selected="false" data-tab="code">Code</button>
+    <button class="tab" role="tab" aria-selected="false" data-tab="outline">Outline</button>
+  </nav>
+  <div class="searchbox">
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg>
+    <input id="search" type="search" placeholder="Search nodes…" aria-label="Search nodes">
+  </div>
+  <button class="iconbtn" id="themeBtn" title="Toggle theme" aria-label="Toggle theme">
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8z"/></svg>
+  </button>
+</header>
+
+<main class="stage" id="stage">
+  <div class="canvas-wrap" id="canvasWrap">
+    <svg class="graph" id="graphSvg" role="img" aria-label="Force-directed graph"></svg>
+    <div class="edgestyle" id="edgeChips"><span class="cap">Edges</span></div>
+    <div class="lcount" id="lcount"></div>
+    <div class="legend" id="legend"></div>
+    <div class="zoomctl">
+      <button class="iconbtn" id="zin" aria-label="Zoom in">+</button>
+      <button class="iconbtn" id="zout" aria-label="Zoom out">−</button>
+      <button class="iconbtn" id="zreset" aria-label="Reset view">⟲</button>
+    </div>
+    <div class="emptytab" id="graphEmpty" hidden></div>
+  </div>
+  <div class="outline" id="outlineView" hidden>
+    <div class="tree" id="tree"></div>
+  </div>
+  <aside class="detail" id="detail"><div class="empty">Select a node to view details</div></aside>
+</main>
+
+<script type="module" src="/app.js"></script>
+</body>
+</html>

--- a/viewer/main.ts
+++ b/viewer/main.ts
@@ -1,0 +1,232 @@
+/**
+ * graft viz — viewer entry point. Wires tabs, chips, legend, search, theme,
+ * SSE live reload, and the three views (Context graph / Code graph / Outline).
+ */
+import { loadContextGraph, loadCodeGraph, onServerChange, chipKey, CHIP_HINT, colorToken, cvar, famOf, type VizGraph } from "./data.js";
+import { GraphView } from "./graph.js";
+import { renderDetail } from "./detail.js";
+import { renderOutline } from "./tree.js";
+
+type Tab = "context" | "code" | "outline";
+
+const $ = <T extends HTMLElement>(id: string): T => document.getElementById(id) as T;
+
+const state = {
+  tab: "context" as Tab,
+  context: null as VizGraph | null,
+  code: null as VizGraph | null,
+  outlineOpen: {} as Record<string, boolean>,
+};
+
+const view = new GraphView($("graphSvg") as unknown as SVGSVGElement);
+
+function activeGraph(): VizGraph | null {
+  return state.tab === "context" ? state.context : state.code;
+}
+
+function graphTab(): "context" | "code" {
+  return state.tab === "code" || state.tab === "outline" ? "code" : "context";
+}
+
+/* ---------- chips: verbs actually present, grouped only where obvious ---------- */
+function renderChips(): void {
+  const host = $("edgeChips");
+  host.innerHTML = '<span class="cap">Edges</span>';
+  const graph = activeGraph();
+  if (!graph) return;
+  const counts = new Map<string, number>();
+  for (const e of graph.edges) {
+    const key = chipKey(e.relation);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  const keys = [...counts.keys()].sort((a, b) => {
+    const rank = (k: string) => (k === "part of" ? 0 : k === "uses" ? 1 : 2);
+    return rank(a) - rank(b) || a.localeCompare(b);
+  });
+  for (const key of keys) {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "echip" + (view.hiddenRels[key] ? "" : " on");
+    btn.innerHTML = `${glyphFor(key)} ${key} <span style="opacity:.55">${counts.get(key)}</span>`;
+    btn.title = (CHIP_HINT[key] ?? `"${key}" edges`) + " — click to " + (view.hiddenRels[key] ? "show" : "hide");
+    btn.addEventListener("click", () => {
+      view.hiddenRels[key] = !view.hiddenRels[key];
+      renderChips();
+      view.restyle();
+      updateShownCount();
+    });
+    host.appendChild(btn);
+  }
+}
+
+function glyphFor(key: string): string {
+  const fam = key === "part of" ? "structure" : key === "uses" ? "dependency" : famOf(key.replace(/ /g, "_"));
+  const glyphs: Record<string, string> = {
+    structure: '<svg width="20" height="8" aria-hidden="true"><line x1="1" y1="4" x2="19" y2="4" stroke="currentColor" stroke-width="3" opacity=".5"/></svg>',
+    dependency: '<svg width="20" height="8" aria-hidden="true"><line x1="1" y1="4" x2="14" y2="4" stroke="currentColor" stroke-width="1.6"/><path d="M14,1 L19,4 L14,7 z" fill="currentColor"/></svg>',
+    contract: '<svg width="20" height="8" aria-hidden="true"><line x1="1" y1="4" x2="13" y2="4" stroke="currentColor" stroke-width="1.4"/><path d="M13,1 L19,4 L13,7 z" fill="none" stroke="currentColor" stroke-width="1.2"/></svg>',
+    association: '<svg width="20" height="8" aria-hidden="true"><line x1="1" y1="4" x2="19" y2="4" stroke="currentColor" stroke-width="1.4" stroke-dasharray="2 4" opacity=".7"/></svg>',
+  };
+  return glyphs[fam];
+}
+
+/* ---------- node-type legend ---------- */
+function renderLegend(): void {
+  const host = $("legend");
+  host.innerHTML = "";
+  const graph = activeGraph();
+  if (!graph) return;
+  const counts = new Map<string, number>();
+  for (const n of graph.nodes) counts.set(n.type, (counts.get(n.type) ?? 0) + 1);
+  for (const [type, count] of counts) {
+    const chip = document.createElement("button");
+    chip.type = "button";
+    chip.className = "lchip" + (view.hiddenTypes[type] ? " off" : "");
+    chip.innerHTML = `<span class="sw" style="background:${cvar(colorToken(graphTab(), type))}"></span>${type} <span style="color:var(--muted);font-weight:500">${count}</span>`;
+    chip.addEventListener("click", () => {
+      view.hiddenTypes[type] = !view.hiddenTypes[type];
+      renderLegend();
+      view.restyle();
+      updateShownCount();
+    });
+    host.appendChild(chip);
+  }
+}
+
+function updateShownCount(): void {
+  const graph = activeGraph();
+  if (!graph) { $("lcount").textContent = ""; return; }
+  const shown = graph.nodes.filter((n) => !view.hiddenTypes[n.type]).length;
+  $("lcount").textContent = `${shown} / ${graph.nodes.length} nodes shown`;
+}
+
+function updateCounts(): void {
+  const el = $("counts");
+  if (state.tab === "outline" && state.code) {
+    const files = state.code.nodes.filter((n) => n.type === "file").length;
+    el.textContent = `${files} files · ${state.code.nodes.length} symbols`;
+  } else {
+    const graph = activeGraph();
+    el.textContent = graph ? `${graph.meta.nodeCount} nodes · ${graph.meta.edgeCount} links` : "";
+  }
+}
+
+/* ---------- detail panel ---------- */
+function showDetail(id: string | null): void {
+  renderDetail($("detail"), state.tab === "context" ? state.context : state.code, graphTab(), id, (next) => {
+    if (state.tab === "outline") {
+      showDetail(next);
+      renderOutline($("tree"), state.code!, next, state.outlineOpen, showDetail);
+    } else {
+      view.focus(next);
+    }
+  });
+}
+
+view.onSelect = (id) => showDetail(id);
+
+/* ---------- tabs ---------- */
+function setTab(tab: Tab): void {
+  state.tab = tab;
+  document.querySelectorAll<HTMLButtonElement>(".tab").forEach((b) => {
+    b.setAttribute("aria-selected", b.dataset.tab === tab ? "true" : "false");
+  });
+  const isOutline = tab === "outline";
+  $("canvasWrap").hidden = isOutline;
+  $("outlineView").hidden = !isOutline;
+  view.hiddenRels = {};
+  view.hiddenTypes = {};
+  view.selected = null;
+  showDetail(null);
+
+  const empty = $("graphEmpty");
+  if (tab === "outline") {
+    if (state.code) renderOutline($("tree"), state.code, null, state.outlineOpen, showDetail);
+    else {
+      $("outlineView").hidden = true;
+      $("canvasWrap").hidden = false;
+      showEmpty("No code graph yet — run <code>graft graph</code> to generate <span class=\"mono\">graph.json</span>.");
+    }
+  } else {
+    const graph = activeGraph();
+    if (!graph) {
+      showEmpty(tab === "code"
+        ? "No code graph yet — run <code>graft graph</code> to generate <span class=\"mono\">graph.json</span>."
+        : "No context graph — run <code>graft init</code> first.");
+    } else {
+      empty.hidden = true;
+      view.resetView();
+      view.setData(graph, graphTab());
+      view.reheat();
+    }
+  }
+  renderChips();
+  renderLegend();
+  updateShownCount();
+  updateCounts();
+}
+
+function showEmpty(html: string): void {
+  const empty = $("graphEmpty");
+  empty.innerHTML = html;
+  empty.hidden = false;
+}
+
+document.querySelectorAll<HTMLButtonElement>(".tab").forEach((b) => {
+  b.addEventListener("click", () => setTab(b.dataset.tab as Tab));
+});
+
+/* ---------- search ---------- */
+const search = $("search") as HTMLInputElement;
+search.addEventListener("input", () => {
+  view.query = search.value.trim();
+  view.restyle();
+});
+search.addEventListener("keydown", (ev) => {
+  if (ev.key === "Enter" && view.query) {
+    const hit = view.firstMatch();
+    if (hit) view.focus(hit.id);
+  }
+});
+
+/* ---------- zoom controls ---------- */
+$("zin").addEventListener("click", () => view.zoomBy(1.25));
+$("zout").addEventListener("click", () => view.zoomBy(1 / 1.25));
+$("zreset").addEventListener("click", () => view.resetView());
+
+/* ---------- theme ---------- */
+const THEME_KEY = "graft-viz-theme";
+const savedTheme = localStorage.getItem(THEME_KEY);
+if (savedTheme) document.documentElement.setAttribute("data-theme", savedTheme);
+$("themeBtn").addEventListener("click", () => {
+  const root = document.documentElement;
+  const current = root.getAttribute("data-theme");
+  const systemDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+  const isDark = current ? current === "dark" : systemDark;
+  const next = isDark ? "light" : "dark";
+  root.setAttribute("data-theme", next);
+  localStorage.setItem(THEME_KEY, next);
+  view.restyle();
+  renderChips();
+  renderLegend();
+  showDetail(view.selected);
+});
+
+/* ---------- data loading + live reload ---------- */
+async function loadAll(): Promise<void> {
+  const [context, code] = await Promise.all([loadContextGraph(), loadCodeGraph()]);
+  state.context = context;
+  state.code = code;
+  $("repoName").textContent = context.meta.repoName ?? "";
+  document.title = `graft viz — ${context.meta.repoName ?? ""}`;
+  setTab(state.tab);
+}
+
+onServerChange(() => {
+  const selected = view.selected;
+  void loadAll().then(() => {
+    if (selected) { view.selected = selected; view.restyle(); showDetail(selected); }
+  });
+});
+
+void loadAll();

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -1,0 +1,119 @@
+/* graft viz — design tokens + app styles.
+   Visual reference of record: docs/superpowers/specs/2026-07-15-graft-viz-design.md */
+:root{
+  --bg:#F4F6F6; --panel:#FFFFFF; --panel2:#FBFCFC; --ink:#17191B; --muted:#6B7278;
+  --border:#E2E6E7; --border2:#EDF0F1; --accent:#0B7A69; --accent-ink:#0B7A69;
+  --chip:#F0F3F3;
+  --sys:#4A7DF0; --con:#A06BDB; --fil:#D98E2B; --api:#D65C7E;
+  --k-file:#D98E2B; --k-class:#4A7DF0; --k-fn:#0FA38A; --k-method:#3AA7C9; --k-iface:#A06BDB; --k-type:#D65C7E; --k-enum:#6BAA3F;
+  --edge:#9AA4A9; --canvas:#F8FAFA;
+}
+@media (prefers-color-scheme: dark){
+  :root{
+    --bg:#0E1012; --panel:#15181B; --panel2:#111417; --ink:#E7E9EA; --muted:#8B9298;
+    --border:#252B30; --border2:#1D2226; --accent:#2FBFA4; --accent-ink:#2FBFA4;
+    --chip:#1C2125;
+    --sys:#6B94F5; --con:#B487E0; --fil:#E0A04A; --api:#E07A97;
+    --k-file:#E0A04A; --k-class:#6B94F5; --k-fn:#2FBFA4; --k-method:#56B9D8; --k-iface:#B487E0; --k-type:#E07A97; --k-enum:#8CC45E;
+    --edge:#4A545B; --canvas:#101315;
+  }
+}
+:root[data-theme="dark"]{
+  --bg:#0E1012; --panel:#15181B; --panel2:#111417; --ink:#E7E9EA; --muted:#8B9298;
+  --border:#252B30; --border2:#1D2226; --accent:#2FBFA4; --accent-ink:#2FBFA4;
+  --chip:#1C2125;
+  --sys:#6B94F5; --con:#B487E0; --fil:#E0A04A; --api:#E07A97;
+  --k-file:#E0A04A; --k-class:#6B94F5; --k-fn:#2FBFA4; --k-method:#56B9D8; --k-iface:#B487E0; --k-type:#E07A97; --k-enum:#8CC45E;
+  --edge:#4A545B; --canvas:#101315;
+}
+:root[data-theme="light"]{
+  --bg:#F4F6F6; --panel:#FFFFFF; --panel2:#FBFCFC; --ink:#17191B; --muted:#6B7278;
+  --border:#E2E6E7; --border2:#EDF0F1; --accent:#0B7A69; --accent-ink:#0B7A69;
+  --chip:#F0F3F3;
+  --sys:#4A7DF0; --con:#A06BDB; --fil:#D98E2B; --api:#D65C7E;
+  --k-file:#D98E2B; --k-class:#4A7DF0; --k-fn:#0FA38A; --k-method:#3AA7C9; --k-iface:#A06BDB; --k-type:#D65C7E; --k-enum:#6BAA3F;
+  --edge:#9AA4A9; --canvas:#F8FAFA;
+}
+
+*{box-sizing:border-box}
+[hidden]{display:none !important}
+html,body{margin:0;padding:0;height:100%}
+body{
+  display:flex;flex-direction:column;
+  background:var(--bg);color:var(--ink);
+  font-family:"Avenir Next","Segoe UI",system-ui,-apple-system,sans-serif;
+  font-size:15px;line-height:1.55;-webkit-font-smoothing:antialiased;
+}
+.mono{font-family:ui-monospace,"SF Mono",SFMono-Regular,Menlo,Consolas,monospace}
+button:focus-visible,input:focus-visible,.tree-row:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+.appbar{display:flex;align-items:center;gap:14px;padding:10px 16px;border-bottom:1px solid var(--border);background:var(--panel);flex:none}
+.brand{display:flex;align-items:baseline;gap:8px;flex:none}
+.brand b{font-weight:700;letter-spacing:-.01em}
+.brand span{color:var(--muted);font-size:13px}
+.counts{color:var(--muted);font-size:12.5px;font-variant-numeric:tabular-nums;flex:none}
+.tabs{display:flex;background:var(--chip);border-radius:9px;padding:3px;gap:2px;margin-left:auto;flex:none}
+.tab{border:0;background:transparent;color:var(--muted);font:inherit;font-size:13px;font-weight:600;padding:5px 14px;border-radius:7px;cursor:pointer}
+.tab:hover{color:var(--ink)}
+.tab[aria-selected="true"]{background:var(--panel);color:var(--ink);box-shadow:0 1px 3px rgba(0,0,0,.12)}
+.searchbox{position:relative;flex:none}
+.searchbox input{width:190px;padding:6px 10px 6px 30px;border:1px solid var(--border);border-radius:8px;background:var(--panel2);color:var(--ink);font:inherit;font-size:13px;outline:none}
+.searchbox input:focus{border-color:var(--accent)}
+.searchbox svg{position:absolute;left:9px;top:50%;transform:translateY(-50%);opacity:.45}
+.iconbtn{border:1px solid var(--border);background:var(--panel2);color:var(--ink);border-radius:8px;width:32px;height:32px;cursor:pointer;display:grid;place-items:center;flex:none;font:inherit;font-size:14px}
+.iconbtn:hover{border-color:var(--muted)}
+
+.stage{display:flex;flex:1;min-height:0;background:var(--canvas)}
+.canvas-wrap{position:relative;flex:1;min-width:0}
+svg.graph{display:block;width:100%;height:100%;cursor:grab}
+svg.graph:active{cursor:grabbing}
+
+.edgestyle{position:absolute;top:12px;left:14px;display:flex;align-items:center;gap:5px;flex-wrap:wrap;max-width:75%}
+.edgestyle .cap{font-size:10px;letter-spacing:.12em;text-transform:uppercase;color:var(--muted);font-weight:700;margin-right:3px}
+.echip{display:inline-flex;align-items:center;gap:5px;border:1px solid var(--border);background:var(--panel);color:var(--muted);border-radius:16px;padding:3px 10px;font:inherit;font-size:11.5px;font-weight:600;cursor:pointer}
+.echip:hover{color:var(--ink)}
+.echip.on{color:var(--ink)}
+.echip:not(.on){opacity:.45}
+
+.legend{position:absolute;left:14px;bottom:14px;display:flex;gap:6px;flex-wrap:wrap;max-width:70%}
+.lchip{display:flex;align-items:center;gap:6px;font-size:12px;font-weight:600;color:var(--ink);background:var(--panel);border:1px solid var(--border);border-radius:20px;padding:4px 11px;cursor:pointer;user-select:none;font-family:inherit}
+.lchip .sw{width:9px;height:9px;border-radius:50%}
+.lchip.off{opacity:.38}
+.lcount{position:absolute;left:14px;bottom:52px;font-size:11.5px;color:var(--muted);font-variant-numeric:tabular-nums}
+.zoomctl{position:absolute;right:14px;bottom:14px;display:flex;flex-direction:column;gap:6px}
+.zoomctl .iconbtn{background:var(--panel)}
+
+.detail{width:300px;flex:none;border-left:1px solid var(--border);background:var(--panel);overflow-y:auto;padding:18px 18px 24px}
+.detail .empty{color:var(--muted);font-size:13.5px;text-align:center;margin-top:200px}
+.d-type{display:inline-flex;align-items:center;gap:6px;font-size:11px;letter-spacing:.1em;text-transform:uppercase;font-weight:700;padding:3px 10px;border-radius:20px;background:var(--chip)}
+.d-type .sw{width:8px;height:8px;border-radius:50%}
+.detail h3{margin:10px 0 6px;font-size:17px;letter-spacing:-.01em}
+.detail p.summary{font-size:13.5px;color:var(--ink);margin:0 0 16px;white-space:pre-line}
+.d-label{font-size:10.5px;letter-spacing:.13em;text-transform:uppercase;color:var(--muted);font-weight:700;margin:16px 0 7px;display:flex;align-items:center;gap:5px}
+.d-label .dot{display:inline-block;width:7px;height:7px;border-radius:50%}
+.src{font-size:12px;color:var(--muted);padding:3px 0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.lnk{display:block;width:100%;text-align:left;border:1px solid var(--border2);background:var(--panel2);border-radius:8px;padding:7px 10px;margin-bottom:6px;cursor:pointer;font:inherit;color:var(--ink)}
+.lnk:hover{border-color:var(--accent)}
+.lnk .rel{font-size:10.5px;letter-spacing:.09em;text-transform:uppercase;color:var(--accent-ink);font-weight:700}
+.lnk .to{font-size:13px;font-weight:600}
+.lnk .desc{font-size:12px;color:var(--muted)}
+
+.outline{flex:1;display:flex;min-width:0}
+.tree{flex:1;overflow-y:auto;padding:14px 8px 20px 14px;background:var(--panel)}
+.tree-tools{display:flex;gap:14px;font-size:12.5px;color:var(--muted);padding:2px 8px 10px}
+.tree-tools button{border:0;background:none;color:var(--accent-ink);font:inherit;font-size:12.5px;cursor:pointer;padding:0}
+.tree-row{display:flex;align-items:center;gap:7px;padding:4px 8px;border-radius:7px;cursor:pointer;border:0;background:none;width:100%;text-align:left;font:inherit;color:var(--ink)}
+.tree-row:hover{background:var(--chip)}
+.tree-row.sel{background:var(--chip)}
+.tree-row .chev{width:14px;flex:none;color:var(--muted);font-size:10px;transition:transform .12s}
+.tree-row.open .chev{transform:rotate(90deg)}
+.tree-row .k{width:9px;height:9px;border-radius:3px;flex:none}
+.tree-row .t{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-size:13.5px}
+.tree-row .badge{margin-left:auto;font-size:11px;color:var(--muted);font-variant-numeric:tabular-nums;flex:none}
+.tree-kids{margin-left:19px;border-left:1px solid var(--border2);padding-left:4px}
+
+.emptytab{position:absolute;inset:0;display:grid;place-items:center;color:var(--muted);font-size:14px;text-align:center;padding:30px;background:var(--canvas)}
+.emptytab code{background:var(--chip);padding:2px 8px;border-radius:6px;font-family:ui-monospace,"SF Mono",Menlo,Consolas,monospace;font-size:.9em}
+
+@media (prefers-reduced-motion:reduce){ .tree-row .chev{transition:none} }
+@media (max-width:760px){ .detail{display:none} .searchbox input{width:120px} .counts{display:none} }

--- a/viewer/tree.ts
+++ b/viewer/tree.ts
@@ -1,0 +1,66 @@
+/**
+ * Outline view: the code graph's `contains` hierarchy (file → class → method)
+ * as a collapsible tree with kind dots and per-file symbol counts.
+ */
+import { type VizGraph, colorToken, cvar } from "./data.js";
+
+function esc(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;");
+}
+
+export function renderOutline(
+  host: HTMLElement,
+  graph: VizGraph,
+  selected: string | null,
+  openState: Record<string, boolean>,
+  onSelect: (id: string) => void,
+): void {
+  const kids = (pid: string) =>
+    graph.edges
+      .filter((e) => e.relation === "contains" && e.source === pid)
+      .map((e) => graph.nodes.find((n) => n.id === e.target))
+      .filter((n): n is NonNullable<typeof n> => Boolean(n));
+  const countDesc = (pid: string): number => {
+    const k = kids(pid);
+    return k.length + k.reduce((sum, c) => sum + countDesc(c.id), 0);
+  };
+  const files = graph.nodes.filter((n) => n.type === "file");
+
+  const row = (node: (typeof files)[number]): string => {
+    const children = kids(node.id);
+    const open = openState[node.id] !== false;
+    let html = `<button class="tree-row${open ? " open" : ""}${selected === node.id ? " sel" : ""}"` +
+      ` data-id="${esc(node.id)}" data-haskids="${children.length ? 1 : 0}">` +
+      `<span class="chev">${children.length ? "▶" : ""}</span>` +
+      `<span class="k" style="background:${cvar(colorToken("code", node.type))}"></span>` +
+      `<span class="t${node.type === "file" ? " mono" : ""}">${esc(node.name)}</span>` +
+      `<span class="badge">${children.length ? countDesc(node.id) + " sym" : esc(node.type)}</span></button>`;
+    if (children.length && open) {
+      html += `<div class="tree-kids">${children.map(row).join("")}</div>`;
+    }
+    return html;
+  };
+
+  host.innerHTML =
+    '<div class="tree-tools"><button data-tool="expand">Expand all</button><button data-tool="collapse">Collapse all</button></div>' +
+    files.map(row).join("");
+
+  host.querySelectorAll<HTMLButtonElement>(".tree-row").forEach((r) => {
+    r.addEventListener("click", () => {
+      const id = r.dataset.id!;
+      if (r.dataset.haskids === "1") {
+        openState[id] = openState[id] === false;
+        renderOutline(host, graph, id, openState, onSelect);
+      }
+      onSelect(id);
+    });
+  });
+  host.querySelector<HTMLButtonElement>('[data-tool="expand"]')?.addEventListener("click", () => {
+    for (const key of Object.keys(openState)) delete openState[key];
+    renderOutline(host, graph, selected, openState, onSelect);
+  });
+  host.querySelector<HTMLButtonElement>('[data-tool="collapse"]')?.addEventListener("click", () => {
+    for (const n of graph.nodes) openState[n.id] = false;
+    renderOutline(host, graph, selected, openState, onSelect);
+  });
+}

--- a/viewer/tsconfig.json
+++ b/viewer/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["./*.ts"]
+}


### PR DESCRIPTION
## What

New `graft viz` command: a local, interactive, nanoindex-style visualization of both Graft artifacts — the `.context/*.md` context graph and the `graph.json` per-symbol code graph.

```bash
graft viz [dir] [--port 4400] [--no-open]
```

No runtime dependencies and no install step at launch: a `node:http` server ships with a prebuilt viewer bundle (vanilla TS + d3-force, built once via esbuild at package build time).

## Highlights

- **Three tabs** — Context (architecture graph), Code (per-symbol graph), Outline (file → class → method tree), with detail panel, search (Enter zooms to match), dark/light themes, zoom/pan/drag, and SSE live reload when `.context/` changes on disk.
- **Edges speak the code's language.** Every relation is one of a closed verb set, each answering a question a reviewer actually asks: `part_of` (where does this live?), `uses` (what breaks if I change this?), `produces`, `configures`, `validates`, `extends`/`implements`. Chips above the canvas show the verbs actually present, with counts, and filter on click.
- **Focus mode.** Selecting a node paints outgoing edges amber (what it depends on) and incoming teal (what depends on it), writes the verb on just those edges, and fades the rest — the primary reading mode on dense graphs.
- **Trust is visible.** Tree-sitter-extracted edges draw solid; LLM-inferred ones draw dashed.
- **Vague verbs banned at the source.** The synthesize schema now constrains `relation` to the closed enum (no more `influences`/`supports`); the viewer normalizes legacy graphs on load so existing `.context/` folders render cleanly without regeneration.

## Implementation

- `src/viz/assemble.ts` — frontmatter → `{meta, nodes, edges}`; drops dangling links, skips malformed files (both counted in `meta`), normalizes legacy relations
- `src/viz/serve.ts` — endpoints `/api/context-graph`, `/api/code-graph` (version-gated), `/events` (SSE, debounced fs.watch); port fallback
- `viewer/` — frontend source; `scripts/build-viewer.mjs` bundles to `dist/viewer/` (~32 kB app.js), shipped in the package
- `src/ai/synthesize.ts` — closed relation enum + reviewer-question prompt
- Spec and plan under `docs/superpowers/`

## Testing

- 12/12 tests passing (`npm test`): graph assembly, relation-normalization table, server endpoint shapes, code-graph gating, port fallback, SSE emission
- Verified end-to-end in a browser against this repo's own `.context/` (7 nodes) and a generated `graph.json` (284 symbols / 637 edges): all three tabs, focus mode, chips, themes, live reload

New devDependencies: `esbuild`, `d3-force` (bundled into the viewer; nothing added at runtime).
