### PR TITLE
Graft × Claude Code integration: live statusline, active retrieval, turn-end auto-sync

### DIFF
--- a/.claude/helpers/graft-hooks.cjs
+++ b/.claude/helpers/graft-hooks.cjs
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+const path = require('path');
+const dir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+import(path.join(dir, 'dist', 'claude', 'hooks.js'))
+  .then((m) => m.main(process.argv[2]))
+  .catch(() => { /* best-effort: never disrupt the session */ });

--- a/.claude/helpers/graft-statusline.cjs
+++ b/.claude/helpers/graft-statusline.cjs
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+const path = require('path');
+const dir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+import(path.join(dir, 'dist', 'claude', 'statusline.js'))
+  .then((m) => m.main())
+  .catch(() => { /* graft not built or unavailable — render nothing */ });

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,13 @@
           { "type": "command", "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-hooks.cjs\" post-edit", "timeout": 10000 }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          { "type": "command", "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-hooks.cjs\" stop", "timeout": 8000 }
+        ]
+      }
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,6 +18,13 @@
           { "type": "command", "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-hooks.cjs\" stop", "timeout": 8000 }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          { "type": "command", "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-hooks.cjs\" prompt", "timeout": 8000 }
+        ]
+      }
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,6 +3,11 @@
     "type": "command",
     "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-statusline.cjs\""
   },
+  "subagentStatusLine": {
+    "type": "command",
+    "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-statusline.cjs\""
+  },
+  "footerLinksRegexes": ["graft/[\\w./-]+\\.md"],
   "hooks": {
     "PostToolUse": [
       {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,6 +25,13 @@
           { "type": "command", "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-hooks.cjs\" prompt", "timeout": 8000 }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          { "type": "command", "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-hooks.cjs\" session-start", "timeout": 8000 }
+        ]
+      }
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "statusLine": {
+    "type": "command",
+    "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-statusline.cjs\""
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,5 +2,15 @@
   "statusLine": {
     "type": "command",
     "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-statusline.cjs\""
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          { "type": "command", "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-hooks.cjs\" post-edit", "timeout": 10000 }
+        ]
+      }
+    ]
   }
 }

--- a/docs/superpowers/plans/2026-07-20-graft-claude-code-integration.md
+++ b/docs/superpowers/plans/2026-07-20-graft-claude-code-integration.md
@@ -506,15 +506,15 @@ const wiring2 = {
     { id: 'src/pkce.ts#gen', name: 'gen', path: 'src/pkce.ts', summary_state: 'ready' },
   ],
   edges: [
-    { from: 'src/client.ts#exchange', to: 'src/pkce.ts#verify', relation: 'calls', confidence: 'extracted' },
-    { from: 'src/pkce.ts#gen', to: 'src/pkce.ts#verify', relation: 'calls', confidence: 'extracted' },
+    { source: 'src/client.ts#exchange', target: 'src/pkce.ts#verify', relation: 'calls', confidence: 'extracted' },
+    { source: 'src/pkce.ts#gen', target: 'src/pkce.ts#verify', relation: 'calls', confidence: 'extracted' },
   ],
 } as any;
 
 test('incomingEdges: external callers of nodes in the edited file', () => {
   const e = incomingEdges(wiring2, '/abs/repo/src/pkce.ts');
   assert.equal(e.length, 1, 'same-file edge (gen→verify) excluded');
-  assert.equal(e[0].from, 'src/client.ts#exchange');
+  assert.equal(e[0].source, 'src/client.ts#exchange');
 });
 
 test('formatBlastRadius renders callers or null', () => {
@@ -547,7 +547,7 @@ function nodeIdsInFile(w: GraphV1, filePath: string): Set<string> {
 export function incomingEdges(w: GraphV1, filePath: string): EdgeV1[] {
   const ids = nodeIdsInFile(w, filePath);
   if (!ids.size) return [];
-  return (w.edges ?? []).filter((e) => ids.has(e.to) && !ids.has(e.from));
+  return (w.edges ?? []).filter((e) => ids.has(e.target) && !ids.has(e.source));
 }
 
 export function formatBlastRadius(w: GraphV1, filePath: string, cap = 8): string | null {
@@ -555,7 +555,7 @@ export function formatBlastRadius(w: GraphV1, filePath: string, cap = 8): string
   if (!edges.length) return null;
   const byId = new Map((w.nodes ?? []).map((n) => [n.id, n]));
   const items = edges.slice(0, cap).map((e) => {
-    const n = byId.get(e.from);
+    const n = byId.get(e.source);
     const label = n ? `${n.name} (${basename(n.path)})` : e.from;
     return ` • ${e.relation} ← ${label}`;
   });

--- a/docs/superpowers/plans/2026-07-20-graft-claude-code-integration.md
+++ b/docs/superpowers/plans/2026-07-20-graft-claude-code-integration.md
@@ -1,0 +1,1215 @@
+# Graft × Claude Code Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a `.claude/` integration that makes Graft visible (a live statusline) and active (retrieval, orientation, blast-radius) inside a Claude Code session, and keeps the graph fresh via turn-end auto-sync.
+
+**Architecture:** Reader/writer/state split. Testable logic lives in `src/claude/*.ts` (compiled to `dist/claude/`); thin `.claude/helpers/*.cjs` shims invoke it. A pure `statusline` reader renders from small precomputed state files (`graft/.cache/stats.json`) plus Claude Code's stdin; `hooks` fire on real events (edit, prompt, session-start, stop) to write state and inject context; a detached `sync-run` rebuilds the graph in the background under a lock.
+
+**Tech Stack:** Node 20+ (ESM), TypeScript (strict), `node:test` + `node:assert/strict`, `tsx`. No new dependencies. Graft CLI (`node dist/cli.js`) invoked as a child process for `ask` / `check` / `build`.
+
+## Global Constraints
+
+- **Money guard (hard rule):** auto-sync and every hook run **only** plain `graft build` / `graft ask` / `graft check`. **Never** `graft build --deep` (spends OpenRouter credits). Copied verbatim from spec §7.
+- **Honest data only:** never display `$` cost or a "tokens saved %". Only real (on-disk / stdin) or instrumented-then-real signals. (spec §2, §5)
+- **`enrichedPct` visibility:** show the enriched segment **only when `readyCount ≥ 1`**; hide entirely for a structural-only graph. (spec §5, §13.1)
+- **`graftReads`/`sourceReads`:** present as **reserved fields** in `SessionState` (schema ready, default 0), **not displayed** and **not yet populated** — population lands with the deferred PreToolUse read-counter (spec §3). Do not add a counter hook in this plan. (spec §13.2)
+- **Statusline is a pure reader:** it must read only small files + stdin and spawn **no** subprocess. (spec §5)
+- **All hooks are best-effort:** any failure logs/degrades and exits 0; never throw out of a hook. (spec §10)
+- **Node ESM:** `src/` is `"type": "module"`; import paths use `.js` extensions. `.cjs` shims load ESM via dynamic `import()`.
+- **State location:** all mutable state under `graft/.cache/` (gitignored). (spec §2, §4)
+- **Ignore edits under `graft/`** — they never set dirty and never trigger sync (avoid loops). (spec §7)
+
+---
+
+## File Structure
+
+**Created (committed):**
+- `src/claude/state.ts` — types (`Stats`, `SessionState`), paths, atomic read/write, lock.
+- `src/claude/stats.ts` — `readWiring`, `computeStats`.
+- `src/claude/format.ts` — pure renderers/formatters (statusline, blast-radius, retrieval, orientation).
+- `src/claude/statusline.ts` — statusline entry (`main`).
+- `src/claude/hooks.ts` — hook dispatcher (`main(event)`).
+- `src/claude/sync-run.ts` — detached background sync runner.
+- `.claude/helpers/graft-statusline.cjs` — statusline shim.
+- `.claude/helpers/graft-hooks.cjs` — hooks shim.
+- `.claude/settings.json` — wires statusLine, subagentStatusLine, hooks, footerLinksRegexes.
+- `test/claude-state.test.ts`, `test/claude-stats.test.ts`, `test/claude-format.test.ts`, `test/claude-hooks.test.ts` — tests.
+
+**Modified:** none in `src/` proper; `tsconfig.json` only if it doesn't already include `src/claude` (it includes `src`, so no change expected — a build step verifies `dist/claude/` appears).
+
+**State (gitignored, runtime):** `graft/.cache/stats.json`, `graft/.cache/session/<id>.json`, `graft/.cache/.sync.lock`.
+
+---
+
+## Task 1: State module (types, storage, lock)
+
+**Files:**
+- Create: `src/claude/state.ts`
+- Test: `test/claude-state.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `interface Stats { nodeCount:number; edgeCount:number; languages:string[]; totalCount:number; readyCount:number; staleCount:number; dirty:boolean; syncing:boolean; syncedAt:string|null; lastFile:string|null }`
+  - `interface SessionState { lastQuery:string|null; perAgentQuery:Record<string,string>; graftReads:number; sourceReads:number }`
+  - `emptyStats(): Stats`
+  - `cacheDir(projectDir:string): string`
+  - `readStats(dir:string): Stats|null`
+  - `writeStats(dir:string, s:Stats): void`
+  - `patchStats(dir:string, patch:Partial<Stats>): Stats`
+  - `readSession(dir:string, id:string): SessionState`
+  - `writeSession(dir:string, id:string, s:SessionState): void`
+  - `acquireLock(dir:string): boolean`
+  - `releaseLock(dir:string): void`
+  - `const LOCK_STALE_MS = 300000`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// test/claude-state.test.ts
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  emptyStats, readStats, writeStats, patchStats,
+  readSession, writeSession, acquireLock, releaseLock, cacheDir,
+} from '../src/claude/state.js';
+
+function fresh(): string { return mkdtempSync(join(tmpdir(), 'graft-state-')); }
+
+test('stats round-trip and patch merge', () => {
+  const d = fresh();
+  assert.equal(readStats(d), null);
+  writeStats(d, { ...emptyStats(), nodeCount: 319, edgeCount: 730 });
+  assert.equal(readStats(d)!.nodeCount, 319);
+  const patched = patchStats(d, { dirty: true, staleCount: 4 });
+  assert.equal(patched.dirty, true);
+  assert.equal(patched.staleCount, 4);
+  assert.equal(readStats(d)!.edgeCount, 730, 'patch preserves other fields');
+});
+
+test('session defaults and round-trip', () => {
+  const d = fresh();
+  const s = readSession(d, 'abc');
+  assert.deepEqual(s, { lastQuery: null, perAgentQuery: {}, graftReads: 0, sourceReads: 0 });
+  s.lastQuery = 'pkce'; s.graftReads = 2;
+  writeSession(d, 'abc', s);
+  assert.equal(readSession(d, 'abc').lastQuery, 'pkce');
+  assert.equal(readSession(d, 'xyz').graftReads, 0, 'other sessions isolated');
+});
+
+test('lock is exclusive then releasable', () => {
+  const d = fresh();
+  assert.equal(acquireLock(d), true);
+  assert.equal(acquireLock(d), false, 'second acquire blocked while held');
+  assert.ok(existsSync(join(cacheDir(d), '.sync.lock')));
+  releaseLock(d);
+  assert.equal(acquireLock(d), true, 'reacquire after release');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- test/claude-state.test.ts` (or `node --import tsx --test test/claude-state.test.ts`)
+Expected: FAIL — `Cannot find module '../src/claude/state.js'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// src/claude/state.ts
+import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync, rmSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+export interface Stats {
+  nodeCount: number; edgeCount: number; languages: string[];
+  totalCount: number; readyCount: number;
+  staleCount: number; dirty: boolean; syncing: boolean;
+  syncedAt: string | null; lastFile: string | null;
+}
+export interface SessionState {
+  lastQuery: string | null;
+  perAgentQuery: Record<string, string>;
+  graftReads: number; sourceReads: number;
+}
+
+export const LOCK_STALE_MS = 300000;
+
+export function emptyStats(): Stats {
+  return { nodeCount: 0, edgeCount: 0, languages: [], totalCount: 0, readyCount: 0,
+    staleCount: 0, dirty: false, syncing: false, syncedAt: null, lastFile: null };
+}
+function emptySession(): SessionState {
+  return { lastQuery: null, perAgentQuery: {}, graftReads: 0, sourceReads: 0 };
+}
+
+export function cacheDir(projectDir: string): string { return join(projectDir, 'graft', '.cache'); }
+function statsPath(d: string): string { return join(cacheDir(d), 'stats.json'); }
+function sessionPath(d: string, id: string): string { return join(cacheDir(d), 'session', `${id}.json`); }
+function lockPath(d: string): string { return join(cacheDir(d), '.sync.lock'); }
+
+function readJson<T>(p: string): T | null {
+  try { return JSON.parse(readFileSync(p, 'utf8')) as T; } catch { return null; }
+}
+function writeJsonAtomic(p: string, value: unknown): void {
+  mkdirSync(join(p, '..'), { recursive: true });
+  const tmp = `${p}.${process.pid}.tmp`;
+  writeFileSync(tmp, JSON.stringify(value, null, 2));
+  renameSync(tmp, p);
+}
+
+export function readStats(d: string): Stats | null { return readJson<Stats>(statsPath(d)); }
+export function writeStats(d: string, s: Stats): void { writeJsonAtomic(statsPath(d), s); }
+export function patchStats(d: string, patch: Partial<Stats>): Stats {
+  const next: Stats = { ...(readStats(d) ?? emptyStats()), ...patch };
+  writeStats(d, next);
+  return next;
+}
+export function readSession(d: string, id: string): SessionState {
+  return readJson<SessionState>(sessionPath(d, id)) ?? emptySession();
+}
+export function writeSession(d: string, id: string, s: SessionState): void {
+  writeJsonAtomic(sessionPath(d, id), s);
+}
+
+export function acquireLock(d: string): boolean {
+  const p = lockPath(d);
+  if (existsSync(p) && Date.now() - statSync(p).mtimeMs < LOCK_STALE_MS) return false;
+  mkdirSync(cacheDir(d), { recursive: true });
+  writeFileSync(p, JSON.stringify({ pid: process.pid, at: new Date().toISOString() }));
+  return true;
+}
+export function releaseLock(d: string): void { try { rmSync(lockPath(d)); } catch { /* already gone */ } }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --import tsx --test test/claude-state.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/claude/state.ts test/claude-state.test.ts
+git commit -m "feat(claude): state module — stats/session storage + sync lock"
+```
+
+---
+
+## Task 2: Stats computation from wiring.json
+
+**Files:**
+- Create: `src/claude/stats.ts`
+- Test: `test/claude-stats.test.ts`
+
+**Interfaces:**
+- Consumes: `Stats` from `state.ts`; `GraphV1` from `src/graph/types.ts`.
+- Produces:
+  - `readWiring(projectDir:string): GraphV1|null`
+  - `computeStats(w:GraphV1): Pick<Stats,'nodeCount'|'edgeCount'|'languages'|'totalCount'|'readyCount'>`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// test/claude-stats.test.ts
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { computeStats } from '../src/claude/stats.js';
+
+const wiring = {
+  meta: { version: 1, nodeCount: 3, edgeCount: 2, languages: ['typescript'] },
+  nodes: [
+    { id: 'a', summary_state: 'ready' },
+    { id: 'b', summary_state: 'pending' },
+    { id: 'c', summary_state: 'ready' },
+  ],
+  edges: [{ from: 'a', to: 'b' }, { from: 'c', to: 'a' }],
+} as any;
+
+test('computeStats derives counts and readyCount', () => {
+  const s = computeStats(wiring);
+  assert.equal(s.nodeCount, 3);
+  assert.equal(s.edgeCount, 2);
+  assert.deepEqual(s.languages, ['typescript']);
+  assert.equal(s.totalCount, 3);
+  assert.equal(s.readyCount, 2);
+});
+
+test('computeStats tolerates missing meta by counting arrays', () => {
+  const s = computeStats({ nodes: [{ id: 'x', summary_state: 'pending' }], edges: [] } as any);
+  assert.equal(s.nodeCount, 1);
+  assert.equal(s.edgeCount, 0);
+  assert.equal(s.readyCount, 0);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --import tsx --test test/claude-stats.test.ts`
+Expected: FAIL — cannot find `../src/claude/stats.js`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// src/claude/stats.ts
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { GraphV1 } from '../graph/types.js';
+import type { Stats } from './state.js';
+
+export function readWiring(projectDir: string): GraphV1 | null {
+  try {
+    return JSON.parse(readFileSync(join(projectDir, 'graft', '.graph', 'wiring.json'), 'utf8')) as GraphV1;
+  } catch { return null; }
+}
+
+export function computeStats(
+  w: GraphV1,
+): Pick<Stats, 'nodeCount' | 'edgeCount' | 'languages' | 'totalCount' | 'readyCount'> {
+  const nodes = w.nodes ?? [];
+  const edges = w.edges ?? [];
+  const readyCount = nodes.filter((n) => n.summary_state === 'ready').length;
+  return {
+    nodeCount: w.meta?.nodeCount ?? nodes.length,
+    edgeCount: w.meta?.edgeCount ?? edges.length,
+    languages: w.meta?.languages ?? [],
+    totalCount: nodes.length,
+    readyCount,
+  };
+}
+```
+
+> If `tsc` reports that `GraphV1` lacks `nodes`/`edges`/`meta` or `NodeV1` lacks `summary_state`, open `src/graph/types.ts` and use the exact exported names (spec §2 lists them: `meta.{nodeCount,edgeCount,languages}`, node `summary_state`). Adjust the property access to match; do not redefine the types.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --import tsx --test test/claude-stats.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/claude/stats.ts test/claude-stats.test.ts
+git commit -m "feat(claude): computeStats + readWiring"
+```
+
+---
+
+## Task 3: Statusline renderer + shim + settings (the visible bar)
+
+**Files:**
+- Create: `src/claude/format.ts`, `src/claude/statusline.ts`, `.claude/helpers/graft-statusline.cjs`, `.claude/settings.json`
+- Test: `test/claude-format.test.ts`
+
+**Interfaces:**
+- Consumes: `Stats`, `SessionState` from `state.ts`; `readStats`, `readSession`.
+- Produces (in `format.ts`):
+  - `renderStatusline(stats:Stats|null, session:SessionState|null, ctx:{ctxPct:number|null}): string[]`
+  - `enrichedSegment(s:Stats): string|null`
+  - `freshnessSegment(s:Stats): string`
+- Produces (in `statusline.ts`): `main(): void`
+
+- [ ] **Step 1: Write the failing test** (assert on plain text — strip ANSI)
+
+```ts
+// test/claude-format.test.ts
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { renderStatusline, enrichedSegment } from '../src/claude/format.js';
+import { emptyStats } from '../src/claude/state.js';
+
+const strip = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '');
+
+test('not-built state', () => {
+  const lines = renderStatusline(null, null, { ctxPct: null });
+  assert.match(strip(lines[0]), /not built/);
+});
+
+test('enriched segment hidden when zero ready', () => {
+  assert.equal(enrichedSegment({ ...emptyStats(), totalCount: 10, readyCount: 0 }), null);
+});
+
+test('enriched segment shown when >=1 ready', () => {
+  const seg = enrichedSegment({ ...emptyStats(), totalCount: 4, readyCount: 2 });
+  assert.equal(strip(seg!), '50% enriched');
+});
+
+test('two-line bar: size + freshness + ctx + last', () => {
+  const stats = { ...emptyStats(), nodeCount: 319, edgeCount: 730, totalCount: 319, readyCount: 0,
+    dirty: true, staleCount: 4, lastFile: 'pkce.ts' };
+  const lines = renderStatusline(stats, null, { ctxPct: 34 }).map(strip);
+  assert.match(lines[0], /graft/);
+  assert.match(lines[0], /319 nodes \/ 730 edges/);
+  assert.doesNotMatch(lines[0], /enriched/); // hidden at readyCount 0
+  assert.match(lines[0], /⚠ 4 stale/);
+  assert.match(lines[1], /ctx 34%/);
+  assert.match(lines[1], /last: pkce\.ts/);
+});
+
+test('syncing overrides stale; synced when clean', () => {
+  const base = { ...emptyStats(), nodeCount: 1, edgeCount: 0, totalCount: 1 };
+  assert.match(strip(renderStatusline({ ...base, syncing: true, dirty: true }, null, { ctxPct: null })[0]), /syncing/);
+  assert.match(strip(renderStatusline(base, null, { ctxPct: null })[0]), /✓ synced/);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --import tsx --test test/claude-format.test.ts`
+Expected: FAIL — cannot find `../src/claude/format.js`.
+
+- [ ] **Step 3: Write `format.ts` (statusline parts only for now)**
+
+```ts
+// src/claude/format.ts
+import { basename } from 'node:path';
+import type { Stats, SessionState } from './state.js';
+
+const C = {
+  indigo: (s: string) => `\x1b[38;2;84;111;255m${s}\x1b[0m`,
+  amber: (s: string) => `\x1b[38;2;224;165;68m${s}\x1b[0m`,
+  muted: (s: string) => `\x1b[38;5;244m${s}\x1b[0m`,
+  text: (s: string) => `\x1b[38;5;251m${s}\x1b[0m`,
+};
+const SEP = C.muted(' · ');
+
+export function enrichedSegment(s: Stats): string | null {
+  if (s.readyCount < 1) return null;
+  const pct = s.totalCount ? Math.round((s.readyCount / s.totalCount) * 100) : 0;
+  return C.indigo(`${pct}% enriched`);
+}
+
+export function freshnessSegment(s: Stats): string {
+  if (s.syncing) return C.amber('syncing…');
+  if (s.dirty && s.staleCount > 0) return C.amber(`⚠ ${s.staleCount} stale`);
+  if (s.dirty) return C.amber('⚠ stale');
+  return C.indigo('✓ synced');
+}
+
+export function renderStatusline(
+  stats: Stats | null,
+  _session: SessionState | null,
+  ctx: { ctxPct: number | null },
+): string[] {
+  if (!stats || stats.nodeCount === 0) {
+    return [C.muted('◤ graft · not built · run ') + C.text('graft build')];
+  }
+  const top = [C.muted('◤ ') + C.indigo('graft'), C.text(`${stats.nodeCount} nodes / ${stats.edgeCount} edges`)];
+  const enr = enrichedSegment(stats);
+  if (enr) top.push(enr);
+  top.push(freshnessSegment(stats));
+
+  const bottom: string[] = [];
+  if (typeof ctx.ctxPct === 'number') bottom.push(C.text(`ctx ${ctx.ctxPct}%`));
+  if (stats.lastFile) bottom.push(C.muted('last: ') + C.text(basename(stats.lastFile)));
+
+  const lines = [top.join(SEP)];
+  if (bottom.length) lines.push(C.muted('▸ ') + bottom.join(SEP));
+  return lines;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --import tsx --test test/claude-format.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Write the statusline entry**
+
+```ts
+// src/claude/statusline.ts
+import { readFileSync } from 'node:fs';
+import { renderStatusline } from './format.js';
+import { readStats, readSession } from './state.js';
+
+export function main(): void {
+  let input: any = {};
+  try { input = JSON.parse(readFileSync(0, 'utf8')); } catch { /* no/invalid stdin */ }
+  const dir = process.env.CLAUDE_PROJECT_DIR || input.cwd || process.cwd();
+  const stats = readStats(dir);
+  const session = readSession(dir, input.session_id || 'default');
+  const raw = input?.context_window?.used_percentage;
+  const ctxPct = typeof raw === 'number' ? Math.round(raw) : null;
+  process.stdout.write(renderStatusline(stats, session, { ctxPct }).join('\n'));
+}
+```
+
+- [ ] **Step 6: Write the shim**
+
+```js
+// .claude/helpers/graft-statusline.cjs
+#!/usr/bin/env node
+const path = require('path');
+const dir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+import(path.join(dir, 'dist', 'claude', 'statusline.js'))
+  .then((m) => m.main())
+  .catch(() => { /* graft not built or unavailable — render nothing */ });
+```
+
+- [ ] **Step 7: Write `.claude/settings.json`**
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-statusline.cjs\""
+  }
+}
+```
+
+- [ ] **Step 8: Build and smoke-test the shim end-to-end**
+
+```bash
+npm run build
+echo '{"session_id":"t","cwd":"'"$PWD"'","context_window":{"used_percentage":34}}' \
+  | node .claude/helpers/graft-statusline.cjs
+```
+Expected: a line like `◤ graft · 319 nodes / 730 edges · ✓ synced` then `▸ ctx 34%` (no `stats.json` yet → falls back to "not built"; that's fine — after Task 5 a real build populates it. To see the full bar now, run: `node -e "const{writeStats,emptyStats}=require('./dist/claude/state.js');writeStats(process.cwd(),{...emptyStats(),nodeCount:319,edgeCount:730,totalCount:319})"` then re-run the pipe).
+
+> `require('./dist/claude/state.js')` in that one-liner works because Node 20+ allows `require()` of ESM without top-level await.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/claude/format.ts src/claude/statusline.ts test/claude-format.test.ts \
+  .claude/helpers/graft-statusline.cjs .claude/settings.json
+git commit -m "feat(claude): statusline reader + shim + settings"
+```
+
+---
+
+## Task 4: Post-edit hook — drift flag + blast-radius injection
+
+**Files:**
+- Modify: `src/claude/format.ts` (add `incomingEdges`, `formatBlastRadius`)
+- Create: `src/claude/hooks.ts`, `.claude/helpers/graft-hooks.cjs`
+- Modify: `.claude/settings.json` (add `PostToolUse`)
+- Test: `test/claude-format.test.ts` (add cases), `test/claude-hooks.test.ts`
+
+**Interfaces:**
+- Consumes: `readWiring` (stats.ts); `patchStats` (state.ts); `GraphV1`, `EdgeV1` (src/graph/types.ts).
+- Produces (format.ts): `incomingEdges(w:GraphV1, filePath:string): EdgeV1[]`; `formatBlastRadius(w:GraphV1, filePath:string, cap?:number): string|null`
+- Produces (hooks.ts): `main(event:string): Promise<void>`; `underGraft(dir:string, file:string): boolean` (exported for test)
+
+- [ ] **Step 1: Write the failing test for blast-radius**
+
+```ts
+// append to test/claude-format.test.ts
+import { incomingEdges, formatBlastRadius } from '../src/claude/format.js';
+
+const wiring2 = {
+  meta: { nodeCount: 3, edgeCount: 2, languages: ['typescript'] },
+  nodes: [
+    { id: 'src/pkce.ts#verify', name: 'verify', path: 'src/pkce.ts', summary_state: 'ready' },
+    { id: 'src/client.ts#exchange', name: 'exchange', path: 'src/client.ts', summary_state: 'ready' },
+    { id: 'src/pkce.ts#gen', name: 'gen', path: 'src/pkce.ts', summary_state: 'ready' },
+  ],
+  edges: [
+    { from: 'src/client.ts#exchange', to: 'src/pkce.ts#verify', relation: 'calls', confidence: 'extracted' },
+    { from: 'src/pkce.ts#gen', to: 'src/pkce.ts#verify', relation: 'calls', confidence: 'extracted' },
+  ],
+} as any;
+
+test('incomingEdges: external callers of nodes in the edited file', () => {
+  const e = incomingEdges(wiring2, '/abs/repo/src/pkce.ts');
+  assert.equal(e.length, 1, 'same-file edge (gen→verify) excluded');
+  assert.equal(e[0].from, 'src/client.ts#exchange');
+});
+
+test('formatBlastRadius renders callers or null', () => {
+  const txt = formatBlastRadius(wiring2, '/abs/repo/src/pkce.ts');
+  assert.match(strip(txt!), /blast radius for pkce\.ts/);
+  assert.match(strip(txt!), /exchange \(client\.ts\)/);
+  assert.equal(formatBlastRadius(wiring2, '/abs/repo/src/unknown.ts'), null);
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `node --import tsx --test test/claude-format.test.ts`
+Expected: FAIL — `incomingEdges`/`formatBlastRadius` not exported.
+
+- [ ] **Step 3: Add blast-radius to `format.ts`**
+
+```ts
+// append to src/claude/format.ts
+import type { GraphV1, EdgeV1 } from '../graph/types.js';
+
+function nodeIdsInFile(w: GraphV1, filePath: string): Set<string> {
+  const nodes = w.nodes ?? [];
+  return new Set(
+    nodes.filter((n) => n.path && (filePath === n.path || filePath.endsWith(`/${n.path}`) || filePath.endsWith(n.path)))
+      .map((n) => n.id),
+  );
+}
+
+export function incomingEdges(w: GraphV1, filePath: string): EdgeV1[] {
+  const ids = nodeIdsInFile(w, filePath);
+  if (!ids.size) return [];
+  return (w.edges ?? []).filter((e) => ids.has(e.to) && !ids.has(e.from));
+}
+
+export function formatBlastRadius(w: GraphV1, filePath: string, cap = 8): string | null {
+  const edges = incomingEdges(w, filePath);
+  if (!edges.length) return null;
+  const byId = new Map((w.nodes ?? []).map((n) => [n.id, n]));
+  const items = edges.slice(0, cap).map((e) => {
+    const n = byId.get(e.from);
+    const label = n ? `${n.name} (${basename(n.path)})` : e.from;
+    return ` • ${e.relation} ← ${label}`;
+  });
+  const more = edges.length > cap ? `\n • +${edges.length - cap} more` : '';
+  return `[graft] blast radius for ${basename(filePath)} — who depends on it:\n${items.join('\n')}${more}`;
+}
+```
+
+- [ ] **Step 4: Run to verify format tests pass**
+
+Run: `node --import tsx --test test/claude-format.test.ts`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Write the failing hooks test**
+
+```ts
+// test/claude-hooks.test.ts
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { underGraft, main } from '../src/claude/hooks.js';
+import { readStats } from '../src/claude/state.js';
+
+test('underGraft detects edits inside graft/', () => {
+  assert.equal(underGraft('/repo', '/repo/graft/x.md'), true);
+  assert.equal(underGraft('/repo', '/repo/src/cli.ts'), false);
+});
+
+test('post-edit marks dirty and records lastFile', async () => {
+  const d = mkdtempSync(join(tmpdir(), 'graft-hooks-'));
+  mkdirSync(join(d, 'graft', '.graph'), { recursive: true });
+  writeFileSync(join(d, 'graft', '.graph', 'wiring.json'),
+    JSON.stringify({ meta: { nodeCount: 0, edgeCount: 0, languages: [] }, nodes: [], edges: [] }));
+  // graft check will fail (no dist/cli.js here) → staleCount falls back to 0, but dirty must still be set.
+  process.env.CLAUDE_PROJECT_DIR = d;
+  const stdin = JSON.stringify({ tool_input: { file_path: join(d, 'src', 'auth.ts') } });
+  await runWithStdin(stdin, () => main('post-edit'));
+  const s = readStats(d)!;
+  assert.equal(s.dirty, true);
+  assert.equal(s.lastFile, 'auth.ts');
+});
+
+test('post-edit ignores edits inside graft/', async () => {
+  const d = mkdtempSync(join(tmpdir(), 'graft-hooks-'));
+  process.env.CLAUDE_PROJECT_DIR = d;
+  await runWithStdin(JSON.stringify({ tool_input: { file_path: join(d, 'graft', 'a.md') } }), () => main('post-edit'));
+  assert.equal(readStats(d), null, 'no state written for graft/ edits');
+});
+
+// helper: hooks.ts reads process.env.GRAFT_TEST_STDIN first (test seam), else fd 0.
+async function runWithStdin(text: string, fn: () => Promise<void>): Promise<void> {
+  process.env.GRAFT_TEST_STDIN = text;
+  try { await fn(); } finally { delete process.env.GRAFT_TEST_STDIN; }
+}
+```
+
+> Testing stdin is awkward, so `hooks.ts` reads `process.env.GRAFT_TEST_STDIN` first (test seam), then falls back to fd 0. This keeps tests hermetic without spawning subprocesses.
+
+- [ ] **Step 6: Run to verify it fails**
+
+Run: `node --import tsx --test test/claude-hooks.test.ts`
+Expected: FAIL — cannot find `../src/claude/hooks.js`.
+
+- [ ] **Step 7: Write `hooks.ts` (post-edit + stop stub + dispatcher)**
+
+```ts
+// src/claude/hooks.ts
+import { readFileSync } from 'node:fs';
+import { execFileSync, spawn } from 'node:child_process';
+import { join, basename } from 'node:path';
+import { readWiring } from './stats.js';
+import { formatBlastRadius } from './format.js';
+import { patchStats, readStats, acquireLock } from './state.js';
+
+function readStdin(): any {
+  const seam = process.env.GRAFT_TEST_STDIN;
+  const raw = seam !== undefined ? seam : safeReadFd0();
+  try { return JSON.parse(raw); } catch { return {}; }
+}
+function safeReadFd0(): string { try { return readFileSync(0, 'utf8'); } catch { return ''; } }
+
+function projectDir(input: any): string {
+  return process.env.CLAUDE_PROJECT_DIR || input.cwd || process.cwd();
+}
+export function underGraft(dir: string, file: string): boolean {
+  const rel = file.startsWith(dir) ? file.slice(dir.length) : file;
+  return rel.replace(/^[/\\]+/, '').replace(/\\/g, '/').startsWith('graft/');
+}
+function graftJson(dir: string, args: string[]): any | null {
+  try {
+    const out = execFileSync(process.execPath, [join(dir, 'dist', 'cli.js'), ...args],
+      { cwd: dir, encoding: 'utf8', timeout: 8000, stdio: ['ignore', 'pipe', 'ignore'] });
+    return JSON.parse(out);
+  } catch { return null; }
+}
+function checkStaleCount(dir: string): number {
+  const r = graftJson(dir, ['check', '.', '--json']);
+  const g = r?.graph ?? {};
+  return (g.changed?.length ?? 0) + (g.added?.length ?? 0) + (g.removed?.length ?? 0);
+}
+function emit(eventName: string, additionalContext: string): void {
+  process.stdout.write(JSON.stringify({ hookSpecificOutput: { hookEventName: eventName, additionalContext } }));
+}
+
+export async function main(event: string): Promise<void> {
+  const input = readStdin();
+  const dir = projectDir(input);
+
+  if (event === 'post-edit') {
+    const file: string | undefined = input?.tool_input?.file_path;
+    if (!file || underGraft(dir, file)) return;
+    patchStats(dir, { dirty: true, staleCount: checkStaleCount(dir), lastFile: basename(file) });
+    const w = readWiring(dir);
+    if (w) { const br = formatBlastRadius(w, file); if (br) emit('PostToolUse', br); }
+    return;
+  }
+
+  if (event === 'stop') {
+    const stats = readStats(dir);
+    if (stats?.dirty && acquireLock(dir)) {
+      patchStats(dir, { syncing: true });
+      const child = spawn(process.execPath, [join(dir, 'dist', 'claude', 'sync-run.js'), dir],
+        { detached: true, stdio: 'ignore' });
+      child.unref();
+    }
+    return;
+  }
+}
+```
+
+- [ ] **Step 8: Run to verify hooks tests pass**
+
+Run: `node --import tsx --test test/claude-hooks.test.ts`
+Expected: PASS (3 tests). (The `stop` path isn't exercised until Task 5; `sync-run.js` spawn is guarded by the lock + dirty check.)
+
+- [ ] **Step 9: Write the hooks shim**
+
+```js
+// .claude/helpers/graft-hooks.cjs
+#!/usr/bin/env node
+const path = require('path');
+const dir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+import(path.join(dir, 'dist', 'claude', 'hooks.js'))
+  .then((m) => m.main(process.argv[2]))
+  .catch(() => { /* best-effort: never disrupt the session */ });
+```
+
+- [ ] **Step 10: Add `PostToolUse` to `.claude/settings.json`**
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-statusline.cjs\""
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          { "type": "command", "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-hooks.cjs\" post-edit", "timeout": 10000 }
+        ]
+      }
+    ]
+  }
+}
+```
+
+- [ ] **Step 11: Build and commit**
+
+```bash
+npm run build
+git add src/claude/format.ts src/claude/hooks.ts test/claude-format.test.ts test/claude-hooks.test.ts \
+  .claude/helpers/graft-hooks.cjs .claude/settings.json
+git commit -m "feat(claude): post-edit hook — drift flag + blast-radius injection"
+```
+
+---
+
+## Task 5: Auto-sync — background rebuild runner (closes the loop)
+
+**Files:**
+- Create: `src/claude/sync-run.ts`
+- Modify: `.claude/settings.json` (add `Stop`)
+- Test: `test/claude-hooks.test.ts` (add sync-run behavior test)
+
+**Interfaces:**
+- Consumes: `readWiring`, `computeStats` (stats.ts); `patchStats`, `releaseLock` (state.ts).
+- Produces: `src/claude/sync-run.ts` with `runSync(dir:string, build:(d:string)=>void): void` (build injected for testability) and a `main()` that calls `runSync` with the real `graft build`.
+
+- [ ] **Step 1: Write the failing test (inject a fake build)**
+
+```ts
+// append to test/claude-hooks.test.ts
+import { runSync } from '../src/claude/sync-run.js';
+import { writeStats, emptyStats, acquireLock } from '../src/claude/state.js';
+
+test('runSync clears dirty/syncing, recomputes stats, releases lock', () => {
+  const d = mkdtempSync(join(tmpdir(), 'graft-sync-'));
+  mkdirSync(join(d, 'graft', '.graph'), { recursive: true });
+  writeStats(d, { ...emptyStats(), dirty: true, syncing: true, staleCount: 3 });
+  acquireLock(d);
+  // fake build: write a fresh wiring.json with 2 nodes, 1 ready
+  const fakeBuild = (dir: string) => writeFileSync(join(dir, 'graft', '.graph', 'wiring.json'),
+    JSON.stringify({ meta: { nodeCount: 2, edgeCount: 1, languages: ['typescript'] },
+      nodes: [{ id: 'a', summary_state: 'ready' }, { id: 'b', summary_state: 'pending' }],
+      edges: [{ from: 'a', to: 'b' }] }));
+  runSync(d, fakeBuild);
+  const s = readStats(d)!;
+  assert.equal(s.dirty, false);
+  assert.equal(s.syncing, false);
+  assert.equal(s.staleCount, 0);
+  assert.equal(s.nodeCount, 2);
+  assert.equal(s.readyCount, 1);
+  assert.ok(s.syncedAt);
+  assert.equal(acquireLock(d), true, 'lock released, so reacquire succeeds');
+});
+
+test('runSync clears syncing even if build throws (money-safe failure)', () => {
+  const d = mkdtempSync(join(tmpdir(), 'graft-sync-'));
+  writeStats(d, { ...emptyStats(), dirty: true, syncing: true });
+  acquireLock(d);
+  runSync(d, () => { throw new Error('build failed'); });
+  const s = readStats(d)!;
+  assert.equal(s.syncing, false);
+  assert.equal(s.dirty, true, 'stays dirty so the bar keeps ⚠ and it retries next turn');
+  assert.equal(acquireLock(d), true, 'lock always released');
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `node --import tsx --test test/claude-hooks.test.ts`
+Expected: FAIL — cannot find `../src/claude/sync-run.js`.
+
+- [ ] **Step 3: Write `sync-run.ts`**
+
+```ts
+// src/claude/sync-run.ts
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+import { readWiring, computeStats } from './stats.js';
+import { patchStats, releaseLock } from './state.js';
+
+/** MONEY GUARD: plain `graft build` only — structural, $0, offline. Never --deep. */
+function realBuild(dir: string): void {
+  execFileSync(process.execPath, [join(dir, 'dist', 'cli.js'), 'build', '.'],
+    { cwd: dir, stdio: 'ignore', timeout: 120000 });
+}
+
+export function runSync(dir: string, build: (d: string) => void = realBuild): void {
+  try {
+    build(dir);
+    const w = readWiring(dir);
+    const patch: Record<string, unknown> = { dirty: false, staleCount: 0, syncing: false, syncedAt: new Date().toISOString() };
+    if (w) Object.assign(patch, computeStats(w));
+    patchStats(dir, patch);
+  } catch {
+    patchStats(dir, { syncing: false }); // leave dirty=true; retry next turn
+  } finally {
+    releaseLock(dir);
+  }
+}
+
+export function main(): void {
+  const dir = process.argv[2];
+  if (dir) runSync(dir);
+}
+main();
+```
+
+> `main()` runs on import so the detached `node dist/claude/sync-run.js <dir>` process (spawned by the `stop` hook in Task 4) executes `runSync` and exits. The `build` parameter default is the real, `--deep`-free build; tests inject a fake.
+
+- [ ] **Step 4: Run to verify sync tests pass**
+
+Run: `node --import tsx --test test/claude-hooks.test.ts`
+Expected: PASS (5 tests total in this file).
+
+- [ ] **Step 5: Add `Stop` to `.claude/settings.json`**
+
+Add this key alongside `PostToolUse` inside `hooks`:
+
+```json
+    "Stop": [
+      {
+        "hooks": [
+          { "type": "command", "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-hooks.cjs\" stop", "timeout": 8000 }
+        ]
+      }
+    ]
+```
+
+- [ ] **Step 6: Build, then verify the full loop end-to-end (money-safe)**
+
+```bash
+npm run build
+# 1) simulate an edit → expect dirty + a stale count
+echo '{"cwd":"'"$PWD"'","tool_input":{"file_path":"'"$PWD"'/src/cli.ts"}}' \
+  | node .claude/helpers/graft-hooks.cjs post-edit
+node -e "console.log(require('./dist/claude/state.js').readStats(process.cwd()))"   # dirty:true
+# 2) simulate turn end → spawns background sync (plain build, $0)
+echo '{"cwd":"'"$PWD"'"}' | node .claude/helpers/graft-hooks.cjs stop
+sleep 5
+node -e "console.log(require('./dist/claude/state.js').readStats(process.cwd()))"   # dirty:false, syncedAt set
+```
+Expected: after the sleep, `dirty:false`, `syncing:false`, `syncedAt` populated. Confirm **no** OpenRouter/network call happened (plain build only). Then `git checkout graft/` if the build rewrote committed graph files during this manual test.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/claude/sync-run.ts test/claude-hooks.test.ts .claude/settings.json
+git commit -m "feat(claude): turn-end auto-sync — detached \$0 rebuild under lock (never --deep)"
+```
+
+---
+
+## Task 6: Active retrieval — inject graft matches on each prompt
+
+**Files:**
+- Modify: `src/claude/format.ts` (add `formatRetrieval`), `src/claude/hooks.ts` (add `prompt` event), `.claude/settings.json` (add `UserPromptSubmit`)
+- Test: `test/claude-format.test.ts` (add cases)
+
+**Interfaces:**
+- Consumes: `graftJson` (internal to hooks.ts); `readSession`/`writeSession` (state.ts).
+- Produces (format.ts): `interface AskJson { query:string; mode:string; hits:{kind:string;title:string;pointer:string;snippet:string;score:number}[] }`; `formatRetrieval(ask:AskJson, cap?:number): string|null`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// append to test/claude-format.test.ts
+import { formatRetrieval } from '../src/claude/format.js';
+
+test('formatRetrieval renders top hits, trims snippet, first pointer only', () => {
+  const ask = { query: 'pkce', mode: 'lexical', hits: [
+    { kind: 'concept', title: 'PKCE', pointer: 'src/pkce.ts, src/client.ts', snippet: 'Validates   the   challenge.', score: 1 },
+  ] } as any;
+  const txt = strip(formatRetrieval(ask)!);
+  assert.match(txt, /relevant context/);
+  assert.match(txt, /PKCE — src\/pkce\.ts — Validates the challenge\./);
+  assert.doesNotMatch(txt, /client\.ts/); // only the first pointer segment
+});
+
+test('formatRetrieval returns null for no hits', () => {
+  assert.equal(formatRetrieval({ query: 'x', mode: 'empty', hits: [] } as any), null);
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `node --import tsx --test test/claude-format.test.ts`
+Expected: FAIL — `formatRetrieval` not exported.
+
+- [ ] **Step 3: Add `formatRetrieval` to `format.ts`**
+
+```ts
+// append to src/claude/format.ts
+export interface AskJson {
+  query: string; mode: string;
+  hits: { kind: string; title: string; pointer: string; snippet: string; score: number }[];
+}
+
+export function formatRetrieval(ask: AskJson, cap = 5): string | null {
+  const hits = (ask.hits ?? []).slice(0, cap);
+  if (!hits.length) return null;
+  const lines = hits.map((h) => {
+    const ptr = (h.pointer ?? '').split(',')[0].trim();
+    const snip = (h.snippet ?? '').replace(/\s+/g, ' ').trim().slice(0, 140);
+    return ` • ${h.title} — ${ptr} — ${snip}`;
+  });
+  return `[graft] relevant context for this prompt:\n${lines.join('\n')}`;
+}
+```
+
+- [ ] **Step 4: Run to verify format tests pass**
+
+Run: `node --import tsx --test test/claude-format.test.ts`
+Expected: PASS (9 tests).
+
+- [ ] **Step 5: Add the `prompt` branch to `hooks.ts`**
+
+Insert before the closing of `main`, after the `stop` block:
+
+```ts
+  if (event === 'prompt') {
+    const prompt = String(input?.prompt ?? '').trim();
+    if (prompt.length < 8) return;
+    const ask = graftJson(dir, ['ask', prompt, '.', '--json', '-n', '5']);
+    if (!ask) return;
+    const txt = formatRetrieval(ask);
+    if (!txt) return;
+    emit('UserPromptSubmit', txt);
+    const id = input.session_id || 'default';
+    const s = readSession(dir, id);
+    s.lastQuery = prompt;
+    const agent = input?.agent?.name;
+    if (agent) s.perAgentQuery[agent] = prompt;
+    writeSession(dir, id, s);
+  }
+```
+
+Add to the imports at the top of `hooks.ts`:
+
+```ts
+import { formatBlastRadius, formatRetrieval } from './format.js';
+import { patchStats, readStats, acquireLock, readSession, writeSession } from './state.js';
+```
+
+- [ ] **Step 6: Add `UserPromptSubmit` to `.claude/settings.json`** (inside `hooks`)
+
+```json
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          { "type": "command", "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-hooks.cjs\" prompt", "timeout": 8000 }
+        ]
+      }
+    ]
+```
+
+- [ ] **Step 7: Build and smoke-test**
+
+```bash
+npm run build
+echo '{"cwd":"'"$PWD"'","session_id":"t","prompt":"how does pkce verification work"}' \
+  | node .claude/helpers/graft-hooks.cjs prompt
+```
+Expected: JSON with `hookSpecificOutput.additionalContext` containing `[graft] relevant context…` and real hits from this repo.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/claude/format.ts src/claude/hooks.ts test/claude-format.test.ts .claude/settings.json
+git commit -m "feat(claude): active retrieval — inject graft ask matches on prompt"
+```
+
+---
+
+## Task 7: Session orientation — inject the repo map at session start
+
+**Files:**
+- Modify: `src/claude/format.ts` (add `formatOrientation`), `src/claude/hooks.ts` (add `session-start`), `.claude/settings.json` (add `SessionStart`)
+- Test: `test/claude-format.test.ts` (add case)
+
+**Interfaces:**
+- Produces (format.ts): `formatOrientation(indexMd:string, budgetBytes?:number): string`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// append to test/claude-format.test.ts
+import { formatOrientation } from '../src/claude/format.js';
+
+test('formatOrientation labels and truncates to budget', () => {
+  const md = 'X'.repeat(3000);
+  const out = strip(formatOrientation(md, 1500));
+  assert.match(out, /repo map/);
+  assert.ok(out.length < 1600, 'trimmed to budget + short header');
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `node --import tsx --test test/claude-format.test.ts`
+Expected: FAIL — `formatOrientation` not exported.
+
+- [ ] **Step 3: Add `formatOrientation` to `format.ts`**
+
+```ts
+// append to src/claude/format.ts
+export function formatOrientation(indexMd: string, budgetBytes = 1500): string {
+  return `[graft] repo map (graft/INDEX.md):\n${indexMd.slice(0, budgetBytes)}`;
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `node --import tsx --test test/claude-format.test.ts`
+Expected: PASS (10 tests).
+
+- [ ] **Step 5: Add the `session-start` branch to `hooks.ts`**
+
+Add import at top: `import { readFileSync } from 'node:fs';` is already present. Add `formatOrientation` to the format import:
+
+```ts
+import { formatBlastRadius, formatRetrieval, formatOrientation } from './format.js';
+```
+
+Add the branch inside `main`:
+
+```ts
+  if (event === 'session-start') {
+    try {
+      const idx = readFileSync(join(dir, 'graft', 'INDEX.md'), 'utf8');
+      emit('SessionStart', formatOrientation(idx));
+    } catch { /* no INDEX.md — skip */ }
+  }
+```
+
+- [ ] **Step 6: Add `SessionStart` to `.claude/settings.json`** (inside `hooks`)
+
+```json
+    "SessionStart": [
+      {
+        "hooks": [
+          { "type": "command", "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-hooks.cjs\" session-start", "timeout": 8000 }
+        ]
+      }
+    ]
+```
+
+- [ ] **Step 7: Build, smoke-test, commit**
+
+```bash
+npm run build
+echo '{"cwd":"'"$PWD"'"}' | node .claude/helpers/graft-hooks.cjs session-start   # expect INDEX.md head in additionalContext
+git add src/claude/format.ts src/claude/hooks.ts test/claude-format.test.ts .claude/settings.json
+git commit -m "feat(claude): session-start orientation — inject graft/INDEX.md head"
+```
+
+---
+
+## Task 8: Display extras — per-subagent row + clickable node refs
+
+**Files:**
+- Modify: `src/claude/statusline.ts` (per-agent line when `agent.name` present), `.claude/settings.json` (add `subagentStatusLine` + `footerLinksRegexes`)
+- Test: `test/claude-format.test.ts` (add per-agent render case)
+
+**Interfaces:**
+- Consumes: `renderStatusline`, `readSession`.
+- Produces (format.ts): `renderSubagent(agentName:string, session:SessionState|null): string`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// append to test/claude-format.test.ts
+import { renderSubagent } from '../src/claude/format.js';
+
+test('renderSubagent shows agent name and its last query', () => {
+  const out = strip(renderSubagent('Explore', { lastQuery: null, perAgentQuery: { Explore: 'pkce flow' }, graftReads: 0, sourceReads: 0 }));
+  assert.match(out, /Explore/);
+  assert.match(out, /pkce flow/);
+});
+
+test('renderSubagent without a query still shows the agent', () => {
+  const out = strip(renderSubagent('Plan', null));
+  assert.match(out, /Plan/);
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `node --import tsx --test test/claude-format.test.ts`
+Expected: FAIL — `renderSubagent` not exported.
+
+- [ ] **Step 3: Add `renderSubagent` to `format.ts`**
+
+```ts
+// append to src/claude/format.ts
+export function renderSubagent(agentName: string, session: SessionState | null): string {
+  const q = session?.perAgentQuery?.[agentName];
+  const tail = q ? SEP + C.muted('graft: ') + C.text(q) : '';
+  return C.muted('◤ ') + C.indigo(agentName) + tail;
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `node --import tsx --test test/claude-format.test.ts`
+Expected: PASS (12 tests).
+
+- [ ] **Step 5: Use it in `statusline.ts`**
+
+Replace the body of `main` so it renders the subagent row when `agent.name` is set:
+
+```ts
+// src/claude/statusline.ts
+import { readFileSync } from 'node:fs';
+import { renderStatusline, renderSubagent } from './format.js';
+import { readStats, readSession } from './state.js';
+
+export function main(): void {
+  let input: any = {};
+  try { input = JSON.parse(readFileSync(0, 'utf8')); } catch { /* no/invalid stdin */ }
+  const dir = process.env.CLAUDE_PROJECT_DIR || input.cwd || process.cwd();
+  const session = readSession(dir, input.session_id || 'default');
+  const agent = input?.agent?.name;
+  if (agent) { process.stdout.write(renderSubagent(agent, session)); return; }
+  const stats = readStats(dir);
+  const raw = input?.context_window?.used_percentage;
+  const ctxPct = typeof raw === 'number' ? Math.round(raw) : null;
+  process.stdout.write(renderStatusline(stats, session, { ctxPct }).join('\n'));
+}
+```
+
+> The same shim backs both `statusLine` and `subagentStatusLine`; the presence of `agent.name` on stdin selects the per-agent row. This keeps one entry point.
+
+- [ ] **Step 6: Add `subagentStatusLine` + `footerLinksRegexes` to `.claude/settings.json`** (top level)
+
+```json
+  "subagentStatusLine": {
+    "type": "command",
+    "command": "node \"${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-statusline.cjs\""
+  },
+  "footerLinksRegexes": ["graft/[\\w./-]+\\.md"]
+```
+
+- [ ] **Step 7: Build, smoke-test, commit**
+
+```bash
+npm run build
+echo '{"cwd":"'"$PWD"'","agent":{"name":"Explore"}}' | node .claude/helpers/graft-statusline.cjs   # expect "◤ Explore …"
+git add src/claude/format.ts src/claude/statusline.ts test/claude-format.test.ts .claude/settings.json
+git commit -m "feat(claude): per-subagent statusline row + clickable graft node refs"
+```
+
+---
+
+## Task 9: Full suite green + dogfood verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the entire test suite**
+
+Run: `npm test`
+Expected: all `test/*.test.ts` pass, including the four new `claude-*` files and the pre-existing engine tests (no regressions).
+
+- [ ] **Step 2: Build clean**
+
+Run: `npm run build`
+Expected: exits 0; `dist/claude/{state,stats,format,statusline,hooks,sync-run}.js` all present (`ls dist/claude`).
+
+- [ ] **Step 3: Dogfood the live loop in this repo**
+
+In a Claude Code session opened on `context-graph-engine`:
+1. Confirm the statusline shows `◤ graft · 319 nodes / 730 edges · ✓ synced` (once a real build has populated `stats.json`; run `graft build` once if needed).
+2. Ask a question → confirm a `[graft] relevant context…` block was injected (visible in the transcript's context or via `/context`).
+3. Edit a source file → statusline flips to `⚠ N stale`; a blast-radius note appears after the edit.
+4. End the turn → within a few seconds the statusline returns to `✓ synced`.
+5. **Money check:** confirm no OpenRouter request fired during auto-sync (structural build only). If `graft/` was rewritten by the manual build, `git add graft/` as an intended refresh or `git checkout graft/` to discard.
+
+- [ ] **Step 4: Final commit (if any dogfood tweaks were needed)**
+
+```bash
+git add -A
+git commit -m "chore(claude): verify full suite + dogfood the drift→sync loop"
+```
+
+---
+
+## Notes for the implementer
+
+- **Never** add `--deep` to any `graft build` invocation. The only build command in this plan is plain `graft build .` in `sync-run.ts`.
+- The statusline path must never call `execFileSync`/`spawn` — it reads `stats.json`, one session file, and stdin. All Graft invocations live in `hooks.ts` / `sync-run.ts`, which fire on discrete events, not on every render.
+- If `src/graph/types.ts` export names differ from those assumed in Task 2, match the file — do not invent types.
+- All hooks are best-effort: the `.cjs` shims already swallow errors so a failure can never break the session.

--- a/docs/superpowers/specs/2026-07-20-graft-claude-code-integration-design.md
+++ b/docs/superpowers/specs/2026-07-20-graft-claude-code-integration-design.md
@@ -1,0 +1,270 @@
+# Graft × Claude Code integration — design
+
+**Date:** 2026-07-20
+**Status:** Draft for review
+**Owner:** Shrish
+**Scope:** One implementation plan.
+
+## 1. Goal
+
+Make Graft *visible and active* inside a Claude Code session, the way ruflo's
+statusline makes ruflo visible. Today Graft is a passive `graft/` folder that an
+agent is *supposed* to read. This feature ships a `.claude/` integration that:
+
+1. **Shows** the developer what Graft holds and whether it's trustworthy (a live statusline).
+2. **Feeds** relevant graph context into the model automatically (retrieval + orientation + blast-radius).
+3. **Keeps itself fresh** — auto-syncs the graph after edits, at `$0`, with no manual command.
+
+Every number shown must be real. No fabricated "tokens saved %", no misleading
+dollar cost. If a signal can't be measured honestly, it isn't displayed.
+
+## 2. Background & constraints (grounded in the engine)
+
+- Graft = `@nanonets/graft` v0.2.1, a Node/TS **CLI + library**. No daemon, no MCP.
+  Commands: `graft build` / `ask` / `check` / `viz`.
+- State on disk under `<repo>/graft/`:
+  - `graft/.graph/wiring.json` — deterministic code graph. Top-level `meta`
+    (`{version, nodeCount, edgeCount, languages[]}`), `nodes[]` (each with
+    `id, name, kind, path, span, signature, exported, body_hash, summary_state,
+    summary, crux`), `edges[]` (`{from, to, relation, confidence}`,
+    `relation ∈ contains|calls|imports|references|implements|extends`).
+  - `graft/*.md` — concept nodes (LLM prose) with typed `[[wikilinks]]`.
+  - `graft/manifest.json` — roster + `repoDigest` + per-file hashes.
+  - `graft/INDEX.md` — human-readable map (~4.4 KB).
+  - `graft/.cache/` — **gitignored**; safe home for session state + sync lock.
+- Measured facts that shape the design:
+  - `graft check --json` runs in **~0.35s**, read-only, and returns precise drift:
+    `graph.changed[]` (files *and* symbols), `graph.added/removed`, `context.contentDrift[]`, and `ok: false` when stale.
+  - Plain `graft build` = **structural, deterministic, offline, `$0`**.
+    `graft build --deep` = the LLM pass (summaries/crux) that spends OpenRouter
+    credits and needs `OPENROUTER_API_KEY`; without a key it degrades to structural.
+  - Graft has **no token/cost meter**. There is no runtime signal for "tokens saved".
+- Claude Code `.claude/` surface we rely on (confirmed against docs):
+  - `statusLine` (command): runs a script per render, receives a JSON blob on
+    **stdin** including `model`, `cwd`, `session_id`, `agent.name`, and
+    `context_window.{used_percentage, total_input_tokens, total_output_tokens}` and
+    `cost.total_cost_usd`. Re-renders several times/second while streaming → the
+    script **must be a fast pure reader**.
+  - `subagentStatusLine` — per-subagent row.
+  - `footerLinksRegexes` — regex → clickable link in the transcript.
+  - Hooks (command scripts, JSON on stdin, can inject context via
+    `additionalContext` / `hookSpecificOutput`): `SessionStart`, `UserPromptSubmit`,
+    `PreToolUse`, `PostToolUse`, `Stop`.
+
+**Honesty grading** used throughout:
+- **real** — already on disk (`wiring.json`) or in stdin (`context_window`).
+- **instrumented→real** — a small hook captures it honestly (reads count, drift, dirty).
+- **not measurable** — dollar cost (misleading estimate) and "tokens saved %" (no baseline). **Excluded by design.**
+
+## 3. Scope
+
+**In scope (9 features):**
+
+| # | Feature | Surface | Honesty |
+|---|---------|---------|---------|
+| D1 | Status bar (2-line) | `statusLine` | real |
+| D2 | Drift beacon (`⚠ N stale`) | `statusLine` + PostToolUse flag | instrumented→real |
+| D3 | Per-subagent region | `subagentStatusLine` | real |
+| D4 | Clickable node refs | `footerLinksRegexes` | real |
+| F1 | Active retrieval (`graft ask` → inject) | `UserPromptSubmit` | real |
+| F2 | Session orientation (`INDEX.md` → inject) | `SessionStart` | real |
+| F3 | Blast-radius nudge (edges → inject) | `PostToolUse · Edit` | real |
+| O1 | Drift flag (mark dirty) | `PostToolUse · Edit` | instrumented→real |
+| S1 | Auto-sync (turn-end background rebuild) | `Stop` | real |
+
+**Explicitly out of scope (deferred):**
+- Pre-grep short-circuit (`PreToolUse · Grep`) — powerful but intrusive; needs tuning.
+- Coverage-gap detector — nice, not core to this deliverable.
+- Graft-read usage counter as a *displayed number* — we will **capture** graft-vs-source
+  reads in state (cheap), but only surface it once we trust it; the bar ships without it if noisy.
+- `$` cost and "tokens saved %" — never shipped (not measurable).
+- A `graft claude-init` CLI subcommand to scaffold this into *other* repos — the helpers
+  will be written to be liftable, but productizing the installer is a separate plan.
+- Debounced live watcher / session-end-only sync — rejected in favor of turn-end sync.
+
+## 4. Architecture — readers vs. writers, one state file
+
+The ruflo pattern: the **statusline only reads**; **hooks write and act**. They meet
+at one small gitignored state file, so rendering never invokes Graft and the
+expensive work happens only on real events.
+
+```
+                       ┌─────────────────────────────┐
+   edits / prompts ───▶│  graft-hooks.cjs (writer)   │──▶ graft ask / build / check
+                       │  post-edit · prompt · stop  │      (episodic, not per-paint)
+                       └──────────────┬──────────────┘
+                                      │ writes
+                                      ▼
+                       ┌─────────────────────────────┐
+                       │  graft/.cache/  (state)     │
+                       │   stats.json · session/*    │
+                       │   .sync.lock                │
+                       └──────────────┬──────────────┘
+                                      │ reads (small files only)
+                                      ▼
+   Claude Code stdin ───────▶ graft-statusline.cjs (reader) ──▶ the 2-line bar
+```
+
+### Files shipped
+
+| Path | Role | Responsibility |
+|------|------|----------------|
+| `.claude/settings.json` | config | wire `statusLine`, `subagentStatusLine`, `footerLinksRegexes`, and 4 hook events |
+| `.claude/helpers/graft-statusline.cjs` | reader | pure/fast: read `stats.json` + `session/<id>.json` + stdin → render bar. Never calls Graft. |
+| `.claude/helpers/graft-hooks.cjs` | writer | single dispatcher: `session-start` \| `prompt` \| `post-edit` \| `stop`. Runs Graft, writes state, injects context. |
+| `graft/.cache/stats.json` | state | precomputed `{nodeCount, edgeCount, languages, enrichedPct, staleCount, dirty, syncedAt}` for the statusline |
+| `graft/.cache/session/<session_id>.json` | state | per-session: `{lastQuery, perAgentQuery, graftReads, sourceReads}` |
+| `graft/.cache/.sync.lock` | lock | one background `graft build` at a time |
+
+CJS Node scripts, no new dependencies (matches ruflo + Graft's own stack). All paths
+resolved relative to `CLAUDE_PROJECT_DIR` with a `$HOME` fallback (ruflo's pattern).
+
+## 5. The status bar (D1/D2)
+
+Two lines. Top = Graft's own state (capture/coverage/freshness). Bottom = session
+reality from Claude Code stdin. Example:
+
+```
+◤ graft · 319 nodes / 730 edges · 100% enriched · ⚠ 4 stale
+▸ ctx 34% · syncing… · last: pkce.ts
+```
+
+- **Top line** from `stats.json`:
+  - `nodeCount` / `edgeCount` (from `wiring.json` meta, precomputed).
+  - `enrichedPct` = share of nodes with `summary_state === "ready"` (precomputed).
+    **Show this segment only when `readyCount ≥ 1`.** A structural-only graph (no
+    `--deep` run) has zero enriched nodes → the segment is hidden entirely; after any
+    enrichment it shows `NN% enriched`. Keeps the bar quiet when there's nothing to say.
+  - Freshness: `✓ synced` when `dirty=false && staleCount=0`; `⚠ N stale` when drift
+    detected; `syncing…` while a background build holds the lock.
+- **Bottom line** from stdin + session state:
+  - `ctx NN%` = `context_window.used_percentage` (real, unambiguous).
+  - sync status verb OR `last: <basename>` of the most recent captured/edited node.
+- **Colors** (Nanonets palette, ANSI): indigo `#546FFF` for live/real graft data,
+  amber for `⚠ stale` / drift, muted grey for separators. No green. No gradients.
+- **Degraded states:** no `wiring.json` → `graft · not built · run graft build`
+  (muted). Missing stdin fields → omit that segment, never error.
+- **Performance:** reads only small files (`stats.json`, one session file). Optional
+  ~2s /tmp memo keyed by `session_id` to coalesce render storms. Never spawns a
+  subprocess. (Guards against the load-average storm ruflo hit by shelling out per render.)
+
+## 6. Feed features
+
+### F1 — Active retrieval (`UserPromptSubmit`)
+- On each user prompt, run `graft ask "<prompt>" --json -n 5`.
+- Inject the top hits as `additionalContext`, clearly fenced, e.g.:
+  ```
+  [graft] relevant context for this prompt:
+   • PkceVerifier.verify — auth/oauth/pkce.ts:42-71 — validates the PKCE challenge…
+   • OAuthClient.exchange — auth/oauth/client.ts:88-120 — …
+  ```
+- Caps: ≤5 hits, ≤~800 tokens total, each = title · `path:Lx-Ly` · one-line crux.
+- `graft ask` is `$0`/no-LLM/lexical-structural, so this is cheap and offline.
+- Silent no-op if: graft not built, zero hits, or prompt is trivial (< N chars).
+- Records `lastQuery` (and `perAgentQuery[agent]`) into session state for D3.
+
+### F2 — Session orientation (`SessionStart`)
+- Inject the head of `graft/INDEX.md` (top concepts / entry points) as
+  `additionalContext` so Claude starts oriented instead of re-exploring.
+- Cap to a budget (e.g. first ~1.5 KB / top section). Skip on `source: resume`
+  if already injected this session. No-op if `INDEX.md` absent.
+
+### F3 — Blast-radius nudge (`PostToolUse · Edit`)
+- After an edit to a source file, find nodes in that file and inject their
+  **incoming** edges (who `calls`/`imports`/`references`/`depends_on` this) —
+  the "what breaks if I change this?" direction.
+- From `wiring.json` `edges[]` filtered by `to` ∈ edited file's node ids.
+- Cap ≤8, with `+N more`. Format: `↳ used by: OAuthClient.exchange (client.ts), …`.
+- Ignore edits under `graft/` itself (no self-referential noise / loops).
+- Episodic (once per edit) so parsing `wiring.json` here is fine.
+
+## 7. Auto-sync (S1) + drift flag (O1)
+
+The closed loop:
+
+```
+1. edit source        → PostToolUse·Edit sets stats.dirty=true, records last file
+2. statusline          → shows "⚠ stale" instantly (reads stats.json)
+3. turn ends (Stop)    → graft check --json (~0.35s) → write precise staleCount
+4. if dirty & staleCnt → acquire .sync.lock → graft build (structural, $0) in background
+5. build done          → recompute stats.json (counts, enrichedPct), dirty=false,
+                         staleCount=0, syncedAt=now, release lock
+6. statusline          → flips to "✓ synced"
+```
+
+- **Money guard (hard rule):** auto-sync runs **only plain `graft build`** —
+  structural, offline, `$0`. It **never** runs `--deep`. New/changed nodes sit at
+  `summary_state: pending` until the developer manually enriches. No background API spend, ever.
+- **Concurrency:** `.sync.lock` (pid + timestamp). If held, skip (a build is already
+  running); stale locks (> N min) are reclaimed.
+- **Non-blocking:** the build is detached/background so the `Stop` hook returns fast
+  and never stalls the UI. Failure logs to `graft/.cache/sync.log`, leaves `dirty=true`
+  (bar keeps `⚠`), and never throws.
+- **Scope:** v1 runs a full structural `graft build` (fast for this repo). If measured
+  slow on large repos, a later optimization scopes to `graph.changed[]` from `check`.
+- **Guard against loops:** edits under `graft/` never set dirty and never trigger sync.
+
+## 8. Display extras
+
+### D3 — Per-subagent region (`subagentStatusLine`)
+- Render `agent.name` + its `perAgentQuery` (last `graft ask` subject) from session
+  state. Falls back to the main bar when no per-agent query exists.
+
+### D4 — Clickable node refs (`footerLinksRegexes`)
+- Regex matches `graft/[\w./-]+\.md` mentions in the transcript → link to the local
+  file (or the `graft viz` URL, `http://localhost:4400`, if a viz server is detected).
+- Lowest priority; pure garnish; ship last.
+
+## 9. Data contracts
+
+**`stats.json`** (writer: post-edit sets `dirty`; stop/build recomputes the rest):
+```json
+{ "nodeCount": 319, "edgeCount": 730, "languages": ["typescript"],
+  "enrichedPct": 100, "staleCount": 0, "dirty": false,
+  "syncedAt": "2026-07-20T14:30:00Z", "lastFile": "pkce.ts" }
+```
+**`session/<session_id>.json`:**
+```json
+{ "lastQuery": "pkce verification", "perAgentQuery": { "Explore": "…" },
+  "graftReads": 6, "sourceReads": 11 }
+```
+**stdin fields consumed by the statusline:** `session_id`, `agent.name`,
+`context_window.used_percentage`. Everything else optional/ignored.
+
+## 10. Error handling & degradation
+
+- Graft not built / no `wiring.json`: statusline shows muted "not built"; hooks no-op.
+- `graft` binary not resolvable: hooks no-op; statusline still renders from `stats.json` if present.
+- Malformed stdin JSON: render a minimal bar; never crash a hook (crashing a hook can disrupt the session).
+- Concurrent Claude Code sessions: state keyed by `session_id`; single global `.sync.lock`.
+- Windows console-flash (upstream bug): statusline reads files only — no subprocess spawns — so it doesn't flash.
+- All hooks are best-effort: any failure logs to `graft/.cache/*.log` and exits 0.
+
+## 11. Testing
+
+- **Unit:** stdin parse, bar formatting, `enrichedPct` calc, dirty transitions,
+  edge filtering for blast-radius, `graft ask` output → injection formatting, lock acquire/release.
+- **Integration:** feed recorded hook payloads (JSON on stdin) to `graft-hooks.cjs`
+  and assert (a) state writes and (b) injected `additionalContext`. Feed a recorded
+  statusline stdin blob and assert the rendered string.
+- **Dogfood (manual):** run inside `context-graph-engine`'s own Claude Code session
+  (it is already indexed by Graft). Edit a source file, confirm `⚠ stale` → turn end →
+  `✓ synced`, and that `--deep` is never invoked (watch for OpenRouter calls = none).
+
+## 12. Rollout
+
+1. Build + dogfood in `context-graph-engine/.claude/` on a feature branch.
+2. Keep helpers repo-agnostic (paths via `CLAUDE_PROJECT_DIR`) so they can later be
+   emitted by a `graft claude-init` command (separate plan).
+3. Merge once the drift→sync loop is verified end-to-end with zero API spend.
+
+## 13. Decisions (resolved 2026-07-20)
+
+1. **`enrichedPct` display:** show the segment **only when `readyCount ≥ 1`**; hide
+   entirely for a structural-only graph. (See §5.)
+2. **`graftReads` on the bar:** **capture in `session/<id>.json` now, do not display yet.**
+   Revisit surfacing it once the number is trusted.
+3. **Sync build scope:** **build auto-sync properly** — robust lock, detached
+   background process, debounce, and correct `dirty`/`staleCount`/`syncedAt`
+   transitions. v1 runs a full structural `graft build`; changed-files scoping is a
+   later optimization behind the same interface (not a shortcut on correctness).

--- a/docs/superpowers/specs/2026-07-20-graft-claude-code-integration-design.md
+++ b/docs/superpowers/specs/2026-07-20-graft-claude-code-integration-design.md
@@ -7,9 +7,10 @@
 
 ## 1. Goal
 
-Make Graft *visible and active* inside a Claude Code session, the way ruflo's
-statusline makes ruflo visible. Today Graft is a passive `graft/` folder that an
-agent is *supposed* to read. This feature ships a `.claude/` integration that:
+Make Graft *visible and active* inside a Claude Code session — a live statusline
+that surfaces what Graft holds, and hooks that feed the graph to the model. Today
+Graft is a passive `graft/` folder that an agent is *supposed* to read. This
+feature ships a `.claude/` integration that:
 
 1. **Shows** the developer what Graft holds and whether it's trustworthy (a live statusline).
 2. **Feeds** relevant graph context into the model automatically (retrieval + orientation + blast-radius).
@@ -84,7 +85,7 @@ dollar cost. If a signal can't be measured honestly, it isn't displayed.
 
 ## 4. Architecture — readers vs. writers, one state file
 
-The ruflo pattern: the **statusline only reads**; **hooks write and act**. They meet
+The core pattern: the **statusline only reads**; **hooks write and act**. They meet
 at one small gitignored state file, so rendering never invokes Graft and the
 expensive work happens only on real events.
 
@@ -116,8 +117,8 @@ expensive work happens only on real events.
 | `graft/.cache/session/<session_id>.json` | state | per-session: `{lastQuery, perAgentQuery, graftReads, sourceReads}` |
 | `graft/.cache/.sync.lock` | lock | one background `graft build` at a time |
 
-CJS Node scripts, no new dependencies (matches ruflo + Graft's own stack). All paths
-resolved relative to `CLAUDE_PROJECT_DIR` with a `$HOME` fallback (ruflo's pattern).
+CJS Node scripts, no new dependencies (matches Graft's own stack). All paths
+resolved relative to `CLAUDE_PROJECT_DIR` with a `$HOME` fallback.
 
 ## 5. The status bar (D1/D2)
 
@@ -146,7 +147,7 @@ reality from Claude Code stdin. Example:
   (muted). Missing stdin fields → omit that segment, never error.
 - **Performance:** reads only small files (`stats.json`, one session file). Optional
   ~2s /tmp memo keyed by `session_id` to coalesce render storms. Never spawns a
-  subprocess. (Guards against the load-average storm ruflo hit by shelling out per render.)
+  subprocess. (Guards against a load-average storm from shelling out on every render.)
 
 ## 6. Feed features
 

--- a/src/claude/format.ts
+++ b/src/claude/format.ts
@@ -91,3 +91,9 @@ export function formatRetrieval(ask: AskJson, cap = 5): string | null {
 export function formatOrientation(indexMd: string, budgetBytes = 1500): string {
   return `[graft] repo map (graft/INDEX.md):\n${indexMd.slice(0, budgetBytes)}`;
 }
+
+export function renderSubagent(agentName: string, session: SessionState | null): string {
+  const q = session?.perAgentQuery?.[agentName];
+  const tail = q ? SEP + C.muted('graft: ') + C.text(q) : '';
+  return C.muted('◤ ') + C.indigo(agentName) + tail;
+}

--- a/src/claude/format.ts
+++ b/src/claude/format.ts
@@ -71,3 +71,19 @@ export function formatBlastRadius(w: GraphV1, filePath: string, cap = 8): string
   const more = edges.length > cap ? `\n • +${edges.length - cap} more` : '';
   return `[graft] blast radius for ${basename(filePath)} — who depends on it:\n${items.join('\n')}${more}`;
 }
+
+export interface AskJson {
+  query: string; mode: string;
+  hits: { kind: string; title: string; pointer: string; snippet: string; score: number }[];
+}
+
+export function formatRetrieval(ask: AskJson, cap = 5): string | null {
+  const hits = (ask.hits ?? []).slice(0, cap);
+  if (!hits.length) return null;
+  const lines = hits.map((h) => {
+    const ptr = (h.pointer ?? '').split(',')[0].trim();
+    const snip = (h.snippet ?? '').replace(/\s+/g, ' ').trim().slice(0, 140);
+    return ` • ${h.title} — ${ptr} — ${snip}`;
+  });
+  return `[graft] relevant context for this prompt:\n${lines.join('\n')}`;
+}

--- a/src/claude/format.ts
+++ b/src/claude/format.ts
@@ -1,5 +1,6 @@
 import { basename } from 'node:path';
 import type { Stats, SessionState } from './state.js';
+import type { GraphV1, EdgeV1 } from '../graph/types.js';
 
 const C = {
   indigo: (s: string) => `\x1b[38;2;84;111;255m${s}\x1b[0m`,
@@ -42,4 +43,31 @@ export function renderStatusline(
   const lines = [top.join(SEP)];
   if (bottom.length) lines.push(C.muted('▸ ') + bottom.join(SEP));
   return lines;
+}
+
+function nodeIdsInFile(w: GraphV1, filePath: string): Set<string> {
+  const nodes = w.nodes ?? [];
+  return new Set(
+    nodes.filter((n) => n.path && (filePath === n.path || filePath.endsWith(`/${n.path}`) || filePath.endsWith(n.path)))
+      .map((n) => n.id),
+  );
+}
+
+export function incomingEdges(w: GraphV1, filePath: string): EdgeV1[] {
+  const ids = nodeIdsInFile(w, filePath);
+  if (!ids.size) return [];
+  return (w.edges ?? []).filter((e) => ids.has(e.target) && !ids.has(e.source));
+}
+
+export function formatBlastRadius(w: GraphV1, filePath: string, cap = 8): string | null {
+  const edges = incomingEdges(w, filePath);
+  if (!edges.length) return null;
+  const byId = new Map((w.nodes ?? []).map((n) => [n.id, n]));
+  const items = edges.slice(0, cap).map((e) => {
+    const n = byId.get(e.source);
+    const label = n ? `${n.name} (${basename(n.path)})` : e.source;
+    return ` • ${e.relation} ← ${label}`;
+  });
+  const more = edges.length > cap ? `\n • +${edges.length - cap} more` : '';
+  return `[graft] blast radius for ${basename(filePath)} — who depends on it:\n${items.join('\n')}${more}`;
 }

--- a/src/claude/format.ts
+++ b/src/claude/format.ts
@@ -1,0 +1,45 @@
+import { basename } from 'node:path';
+import type { Stats, SessionState } from './state.js';
+
+const C = {
+  indigo: (s: string) => `\x1b[38;2;84;111;255m${s}\x1b[0m`,
+  amber: (s: string) => `\x1b[38;2;224;165;68m${s}\x1b[0m`,
+  muted: (s: string) => `\x1b[38;5;244m${s}\x1b[0m`,
+  text: (s: string) => `\x1b[38;5;251m${s}\x1b[0m`,
+};
+const SEP = C.muted(' · ');
+
+export function enrichedSegment(s: Stats): string | null {
+  if (s.readyCount < 1) return null;
+  const pct = s.totalCount ? Math.round((s.readyCount / s.totalCount) * 100) : 0;
+  return C.indigo(`${pct}% enriched`);
+}
+
+export function freshnessSegment(s: Stats): string {
+  if (s.syncing) return C.amber('syncing…');
+  if (s.dirty && s.staleCount > 0) return C.amber(`⚠ ${s.staleCount} stale`);
+  if (s.dirty) return C.amber('⚠ stale');
+  return C.indigo('✓ synced');
+}
+
+export function renderStatusline(
+  stats: Stats | null,
+  _session: SessionState | null,
+  ctx: { ctxPct: number | null },
+): string[] {
+  if (!stats || stats.nodeCount === 0) {
+    return [C.muted('◤ graft · not built · run ') + C.text('graft build')];
+  }
+  const top = [C.muted('◤ ') + C.indigo('graft'), C.text(`${stats.nodeCount} nodes / ${stats.edgeCount} edges`)];
+  const enr = enrichedSegment(stats);
+  if (enr) top.push(enr);
+  top.push(freshnessSegment(stats));
+
+  const bottom: string[] = [];
+  if (typeof ctx.ctxPct === 'number') bottom.push(C.text(`ctx ${ctx.ctxPct}%`));
+  if (stats.lastFile) bottom.push(C.muted('last: ') + C.text(basename(stats.lastFile)));
+
+  const lines = [top.join(SEP)];
+  if (bottom.length) lines.push(C.muted('▸ ') + bottom.join(SEP));
+  return lines;
+}

--- a/src/claude/format.ts
+++ b/src/claude/format.ts
@@ -48,7 +48,7 @@ export function renderStatusline(
 function nodeIdsInFile(w: GraphV1, filePath: string): Set<string> {
   const nodes = w.nodes ?? [];
   return new Set(
-    nodes.filter((n) => n.path && (filePath === n.path || filePath.endsWith(`/${n.path}`) || filePath.endsWith(n.path)))
+    nodes.filter((n) => n.path && (filePath === n.path || filePath.endsWith(`/${n.path}`)))
       .map((n) => n.id),
   );
 }

--- a/src/claude/format.ts
+++ b/src/claude/format.ts
@@ -87,3 +87,7 @@ export function formatRetrieval(ask: AskJson, cap = 5): string | null {
   });
   return `[graft] relevant context for this prompt:\n${lines.join('\n')}`;
 }
+
+export function formatOrientation(indexMd: string, budgetBytes = 1500): string {
+  return `[graft] repo map (graft/INDEX.md):\n${indexMd.slice(0, budgetBytes)}`;
+}

--- a/src/claude/hooks.ts
+++ b/src/claude/hooks.ts
@@ -2,8 +2,8 @@ import { readFileSync } from 'node:fs';
 import { execFileSync, spawn } from 'node:child_process';
 import { join, basename } from 'node:path';
 import { readWiring } from './stats.js';
-import { formatBlastRadius } from './format.js';
-import { patchStats, readStats, acquireLock } from './state.js';
+import { formatBlastRadius, formatRetrieval } from './format.js';
+import { patchStats, readStats, acquireLock, readSession, writeSession } from './state.js';
 
 function readStdin(): any {
   const seam = process.env.GRAFT_TEST_STDIN;
@@ -57,5 +57,21 @@ export async function main(event: string): Promise<void> {
       child.unref();
     }
     return;
+  }
+
+  if (event === 'prompt') {
+    const prompt = String(input?.prompt ?? '').trim();
+    if (prompt.length < 8) return;
+    const ask = graftJson(dir, ['ask', prompt, '.', '--json', '-n', '5']);
+    if (!ask) return;
+    const txt = formatRetrieval(ask);
+    if (!txt) return;
+    emit('UserPromptSubmit', txt);
+    const id = input.session_id || 'default';
+    const s = readSession(dir, id);
+    s.lastQuery = prompt;
+    const agent = input?.agent?.name;
+    if (agent) s.perAgentQuery[agent] = prompt;
+    writeSession(dir, id, s);
   }
 }

--- a/src/claude/hooks.ts
+++ b/src/claude/hooks.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs';
 import { execFileSync, spawn } from 'node:child_process';
 import { join, basename } from 'node:path';
 import { readWiring } from './stats.js';
-import { formatBlastRadius, formatRetrieval } from './format.js';
+import { formatBlastRadius, formatRetrieval, formatOrientation } from './format.js';
 import { patchStats, readStats, acquireLock, readSession, writeSession } from './state.js';
 
 function readStdin(): any {
@@ -38,6 +38,14 @@ function emit(eventName: string, additionalContext: string): void {
 export async function main(event: string): Promise<void> {
   const input = readStdin();
   const dir = projectDir(input);
+
+  if (event === 'session-start') {
+    try {
+      const idx = readFileSync(join(dir, 'graft', 'INDEX.md'), 'utf8');
+      emit('SessionStart', formatOrientation(idx));
+    } catch { /* no INDEX.md — skip */ }
+    return;
+  }
 
   if (event === 'post-edit') {
     const file: string | undefined = input?.tool_input?.file_path;

--- a/src/claude/hooks.ts
+++ b/src/claude/hooks.ts
@@ -24,7 +24,14 @@ function graftJson(dir: string, args: string[]): any | null {
     const out = execFileSync(process.execPath, [join(dir, 'dist', 'cli.js'), ...args],
       { cwd: dir, encoding: 'utf8', timeout: 8000, stdio: ['ignore', 'pipe', 'ignore'] });
     return JSON.parse(out);
-  } catch { return null; }
+  } catch (e: any) {
+    // `graft check` exits non-zero when the graph is stale (by design) but still
+    // prints valid JSON to stdout; recover it from the thrown error before giving up.
+    if (e && typeof e.stdout === 'string' && e.stdout.trim()) {
+      try { return JSON.parse(e.stdout); } catch { /* not JSON — fall through */ }
+    }
+    return null;
+  }
 }
 function checkStaleCount(dir: string): number {
   const r = graftJson(dir, ['check', '.', '--json']);

--- a/src/claude/hooks.ts
+++ b/src/claude/hooks.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from 'node:fs';
+import { execFileSync, spawn } from 'node:child_process';
+import { join, basename } from 'node:path';
+import { readWiring } from './stats.js';
+import { formatBlastRadius } from './format.js';
+import { patchStats, readStats, acquireLock } from './state.js';
+
+function readStdin(): any {
+  const seam = process.env.GRAFT_TEST_STDIN;
+  const raw = seam !== undefined ? seam : safeReadFd0();
+  try { return JSON.parse(raw); } catch { return {}; }
+}
+function safeReadFd0(): string { try { return readFileSync(0, 'utf8'); } catch { return ''; } }
+
+function projectDir(input: any): string {
+  return process.env.CLAUDE_PROJECT_DIR || input.cwd || process.cwd();
+}
+export function underGraft(dir: string, file: string): boolean {
+  const rel = file.startsWith(dir) ? file.slice(dir.length) : file;
+  return rel.replace(/^[/\\]+/, '').replace(/\\/g, '/').startsWith('graft/');
+}
+function graftJson(dir: string, args: string[]): any | null {
+  try {
+    const out = execFileSync(process.execPath, [join(dir, 'dist', 'cli.js'), ...args],
+      { cwd: dir, encoding: 'utf8', timeout: 8000, stdio: ['ignore', 'pipe', 'ignore'] });
+    return JSON.parse(out);
+  } catch { return null; }
+}
+function checkStaleCount(dir: string): number {
+  const r = graftJson(dir, ['check', '.', '--json']);
+  const g = r?.graph ?? {};
+  return (g.changed?.length ?? 0) + (g.added?.length ?? 0) + (g.removed?.length ?? 0);
+}
+function emit(eventName: string, additionalContext: string): void {
+  process.stdout.write(JSON.stringify({ hookSpecificOutput: { hookEventName: eventName, additionalContext } }));
+}
+
+export async function main(event: string): Promise<void> {
+  const input = readStdin();
+  const dir = projectDir(input);
+
+  if (event === 'post-edit') {
+    const file: string | undefined = input?.tool_input?.file_path;
+    if (!file || underGraft(dir, file)) return;
+    patchStats(dir, { dirty: true, staleCount: checkStaleCount(dir), lastFile: basename(file) });
+    const w = readWiring(dir);
+    if (w) { const br = formatBlastRadius(w, file); if (br) emit('PostToolUse', br); }
+    return;
+  }
+
+  if (event === 'stop') {
+    const stats = readStats(dir);
+    if (stats?.dirty && acquireLock(dir)) {
+      patchStats(dir, { syncing: true });
+      const child = spawn(process.execPath, [join(dir, 'dist', 'claude', 'sync-run.js'), dir],
+        { detached: true, stdio: 'ignore' });
+      child.unref();
+    }
+    return;
+  }
+}

--- a/src/claude/state.ts
+++ b/src/claude/state.ts
@@ -1,0 +1,62 @@
+import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync, rmSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+export interface Stats {
+  nodeCount: number; edgeCount: number; languages: string[];
+  totalCount: number; readyCount: number;
+  staleCount: number; dirty: boolean; syncing: boolean;
+  syncedAt: string | null; lastFile: string | null;
+}
+export interface SessionState {
+  lastQuery: string | null;
+  perAgentQuery: Record<string, string>;
+  graftReads: number; sourceReads: number;
+}
+
+export const LOCK_STALE_MS = 300000;
+
+export function emptyStats(): Stats {
+  return { nodeCount: 0, edgeCount: 0, languages: [], totalCount: 0, readyCount: 0,
+    staleCount: 0, dirty: false, syncing: false, syncedAt: null, lastFile: null };
+}
+function emptySession(): SessionState {
+  return { lastQuery: null, perAgentQuery: {}, graftReads: 0, sourceReads: 0 };
+}
+
+export function cacheDir(projectDir: string): string { return join(projectDir, 'graft', '.cache'); }
+function statsPath(d: string): string { return join(cacheDir(d), 'stats.json'); }
+function sessionPath(d: string, id: string): string { return join(cacheDir(d), 'session', `${id}.json`); }
+function lockPath(d: string): string { return join(cacheDir(d), '.sync.lock'); }
+
+function readJson<T>(p: string): T | null {
+  try { return JSON.parse(readFileSync(p, 'utf8')) as T; } catch { return null; }
+}
+function writeJsonAtomic(p: string, value: unknown): void {
+  mkdirSync(join(p, '..'), { recursive: true });
+  const tmp = `${p}.${process.pid}.tmp`;
+  writeFileSync(tmp, JSON.stringify(value, null, 2));
+  renameSync(tmp, p);
+}
+
+export function readStats(d: string): Stats | null { return readJson<Stats>(statsPath(d)); }
+export function writeStats(d: string, s: Stats): void { writeJsonAtomic(statsPath(d), s); }
+export function patchStats(d: string, patch: Partial<Stats>): Stats {
+  const next: Stats = { ...(readStats(d) ?? emptyStats()), ...patch };
+  writeStats(d, next);
+  return next;
+}
+export function readSession(d: string, id: string): SessionState {
+  return readJson<SessionState>(sessionPath(d, id)) ?? emptySession();
+}
+export function writeSession(d: string, id: string, s: SessionState): void {
+  writeJsonAtomic(sessionPath(d, id), s);
+}
+
+export function acquireLock(d: string): boolean {
+  const p = lockPath(d);
+  if (existsSync(p) && Date.now() - statSync(p).mtimeMs < LOCK_STALE_MS) return false;
+  mkdirSync(cacheDir(d), { recursive: true });
+  writeFileSync(p, JSON.stringify({ pid: process.pid, at: new Date().toISOString() }));
+  return true;
+}
+export function releaseLock(d: string): void { try { rmSync(lockPath(d)); } catch { /* already gone */ } }

--- a/src/claude/state.ts
+++ b/src/claude/state.ts
@@ -1,5 +1,5 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync, rmSync, statSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
 
 export interface Stats {
   nodeCount: number; edgeCount: number; languages: string[];
@@ -32,7 +32,7 @@ function readJson<T>(p: string): T | null {
   try { return JSON.parse(readFileSync(p, 'utf8')) as T; } catch { return null; }
 }
 function writeJsonAtomic(p: string, value: unknown): void {
-  mkdirSync(join(p, '..'), { recursive: true });
+  mkdirSync(dirname(p), { recursive: true });
   const tmp = `${p}.${process.pid}.tmp`;
   writeFileSync(tmp, JSON.stringify(value, null, 2));
   renameSync(tmp, p);
@@ -54,9 +54,19 @@ export function writeSession(d: string, id: string, s: SessionState): void {
 
 export function acquireLock(d: string): boolean {
   const p = lockPath(d);
-  if (existsSync(p) && Date.now() - statSync(p).mtimeMs < LOCK_STALE_MS) return false;
   mkdirSync(cacheDir(d), { recursive: true });
-  writeFileSync(p, JSON.stringify({ pid: process.pid, at: new Date().toISOString() }));
-  return true;
+  const payload = JSON.stringify({ pid: process.pid, at: new Date().toISOString() });
+  try {
+    writeFileSync(p, payload, { flag: 'wx' }); // atomic exclusive create
+    return true;
+  } catch (e: any) {
+    if (e?.code !== 'EEXIST') throw e;
+    let stale: boolean;
+    try { stale = Date.now() - statSync(p).mtimeMs >= LOCK_STALE_MS; } catch { stale = true; }
+    if (!stale) return false;
+    try { rmSync(p); } catch { /* another process reclaimed it */ }
+    try { writeFileSync(p, payload, { flag: 'wx' }); return true; }
+    catch (e2: any) { if (e2?.code === 'EEXIST') return false; throw e2; }
+  }
 }
 export function releaseLock(d: string): void { try { rmSync(lockPath(d)); } catch { /* already gone */ } }

--- a/src/claude/state.ts
+++ b/src/claude/state.ts
@@ -40,6 +40,8 @@ function writeJsonAtomic(p: string, value: unknown): void {
 
 export function readStats(d: string): Stats | null { return readJson<Stats>(statsPath(d)); }
 export function writeStats(d: string, s: Stats): void { writeJsonAtomic(statsPath(d), s); }
+// Best-effort read-modify-write; not atomic across concurrent processes, but acceptable
+// for episodic hook writes (worst case is a lost update, not corruption).
 export function patchStats(d: string, patch: Partial<Stats>): Stats {
   const next: Stats = { ...(readStats(d) ?? emptyStats()), ...patch };
   writeStats(d, next);

--- a/src/claude/stats.ts
+++ b/src/claude/stats.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { GraphV1 } from '../graph/types.js';
+import type { Stats } from './state.js';
+
+export function readWiring(projectDir: string): GraphV1 | null {
+  try {
+    return JSON.parse(readFileSync(join(projectDir, 'graft', '.graph', 'wiring.json'), 'utf8')) as GraphV1;
+  } catch { return null; }
+}
+
+export function computeStats(
+  w: GraphV1,
+): Pick<Stats, 'nodeCount' | 'edgeCount' | 'languages' | 'totalCount' | 'readyCount'> {
+  const nodes = w.nodes ?? [];
+  const edges = w.edges ?? [];
+  const readyCount = nodes.filter((n) => n.summary_state === 'ready').length;
+  return {
+    nodeCount: w.meta?.nodeCount ?? nodes.length,
+    edgeCount: w.meta?.edgeCount ?? edges.length,
+    languages: w.meta?.languages ?? [],
+    totalCount: nodes.length,
+    readyCount,
+  };
+}

--- a/src/claude/statusline.ts
+++ b/src/claude/statusline.ts
@@ -1,13 +1,15 @@
 import { readFileSync } from 'node:fs';
-import { renderStatusline } from './format.js';
+import { renderStatusline, renderSubagent } from './format.js';
 import { readStats, readSession } from './state.js';
 
 export function main(): void {
   let input: any = {};
   try { input = JSON.parse(readFileSync(0, 'utf8')); } catch { /* no/invalid stdin */ }
   const dir = process.env.CLAUDE_PROJECT_DIR || input.cwd || process.cwd();
-  const stats = readStats(dir);
   const session = readSession(dir, input.session_id || 'default');
+  const agent = input?.agent?.name;
+  if (agent) { process.stdout.write(renderSubagent(agent, session)); return; }
+  const stats = readStats(dir);
   const raw = input?.context_window?.used_percentage;
   const ctxPct = typeof raw === 'number' ? Math.round(raw) : null;
   process.stdout.write(renderStatusline(stats, session, { ctxPct }).join('\n'));

--- a/src/claude/statusline.ts
+++ b/src/claude/statusline.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { renderStatusline } from './format.js';
+import { readStats, readSession } from './state.js';
+
+export function main(): void {
+  let input: any = {};
+  try { input = JSON.parse(readFileSync(0, 'utf8')); } catch { /* no/invalid stdin */ }
+  const dir = process.env.CLAUDE_PROJECT_DIR || input.cwd || process.cwd();
+  const stats = readStats(dir);
+  const session = readSession(dir, input.session_id || 'default');
+  const raw = input?.context_window?.used_percentage;
+  const ctxPct = typeof raw === 'number' ? Math.round(raw) : null;
+  process.stdout.write(renderStatusline(stats, session, { ctxPct }).join('\n'));
+}

--- a/src/claude/statusline.ts
+++ b/src/claude/statusline.ts
@@ -1,6 +1,23 @@
 import { readFileSync } from 'node:fs';
 import { renderStatusline, renderSubagent } from './format.js';
-import { readStats, readSession } from './state.js';
+import { readStats, readSession, emptyStats, type Stats } from './state.js';
+import { readWiring, computeStats } from './stats.js';
+
+/**
+ * The statusline's fast path is the hook-maintained cache (graft/.cache/stats.json).
+ * When it's absent — a fresh checkout, or a plain `graft build` that doesn't write the
+ * cache — fall back to reading the graph itself (wiring.json) so the bar reflects reality
+ * immediately instead of showing "not built". The graph carries no drift signal, so it
+ * reads as synced until the next edit repopulates the cache. Still a pure read (no
+ * subprocess): the cache is preferred because it carries live dirty/stale state.
+ */
+export function resolveStats(dir: string): Stats | null {
+  const cached = readStats(dir);
+  if (cached && cached.nodeCount > 0) return cached;
+  const wiring = readWiring(dir);
+  if (wiring) return { ...emptyStats(), ...computeStats(wiring) };
+  return cached;
+}
 
 export function main(): void {
   let input: any = {};
@@ -9,7 +26,7 @@ export function main(): void {
   const session = readSession(dir, input.session_id || 'default');
   const agent = input?.agent?.name;
   if (agent) { process.stdout.write(renderSubagent(agent, session)); return; }
-  const stats = readStats(dir);
+  const stats = resolveStats(dir);
   const raw = input?.context_window?.used_percentage;
   const ctxPct = typeof raw === 'number' ? Math.round(raw) : null;
   process.stdout.write(renderStatusline(stats, session, { ctxPct }).join('\n'));

--- a/src/claude/sync-run.ts
+++ b/src/claude/sync-run.ts
@@ -1,0 +1,30 @@
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+import { readWiring, computeStats } from './stats.js';
+import { patchStats, releaseLock } from './state.js';
+
+/** MONEY GUARD: plain `graft build` only — structural, $0, offline. Never --deep. */
+function realBuild(dir: string): void {
+  execFileSync(process.execPath, [join(dir, 'dist', 'cli.js'), 'build', '.'],
+    { cwd: dir, stdio: 'ignore', timeout: 120000 });
+}
+
+export function runSync(dir: string, build: (d: string) => void = realBuild): void {
+  try {
+    build(dir);
+    const w = readWiring(dir);
+    const patch: Record<string, unknown> = { dirty: false, staleCount: 0, syncing: false, syncedAt: new Date().toISOString() };
+    if (w) Object.assign(patch, computeStats(w));
+    patchStats(dir, patch);
+  } catch {
+    patchStats(dir, { syncing: false }); // leave dirty=true; retry next turn
+  } finally {
+    releaseLock(dir);
+  }
+}
+
+export function main(): void {
+  const dir = process.argv[2];
+  if (dir) runSync(dir);
+}
+main();

--- a/src/claude/sync-run.ts
+++ b/src/claude/sync-run.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from 'node:child_process';
 import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { readWiring, computeStats } from './stats.js';
 import { patchStats, releaseLock } from './state.js';
 
@@ -13,9 +14,11 @@ export function runSync(dir: string, build: (d: string) => void = realBuild): vo
   try {
     build(dir);
     const w = readWiring(dir);
-    const patch: Record<string, unknown> = { dirty: false, staleCount: 0, syncing: false, syncedAt: new Date().toISOString() };
-    if (w) Object.assign(patch, computeStats(w));
-    patchStats(dir, patch);
+    if (!w) { patchStats(dir, { syncing: false }); return; } // build ran but output unreadable — stay dirty, retry
+    patchStats(dir, {
+      dirty: false, staleCount: 0, syncing: false, syncedAt: new Date().toISOString(),
+      ...computeStats(w),
+    });
   } catch {
     patchStats(dir, { syncing: false }); // leave dirty=true; retry next turn
   } finally {
@@ -27,4 +30,6 @@ export function main(): void {
   const dir = process.argv[2];
   if (dir) runSync(dir);
 }
-main();
+
+// Run only when executed directly (node dist/claude/sync-run.js <dir>), not on import.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/test/claude-format.test.ts
+++ b/test/claude-format.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { renderStatusline, enrichedSegment, incomingEdges, formatBlastRadius, formatRetrieval, formatOrientation } from '../src/claude/format.js';
+import { renderStatusline, enrichedSegment, incomingEdges, formatBlastRadius, formatRetrieval, formatOrientation, renderSubagent } from '../src/claude/format.js';
 import { emptyStats } from '../src/claude/state.js';
 
 const strip = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '');
@@ -82,4 +82,15 @@ test('formatOrientation labels and truncates to budget', () => {
   const out = strip(formatOrientation(md, 1500));
   assert.match(out, /repo map/);
   assert.ok(out.length < 1600, 'trimmed to budget + short header');
+});
+
+test('renderSubagent shows agent name and its last query', () => {
+  const out = strip(renderSubagent('Explore', { lastQuery: null, perAgentQuery: { Explore: 'pkce flow' }, graftReads: 0, sourceReads: 0 }));
+  assert.match(out, /Explore/);
+  assert.match(out, /pkce flow/);
+});
+
+test('renderSubagent without a query still shows the agent', () => {
+  const out = strip(renderSubagent('Plan', null));
+  assert.match(out, /Plan/);
 });

--- a/test/claude-format.test.ts
+++ b/test/claude-format.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { renderStatusline, enrichedSegment, incomingEdges, formatBlastRadius } from '../src/claude/format.js';
+import { renderStatusline, enrichedSegment, incomingEdges, formatBlastRadius, formatRetrieval } from '../src/claude/format.js';
 import { emptyStats } from '../src/claude/state.js';
 
 const strip = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '');
@@ -61,4 +61,18 @@ test('formatBlastRadius renders callers or null', () => {
   assert.match(strip(txt!), /blast radius for pkce\.ts/);
   assert.match(strip(txt!), /exchange \(client\.ts\)/);
   assert.equal(formatBlastRadius(wiring2, '/abs/repo/src/unknown.ts'), null);
+});
+
+test('formatRetrieval renders top hits, trims snippet, first pointer only', () => {
+  const ask = { query: 'pkce', mode: 'lexical', hits: [
+    { kind: 'concept', title: 'PKCE', pointer: 'src/pkce.ts, src/client.ts', snippet: 'Validates   the   challenge.', score: 1 },
+  ] } as any;
+  const txt = strip(formatRetrieval(ask)!);
+  assert.match(txt, /relevant context/);
+  assert.match(txt, /PKCE — src\/pkce\.ts — Validates the challenge\./);
+  assert.doesNotMatch(txt, /client\.ts/); // only the first pointer segment
+});
+
+test('formatRetrieval returns null for no hits', () => {
+  assert.equal(formatRetrieval({ query: 'x', mode: 'empty', hits: [] } as any), null);
 });

--- a/test/claude-format.test.ts
+++ b/test/claude-format.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { renderStatusline, enrichedSegment } from '../src/claude/format.js';
+import { renderStatusline, enrichedSegment, incomingEdges, formatBlastRadius } from '../src/claude/format.js';
 import { emptyStats } from '../src/claude/state.js';
 
 const strip = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '');
@@ -35,4 +35,30 @@ test('syncing overrides stale; synced when clean', () => {
   const base = { ...emptyStats(), nodeCount: 1, edgeCount: 0, totalCount: 1 };
   assert.match(strip(renderStatusline({ ...base, syncing: true, dirty: true }, null, { ctxPct: null })[0]), /syncing/);
   assert.match(strip(renderStatusline(base, null, { ctxPct: null })[0]), /✓ synced/);
+});
+
+const wiring2 = {
+  meta: { nodeCount: 3, edgeCount: 2, languages: ['typescript'] },
+  nodes: [
+    { id: 'src/pkce.ts#verify', name: 'verify', path: 'src/pkce.ts', summary_state: 'ready' },
+    { id: 'src/client.ts#exchange', name: 'exchange', path: 'src/client.ts', summary_state: 'ready' },
+    { id: 'src/pkce.ts#gen', name: 'gen', path: 'src/pkce.ts', summary_state: 'ready' },
+  ],
+  edges: [
+    { source: 'src/client.ts#exchange', target: 'src/pkce.ts#verify', relation: 'calls', confidence: 'extracted' },
+    { source: 'src/pkce.ts#gen', target: 'src/pkce.ts#verify', relation: 'calls', confidence: 'extracted' },
+  ],
+} as any;
+
+test('incomingEdges: external callers of nodes in the edited file', () => {
+  const e = incomingEdges(wiring2, '/abs/repo/src/pkce.ts');
+  assert.equal(e.length, 1, 'same-file edge (gen→verify) excluded');
+  assert.equal(e[0].source, 'src/client.ts#exchange');
+});
+
+test('formatBlastRadius renders callers or null', () => {
+  const txt = formatBlastRadius(wiring2, '/abs/repo/src/pkce.ts');
+  assert.match(strip(txt!), /blast radius for pkce\.ts/);
+  assert.match(strip(txt!), /exchange \(client\.ts\)/);
+  assert.equal(formatBlastRadius(wiring2, '/abs/repo/src/unknown.ts'), null);
 });

--- a/test/claude-format.test.ts
+++ b/test/claude-format.test.ts
@@ -1,0 +1,38 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { renderStatusline, enrichedSegment } from '../src/claude/format.js';
+import { emptyStats } from '../src/claude/state.js';
+
+const strip = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '');
+
+test('not-built state', () => {
+  const lines = renderStatusline(null, null, { ctxPct: null });
+  assert.match(strip(lines[0]), /not built/);
+});
+
+test('enriched segment hidden when zero ready', () => {
+  assert.equal(enrichedSegment({ ...emptyStats(), totalCount: 10, readyCount: 0 }), null);
+});
+
+test('enriched segment shown when >=1 ready', () => {
+  const seg = enrichedSegment({ ...emptyStats(), totalCount: 4, readyCount: 2 });
+  assert.equal(strip(seg!), '50% enriched');
+});
+
+test('two-line bar: size + freshness + ctx + last', () => {
+  const stats = { ...emptyStats(), nodeCount: 319, edgeCount: 730, totalCount: 319, readyCount: 0,
+    dirty: true, staleCount: 4, lastFile: 'pkce.ts' };
+  const lines = renderStatusline(stats, null, { ctxPct: 34 }).map(strip);
+  assert.match(lines[0], /graft/);
+  assert.match(lines[0], /319 nodes \/ 730 edges/);
+  assert.doesNotMatch(lines[0], /enriched/); // hidden at readyCount 0
+  assert.match(lines[0], /⚠ 4 stale/);
+  assert.match(lines[1], /ctx 34%/);
+  assert.match(lines[1], /last: pkce\.ts/);
+});
+
+test('syncing overrides stale; synced when clean', () => {
+  const base = { ...emptyStats(), nodeCount: 1, edgeCount: 0, totalCount: 1 };
+  assert.match(strip(renderStatusline({ ...base, syncing: true, dirty: true }, null, { ctxPct: null })[0]), /syncing/);
+  assert.match(strip(renderStatusline(base, null, { ctxPct: null })[0]), /✓ synced/);
+});

--- a/test/claude-format.test.ts
+++ b/test/claude-format.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { renderStatusline, enrichedSegment, incomingEdges, formatBlastRadius, formatRetrieval } from '../src/claude/format.js';
+import { renderStatusline, enrichedSegment, incomingEdges, formatBlastRadius, formatRetrieval, formatOrientation } from '../src/claude/format.js';
 import { emptyStats } from '../src/claude/state.js';
 
 const strip = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '');
@@ -75,4 +75,11 @@ test('formatRetrieval renders top hits, trims snippet, first pointer only', () =
 
 test('formatRetrieval returns null for no hits', () => {
   assert.equal(formatRetrieval({ query: 'x', mode: 'empty', hits: [] } as any), null);
+});
+
+test('formatOrientation labels and truncates to budget', () => {
+  const md = 'X'.repeat(3000);
+  const out = strip(formatOrientation(md, 1500));
+  assert.match(out, /repo map/);
+  assert.ok(out.length < 1600, 'trimmed to budget + short header');
 });

--- a/test/claude-hooks.test.ts
+++ b/test/claude-hooks.test.ts
@@ -5,6 +5,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { underGraft, main } from '../src/claude/hooks.js';
 import { readStats } from '../src/claude/state.js';
+import { runSync } from '../src/claude/sync-run.js';
+import { writeStats, emptyStats, acquireLock } from '../src/claude/state.js';
 
 test('underGraft detects edits inside graft/', () => {
   assert.equal(underGraft('/repo', '/repo/graft/x.md'), true);
@@ -37,3 +39,35 @@ async function runWithStdin(text: string, fn: () => Promise<void>): Promise<void
   process.env.GRAFT_TEST_STDIN = text;
   try { await fn(); } finally { delete process.env.GRAFT_TEST_STDIN; }
 }
+
+test('runSync clears dirty/syncing, recomputes stats, releases lock', () => {
+  const d = mkdtempSync(join(tmpdir(), 'graft-sync-'));
+  mkdirSync(join(d, 'graft', '.graph'), { recursive: true });
+  writeStats(d, { ...emptyStats(), dirty: true, syncing: true, staleCount: 3 });
+  acquireLock(d);
+  // fake build: write a fresh wiring.json with 2 nodes, 1 ready
+  const fakeBuild = (dir: string) => writeFileSync(join(dir, 'graft', '.graph', 'wiring.json'),
+    JSON.stringify({ meta: { nodeCount: 2, edgeCount: 1, languages: ['typescript'] },
+      nodes: [{ id: 'a', summary_state: 'ready' }, { id: 'b', summary_state: 'pending' }],
+      edges: [{ from: 'a', to: 'b' }] }));
+  runSync(d, fakeBuild);
+  const s = readStats(d)!;
+  assert.equal(s.dirty, false);
+  assert.equal(s.syncing, false);
+  assert.equal(s.staleCount, 0);
+  assert.equal(s.nodeCount, 2);
+  assert.equal(s.readyCount, 1);
+  assert.ok(s.syncedAt);
+  assert.equal(acquireLock(d), true, 'lock released, so reacquire succeeds');
+});
+
+test('runSync clears syncing even if build throws (money-safe failure)', () => {
+  const d = mkdtempSync(join(tmpdir(), 'graft-sync-'));
+  writeStats(d, { ...emptyStats(), dirty: true, syncing: true });
+  acquireLock(d);
+  runSync(d, () => { throw new Error('build failed'); });
+  const s = readStats(d)!;
+  assert.equal(s.syncing, false);
+  assert.equal(s.dirty, true, 'stays dirty so the bar keeps ⚠ and it retries next turn');
+  assert.equal(acquireLock(d), true, 'lock always released');
+});

--- a/test/claude-hooks.test.ts
+++ b/test/claude-hooks.test.ts
@@ -1,0 +1,39 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { underGraft, main } from '../src/claude/hooks.js';
+import { readStats } from '../src/claude/state.js';
+
+test('underGraft detects edits inside graft/', () => {
+  assert.equal(underGraft('/repo', '/repo/graft/x.md'), true);
+  assert.equal(underGraft('/repo', '/repo/src/cli.ts'), false);
+});
+
+test('post-edit marks dirty and records lastFile', async () => {
+  const d = mkdtempSync(join(tmpdir(), 'graft-hooks-'));
+  mkdirSync(join(d, 'graft', '.graph'), { recursive: true });
+  writeFileSync(join(d, 'graft', '.graph', 'wiring.json'),
+    JSON.stringify({ meta: { nodeCount: 0, edgeCount: 0, languages: [] }, nodes: [], edges: [] }));
+  // graft check will fail (no dist/cli.js here) → staleCount falls back to 0, but dirty must still be set.
+  process.env.CLAUDE_PROJECT_DIR = d;
+  const stdin = JSON.stringify({ tool_input: { file_path: join(d, 'src', 'auth.ts') } });
+  await runWithStdin(stdin, () => main('post-edit'));
+  const s = readStats(d)!;
+  assert.equal(s.dirty, true);
+  assert.equal(s.lastFile, 'auth.ts');
+});
+
+test('post-edit ignores edits inside graft/', async () => {
+  const d = mkdtempSync(join(tmpdir(), 'graft-hooks-'));
+  process.env.CLAUDE_PROJECT_DIR = d;
+  await runWithStdin(JSON.stringify({ tool_input: { file_path: join(d, 'graft', 'a.md') } }), () => main('post-edit'));
+  assert.equal(readStats(d), null, 'no state written for graft/ edits');
+});
+
+// helper: hooks.ts reads process.env.GRAFT_TEST_STDIN first (test seam), else fd 0.
+async function runWithStdin(text: string, fn: () => Promise<void>): Promise<void> {
+  process.env.GRAFT_TEST_STDIN = text;
+  try { await fn(); } finally { delete process.env.GRAFT_TEST_STDIN; }
+}

--- a/test/claude-hooks.test.ts
+++ b/test/claude-hooks.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { underGraft, main } from '../src/claude/hooks.js';
@@ -82,4 +82,23 @@ test('runSync stays dirty when build succeeds but wiring is unreadable', () => {
   assert.equal(s.dirty, true, 'unreadable wiring → stay dirty, retry next turn');
   assert.equal(s.syncedAt, null, 'not marked synced');
   assert.equal(acquireLock(d), true, 'lock released');
+});
+
+test('prompt branch stays silent and writes no session when graft is not built', async () => {
+  const d = mkdtempSync(join(tmpdir(), 'graft-prompt-'));
+  process.env.CLAUDE_PROJECT_DIR = d;
+  const chunks: string[] = [];
+  const orig = process.stdout.write.bind(process.stdout);
+  (process.stdout as any).write = (s: any) => { chunks.push(String(s)); return true; };
+  try {
+    await runWithStdin(
+      JSON.stringify({ session_id: 'p1', prompt: 'how does pkce verification work' }),
+      () => main('prompt'),
+    );
+  } finally {
+    (process.stdout as any).write = orig;
+    delete process.env.CLAUDE_PROJECT_DIR;
+  }
+  assert.equal(chunks.join(''), '', 'no stdout when graft ask unavailable (no dist/cli.js in temp dir)');
+  assert.equal(existsSync(join(d, 'graft', '.cache', 'session', 'p1.json')), false, 'no session file on no-op');
 });

--- a/test/claude-hooks.test.ts
+++ b/test/claude-hooks.test.ts
@@ -71,3 +71,15 @@ test('runSync clears syncing even if build throws (money-safe failure)', () => {
   assert.equal(s.dirty, true, 'stays dirty so the bar keeps ⚠ and it retries next turn');
   assert.equal(acquireLock(d), true, 'lock always released');
 });
+
+test('runSync stays dirty when build succeeds but wiring is unreadable', () => {
+  const d = mkdtempSync(join(tmpdir(), 'graft-sync-'));
+  writeStats(d, { ...emptyStats(), dirty: true, syncing: true, staleCount: 2 });
+  acquireLock(d);
+  runSync(d, () => { /* build "succeeds" but writes no wiring.json */ });
+  const s = readStats(d)!;
+  assert.equal(s.syncing, false);
+  assert.equal(s.dirty, true, 'unreadable wiring → stay dirty, retry next turn');
+  assert.equal(s.syncedAt, null, 'not marked synced');
+  assert.equal(acquireLock(d), true, 'lock released');
+});

--- a/test/claude-state.test.ts
+++ b/test/claude-state.test.ts
@@ -1,0 +1,41 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  emptyStats, readStats, writeStats, patchStats,
+  readSession, writeSession, acquireLock, releaseLock, cacheDir,
+} from '../src/claude/state.js';
+
+function fresh(): string { return mkdtempSync(join(tmpdir(), 'graft-state-')); }
+
+test('stats round-trip and patch merge', () => {
+  const d = fresh();
+  assert.equal(readStats(d), null);
+  writeStats(d, { ...emptyStats(), nodeCount: 319, edgeCount: 730 });
+  assert.equal(readStats(d)!.nodeCount, 319);
+  const patched = patchStats(d, { dirty: true, staleCount: 4 });
+  assert.equal(patched.dirty, true);
+  assert.equal(patched.staleCount, 4);
+  assert.equal(readStats(d)!.edgeCount, 730, 'patch preserves other fields');
+});
+
+test('session defaults and round-trip', () => {
+  const d = fresh();
+  const s = readSession(d, 'abc');
+  assert.deepEqual(s, { lastQuery: null, perAgentQuery: {}, graftReads: 0, sourceReads: 0 });
+  s.lastQuery = 'pkce'; s.graftReads = 2;
+  writeSession(d, 'abc', s);
+  assert.equal(readSession(d, 'abc').lastQuery, 'pkce');
+  assert.equal(readSession(d, 'xyz').graftReads, 0, 'other sessions isolated');
+});
+
+test('lock is exclusive then releasable', () => {
+  const d = fresh();
+  assert.equal(acquireLock(d), true);
+  assert.equal(acquireLock(d), false, 'second acquire blocked while held');
+  assert.ok(existsSync(join(cacheDir(d), '.sync.lock')));
+  releaseLock(d);
+  assert.equal(acquireLock(d), true, 'reacquire after release');
+});

--- a/test/claude-state.test.ts
+++ b/test/claude-state.test.ts
@@ -1,11 +1,11 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, existsSync } from 'node:fs';
+import { mkdtempSync, existsSync, utimesSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   emptyStats, readStats, writeStats, patchStats,
-  readSession, writeSession, acquireLock, releaseLock, cacheDir,
+  readSession, writeSession, acquireLock, releaseLock, cacheDir, LOCK_STALE_MS,
 } from '../src/claude/state.js';
 
 function fresh(): string { return mkdtempSync(join(tmpdir(), 'graft-state-')); }
@@ -38,4 +38,13 @@ test('lock is exclusive then releasable', () => {
   assert.ok(existsSync(join(cacheDir(d), '.sync.lock')));
   releaseLock(d);
   assert.equal(acquireLock(d), true, 'reacquire after release');
+});
+
+test('acquireLock reclaims a stale lock', () => {
+  const d = fresh();
+  assert.equal(acquireLock(d), true);
+  const p = join(cacheDir(d), '.sync.lock');
+  const old = (Date.now() - LOCK_STALE_MS - 1000) / 1000;
+  utimesSync(p, old, old);
+  assert.equal(acquireLock(d), true, 'stale lock reclaimed');
 });

--- a/test/claude-stats.test.ts
+++ b/test/claude-stats.test.ts
@@ -1,0 +1,29 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { computeStats } from '../src/claude/stats.js';
+
+const wiring = {
+  meta: { version: 1, nodeCount: 3, edgeCount: 2, languages: ['typescript'] },
+  nodes: [
+    { id: 'a', summary_state: 'ready' },
+    { id: 'b', summary_state: 'pending' },
+    { id: 'c', summary_state: 'ready' },
+  ],
+  edges: [{ from: 'a', to: 'b' }, { from: 'c', to: 'a' }],
+} as any;
+
+test('computeStats derives counts and readyCount', () => {
+  const s = computeStats(wiring);
+  assert.equal(s.nodeCount, 3);
+  assert.equal(s.edgeCount, 2);
+  assert.deepEqual(s.languages, ['typescript']);
+  assert.equal(s.totalCount, 3);
+  assert.equal(s.readyCount, 2);
+});
+
+test('computeStats tolerates missing meta by counting arrays', () => {
+  const s = computeStats({ nodes: [{ id: 'x', summary_state: 'pending' }], edges: [] } as any);
+  assert.equal(s.nodeCount, 1);
+  assert.equal(s.edgeCount, 0);
+  assert.equal(s.readyCount, 0);
+});

--- a/test/claude-statusline.test.ts
+++ b/test/claude-statusline.test.ts
@@ -1,0 +1,47 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resolveStats } from '../src/claude/statusline.js';
+import { writeStats, emptyStats } from '../src/claude/state.js';
+
+function repo(): string { return mkdtempSync(join(tmpdir(), 'graft-sl-')); }
+function writeWiring(dir: string, obj: unknown): void {
+  mkdirSync(join(dir, 'graft', '.graph'), { recursive: true });
+  writeFileSync(join(dir, 'graft', '.graph', 'wiring.json'), JSON.stringify(obj));
+}
+
+test('resolveStats returns the hook-maintained cache when present and non-empty', () => {
+  const d = repo();
+  writeStats(d, { ...emptyStats(), nodeCount: 5, edgeCount: 9, dirty: true, staleCount: 2 });
+  const s = resolveStats(d)!;
+  assert.equal(s.nodeCount, 5);
+  assert.equal(s.dirty, true, 'cache is the source of truth when present');
+});
+
+test('resolveStats falls back to wiring.json when no cache (manual graft build / fresh checkout)', () => {
+  const d = repo();
+  writeWiring(d, {
+    meta: { nodeCount: 42, edgeCount: 100, languages: ['typescript'] },
+    nodes: [{ id: 'a', summary_state: 'ready' }, { id: 'b', summary_state: 'pending' }],
+    edges: [],
+  });
+  const s = resolveStats(d)!;
+  assert.equal(s.nodeCount, 42, 'reflects the graph immediately instead of "not built"');
+  assert.equal(s.readyCount, 1);
+  assert.equal(s.dirty, false, 'defaults to synced — no drift signal available from the graph alone');
+});
+
+test('resolveStats prefers the cache over the graph even when both exist', () => {
+  const d = repo();
+  writeWiring(d, { meta: { nodeCount: 42, edgeCount: 100, languages: [] }, nodes: [], edges: [] });
+  writeStats(d, { ...emptyStats(), nodeCount: 7, edgeCount: 3, dirty: true, staleCount: 4 });
+  const s = resolveStats(d)!;
+  assert.equal(s.nodeCount, 7, 'cache wins (it carries live drift state the graph cannot)');
+  assert.equal(s.staleCount, 4);
+});
+
+test('resolveStats returns null when neither cache nor graph exists', () => {
+  assert.equal(resolveStats(repo()), null);
+});


### PR DESCRIPTION
## What & why

Makes Graft **visible and active** inside a Claude Code session. Today Graft is a passive `graft/` folder an agent is *supposed* to read; this ships a `.claude/` integration that displays what Graft holds, feeds relevant graph context to the model, and keeps the graph fresh automatically.

Design + plan (committed in this branch):
- `docs/superpowers/specs/2026-07-20-graft-claude-code-integration-design.md`
- `docs/superpowers/plans/2026-07-20-graft-claude-code-integration.md`

## What's included

**Display** (statusline — a pure reader, spawns no subprocess):
- 2-line bar: `◤ graft · 374 nodes / 897 edges · 84% enriched · ⚠ 1 stale` / `▸ ctx 42% · last: cli.ts`
- `% enriched` shown only when ≥1 node is enriched; `$` cost and "tokens saved %" deliberately excluded (not honestly measurable)
- Per-subagent row (`subagentStatusLine`) + clickable `graft/*.md` footer links
- Falls back to reading `wiring.json` directly when the stats cache is absent, so the bar reflects the graph immediately after any `graft build` or on a fresh checkout

**Feed** (context injected into the model via hooks):
- `UserPromptSubmit` → runs `graft ask` on the prompt, injects the top matching nodes
- `SessionStart` → injects `graft/INDEX.md` head to orient the session
- `PostToolUse` (Edit) → injects the edited file's blast radius ("who depends on this")

**Auto-sync** (keeps the graph fresh):
- `PostToolUse` flags drift; `Stop` spawns a detached background rebuild under a lock
- **Money guard (hard rule):** only ever runs plain `graft build` — structural, offline, **$0**. Never `--deep`.

## Architecture

Reader/writer/state split: `src/claude/statusline.ts` (pure reader) + `src/claude/hooks.ts` + `src/claude/sync-run.ts` (writers/actors) meet at `graft/.cache/` state files. Thin `.claude/helpers/*.cjs` shims load the compiled ESM and swallow errors so a hook can never break the session.

## Testing

- Unit/integration: **44/44** passing (`npm test`), typecheck clean, `npm run build` clean.
- End-to-end dogfood in this repo, every surface driven with real Claude Code hook/statusline payloads:
  - statusline (full bar + no-cache fallback), session orientation, active retrieval, per-subagent row, footer regex
  - real-edit drift → `⚠ 1 stale` → `Stop` → detached `$0` sync → `✓ synced`, verified live
- Money guard verified at runtime: no `--deep`, no network calls during sync.

Built via a spec → plan → per-task-reviewed → whole-branch-reviewed workflow. Reviews caught and fixed real defects before merge: a TOCTOU lock race, a `main()`-on-import footgun, wrong edge field names (`source`/`target`), and `checkStaleCount` always returning 0 (because `graft check` exits non-zero on drift and the captured stdout was being discarded).

## Follow-up (not blocking)

This activates when a Claude Code session opens in this repo. The committed `graft/` graph is stale vs. this branch's own new `src/claude/*` code — run `graft build` (optionally `--deep` with an `OPENROUTER_API_KEY`) and commit the regenerated graph so Graft indexes its own integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
