### PR TITLE
fix: make hooks + auto-sync work in consumer repos (0.3.1) + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,25 @@ That is it. Point your agent at `graft/` and it reads the graph before it starts
 
 ---
 
+## Claude Code integration
+
+If you use [Claude Code](https://claude.com/claude-code), one command wires Graft into every session in the repo:
+
+```bash
+npx @nanonets/graft init
+# writes .claude/ (statusline + hooks) and builds the graph if it's missing
+```
+
+From then on, any Claude Code session opened in the repo gets:
+
+- **a live statusline** — graph size, % enriched, and a `⚠ N stale` warning when the code has moved ahead of the graph
+- **auto-sync** — after you edit code, Graft rebuilds the graph in the background at the end of the turn (structural, `$0` — it never calls the LLM on its own)
+- **context on tap** — each prompt pulls the matching nodes into the session; editing a file surfaces what depends on it ("blast radius"); new sessions start with the repo map
+
+`graft init` is idempotent and never clobbers your existing `.claude/settings.json` — it merges its blocks and leaves the rest alone. Want the LLM summaries too? Run `graft build --deep` (with a key) whenever you like; auto-sync will never do it for you.
+
+---
+
 ## The problem
 
 Every task, your coding agent starts blind. Before it changes anything, it re-explores the repo: grep a term, open a file, follow an import, back out, try again. It is rebuilding a picture of a codebase it mapped an hour ago and threw away. That rediscovery burns most of a run's tool calls, tokens, and latency, and it is pure overhead:
@@ -158,6 +177,9 @@ graft check --json                   # print the drift report as JSON
 
 graft viz [dir]                      # see the graph: serves an interactive viewer on localhost
 graft viz --port 5000 --no-open      # pick a port; don't auto-open the browser
+
+graft init [dir]                     # set up the Claude Code integration (.claude/ statusline + hooks) in this repo
+graft init --no-build                # wire the files only; don't build the graph
 
 # global
 graft --dir <path>                   # use a context dir other than <repo>/graft

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nanonets/graft",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nanonets/graft",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "commander": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nanonets/graft",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Build a repo's context graph as a folder of linked markdown files that live in the repo and stay in sync with the code through git.",
   "keywords": [
     "ai",

--- a/src/claude/hooks.ts
+++ b/src/claude/hooks.ts
@@ -4,6 +4,7 @@ import { join, basename } from 'node:path';
 import { readWiring } from './stats.js';
 import { formatBlastRadius, formatRetrieval, formatOrientation } from './format.js';
 import { patchStats, readStats, acquireLock, readSession, writeSession } from './state.js';
+import { graftCliPath, claudeScriptPath } from './paths.js';
 
 function readStdin(): any {
   const seam = process.env.GRAFT_TEST_STDIN;
@@ -21,7 +22,7 @@ export function underGraft(dir: string, file: string): boolean {
 }
 function graftJson(dir: string, args: string[]): any | null {
   try {
-    const out = execFileSync(process.execPath, [join(dir, 'dist', 'cli.js'), ...args],
+    const out = execFileSync(process.execPath, [graftCliPath(), ...args],
       { cwd: dir, encoding: 'utf8', timeout: 8000, stdio: ['ignore', 'pipe', 'ignore'] });
     return JSON.parse(out);
   } catch (e: any) {
@@ -67,7 +68,7 @@ export async function main(event: string): Promise<void> {
     const stats = readStats(dir);
     if (stats?.dirty && acquireLock(dir)) {
       patchStats(dir, { syncing: true });
-      const child = spawn(process.execPath, [join(dir, 'dist', 'claude', 'sync-run.js'), dir],
+      const child = spawn(process.execPath, [claudeScriptPath('sync-run.js'), dir],
         { detached: true, stdio: 'ignore' });
       child.unref();
     }

--- a/src/claude/paths.ts
+++ b/src/claude/paths.ts
@@ -1,0 +1,18 @@
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+// This module ships inside the package at <pkgRoot>/dist/claude/paths.js. Resolving graft's
+// own CLI and sibling scripts relative to THIS file — not the project dir — is what makes the
+// hooks work when graft is installed as a dependency in someone else's repo (where
+// <projectDir>/dist/ does not exist). In graft's own repo it resolves to ./dist all the same.
+const CLAUDE_DIR = dirname(fileURLToPath(import.meta.url));
+
+/** Absolute path to the graft CLI (`<pkgRoot>/dist/cli.js`), resolved from this module. */
+export function graftCliPath(): string {
+  return join(CLAUDE_DIR, '..', 'cli.js');
+}
+
+/** Absolute path to a sibling script in the claude dir (e.g. `sync-run.js`). */
+export function claudeScriptPath(name: string): string {
+  return join(CLAUDE_DIR, name);
+}

--- a/src/claude/sync-run.ts
+++ b/src/claude/sync-run.ts
@@ -1,12 +1,12 @@
 import { execFileSync } from 'node:child_process';
-import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { readWiring, computeStats } from './stats.js';
 import { patchStats, releaseLock } from './state.js';
+import { graftCliPath } from './paths.js';
 
 /** MONEY GUARD: plain `graft build` only — structural, $0, offline. Never --deep. */
 function realBuild(dir: string): void {
-  execFileSync(process.execPath, [join(dir, 'dist', 'cli.js'), 'build', '.'],
+  execFileSync(process.execPath, [graftCliPath(), 'build', '.'],
     { cwd: dir, stdio: 'ignore', timeout: 120000 });
 }
 

--- a/test/claude-paths.test.ts
+++ b/test/claude-paths.test.ts
@@ -1,0 +1,23 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { basename, dirname } from 'node:path';
+import { graftCliPath, claudeScriptPath } from '../src/claude/paths.js';
+
+test('graftCliPath is module-relative (cwd-independent) and points at a sibling cli.js', () => {
+  const a = graftCliPath();
+  const orig = process.cwd();
+  try { process.chdir('/'); assert.equal(graftCliPath(), a, 'must not depend on cwd / project dir'); }
+  finally { process.chdir(orig); }
+  assert.match(a, /[/\\]cli\.js$/);
+  // cli.js sits one level above the claude module dir → its parent dir is src (tsx) or dist (built)
+  assert.match(basename(dirname(a)), /^(src|dist)$/);
+});
+
+test('claudeScriptPath resolves a sibling script in the claude dir (cwd-independent)', () => {
+  const a = claudeScriptPath('sync-run.js');
+  const orig = process.cwd();
+  try { process.chdir('/'); assert.equal(claudeScriptPath('sync-run.js'), a); }
+  finally { process.chdir(orig); }
+  assert.match(a, /[/\\]sync-run\.js$/);
+  assert.equal(basename(dirname(a)), 'claude');
+});


### PR DESCRIPTION
## Summary

`0.3.1` — fixes a bug that made most of the Claude Code integration silently no-op in **consumer** repos, plus documents the integration in the README. Found by end-to-end testing the published `0.3.0` in a clean repo.

## The bug (why `0.3.0` was broken for consumers)

The hooks and auto-sync resolved the `graft` CLI and background script relative to the **project dir**:
- `hooks.ts` → `<projectDir>/dist/cli.js` for `graft check` / `graft ask`
- `hooks.ts` → `<projectDir>/dist/claude/sync-run.js` for the Stop-hook sync
- `sync-run.ts` → `<projectDir>/dist/cli.js` for the rebuild

Those paths only exist in Graft's *own* repo. In a repo that installs `@nanonets/graft` as a dependency, `<projectDir>/dist/` doesn't exist, so:
- **retrieval** (`graft ask` on each prompt) returned nothing,
- the **drift count** (`⚠ N stale`) was always 0,
- **auto-sync** never ran (the Stop hook spawned a nonexistent script → stuck on `syncing`).

The statusline, session orientation, and blast-radius worked because they read files directly (no CLI shell-out) — which is why the earlier statusline-only smoke test missed this.

## The fix

New `src/claude/paths.ts` resolves Graft's CLI and sibling scripts **relative to the module** (`import.meta.url`), since they ship together inside the package. `hooks.ts` and `sync-run.ts` use it. Works in a consumer install (`node_modules/@nanonets/graft/dist/…`) and in Graft's own repo alike. The project dir is still used for cwd and reading the repo's own `graft/` state.

## Verification (end-to-end, against the packed 0.3.1 tarball in a clean repo)

- install tarball → `npx graft init` (builds graph) → all files written
- **retrieval**: prompt hook injected the matching node (`calculateTotal · function — src/a.ts:L1`) ✅
- **drift count**: edit a source file → post-edit hook → `stale=2` (was `0`) ✅
- **auto-sync**: Stop hook → `dirty=false, synced` in ~0.5s (was stuck on `syncing` forever) ✅
- **blast-radius**: edit surfaces dependents ✅ · **statusline**: renders real bar, `last: a.ts` ✅
- Money guard intact: auto-sync runs plain `graft build` only, never `--deep`.
- 62/62 unit tests pass; new `test/claude-paths.test.ts` asserts the resolver is module-relative (cwd-independent).

## Also

- **README**: documents the Claude Code integration and makes `npx graft init` the entry point (the postinstall nudge is best-effort — npm hides lifecycle-script output by default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
