### PR TITLE
fix(init): resolve graft from global install in Claude shims

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nanonets/graft",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nanonets/graft",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "commander": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nanonets/graft",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Build a repo's context graph as a folder of linked markdown files that live in the repo and stay in sync with the code through git.",
   "keywords": [
     "ai",

--- a/src/claude/shim-template.ts
+++ b/src/claude/shim-template.ts
@@ -3,12 +3,14 @@ function shim(entryFile: string, call: string): string {
 const path = require('path');
 const dir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
 function entry(name) {
-  try {
-    const pkg = require.resolve('@nanonets/graft/package.json', { paths: [dir] });
-    return path.join(path.dirname(pkg), 'dist', 'claude', name);
-  } catch {
-    return path.join(dir, 'dist', 'claude', name);
+  const globalBase = path.join(path.dirname(process.execPath), '..', 'lib');
+  for (const base of [dir, globalBase]) {
+    try {
+      const pkg = require.resolve('@nanonets/graft/package.json', { paths: [base] });
+      return path.join(path.dirname(pkg), 'dist', 'claude', name);
+    } catch { /* try next base */ }
   }
+  return path.join(dir, 'dist', 'claude', name);
 }
 import(entry(${JSON.stringify(entryFile)})).then((m) => ${call}).catch(() => { /* graft unavailable — no-op */ });
 `;

--- a/test/claude-shim-template.test.ts
+++ b/test/claude-shim-template.test.ts
@@ -4,10 +4,12 @@ import vm from 'node:vm';
 import { statuslineShim, hooksShim } from '../src/claude/shim-template.js';
 
 for (const [name, src] of [['statusline', statuslineShim()], ['hooks', hooksShim()]] as const) {
-  test(`${name} shim parses and has package-resolve + local fallback`, () => {
+  test(`${name} shim parses and resolves local + global, with local fallback`, () => {
     const body = src.replace(/^#!.*\n/, ''); // strip shebang for vm
     assert.doesNotThrow(() => new vm.Script(body), 'valid JS');
-    assert.match(src, /require\.resolve\('@nanonets\/graft\/package\.json', \{ paths: \[dir\] \}\)/);
+    assert.match(src, /require\.resolve\('@nanonets\/graft\/package\.json', \{ paths: \[base\] \}\)/);
+    assert.match(src, /const globalBase = path\.join\(path\.dirname\(process\.execPath\), '\.\.', 'lib'\)/);
+    assert.match(src, /for \(const base of \[dir, globalBase\]\)/);
     assert.match(src, /path\.join\(dir, 'dist', 'claude'/);
     assert.match(src, /\.catch\(\(\) => \{/); // best-effort
   });


### PR DESCRIPTION
## Problem
`graft init` writes statusline + hook shims that resolved `@nanonets/graft` only from the repo's own `node_modules` (`paths: [dir]`). With a global-only install (`npm i -g`) the lookup fails, falls back to a nonexistent `<repo>/dist/claude/` path, and the import silently no-ops — so the statusline is blank and no context/tokens-saved footer is injected.

## Fix
Also search the global `lib` dir derived from `process.execPath` (`<node>/../lib`), trying repo-local first, then global. No local install or global uninstall needed.

- `src/claude/shim-template.ts` — loop over `[dir, globalBase]`
- test updated to assert the global-aware resolve + local fallback
- version bump 0.3.1 → 0.3.2

## Verify
`npm run build` + shim test pass (3/3).