### PR TITLE
feat(hosts): dedicated AdaL skill host

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,11 +165,11 @@ npx @nanonets/graft init
 # Claude Code additionally gets the live statusline + hooks below
 ```
 
-`init` auto-detects which agents are present (via their config directories) and writes a marker-fenced Graft section into each one's shared instruction file — `AGENTS.md`, `GEMINI.md`, `.github/copilot-instructions.md` — or a wholly-owned rule file for the agents that use one — `.cursor/rules/graft.mdc`, `.kiro/steering/graft.md`, `.windsurf/rules/graft.md`. Re-running only updates Graft's own section (or replaces the owned file) and never touches the rest of your content.
+`init` auto-detects which agents are present (via their config directories) and writes a marker-fenced Graft section into each one's shared instruction file — `AGENTS.md` (Codex, OpenCode and other CLIs that read it), `GEMINI.md`, `.github/copilot-instructions.md` — or a wholly-owned rule/skill file for the agents that use one — `.cursor/rules/graft.mdc`, `.kiro/steering/graft.md`, `.windsurf/rules/graft.md`, `.adal/skills/graft/SKILL.md` for [AdaL](https://adal.sylph.ai) (progressive-disclosure skill, same shape as the Claude Code skill below). Re-running only updates Graft's own section (or replaces the owned file) and never touches the rest of your content.
 
 | Flag | Effect |
 |---|---|
-| `--agents <ids...>` | wire only these — ids: `agents`, `cursor`, `gemini`, `copilot`, `kiro`, `windsurf`, `claude` |
+| `--agents <ids...>` | wire only these — ids: `agents`, `cursor`, `gemini`, `copilot`, `kiro`, `windsurf`, `adal`, `claude` |
 | `--all-agents` | write instruction files for every known agent, detected or not |
 | `--no-agents` | Claude Code wiring only; skip other agents |
 | `--list-agents` | print the known agent ids and exit |
@@ -246,7 +246,7 @@ graft viz --port 5000 --no-open      # pick a port; don't auto-open the browser
 
 graft init [dir]                     # wire Graft into the coding agents detected in this repo (Claude Code always gets full hooks + statusline + MCP)
 graft init --no-build                # wire the files only; don't build the graph
-graft init --agents cursor kiro      # wire only these agents (ids: agents, cursor, gemini, copilot, kiro, windsurf, claude)
+graft init --agents cursor kiro      # wire only these agents (ids: agents, cursor, gemini, copilot, kiro, windsurf, adal, claude)
 graft init --all-agents              # wire every known agent, detected or not
 graft init --list-agents             # list known agent ids and exit
 

--- a/src/hosts/registry.ts
+++ b/src/hosts/registry.ts
@@ -8,6 +8,7 @@
  */
 import { join } from 'node:path';
 import { instructionBody, cursorRule, kiroSteering, windsurfRule } from './instructions.js';
+import { skillTemplate } from '../claude/skill-template.js';
 
 export interface DetectProbe {
   home: string;
@@ -36,6 +37,14 @@ export const HOSTS: HostTarget[] = [
       p.dirExists(join(p.home, '.codex')) ||
       p.dirExists(join(p.home, '.config', 'opencode')) ||
       p.dirExists(join(p.home, '.config', 'agents')),
+  },
+  {
+    id: 'adal',
+    name: 'AdaL',
+    kind: 'owned',
+    relPath: join('.adal', 'skills', 'graft', 'SKILL.md'),
+    content: skillTemplate,
+    detect: (p) => p.dirExists(join(p.home, '.adal')) || p.dirExists(join(p.repo, '.adal')),
   },
   {
     id: 'cursor',

--- a/test/hosts-init.test.ts
+++ b/test/hosts-init.test.ts
@@ -29,7 +29,7 @@ test('explicit agents list overrides detection and flags unknown ids', () => {
 test('all writes every host and re-run converges (idempotent)', () => {
   const home = fresh(); const repo = fresh();
   const first = runHostsInit(repo, { home, all: true });
-  assert.equal(first.written.length, 6);
+  assert.equal(first.written.length, 7);
   const second = runHostsInit(repo, { home, all: true });
   assert.ok(second.written.every((w) => w.action === 'unchanged'));
   const agents = readFileSync(join(repo, 'AGENTS.md'), 'utf8');

--- a/test/hosts-registry.test.ts
+++ b/test/hosts-registry.test.ts
@@ -14,8 +14,8 @@ function probeFor(home: string, repo: string): DetectProbe {
 }
 function fresh(): string { return mkdtempSync(join(tmpdir(), 'graft-registry-')); }
 
-test('registry exposes the six phase-1 hosts', () => {
-  assert.deepEqual(hostIds().sort(), ['agents', 'copilot', 'cursor', 'gemini', 'kiro', 'windsurf']);
+test('registry exposes the known hosts', () => {
+  assert.deepEqual(hostIds().sort(), ['adal', 'agents', 'copilot', 'cursor', 'gemini', 'kiro', 'windsurf']);
   for (const h of HOSTS) {
     assert.ok(h.relPath.length > 0);
     assert.ok(h.content().length > 0);
@@ -41,4 +41,18 @@ test('repo-local markers also light up hosts', () => {
   mkdirSync(join(repo, '.kiro'));
   const ids = detectHosts(probeFor(home, repo)).map((h) => h.id).sort();
   assert.deepEqual(ids, ['copilot', 'kiro']);
+});
+
+test('~/.adal lights up the adal host', () => {
+  const home = fresh(); const repo = fresh();
+  mkdirSync(join(home, '.adal'));
+  const ids = detectHosts(probeFor(home, repo)).map((h) => h.id).sort();
+  assert.deepEqual(ids, ['adal']);
+});
+
+test('repo-local .adal also lights up the adal host', () => {
+  const home = fresh(); const repo = fresh();
+  mkdirSync(join(repo, '.adal'));
+  const ids = detectHosts(probeFor(home, repo)).map((h) => h.id).sort();
+  assert.deepEqual(ids, ['adal']);
 });


### PR DESCRIPTION
## What

Give [AdaL](https://adal.sylph.ai) its own dedicated `graft init` host, writing
a native skill file instead of a generic `AGENTS.md` paragraph.

## Why

AdaL ships a progressive-disclosure skill system: a lightweight index
(name + description) is always visible in the agent's system prompt, and the
full `SKILL.md` body is loaded on demand once the description matches the
task. This is architecturally identical to Claude Code's skill mechanism —
same YAML frontmatter (`name` + `description`), same on-demand loading.

Given that, AdaL deserves the same treatment as Cursor/Kiro/Windsurf (each
gets its own owned file) rather than sharing the generic `AGENTS.md` bucket
with Codex/OpenCode — the richer skill format teaches graft's full
tool-selection heuristics (which command fits which task shape), the same
content Claude Code already gets, instead of a short always-on paragraph.

## Changes

- `src/hosts/registry.ts`: new `adal` host, `kind: 'owned'`, writing the
  **existing** Claude Code skill content (reused via `skillTemplate()`, no
  duplication) to `.adal/skills/graft/SKILL.md`. Detected via `~/.adal`
  (global config dir) or `.adal` (project-local skills/memory dir).
- `test/hosts-registry.test.ts`, `test/hosts-init.test.ts`: regression tests
  for `adal` detection (global + repo-local) and updated host-count
  assertions.
- `README.md`: documents the new `adal` host id and skill file.

## Not included (scoped out deliberately)

MCP auto-registration. AdaL's MCP config lives in the **global**
`~/.adal/settings.json`, keyed by absolute project path, next to unrelated
state (API keys, theme, auth type) — not a project-local file like
`.cursor/mcp.json` or `.gemini/settings.json`. The existing `mergeJsonKey()`
helper is built for scoped, project-local files, so it doesn't apply safely
here without new AdaL-specific write logic. AdaL users can still register the
MCP server manually via the README snippet.

## Testing

```
npm run build   # clean
npm test        # 398/398 passing
```

Also manually verified `runHostsInit({ all: true })` writes
`.adal/skills/graft/SKILL.md` with correct frontmatter and content.
