### PR TITLE
Make graft reachable: strength-gated hint, MCP instructions, greppable cards, self-describing tool names

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -70,7 +70,9 @@
   "permissions": {
     "allow": [
       "Bash(graft:*)",
-      "Bash(npx graft:*)"
+      "Bash(npx graft:*)",
+      "Bash(graft-dev:*)",
+      "Bash(node dist/cli.js:*)"
     ]
   }
 }

--- a/.claude/skills/graft/SKILL.md
+++ b/.claude/skills/graft/SKILL.md
@@ -116,6 +116,6 @@ This is the per-turn figure; the statusline carries the running session total.
   exhaustive where it matters, so reach for them first.
 
 When the graft MCP server is connected, these are exposed as tools too:
-`graft_ask`, `graft_grep`, `graft_skeleton`, `graft_callers` (with
-`direction` / `depth`), `graft_map`, `graft_check`. Use whichever surface is
+`graft_find_code`, `graft_find_all`, `graft_file_api`, `graft_trace_calls` (with
+`direction` / `depth`), `graft_repo_map`, `graft_check_freshness`. Use whichever surface is
 available; the guidance is identical.

--- a/.claude/skills/graft/SKILL.md
+++ b/.claude/skills/graft/SKILL.md
@@ -38,8 +38,13 @@ enclosing symbol** and ranked by coupling; it also reports files it couldn't rea
 - **Use it when** you need every occurrence: all call sites, all uses of a
   constant, all providers. `ask` is ranked top-N and *will* miss instances;
   grep won't. One grep replaces a spray of asks.
-- `-i` case-insensitive; `--in <path>` scopes to a subtree. Fall back to raw
-  `grep -rn` only for files graft doesn't index (docs, configs, new files).
+- Search a **short symbol name or literal**, not a full guessed signature: an
+  over-specific regex (`func (s *Server) GenerateHandler`) returns nothing even
+  when the code is indexed. If a grep misses, **loosen it** (drop the receiver
+  and signature, keep the bare name) and retry `graft grep` — do NOT switch to
+  raw `grep -rn`, which is slower and unranked.
+- `-i` case-insensitive; `--in <path>` scopes to a subtree. Raw `grep -rn` is
+  only for files graft genuinely doesn't index (docs, configs, brand-new files).
 
 ### 3 · `graft skeleton <file>`: a file's API at a glance
 Signatures-only view of one file (every function / method / type with its span)
@@ -56,6 +61,10 @@ Precomputed call/reference edges, not a text search. Symbol can be bare
 - `--direction out`: **what this symbol itself calls/depends on** (the old `callees`).
 - `--depth N`: walk transitively N hops for the **full blast radius** (the old
   `impact`); `--depth 2` is the usual "what breaks if I touch this".
+- `--depth all`: the **entire connected closure** — every source reachable
+  through the edges. Reach for this before a **refactor, rename, or any
+  multi-file change**: it surfaces the sibling and downstream files (platform
+  variants, a module you must split out) that a single-file edit would miss.
 
 ### 5 · `graft map`: orientation for an unfamiliar repo or area
 A token-budgeted tour: directory clusters, per-directory hubs, and global
@@ -65,9 +74,17 @@ hotspots, straight from the wiring graph.
   or ask your way through every subsystem it lists. `--max-dirs N` widens it.
 
 ### 6 · Lifecycle: `graft build` / `graft check`
-`build` regenerates the graph after code changes (`$0`; `--deep` adds an LLM
-concept map, skip unless asked). `check` fails when `graft/` is stale (for CI).
-You rarely touch these mid-task; the graph is already built and committed.
+Every tool above refreshes the graph itself before answering, so what those tools
+return always describes the code as it is right now — including edits you just made
+and have not committed. You do **not** need to run `build` after editing.
+
+One caveat, if you `grep` the markdown under `graft/` directly: those cards are a
+projection, rebuilt at the end of the turn rather than on each query, so after an edit
+they can lag. The tools above never do — prefer them, and treat a card's spans as
+stale if you have edited that file this turn.
+
+`build` is for the LLM layer (`--deep` adds a concept map; skip unless asked);
+`check` fails when `graft/` is stale, for CI.
 
 ## Scenarios: the shortest path through a coding task
 
@@ -76,8 +93,9 @@ You rarely touch these mid-task; the graph is already built and committed.
 | Onboarding / "explain this codebase" | `graft map`, then read the named hub cards | 1 |
 | Understanding a flow ("how does X work") | `graft ask "<flow>" --source` | 1 |
 | Finding where a change belongs | `graft ask "where is <behavior>" --source` | 1 |
-| Editing a known symbol | `graft ask "<symbol>" --source`, edit at the `file:line` | 1 |
+| Editing a symbol you can already name | `graft grep "<symbol>"`, edit at the `file:line` (skip `ask` — you know where it is) | 1 |
 | Renaming / deleting / changing a signature | `graft callers <sym> --depth 2` first | 1 |
+| Refactor / multi-file change (before editing) | `graft callers <sym> --depth all` — map every connected file, don't stop at the first | 1 |
 | "What does this depend on?" | `graft callers <sym> --direction out` | 1 |
 | Finding every occurrence of a pattern | `graft grep "<literal>"` | 1 |
 | "What's the API of this file?" | `graft skeleton <file>` | 1 |
@@ -93,10 +111,15 @@ you already know where you're working, narrow with `graft ask "<task>" --in <sco
 - A node's `covers:` list already gives exact `file:line` for every symbol, so
   cite straight from it. The spans are generated from source and authoritative;
   don't re-open or re-grep files to "double-check".
-- When editing, pull the span with `graft ask "<symbol>" --source` and edit at
-  that `file:line`; never read the whole file to orient, the pack did that.
+- When the task already names the file or symbol to change, go straight there:
+  `graft grep "<symbol>"` for the exact `file:line`, then edit. Reserve
+  `graft ask` for when you don't yet know where the code lives — an `ask`
+  round-trip is wasted on a target you can already name.
 - Trust the answer and act. Reach for a second tool only when the first genuinely
   fell short: weak hits, a truncated span, or a need to be exhaustive.
+- If graft names a path that isn't on disk, its index is ahead of your checkout
+  (a branch switch or unpulled move). Don't read the missing file — `graft grep`
+  the symbol to find where it lives now, or run `graft build` to refresh.
 
 ## Report what graft saved, every turn
 Each retrieval tool ends its output with a `[graft] tokens saved ≈ N` line: the

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ graft/
 
 # OS
 .DS_Store
+
+# Session transcripts and prompt traces — local analysis, not product.
+transcripts/

--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,5 @@
+# graft's cards are gitignored but should stay greppable: ripgrep reads
+# .ignore before .gitignore, so this re-admits the tree to search only.
+!graft/
+graft/.cache/
+graft/.graph/

--- a/README.md
+++ b/README.md
@@ -203,12 +203,12 @@ Both configs are user-level, so they apply to **every** repo you open with Codex
 
 | Tool | Takes | What it's for |
 |---|---|---|
-| `graft_ask` | a question | Ranked nodes with file:line, source inlined — usually the full answer, no follow-up read needed. |
-| `graft_skeleton` | a file path | Every signature in that file, no bodies — the API surface for a tenth of the tokens. |
-| `graft_callers` | a symbol | Who depends on it, or what it depends on with `direction: out`, N levels deep for blast radius. |
-| `graft_grep` | a regex | Every hit, grouped by enclosing symbol, ranked by how coupled that symbol is. |
-| `graft_map` | nothing | A first look at an unfamiliar repo: directory clusters, hubs, hotspots. |
-| `graft_check` | nothing | Whether the local graph has drifted from the code. |
+| `graft_find_code` | a question | Ranked nodes with file:line, source inlined — usually the full answer, no follow-up read needed. |
+| `graft_file_api` | a file path | Every signature in that file, no bodies — the API surface for a tenth of the tokens. |
+| `graft_trace_calls` | a symbol | Who depends on it, or what it depends on with `direction: out`, N levels deep for blast radius. |
+| `graft_find_all` | a regex | Every hit, grouped by enclosing symbol, ranked by how coupled that symbol is. |
+| `graft_repo_map` | nothing | A first look at an unfamiliar repo: directory clusters, hubs, hotspots. |
+| `graft_check_freshness` | nothing | Whether the local graph has drifted from the code. |
 
 Register it by hand if your agent needs it explicit:
 
@@ -384,7 +384,7 @@ normalized on load — no regeneration needed.
 
 An agent that reads the graph should be cheaper and faster without getting more answers wrong. That's the whole claim, so we measured it instead of asserting it.
 
-The harness ran three variants of the same Claude Sonnet 5 agent with the same file tools: **cold** (explores from zero), **Graft** (a `graft ask --source` bundle pushed up front), and **pull** (graft_ask/graft_skeleton tools, nothing injected — context paid for only when asked). An Opus 4.8 judge scored correctness with a required-keyword floor, so a fast-but-wrong answer couldn't win by being fast. Cost is cache-aware: reads ≈0.1×, writes 1.25×, the billing model agents actually run under.
+The harness ran three variants of the same Claude Sonnet 5 agent with the same file tools: **cold** (explores from zero), **Graft** (a `graft ask --source` bundle pushed up front), and **pull** (graft_find_code/graft_file_api tools, nothing injected — context paid for only when asked). An Opus 4.8 judge scored correctness with a required-keyword floor, so a fast-but-wrong answer couldn't win by being fast. Cost is cache-aware: reads ≈0.1×, writes 1.25×, the billing model agents actually run under.
 
 162 runs, two repos (graft itself and a real Node/Express auth service), 3 trials each, tasks split between single-file and multi-file questions.
 

--- a/src/claude/format.ts
+++ b/src/claude/format.ts
@@ -1,6 +1,10 @@
 import { basename } from 'node:path';
 import type { Stats, SessionState } from './state.js';
 import type { GraphV1, EdgeV1 } from '../graph/types.js';
+// The injection gate reuses the federation floors rather than inventing its own:
+// "did we hit a real name, or match broadly enough to trust anyway" is the same
+// question in both places, and one set of calibrated numbers beats two.
+import { HIGH_FLOOR, STRONG_FLOOR } from '../ask/fuse.js';
 
 const C = {
   indigo: (s: string) => `\x1b[38;2;84;111;255m${s}\x1b[0m`,
@@ -73,6 +77,10 @@ export interface AskJson {
   saved?: { files: number; baselineChars: number };
   /** Lexical mode: share (0..1) of the query's distinct terms the top hit matched. */
   coverage?: number;
+  /** Lexical mode: the same share over the top hit's NAME field only — "did the
+   * query hit a real symbol, or only words buried in some body?". `ask --json`
+   * has always emitted it; the gate below is what finally reads it. */
+  coverageStrong?: number;
 }
 
 function tokensOf(chars: number): number { return Math.round(chars / 4); }
@@ -123,27 +131,65 @@ export function formatRetrieval(ask: AskJson, cap = 5): string | null {
   );
 }
 
-/** Coverage below this → skip the pack. A floor, not a classifier: lexical
- * coverage can't reliably rank mid-range prompts, so the floor sits where it
- * only rejects flagrantly off-repo prompts (chatter, greetings, unrelated
- * asks — these probe well under 0.1) and never a genuinely on-repo task. The
- * cost asymmetry justifies leaning low: a wrongly-skipped pack is recoverable
- * (the agent pulls with `graft ask`), a wrongly-injected one is pure noise. */
+/**
+ * Superseded by the two-clause strength gate in {@link relevantRetrieval} (see
+ * {@link STRONG_FLOOR} / {@link HIGH_FLOOR}). Kept exported because the old
+ * single-clause floor is still the documented reference point for why it changed:
+ * it sat at 0.15, and a prompt measuring 0.165 / strong 0.033 cleared it by 0.015
+ * and injected three test files for a question whose answer was elsewhere. The
+ * comment it used to carry justified leaning low — "a wrongly-skipped pack is
+ * recoverable, the agent pulls with `graft ask`" — and that assumption is exactly
+ * what a traced session falsified: the agent did not pull. It grepped 38 times.
+ */
 export const INJECT_MIN_COVERAGE = 0.15;
 
 /** How many recently-injected pointers the novelty gate remembers per session. */
 const INJECTED_POINTERS_CAP = 40;
 
-/** The per-prompt injection gate. Returns the pack text to inject, or null to
- * stay silent. Mutates `s` to remember what was shown (caller persists it).
- * Gates, in order:
- *   1. relevance — lexical coverage below {@link INJECT_MIN_COVERAGE} → skip
- *      (structural results carry no coverage; the intent match is the signal);
- *   2. novelty — hits whose pointer was already injected this session are
- *      dropped, and if none remain the whole pack is skipped. */
+/** How many weak-match nudges one session may spend. A line that shows up every
+ * turn stops being read; two is enough to land the habit without becoming
+ * wallpaper. */
+export const NUDGE_CAP = 2;
+
+/** The line injected instead of a weak pack: names the command, says why, once.
+ * Deliberately not an imperative about graft in general — it's a fact about this
+ * prompt's match quality plus the command that fixes it. */
+export function weakMatchNudge(s: SessionState, strong: number): string | null {
+  const spent = s.nudges ?? 0;
+  if (spent >= NUDGE_CAP) return null;
+  s.nudges = spent + 1;
+  return (
+    `[graft] no strong match for this prompt (name-field match ${strong.toFixed(2)}) — the graph ` +
+    `has more than this probe found. Run \`graft ask "<your task>" --source\` before grepping.`
+  );
+}
+
+/**
+ * The per-prompt injection gate. Returns the text to inject, or null to stay
+ * silent. Mutates `s` to remember what was shown (caller persists it).
+ *
+ * Gate 1 — **strength**. A pack earns its place only if the top hit either landed
+ * on a real symbol NAME (`coverageStrong ≥ STRONG_FLOOR`) or matched the query
+ * broadly enough to trust regardless (`coverage ≥ HIGH_FLOOR`). This is the same
+ * two-clause rule `fuse.ts` already uses to decide whether a whole sub-repo joins
+ * a cross-repo ranking — a cheaper decision than this one, previously held to a
+ * stricter standard. Failing it emits {@link weakMatchNudge} rather than nothing:
+ * silence leaves the agent with no signal at all, and a borderline pack is worse
+ * than either, because it reads as orientation and suppresses the very retrieval
+ * call it should have triggered. Structural results carry neither score — the
+ * resolved intent is itself the relevance signal — so they always pass.
+ *
+ * Gate 2 — **novelty**. Hits whose pointer was already injected this session are
+ * dropped; if none remain, the pack is skipped.
+ */
 export function relevantRetrieval(ask: AskJson, s: SessionState, cap = 3): string | null {
   if (!(ask.hits ?? []).length) return null;
-  if (typeof ask.coverage === 'number' && ask.coverage < INJECT_MIN_COVERAGE) return null;
+  const lexical = typeof ask.coverage === 'number' || typeof ask.coverageStrong === 'number';
+  if (lexical) {
+    const strong = ask.coverageStrong ?? 0;
+    const broad = ask.coverage ?? 0;
+    if (strong < STRONG_FLOOR && broad < HIGH_FLOOR) return weakMatchNudge(s, strong);
+  }
   const seen = new Set(s.injectedPointers ?? []);
   const fresh = ask.hits.filter((h) => !seen.has(h.pointer));
   if (!fresh.length) return null;

--- a/src/claude/init.ts
+++ b/src/claude/init.ts
@@ -5,7 +5,7 @@ import { mergeGraftSettings } from './settings-merge.js';
 import { statuslineShim, hooksShim } from './shim-template.js';
 import { skillTemplate } from './skill-template.js';
 import { claudeDistDir } from './paths.js';
-import { mergeJsonKey, SERVER_ENTRY, type McpWrite } from '../hosts/mcp-config.js';
+import { mergeJsonKey, serverEntry, type McpWrite } from '../hosts/mcp-config.js';
 import type { PlannedWrite } from '../hosts/plan.js';
 
 /**
@@ -78,9 +78,9 @@ export function runInit(dir: string, opts: { build?: boolean; cliPath?: string }
   writeFileSync(skillPath, skillTemplate());
 
   // Register the graft MCP server in the project's .mcp.json so Claude Code
-  // exposes graft_ask/graft_callers/etc. as tools — the same keyed merge the
+  // exposes graft_find_code/graft_trace_calls/etc. as tools — the same keyed merge the
   // other hosts use (existing servers preserved; unparseable files skipped).
-  const mcp = mergeJsonKey('claude', mcpTarget, 'mcpServers', SERVER_ENTRY);
+  const mcp = mergeJsonKey('claude', mcpTarget, 'mcpServers', serverEntry());
 
   const built = buildGraphIfMissing(dir, opts);
   return { settingsPath, shims: [sl, hk], skill: skillPath, mcp, warnings, built };

--- a/src/claude/settings-merge.ts
+++ b/src/claude/settings-merge.ts
@@ -2,7 +2,16 @@ type Json = Record<string, any>;
 
 const SL_CMD = 'node "${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-statusline.cjs"';
 const FOOTER = 'graft/[\\w./-]+\\.md';
-const ALLOW_ENTRIES = ['Bash(graft:*)', 'Bash(npx graft:*)'];
+// Every form graft is actually invoked as. 'graft:*' covers a global install;
+// the other two cover a repo working on graft itself (or any consumer running it
+// from a checkout), where the binary is not on PATH under that name. A retrieval
+// call that raises a permission prompt loses to grep, which never does.
+const ALLOW_ENTRIES = [
+  'Bash(graft:*)',
+  'Bash(npx graft:*)',
+  'Bash(graft-dev:*)',
+  'Bash(node dist/cli.js:*)',
+];
 
 function hookCmd(arg: string): string {
   return `node "\${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-hooks.cjs" ${arg}`;

--- a/src/claude/skill-template.ts
+++ b/src/claude/skill-template.ts
@@ -145,8 +145,8 @@ This is the per-turn figure; the statusline carries the running session total.
   exhaustive where it matters, so reach for them first.
 
 When the graft MCP server is connected, these are exposed as tools too:
-\`graft_ask\`, \`graft_grep\`, \`graft_skeleton\`, \`graft_callers\` (with
-\`direction\` / \`depth\`), \`graft_map\`, \`graft_check\`. Use whichever surface is
+\`graft_find_code\`, \`graft_find_all\`, \`graft_file_api\`, \`graft_trace_calls\` (with
+\`direction\` / \`depth\`), \`graft_repo_map\`, \`graft_check_freshness\`. Use whichever surface is
 available; the guidance is identical.
 `;
 }

--- a/src/claude/state.ts
+++ b/src/claude/state.ts
@@ -32,10 +32,13 @@ export interface SessionState {
    * a hit whose pointer was shown once is never re-injected). Optional so
    * session files written before this field still parse. */
   injectedPointers?: string[];
+  /** Weak-match nudges spent this session, capped so the line stays signal.
+   * Optional for the same backwards-compatibility reason as above. */
+  nudges?: number;
 }
 
 function emptySession(): SessionState {
-  return { lastQuery: null, perAgentQuery: {}, graftReads: 0, sourceReads: 0, savedTokens: 0, injectedPointers: [] };
+  return { lastQuery: null, perAgentQuery: {}, graftReads: 0, sourceReads: 0, savedTokens: 0, injectedPointers: [], nudges: 0 };
 }
 
 function sessionPath(d: string, id: string): string { return join(cacheDir(d), 'session', `${id}.json`); }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -339,7 +339,7 @@ program
     const { resolve } = await import("node:path");
     const { startMcpServer } = await import("./mcp/server.js");
     const globalOpts = program.opts<{ dir?: string }>();
-    startMcpServer(resolve(dir), globalOpts.dir);
+    startMcpServer(resolve(dir), globalOpts.dir, currentVersion);
   });
 
 program

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -333,7 +333,7 @@ program
 
 program
   .command("mcp")
-  .description("Serve the graph over MCP (stdio) — exposes graft_ask, graft_callers, graft_grep, graft_skeleton, graft_map and graft_check as tools")
+  .description("Serve the graph over MCP (stdio) — exposes graft_find_code, graft_trace_calls, graft_find_all, graft_file_api, graft_repo_map and graft_check_freshness as tools")
   .argument("[dir]", "repository root", ".")
   .action(async (dir: string) => {
     const { resolve } = await import("node:path");

--- a/src/context/node-file.ts
+++ b/src/context/node-file.ts
@@ -25,6 +25,8 @@ import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync, rmSync
 import { join, relative, sep } from "node:path";
 import matter from "gray-matter";
 import { contentHash, normalizeName } from "../util/id.js";
+// Value-only import of a constant; `write.ts` pulls in nothing from here, so no cycle.
+import { GRAPH_DIR } from "../graph/write.js";
 
 /** A source file a node was derived from, with its content hash at generation time. */
 export interface SourceRef {
@@ -126,6 +128,45 @@ export function ensureGitignored(root: string, contextDir: string): void {
   const gap = current === "" ? "" : current.endsWith("\n") ? "\n" : "\n\n";
   const block = `${gap}# graft's local graph cache — regenerable, not committed (run \`graft build\`).\n${entry}\n`;
   try { writeFileSync(path, current + block); } catch { /* best-effort — build already succeeded */ }
+}
+
+/**
+ * Keep the card tree greppable even though it's gitignored, by writing a root
+ * `.ignore` that re-admits it.
+ *
+ * The cards exist so that a `grep <symbol>` lands on a ~150-token card instead of
+ * a whole source file. Making the graph a local cache (and so gitignored) silently
+ * broke that: **ripgrep honours `.gitignore`**, and every ripgrep-backed search
+ * tool inherits the blind spot — verified by a card that names a symbol which
+ * default `rg` will not return and `rg -uu` finds instantly. `.ignore` is read at
+ * higher precedence than `.gitignore`, so re-admitting the tree there restores
+ * search without git ever tracking a byte of it.
+ *
+ * The two negative entries matter as much as the positive one: `.cache/` holds a
+ * multi-MB parse memo and `.graph/` holds `wiring.json`, and dropping either into
+ * every repo-wide search would be worse than the problem being fixed.
+ *
+ * Same contract as {@link ensureGitignored}: idempotent, skips a context dir
+ * outside `root`, and swallows write failures — a build that already succeeded
+ * must not fail over a convenience file.
+ */
+export function ensureSearchable(root: string, contextDir: string): void {
+  const rel = relative(root, contextDir).split(sep).join("/");
+  if (rel === "" || rel.startsWith("..")) return; // outside the repo — nothing to re-admit
+  const dir = rel.replace(/\/+$/, "");
+  const entry = `!${dir}/`;
+  const path = join(root, ".ignore");
+  let current = "";
+  try { current = readFileSync(path, "utf8"); } catch { /* no .ignore yet — we create one */ }
+  // Any mention of the negation means a human (or a previous build) has already
+  // had an opinion here; leave it alone rather than append a second copy.
+  if (current.split("\n").some((l) => l.trim() === entry)) return;
+  const gap = current === "" ? "" : current.endsWith("\n") ? "\n" : "\n\n";
+  const block =
+    `${gap}# graft's cards are gitignored but should stay greppable: ripgrep reads\n` +
+    `# .ignore before .gitignore, so this re-admits the tree to search only.\n` +
+    `${entry}\n${dir}/${CACHE_DIR}/\n${dir}/${GRAPH_DIR}/\n`;
+  try { writeFileSync(path, current + block); } catch { /* best-effort */ }
 }
 
 /** Render the generated body (Summary + Related) for a node. */

--- a/src/context/node-file.ts
+++ b/src/context/node-file.ts
@@ -105,6 +105,21 @@ export function contextDirFor(root: string, override?: string): string {
 }
 
 /**
+ * Trailing `/` off a repo-relative dir path, in linear time.
+ *
+ * The obvious `replace(/\/+$/, "")` is a polynomial-ReDoS shape — `\/+$` can begin
+ * matching at any point inside a run of slashes, so a path ending in many slashes
+ * and then anything else costs O(n²). CodeQL flags it (`js/polynomial-redos`), and
+ * rightly: the input here is a `--dir` value, so it is not attacker-controlled, but
+ * the ambiguity buys nothing and a loop is both faster and plainer.
+ */
+function stripTrailingSlashes(path: string): string {
+  let end = path.length;
+  while (end > 0 && path[end - 1] === "/") end--;
+  return path.slice(0, end);
+}
+
+/**
  * Make sure the repo's root `.gitignore` ignores the graft output dir. The
  * graph is a local, regenerable cache (like `node_modules`), not a committed
  * artifact, so every `graft build` adds the entry itself the first time — the
@@ -116,7 +131,7 @@ export function contextDirFor(root: string, override?: string): string {
 export function ensureGitignored(root: string, contextDir: string): void {
   const rel = relative(root, contextDir).split(sep).join("/");
   if (rel === "" || rel.startsWith("..")) return; // dir is at/above the repo root — nothing sane to ignore
-  const entry = `${rel.replace(/\/+$/, "")}/`;
+  const entry = `${stripTrailingSlashes(rel)}/`;
   const path = join(root, ".gitignore");
   let current = "";
   try { current = readFileSync(path, "utf8"); } catch { /* no .gitignore yet — we create one */ }
@@ -153,7 +168,7 @@ export function ensureGitignored(root: string, contextDir: string): void {
 export function ensureSearchable(root: string, contextDir: string): void {
   const rel = relative(root, contextDir).split(sep).join("/");
   if (rel === "" || rel.startsWith("..")) return; // outside the repo — nothing to re-admit
-  const dir = rel.replace(/\/+$/, "");
+  const dir = stripTrailingSlashes(rel);
   const entry = `!${dir}/`;
   const path = join(root, ".ignore");
   let current = "";

--- a/src/graph/build.ts
+++ b/src/graph/build.ts
@@ -16,7 +16,7 @@
 import { readFileSync } from "node:fs";
 import { basename, dirname, relative, resolve, sep } from "node:path";
 import { walkDir } from "../ingest/fs.js";
-import { contextDirFor, ensureGitignored } from "../context/node-file.js";
+import { contextDirFor, ensureGitignored, ensureSearchable } from "../context/node-file.js";
 import { extractFile, languageOf, type Language, type RawEdge } from "./extract.js";
 import { contentHash } from "../util/id.js";
 import {
@@ -285,6 +285,10 @@ export async function buildGraph(
     // The graph is a local, regenerable cache — make sure git ignores it. Cheap and
     // idempotent, so a fresh clone's first build self-ignores.
     ensureGitignored(root, outDir);
+    // …and that gitignoring it doesn't hide the cards from search: ripgrep honours
+    // .gitignore, so without this the cards can never be grepped, which is the one
+    // way an agent was supposed to stumble onto them.
+    ensureSearchable(root, outDir);
     cardStats = writeCards(graph, outDir);
     writeIndex(outDir, cardStats.files);
     // Backfill concept nodes with their `covers:` symbol/file:line list (the

--- a/src/graph/cards.ts
+++ b/src/graph/cards.ts
@@ -194,6 +194,14 @@ export function writeIndex(outDir: string, files: CardFileInfo[]): void {
     'filename here, or run `graft ask "<task>"`. Each node carries prose plus exact',
     "`file:line`; open a source file only to edit the named span.",
     "",
+    // Whoever reads this file has already decided to look at graft, so this is the
+    // one place a pointer to the richer surface is welcome rather than noise. Stated
+    // as what exists, not as an instruction — see `mcp/instructions.ts` for why.
+    "The same graph is queryable as MCP tools (`graft_ask`, `graft_grep`,",
+    "`graft_callers`, `graft_skeleton`, `graft_map`) where a host exposes them, and",
+    "as the `graft` CLI everywhere else. Edges — who calls what — live only in the",
+    "graph, not in these files: `graft callers <symbol>` is the only way to read them.",
+    "",
   ];
 
   const concepts = readNodes(outDir).sort((a, b) => a.slug.localeCompare(b.slug));

--- a/src/graph/cards.ts
+++ b/src/graph/cards.ts
@@ -197,8 +197,8 @@ export function writeIndex(outDir: string, files: CardFileInfo[]): void {
     // Whoever reads this file has already decided to look at graft, so this is the
     // one place a pointer to the richer surface is welcome rather than noise. Stated
     // as what exists, not as an instruction — see `mcp/instructions.ts` for why.
-    "The same graph is queryable as MCP tools (`graft_ask`, `graft_grep`,",
-    "`graft_callers`, `graft_skeleton`, `graft_map`) where a host exposes them, and",
+    "The same graph is queryable as MCP tools (`graft_find_code`, `graft_find_all`,",
+    "`graft_trace_calls`, `graft_file_api`, `graft_repo_map`) where a host exposes them, and",
     "as the `graft` CLI everywhere else. Edges — who calls what — live only in the",
     "graph, not in these files: `graft callers <symbol>` is the only way to read them.",
     "",

--- a/src/graph/traverse-cli.ts
+++ b/src/graph/traverse-cli.ts
@@ -8,7 +8,7 @@
  * unit-testable without shelling out to the CLI on every case.
  *
  * `--direction out` subsumes the old `graft callees`; `--depth N` subsumes the
- * old `graft impact`. Exported formatters are reused by the MCP `graft_callers`
+ * old `graft impact`. Exported formatters are reused by the MCP `graft_trace_calls`
  * tool (`src/mcp/tools.ts`), so both surfaces render identical reports.
  */
 import { resolve } from "node:path";
@@ -32,7 +32,7 @@ export interface CallersCliOptions {
 const ARROW: Record<Direction, "←" | "→"> = { in: "←", out: "→" };
 const DEFAULT_DEPTH = 1;
 
-/** Exported so the MCP `graft_callers` tool (`src/mcp/tools.ts`) can render the
+/** Exported so the MCP `graft_trace_calls` tool (`src/mcp/tools.ts`) can render the
  * same human report format as the CLI, rather than re-implementing it — both
  * surfaces walk the same edges via the same `resolveSymbol` / `edgeWalk` core. */
 export function headerOf(n: NodeV1): string {

--- a/src/graph/traverse.ts
+++ b/src/graph/traverse.ts
@@ -1,6 +1,6 @@
 /**
  * Pure graph-traversal core shared by `graft callers` (its `--direction`/
- * `--depth` flags), the MCP `graft_callers` tool, and `ask`'s structural
+ * `--depth` flags), the MCP `graft_trace_calls` tool, and `ask`'s structural
  * intent path.
  *
  * Centralizes the symbol-resolution contract (bare name, qualified id-suffix,
@@ -203,7 +203,7 @@ export function impactOfFile(graph: GraphV1, fileNode: NodeV1, maxDepth = 2, dir
 }
 
 /**
- * The single entry point behind `graft callers` and the MCP `graft_callers`
+ * The single entry point behind `graft callers` and the MCP `graft_trace_calls`
  * tool, covering all of what were once three commands:
  *   - `direction:in,  depth:1`  → callers      (who calls/references this)
  *   - `direction:out, depth:1`  → callees      (what this calls/references)

--- a/src/hosts/mcp-config.ts
+++ b/src/hosts/mcp-config.ts
@@ -8,6 +8,7 @@
  * `registerMcpConfigs()` walks that same list to do the writing.
  */
 import { readFileSync, writeFileSync, mkdirSync, existsSync, statSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
 import { dirname, join } from 'node:path';
 import { homedir } from 'node:os';
 import type { PlannedWrite } from './plan.js';
@@ -27,8 +28,50 @@ export interface McpTarget extends PlannedWrite {
   entry?: object;
 }
 
-export const SERVER_ENTRY = { command: 'npx', args: ['-y', '@nanonets/graft', 'mcp'] };
-const OPENCODE_ENTRY = { type: 'local', command: ['npx', '-y', '@nanonets/graft', 'mcp'], enabled: true };
+/**
+ * How to launch the MCP server, decided once at init time.
+ *
+ * `npx -y` resolves the package before it can serve: measured at a 211 ms
+ * spawn→`initialize` handshake against 80 ms for the installed binary, five runs
+ * each. The harness registers a server's tools only once that handshake lands, and
+ * a slow one can miss the first request entirely — in a traced session graft's
+ * tools arrived 13.9 s in, four model turns too late to shape the approach. (That
+ * 13.9 s is NOT explained by 130 ms; the gap's cause is still unknown. This is the
+ * cheap half of the fix, not the whole of it.)
+ *
+ * Deliberately a bare command name, never an absolute path: these files get
+ * committed and shared, and this repo already carries the scar of the alternative —
+ * a checked-in hook shim with another machine's home directory baked into it. A
+ * bare `graft` works on any machine that has it installed; `npx` remains the
+ * fallback for machines that don't.
+ */
+const NPX_LAUNCH = { command: 'npx', args: ['-y', '@nanonets/graft', 'mcp'] };
+const BIN_LAUNCH = { command: 'graft', args: ['mcp'] };
+
+function graftOnPath(): boolean {
+  const r = spawnSync('graft', ['--version'], { stdio: 'ignore', timeout: 5000 });
+  return r.status === 0;
+}
+
+/**
+ * JSON hosts: `{ command, args }`.
+ *
+ * `GRAFT_MCP_NPX=1` forces the `npx` form — the escape hatch for a machine whose
+ * global install is stale or shadowed, and what the tests set so their expectations
+ * don't depend on whether the machine running them happens to have graft installed.
+ * `opts.onPath` is the same override for direct unit tests of both branches.
+ */
+export function serverEntry(opts: { onPath?: boolean } = {}): { command: string; args: string[] } {
+  const forced = process.env.GRAFT_MCP_NPX;
+  if (forced !== undefined && forced !== '' && forced !== '0' && forced !== 'false') return NPX_LAUNCH;
+  return (opts.onPath ?? graftOnPath()) ? BIN_LAUNCH : NPX_LAUNCH;
+}
+
+
+function opencodeEntry(): object {
+  const { command, args } = serverEntry();
+  return { type: 'local', command: [command, ...args], enabled: true };
+}
 
 function dirExists(p: string): boolean {
   try { return statSync(p).isDirectory(); } catch { return false; }
@@ -60,7 +103,9 @@ function upsertCodexToml(id: string, path: string): McpWrite {
   const existed = existsSync(path);
   const text = existed ? readFileSync(path, 'utf8') : '';
   if (/^\[mcp_servers\.graft\]$/m.test(text)) return { id, path, action: 'unchanged' };
-  const section = `[mcp_servers.graft]\ncommand = "npx"\nargs = ["-y", "@nanonets/graft", "mcp"]\n`;
+  const { command, args } = serverEntry();
+  const argList = args.map((a) => JSON.stringify(a)).join(", ");
+  const section = `[mcp_servers.graft]\ncommand = \"${command}\"\nargs = [${argList}]\n`;
   const sep = text.length === 0 ? '' : text.endsWith('\n') ? '\n' : '\n\n';
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, `${text}${sep}${section}`);
@@ -89,17 +134,18 @@ export function mcpTargets(
   opts: { home?: string } = {},
 ): McpTarget[] {
   const home = opts.home ?? homedir();
+  const entry = serverEntry();
   const out: McpTarget[] = [];
   for (const id of ids) {
     switch (id) {
       case 'cursor':
-        out.push(jsonTarget(id, id, join(repo, '.cursor', 'mcp.json'), 'mcpServers', SERVER_ENTRY));
+        out.push(jsonTarget(id, id, join(repo, '.cursor', 'mcp.json'), 'mcpServers', entry));
         break;
       case 'gemini':
-        out.push(jsonTarget(id, id, join(repo, '.gemini', 'settings.json'), 'mcpServers', SERVER_ENTRY));
+        out.push(jsonTarget(id, id, join(repo, '.gemini', 'settings.json'), 'mcpServers', entry));
         break;
       case 'kiro':
-        out.push(jsonTarget(id, id, join(repo, '.kiro', 'settings', 'mcp.json'), 'mcpServers', SERVER_ENTRY));
+        out.push(jsonTarget(id, id, join(repo, '.kiro', 'settings', 'mcp.json'), 'mcpServers', entry));
         break;
       case 'agents':
         // Guarded on the CLI actually being installed, so a plan only ever
@@ -111,7 +157,7 @@ export function mcpTargets(
           });
         }
         if (dirExists(join(home, '.config', 'opencode'))) {
-          out.push(jsonTarget(id, 'opencode', join(repo, 'opencode.json'), 'mcp', OPENCODE_ENTRY));
+          out.push(jsonTarget(id, 'opencode', join(repo, 'opencode.json'), 'mcp', opencodeEntry()));
         }
         break;
       default:

--- a/src/mcp/instructions.ts
+++ b/src/mcp/instructions.ts
@@ -26,11 +26,11 @@
 
 /** Tool names in the order an agent should reach for them, most-used first. */
 const TOOL_ORDER = [
-  'graft_ask',
-  'graft_grep',
-  'graft_callers',
-  'graft_skeleton',
-  'graft_map',
+  'graft_find_code',
+  'graft_find_all',
+  'graft_trace_calls',
+  'graft_file_api',
+  'graft_repo_map',
 ] as const;
 
 /** The `select:` argument that loads every graft tool in one lookup. */
@@ -46,11 +46,11 @@ export function mcpInstructions(): string {
     '',
     `**If these tools are deferred (names shown, schemas withheld), load them all in ONE lookup:** ToolSearch "${toolSearchQuery()}" — one round trip for the whole session. Never load them one at a time.`,
     '',
-    '- graft_ask — "how does X work" / "where is Y": ranked hits, code inlined.',
-    '- graft_grep — when you need EVERY occurrence; ask is top-N and misses some.',
-    '- graft_callers — who calls it, what it calls, blast radius before a rename.',
-    '- graft_skeleton — a file\'s whole API in ~200 tokens.',
-    '- graft_map — orientation in an unfamiliar repo.',
+    '- graft_find_code — "how does X work" / "where is Y": ranked hits, code inlined.',
+    '- graft_find_all — when you need EVERY occurrence; find_code is top-N and misses some.',
+    '- graft_trace_calls — who calls it, what it calls, blast radius before a rename.',
+    '- graft_file_api — a file\'s whole API in ~200 tokens.',
+    '- graft_repo_map — orientation in an unfamiliar repo.',
     '',
     'Results already reflect uncommitted edits — the graph refreshes before each query.',
   ].join('\n');

--- a/src/mcp/instructions.ts
+++ b/src/mcp/instructions.ts
@@ -1,0 +1,57 @@
+/**
+ * The `instructions` string returned in graft's MCP `initialize` response.
+ *
+ * This is the one piece of graft prose that survives **tool deferral**. When a
+ * host has more tools than its schema budget allows, it sends tool *names* only
+ * and withholds the JSONSchemas until a `ToolSearch`-style lookup fetches them —
+ * measured in a real session: 111 tools deferred, of which graft's six arrived as
+ * six bare strings with no descriptions at all. The MCP spec's `instructions`
+ * field is delivered on a separate track (Claude Code records it as its own
+ * `mcp_instructions_delta` context layer), so it lands whole even then. Other
+ * servers already rely on this — `claude-in-chrome` uses it for exactly the
+ * batch-your-ToolSearch instruction below; graft used to send nothing.
+ *
+ * Two jobs, in this order:
+ *   1. Defuse the deferral tax. One lookup loads all six tools for the whole
+ *      session, so the cost is a single round trip, not two calls per use. An
+ *      agent that doesn't know this can only assume the worse reading.
+ *   2. Say what each tool is FOR as a decision rule, not a feature summary —
+ *      because in a host with no hooks and no skill listing (a plain chat client
+ *      with an MCP config), this string plus the tool descriptions are the entire
+ *      steering budget graft gets.
+ *
+ * Budget: keep this under ~1,000 characters. Observed sibling servers sit at
+ * 660–984, and nothing proves a longer one survives un-truncated.
+ */
+
+/** Tool names in the order an agent should reach for them, most-used first. */
+const TOOL_ORDER = [
+  'graft_ask',
+  'graft_grep',
+  'graft_callers',
+  'graft_skeleton',
+  'graft_map',
+] as const;
+
+/** The `select:` argument that loads every graft tool in one lookup. */
+export function toolSearchQuery(prefix = 'mcp__graft__'): string {
+  return `select:${TOOL_ORDER.map((t) => `${prefix}${t}`).join(',')}`;
+}
+
+export function mcpInstructions(): string {
+  return [
+    'This repo is indexed by graft: a prebuilt graph of every symbol, its file:line',
+    'span, and who calls what. Prefer these tools over grep/read — one call usually',
+    'replaces several file reads.',
+    '',
+    `**If these tools are deferred (names shown, schemas withheld), load them all in ONE lookup:** ToolSearch "${toolSearchQuery()}" — one round trip for the whole session. Never load them one at a time.`,
+    '',
+    '- graft_ask — "how does X work" / "where is Y": ranked hits, code inlined.',
+    '- graft_grep — when you need EVERY occurrence; ask is top-N and misses some.',
+    '- graft_callers — who calls it, what it calls, blast radius before a rename.',
+    '- graft_skeleton — a file\'s whole API in ~200 tokens.',
+    '- graft_map — orientation in an unfamiliar repo.',
+    '',
+    'Results already reflect uncommitted edits — the graph refreshes before each query.',
+  ].join('\n');
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -4,6 +4,7 @@
  */
 import { createInterface } from 'node:readline';
 import { TOOLS, callTool } from './tools.js';
+import { mcpInstructions } from './instructions.js';
 
 function send(msg: object): void {
   process.stdout.write(`${JSON.stringify(msg)}\n`);
@@ -17,7 +18,12 @@ function replyError(id: unknown, code: number, message: string): void {
   send({ jsonrpc: '2.0', id, error: { code, message } });
 }
 
-export function startMcpServer(root: string, dirOverride?: string): void {
+/**
+ * `version` is threaded in from the CLI rather than read here: `readCurrentVersion`
+ * resolves package.json relative to the calling module, and from `dist/mcp/` that
+ * lookup misses. The caller already knows it.
+ */
+export function startMcpServer(root: string, dirOverride?: string, version = '0'): void {
   const rl = createInterface({ input: process.stdin, crlfDelay: Infinity });
   rl.on('line', (line) => {
     const text = line.trim();
@@ -36,7 +42,9 @@ export function startMcpServer(root: string, dirOverride?: string): void {
         reply(id, {
           protocolVersion: params?.protocolVersion ?? '2024-11-05',
           capabilities: { tools: {} },
-          serverInfo: { name: 'graft', version: '0' },
+          serverInfo: { name: 'graft', version },
+          // The one channel that survives tool deferral — see ./instructions.ts.
+          instructions: mcpInstructions(),
         });
         return;
       case 'notifications/initialized':

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -39,7 +39,7 @@ function unknownSymbolText(query: string): string {
 
 export const TOOLS: ToolDef[] = [
   {
-    name: 'graft_ask',
+    name: 'graft_find_code',
     description:
       'Query the repo context graph in plain words. Returns ranked nodes with exact file:line spans and the relevant source inlined — usually the full answer, no file reads needed.',
     inputSchema: {
@@ -60,7 +60,7 @@ export const TOOLS: ToolDef[] = [
     },
   },
   {
-    name: 'graft_skeleton',
+    name: 'graft_file_api',
     description:
       "Signatures-only view of one file — every definition's signature + line span, ~10× cheaper than reading the file ($0, no LLM).",
     inputSchema: {
@@ -72,12 +72,12 @@ export const TOOLS: ToolDef[] = [
     },
   },
   {
-    name: 'graft_check',
+    name: 'graft_check_freshness',
     description: 'Report whether the committed graph is in sync with the code (drift check).',
     inputSchema: { type: 'object', properties: {} },
   },
   {
-    name: 'graft_callers',
+    name: 'graft_trace_calls',
     description:
       'Structural edges for a symbol, over call/reference/import/implements/extends ($0, no LLM). Defaults to direct callers (who depends on it). Set direction:"out" for callees (what it calls); set depth>1 (or depth:"all" for the full closure) to walk transitively for the full blast radius — every source that breaks if it changes. Run before a multi-file refactor to find ALL affected files.',
     inputSchema: {
@@ -96,7 +96,7 @@ export const TOOLS: ToolDef[] = [
     },
   },
   {
-    name: 'graft_grep',
+    name: 'graft_find_all',
     description:
       'Regex search over the graph\'s indexed files, hits grouped by innermost enclosing symbol and ranked by incoming-edge count (coupling) — which hit matters, not just where it is.',
     inputSchema: {
@@ -111,7 +111,7 @@ export const TOOLS: ToolDef[] = [
     },
   },
   {
-    name: 'graft_map',
+    name: 'graft_repo_map',
     description:
       'Token-budgeted repo orientation — directory clusters, per-directory hubs, and global hotspots computed purely from the wiring graph ($0, no LLM). Use this to get oriented in an unfamiliar repo before diving into files.',
     inputSchema: {
@@ -155,17 +155,17 @@ function callWorkspaceTool(
   args: Record<string, unknown>,
 ): { text: string; isError: boolean } | null {
   switch (name) {
-    case 'graft_ask': {
+    case 'graft_find_code': {
       const query = String(args.query ?? '');
-      if (!query) return { text: 'graft_ask requires a query', isError: true };
+      if (!query) return { text: 'graft_find_code requires a query', isError: true };
       const limit = typeof args.limit === 'number' ? args.limit : 5;
       const inArg = typeof args.in === 'string' && args.in ? args.in : undefined;
       const r = federateAsk(root, dirOverride, query, { limit, source: true, full: args.full === true, in: inArg });
       return { text: formatAsk(r), isError: false };
     }
-    case 'graft_callers': {
+    case 'graft_trace_calls': {
       const symbol = String(args.symbol ?? args.file ?? '');
-      if (!symbol) return { text: 'graft_callers requires a symbol', isError: true };
+      if (!symbol) return { text: 'graft_trace_calls requires a symbol', isError: true };
       const { text, found } = federateCallers(root, dirOverride, symbol, {
         direction: args.direction === 'out' ? 'out' : 'in',
         depth: typeof args.depth === 'number' && Number.isFinite(args.depth) ? args.depth : undefined,
@@ -173,9 +173,9 @@ function callWorkspaceTool(
       });
       return { text, isError: !found };
     }
-    case 'graft_grep': {
+    case 'graft_find_all': {
       const pattern = String(args.pattern ?? '');
-      if (!pattern) return { text: 'graft_grep requires a pattern', isError: true };
+      if (!pattern) return { text: 'graft_find_all requires a pattern', isError: true };
       const { result, coverage } = federateGrep(root, dirOverride, pattern, {
         ignoreCase: typeof args.ignore_case === 'boolean' ? args.ignore_case : undefined,
         fixed: typeof args.fixed === 'boolean' ? args.fixed : undefined,
@@ -183,11 +183,11 @@ function callWorkspaceTool(
       const text = result.totalHits === 0 ? zeroHitNote(result) : formatGrepResult(result);
       return { text: coverage ? `${text}\n${coverage}` : text, isError: false };
     }
-    case 'graft_map': {
+    case 'graft_repo_map': {
       const maxDirs = typeof args.max_dirs === 'number' && Number.isFinite(args.max_dirs) && args.max_dirs > 0 ? args.max_dirs : undefined;
       return { text: federateMap(root, dirOverride, { maxDirs }), isError: false };
     }
-    case 'graft_check': {
+    case 'graft_check_freshness': {
       const { text } = federateCheck(root, dirOverride);
       return { text, isError: false };
     }
@@ -197,16 +197,42 @@ function callWorkspaceTool(
 }
 
 /** Tools whose whole job is to REPORT drift. Rebuilding first would make
- * `graft_check` answer about a graph it just fixed, i.e. always "OK". */
-const NO_REFRESH_TOOLS = new Set(['graft_check']);
+ * `graft_check_freshness` answer about a graph it just fixed, i.e. always "OK". */
+const NO_REFRESH_TOOLS = new Set(['graft_check_freshness']);
+
+/**
+ * The pre-0.8.1 tool names, still accepted.
+ *
+ * The names were the reason for renaming: when a host defers graft's schemas it
+ * shows the model the *names alone* — no descriptions — so `graft_ask` had to
+ * compete with `Grep` on 9 characters of self-description. The new names say what
+ * they do. But a name is an API: skills, saved prompts, scripts and other people's
+ * notes reference the old ones, and silently 404-ing on them would be a worse
+ * outcome than an ugly name. Not advertised in {@link TOOLS} — the roster stays six
+ * — so this costs nothing in the payload and only ever rescues an old caller.
+ */
+const TOOL_ALIASES: Record<string, string> = {
+  graft_ask: 'graft_find_code',
+  graft_grep: 'graft_find_all',
+  graft_callers: 'graft_trace_calls',
+  graft_skeleton: 'graft_file_api',
+  graft_map: 'graft_repo_map',
+  graft_check: 'graft_check_freshness',
+};
+
+/** Canonical name for a requested tool: itself, or what it was renamed to. */
+export function canonicalToolName(name: string): string {
+  return TOOL_ALIASES[name] ?? name;
+}
 
 export async function callTool(
   root: string,
-  name: string,
+  requestedName: string,
   args: Record<string, unknown>,
   dirOverride?: string,
 ): Promise<{ text: string; isError: boolean }> {
   try {
+    const name = canonicalToolName(requestedName);
     const ws = readWorkspace(root, dirOverride);
     // Freshness first: an answer that cites file:line has to be about the code as
     // it is right now, including edits nobody has committed (or even saved through
@@ -234,22 +260,22 @@ function callSingleTool(
   dirOverride?: string,
 ): { text: string; isError: boolean } {
   switch (name) {
-      case 'graft_ask': {
+      case 'graft_find_code': {
         const query = String(args.query ?? '');
-        if (!query) return { text: 'graft_ask requires a query', isError: true };
+        if (!query) return { text: 'graft_find_code requires a query', isError: true };
         const limit = typeof args.limit === 'number' ? args.limit : 5;
         const engine = new Graft({ contextDir: dirOverride });
         const inArg = typeof args.in === 'string' && args.in ? args.in : undefined;
         const r = engine.ask(root, query, { limit, source: true, full: args.full === true, in: inArg });
         return { text: formatAsk(r), isError: false };
       }
-      case 'graft_skeleton': {
+      case 'graft_file_api': {
         const file = String(args.file ?? '');
-        if (!file) return { text: 'graft_skeleton requires a file', isError: true };
+        if (!file) return { text: 'graft_file_api requires a file', isError: true };
         const r = skeleton(root, file, { contextDir: dirOverride });
         return { text: formatSkeleton(r), isError: !r.entries.length && !!r.note };
       }
-      case 'graft_check': {
+      case 'graft_check_freshness': {
         const engine = new Graft({ contextDir: dirOverride });
         const r = engine.check(root);
         const g = engine.checkGraph(root);
@@ -257,7 +283,7 @@ function callSingleTool(
         if (!g.missing) parts.push(formatGraphCheckReport(g));
         return { text: parts.join('\n\n'), isError: false };
       }
-      case 'graft_callers': {
+      case 'graft_trace_calls': {
         // One tool covers callers (direction:in, the default), callees
         // (direction:out), and blast radius (depth>1). edgeWalk handles the
         // file-seed aggregation that the old graft_blast_radius did: for a
@@ -265,7 +291,7 @@ function callSingleTool(
         // it, so dependents that call into a symbol (targeting the SYMBOL id,
         // never the FILE id) aren't silently dropped.
         const symbol = String(args.symbol ?? args.file ?? '');
-        if (!symbol) return { text: 'graft_callers requires a symbol', isError: true };
+        if (!symbol) return { text: 'graft_trace_calls requires a symbol', isError: true };
         const w = loadGraphCached(contextDirFor(root, dirOverride));
         if (!w) return { text: NO_GRAPH, isError: true };
         const inOpt = typeof args.in === 'string' && args.in ? { in: args.in } : {};
@@ -286,9 +312,9 @@ function callSingleTool(
         const text = body + savingsFooter(body, callersSavings(w, results));
         return { text, isError: false };
       }
-      case 'graft_grep': {
+      case 'graft_find_all': {
         const pattern = String(args.pattern ?? '');
-        if (!pattern) return { text: 'graft_grep requires a pattern', isError: true };
+        if (!pattern) return { text: 'graft_find_all requires a pattern', isError: true };
         const w = loadGraphCached(contextDirFor(root, dirOverride));
         if (!w) return { text: NO_GRAPH, isError: true };
         const result = grepGraph(w, root, pattern, {
@@ -299,7 +325,7 @@ function callSingleTool(
         if (result.totalHits === 0) return { text: zeroHitNote(result), isError: false };
         return { text: formatGrepResult(result), isError: false };
       }
-      case 'graft_map': {
+      case 'graft_repo_map': {
         const w = loadGraphCached(contextDirFor(root, dirOverride));
         if (!w) return { text: NO_GRAPH, isError: true };
         const maxDirs = typeof args.max_dirs === 'number' && Number.isFinite(args.max_dirs) && args.max_dirs > 0 ? args.max_dirs : undefined;

--- a/src/search/grep-cli.ts
+++ b/src/search/grep-cli.ts
@@ -4,7 +4,7 @@
  * Kept out of cli.ts (argument wiring only) and out of grep.ts (pure core,
  * unit-testable against hand-built fixture graphs without touching a real
  * repo root) — same split as traverse.ts/traverse-cli.ts. `formatGrepResult`
- * is exported so `graft_grep` in `src/mcp/tools.ts` renders the identical
+ * is exported so `graft_find_all` in `src/mcp/tools.ts` renders the identical
  * report, rather than re-implementing it.
  */
 import { resolve } from "node:path";

--- a/src/search/grep.ts
+++ b/src/search/grep.ts
@@ -7,7 +7,7 @@
  *
  * Pure I/O + regex, no CLI/MCP concerns: `grep-cli.ts` formats this into
  * human text and wires the CLI command; `mcp/tools.ts` renders the same
- * shape for the `graft_grep` tool.
+ * shape for the `graft_find_all` tool.
  */
 import { readFileSync } from "node:fs";
 import { join } from "node:path";

--- a/test/claude-format.test.ts
+++ b/test/claude-format.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { renderStatusline, incomingEdges, formatBlastRadius, formatRetrieval, formatOrientation, renderSubagent, relevantRetrieval, INJECT_MIN_COVERAGE } from '../src/claude/format.js';
+import { renderStatusline, incomingEdges, formatBlastRadius, formatRetrieval, formatOrientation, renderSubagent, relevantRetrieval, INJECT_MIN_COVERAGE, NUDGE_CAP } from '../src/claude/format.js';
 import { emptyStats } from '../src/claude/state.js';
 
 const strip = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '');
@@ -102,10 +102,44 @@ test('relevantRetrieval injects on good coverage and records pointers', () => {
   assert.deepEqual(s.injectedPointers, ['src/pkce.ts:L1-L4', 'src/pkce.ts:L6-L9']);
 });
 
-test('relevantRetrieval skips when coverage is below the floor', () => {
+test('relevantRetrieval nudges instead of injecting when the match is weak both ways', () => {
   const s = freshSession();
-  assert.equal(relevantRetrieval(gateAsk({ coverage: INJECT_MIN_COVERAGE - 0.01 }), s), null);
-  assert.deepEqual(s.injectedPointers, [], 'nothing recorded on skip');
+  const txt = relevantRetrieval(gateAsk({ coverage: 0.2, coverageStrong: 0.05 }), s);
+  assert.match(txt ?? '', /no strong match/, 'a weak pack is replaced by a named command');
+  assert.match(txt ?? '', /graft ask/, 'the nudge names the command to run');
+  assert.deepEqual(s.injectedPointers, [], 'nothing recorded — no pack was shown');
+});
+
+test('relevantRetrieval passes on a NAME hit even when broad coverage is low', () => {
+  // The whole point of the second clause: a short prompt naming one real symbol
+  // has low broad coverage and high strength, and must not be gated out.
+  const txt = relevantRetrieval(gateAsk({ coverage: 0.2, coverageStrong: 0.45 }), freshSession());
+  assert.ok(txt && /verify/.test(strip(txt)), 'strong name match injects');
+});
+
+test('relevantRetrieval: the traced turn-1 regression is now rejected', () => {
+  // Measured from session ce3ca5f4: this exact pair cleared the old 0.15 floor by
+  // 0.015 and injected three test files for a question answered elsewhere.
+  const s = freshSession();
+  const txt = relevantRetrieval(gateAsk({ coverage: 0.1649, coverageStrong: 0.0329 }), s);
+  assert.match(txt ?? '', /no strong match/);
+  assert.match(txt ?? '', /0\.03/, 'the nudge reports the strength it measured');
+  assert.deepEqual(s.injectedPointers, []);
+});
+
+test('relevantRetrieval caps the nudge so it cannot become wallpaper', () => {
+  const s = freshSession();
+  const weak = () => gateAsk({ coverage: 0.1, coverageStrong: 0 });
+  assert.ok(relevantRetrieval(weak(), s), 'first weak prompt nudges');
+  assert.ok(relevantRetrieval(weak(), s), 'second still nudges');
+  assert.equal(relevantRetrieval(weak(), s), null, 'third is silent');
+  assert.equal(s.nudges, NUDGE_CAP);
+});
+
+test('INJECT_MIN_COVERAGE is retained as the superseded reference floor', () => {
+  // Documented history, not live logic: 0.1649 used to clear this and no longer does.
+  assert.equal(INJECT_MIN_COVERAGE, 0.15);
+  assert.ok(0.1649 > INJECT_MIN_COVERAGE, 'the regression case cleared the old floor');
 });
 
 test('relevantRetrieval treats missing coverage (structural mode) as relevant', () => {

--- a/test/claude-init.test.ts
+++ b/test/claude-init.test.ts
@@ -1,5 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+
+// The MCP launch command is resolved from PATH at init time; pin it to the npx
+// form so these expectations are the same on every machine.
+process.env.GRAFT_MCP_NPX = '1';
 import { mkdtempSync, readFileSync, existsSync, writeFileSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -30,7 +34,7 @@ test('runInit scaffolds settings + both shims + the skill (build skipped)', () =
   const s = JSON.parse(readFileSync(join(d, '.claude', 'settings.json'), 'utf8'));
   assert.ok(s.statusLine.command.includes('graft-statusline.cjs'));
   assert.ok(s.hooks.Stop[0].hooks[0].command.includes('graft-hooks.cjs'));
-  assert.deepEqual(s.permissions.allow, ['Bash(graft:*)', 'Bash(npx graft:*)']);
+  assert.deepEqual(s.permissions.allow, ['Bash(graft:*)', 'Bash(npx graft:*)', 'Bash(graft-dev:*)', 'Bash(node dist/cli.js:*)']);
 });
 
 test('runInit overwrites a stale skill file', () => {
@@ -59,7 +63,7 @@ test('runInit is idempotent', () => {
   runInit(d, { build: false });
   const s = JSON.parse(readFileSync(join(d, '.claude', 'settings.json'), 'utf8'));
   assert.equal(s.hooks.PostToolUse.length, 2); // post-edit + tool-savings, not duplicated on re-init
-  assert.deepEqual(s.permissions.allow, ['Bash(graft:*)', 'Bash(npx graft:*)']);
+  assert.deepEqual(s.permissions.allow, ['Bash(graft:*)', 'Bash(npx graft:*)', 'Bash(graft-dev:*)', 'Bash(node dist/cli.js:*)']);
 });
 
 test('runInit appends the allowlist to a pre-existing permissions block, preserving unrelated entries', () => {
@@ -68,7 +72,7 @@ test('runInit appends the allowlist to a pre-existing permissions block, preserv
   writeFileSync(join(d, '.claude', 'settings.json'), JSON.stringify({ permissions: { allow: ['Bash(ls)'] } }));
   runInit(d, { build: false });
   const s = JSON.parse(readFileSync(join(d, '.claude', 'settings.json'), 'utf8'));
-  assert.deepEqual(s.permissions.allow, ['Bash(ls)', 'Bash(graft:*)', 'Bash(npx graft:*)']);
+  assert.deepEqual(s.permissions.allow, ['Bash(ls)', 'Bash(graft:*)', 'Bash(npx graft:*)', 'Bash(graft-dev:*)', 'Bash(node dist/cli.js:*)']);
 });
 
 test('postinstall prints the nudge in a fresh dir', () => {

--- a/test/claude-settings-merge.test.ts
+++ b/test/claude-settings-merge.test.ts
@@ -50,41 +50,41 @@ test('re-running is idempotent (no duplicate Graft entries or footer)', () => {
 test('foreign top-level keys survive', () => {
   const { merged } = mergeGraftSettings({ model: 'claude-sonnet-5', permissions: { allow: ['Bash(ls)'] } });
   assert.equal(merged.model, 'claude-sonnet-5');
-  assert.deepEqual(merged.permissions.allow, ['Bash(ls)', 'Bash(graft:*)', 'Bash(npx graft:*)']);
+  assert.deepEqual(merged.permissions.allow, ['Bash(ls)', 'Bash(graft:*)', 'Bash(npx graft:*)', 'Bash(graft-dev:*)', 'Bash(node dist/cli.js:*)']);
 });
 
 test('fresh init adds the graft CLI allowlist', () => {
   const { merged } = mergeGraftSettings({});
-  assert.deepEqual(merged.permissions.allow, ['Bash(graft:*)', 'Bash(npx graft:*)']);
+  assert.deepEqual(merged.permissions.allow, ['Bash(graft:*)', 'Bash(npx graft:*)', 'Bash(graft-dev:*)', 'Bash(node dist/cli.js:*)']);
 });
 
 test('re-init does not duplicate allowlist entries', () => {
   const once = mergeGraftSettings({}).merged;
   const twice = mergeGraftSettings(once).merged;
-  assert.deepEqual(twice.permissions.allow, ['Bash(graft:*)', 'Bash(npx graft:*)']);
+  assert.deepEqual(twice.permissions.allow, ['Bash(graft:*)', 'Bash(npx graft:*)', 'Bash(graft-dev:*)', 'Bash(node dist/cli.js:*)']);
 });
 
 test('pre-existing unrelated allow entries are preserved and ours appended', () => {
   const existing = { permissions: { allow: ['Bash(ls)', 'Bash(git:*)'] } };
   const { merged } = mergeGraftSettings(existing);
-  assert.deepEqual(merged.permissions.allow, ['Bash(ls)', 'Bash(git:*)', 'Bash(graft:*)', 'Bash(npx graft:*)']);
+  assert.deepEqual(merged.permissions.allow, ['Bash(ls)', 'Bash(git:*)', 'Bash(graft:*)', 'Bash(npx graft:*)', 'Bash(graft-dev:*)', 'Bash(node dist/cli.js:*)']);
 });
 
-test('pre-existing allow list already containing Bash(graft:*) is left unchanged aside from the missing entry', () => {
+test('a partially-present allowlist gains only what it lacks, in order', () => {
   const existing = { permissions: { allow: ['Bash(graft:*)'] } };
   const { merged } = mergeGraftSettings(existing);
-  assert.deepEqual(merged.permissions.allow, ['Bash(graft:*)', 'Bash(npx graft:*)']);
+  assert.deepEqual(merged.permissions.allow, ['Bash(graft:*)', 'Bash(npx graft:*)', 'Bash(graft-dev:*)', 'Bash(node dist/cli.js:*)']);
 });
 
-test('pre-existing allow list already containing both entries is unchanged', () => {
+test('pre-existing allow entries are kept and only the missing ones appended', () => {
   const existing = { permissions: { allow: ['Bash(graft:*)', 'Bash(npx graft:*)'] } };
   const { merged } = mergeGraftSettings(existing);
-  assert.deepEqual(merged.permissions.allow, ['Bash(graft:*)', 'Bash(npx graft:*)']);
+  assert.deepEqual(merged.permissions.allow, ['Bash(graft:*)', 'Bash(npx graft:*)', 'Bash(graft-dev:*)', 'Bash(node dist/cli.js:*)']);
 });
 
 test('permissions object with no allow key gets one added; other keys preserved', () => {
   const existing = { permissions: { deny: ['Bash(rm:*)'] } };
   const { merged } = mergeGraftSettings(existing);
   assert.deepEqual(merged.permissions.deny, ['Bash(rm:*)']);
-  assert.deepEqual(merged.permissions.allow, ['Bash(graft:*)', 'Bash(npx graft:*)']);
+  assert.deepEqual(merged.permissions.allow, ['Bash(graft:*)', 'Bash(npx graft:*)', 'Bash(graft-dev:*)', 'Bash(node dist/cli.js:*)']);
 });

--- a/test/claude-state.test.ts
+++ b/test/claude-state.test.ts
@@ -24,7 +24,7 @@ test('stats round-trip and patch merge', () => {
 test('session defaults and round-trip', () => {
   const d = fresh();
   const s = readSession(d, 'abc');
-  assert.deepEqual(s, { lastQuery: null, perAgentQuery: {}, graftReads: 0, sourceReads: 0, savedTokens: 0, injectedPointers: [] });
+  assert.deepEqual(s, { lastQuery: null, perAgentQuery: {}, graftReads: 0, sourceReads: 0, savedTokens: 0, injectedPointers: [], nudges: 0 });
   s.lastQuery = 'pkce'; s.graftReads = 2;
   writeSession(d, 'abc', s);
   assert.equal(readSession(d, 'abc').lastQuery, 'pkce');

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -10,7 +10,7 @@ import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 import { buildContext } from "../src/context/build.js";
 import { checkContext, indexFreshness, staleBanner } from "../src/context/check.js";
-import { contextDirFor, ensureGitignored } from "../src/context/node-file.js";
+import { contextDirFor, ensureGitignored, ensureSearchable } from "../src/context/node-file.js";
 import { fakeProviders } from "./helpers.js";
 
 // CLI-spawn helper (same pattern as test/graph-traverse-cli.test.ts) — these tests
@@ -299,6 +299,61 @@ test("ensureGitignored: no-op when the graph dir is outside the repo root", () =
   try {
     ensureGitignored(dir, join(tmpdir(), "somewhere-else-graft"));
     assert.equal(existsSync(join(dir, ".gitignore")), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ensureSearchable — gitignoring the graph must not also hide it from `grep`.
+// ripgrep honours .gitignore, so without this the cards are unreachable by the
+// one mechanism they were designed around.
+test("ensureSearchable: re-admits the card tree while excluding the caches", () => {
+  const dir = mkdtempSync(join(tmpdir(), "ctxsearch-"));
+  try {
+    ensureSearchable(dir, contextDirFor(dir));
+    const ig = readFileSync(join(dir, ".ignore"), "utf8");
+    assert.match(ig, /^!graft\/$/m, "the tree is re-admitted to search");
+    assert.match(ig, /^graft\/\.cache\/$/m, "but not the multi-MB parse memo");
+    assert.match(ig, /^graft\/\.graph\/$/m, "and not wiring.json");
+    assert.match(ig, /ripgrep reads/, "carries the why, for whoever finds this file");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("ensureSearchable: appends to an existing .ignore, and is idempotent", () => {
+  const dir = mkdtempSync(join(tmpdir(), "ctxsearch-"));
+  try {
+    writeFileSync(join(dir, ".ignore"), "vendor/\n");
+    ensureSearchable(dir, contextDirFor(dir));
+    const once = readFileSync(join(dir, ".ignore"), "utf8");
+    assert.match(once, /vendor\//, "existing entries survive");
+    ensureSearchable(dir, contextDirFor(dir));
+    const twice = readFileSync(join(dir, ".ignore"), "utf8");
+    assert.equal(once, twice);
+    assert.equal((twice.match(/^!graft\/$/gm) ?? []).length, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("ensureSearchable: leaves a hand-written negation alone", () => {
+  const dir = mkdtempSync(join(tmpdir(), "ctxsearch-"));
+  try {
+    // Someone already had an opinion here — don't append a competing block.
+    writeFileSync(join(dir, ".ignore"), "# mine\n!graft/\n");
+    ensureSearchable(dir, contextDirFor(dir));
+    assert.equal(readFileSync(join(dir, ".ignore"), "utf8"), "# mine\n!graft/\n");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("ensureSearchable: no-op when the graph dir is outside the repo root", () => {
+  const dir = mkdtempSync(join(tmpdir(), "ctxsearch-"));
+  try {
+    ensureSearchable(dir, join(tmpdir(), "somewhere-else-graft"));
+    assert.equal(existsSync(join(dir, ".ignore")), false);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/test/graph-load.test.ts
+++ b/test/graph-load.test.ts
@@ -123,14 +123,14 @@ test("loadAskIndexCached: caches and invalidates the same way as the graph loade
 // the way. `graph-refresh.test.ts` covers the refresh itself.
 process.env.GRAFT_NO_REFRESH = "1";
 
-test("callTool: graft_callers on the same dir twice doesn't reparse the graph", async () => {
+test("callTool: graft_trace_calls on the same dir twice doesn't reparse the graph", async () => {
   const dir = fixtureDir();
   mkdirSync(join(dir, "src"), { recursive: true });
   writeFileSync(join(dir, "src", "math.ts"), "export function add() { return 1; }\n");
   const graph: GraphV1 = {
     version: 1,
     // A real `buildGraph` always emits a `kind: "file"` node per source file;
-    // include one here too so `graft_callers` with depth (a `resolveSymbol` +
+    // include one here too so `graft_trace_calls` with depth (a `resolveSymbol` +
     // `edgeWalk` walk, the old `graft impact`) can resolve the filename-shaped
     // query the way it would against a real build.
     nodes: [
@@ -139,7 +139,7 @@ test("callTool: graft_callers on the same dir twice doesn't reparse the graph", 
     ],
     edges: [],
   } as GraphV1;
-  // graft_callers reads through `contextDirFor(root)`, i.e. `<root>/graft`
+  // graft_trace_calls reads through `contextDirFor(root)`, i.e. `<root>/graft`
   // by default — write the graph there directly rather than round-tripping
   // through a real `graft build`.
   const outDir = join(dir, "graft");
@@ -147,11 +147,11 @@ test("callTool: graft_callers on the same dir twice doesn't reparse the graph", 
   writeGraph(graph, outDir);
   __resetParseCounts();
 
-  const r1 = await callTool(dir, "graft_callers", { symbol: "src/math.ts", depth: 2 });
+  const r1 = await callTool(dir, "graft_trace_calls", { symbol: "src/math.ts", depth: 2 });
   assert.equal(r1.isError, false);
   assert.equal(__parseCount.graph, 1);
 
-  const r2 = await callTool(dir, "graft_callers", { symbol: "src/math.ts", depth: 2 });
+  const r2 = await callTool(dir, "graft_trace_calls", { symbol: "src/math.ts", depth: 2 });
   assert.equal(r2.isError, false);
   assert.equal(__parseCount.graph, 1, "second call on the same dir must not reparse");
 });

--- a/test/graph-refresh.test.ts
+++ b/test/graph-refresh.test.ts
@@ -398,24 +398,24 @@ test("a workspace refreshes its children even under a --dir override", async () 
   assert.equal(hasSymbol(child, "src/math.ts#mul"), true);
 });
 
-test("callTool refreshes before answering — except for graft_check", async () => {
+test("callTool refreshes before answering — except for graft_check_freshness", async () => {
   const d = repo();
   await buildGraph(d);
   writeFileSync(join(d, "src", "math.ts"), `${MATH}export function mul(a: number, b: number): number {\n  return a * b;\n}\n`);
 
-  // graft_check is the drift report: refreshing first would make it always say OK.
-  const check = await callTool(d, "graft_check", {});
+  // graft_check_freshness is the drift report: refreshing first would make it always say OK.
+  const check = await callTool(d, "graft_check_freshness", {});
   assert.equal(check.isError, false);
   assert.ok(!check.text.startsWith("[graft] refreshed"));
   assert.equal(hasSymbol(d, "src/math.ts#mul"), false, "check must not rebuild");
 
-  const ask = await callTool(d, "graft_ask", { query: "multiply two numbers" });
+  const ask = await callTool(d, "graft_find_code", { query: "multiply two numbers" });
   assert.equal(ask.isError, false);
   assert.match(ask.text, /^\[graft\] refreshed the graph/);
   assert.equal(hasSymbol(d, "src/math.ts#mul"), true);
   assert.match(ask.text, /mul/, "and the answer knows about the symbol that was never committed");
 
-  const again = await callTool(d, "graft_ask", { query: "multiply two numbers" });
+  const again = await callTool(d, "graft_find_code", { query: "multiply two numbers" });
   assert.ok(!again.text.startsWith("[graft] refreshed"), "nothing moved — no note, no rebuild");
 });
 

--- a/test/hosts-init.test.ts
+++ b/test/hosts-init.test.ts
@@ -1,5 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+
+// The MCP launch command is resolved from PATH at init time; pin it to the npx
+// form so these expectations are the same on every machine.
+process.env.GRAFT_MCP_NPX = '1';
 import { mkdtempSync, mkdirSync, readFileSync, readdirSync, writeFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';

--- a/test/hosts-mcp-config.test.ts
+++ b/test/hosts-mcp-config.test.ts
@@ -1,9 +1,13 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+
+// The MCP launch command is resolved from PATH at init time; pin it to the npx
+// form so these expectations are the same on every machine.
+process.env.GRAFT_MCP_NPX = '1';
 import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { registerMcpConfigs } from '../src/hosts/mcp-config.js';
+import { registerMcpConfigs, serverEntry } from '../src/hosts/mcp-config.js';
 
 function fresh(): string { return mkdtempSync(join(tmpdir(), 'graft-mcpcfg-')); }
 
@@ -73,4 +77,25 @@ test('JSON with non-object mcpServers value is skipped', () => {
   const w = registerMcpConfigs(repo, ['cursor'], { home });
   assert.deepEqual(w.map((x) => x.action), ['skipped-unparseable']);
   assert.equal(readFileSync(join(repo, '.cursor', 'mcp.json'), 'utf8'), badJson);
+});
+
+// The launch command: bare binary when graft is installed, npx otherwise. Never an
+// absolute path — these files are committed and shared between machines.
+test('serverEntry prefers the installed binary and falls back to npx', () => {
+  const saved = process.env.GRAFT_MCP_NPX;
+  delete process.env.GRAFT_MCP_NPX;
+  try {
+    assert.deepEqual(serverEntry({ onPath: true }), { command: 'graft', args: ['mcp'] });
+    assert.deepEqual(serverEntry({ onPath: false }), { command: 'npx', args: ['-y', '@nanonets/graft', 'mcp'] });
+    for (const e of [serverEntry({ onPath: true }), serverEntry({ onPath: false })]) {
+      assert.ok(!e.command.startsWith('/'), 'never an absolute path — configs get shared');
+    }
+  } finally {
+    if (saved !== undefined) process.env.GRAFT_MCP_NPX = saved;
+  }
+});
+
+test('GRAFT_MCP_NPX overrides an installed binary', () => {
+  process.env.GRAFT_MCP_NPX = '1';
+  assert.equal(serverEntry({ onPath: true }).command, 'npx', 'the escape hatch wins');
 });

--- a/test/mcp-server.test.ts
+++ b/test/mcp-server.test.ts
@@ -34,7 +34,7 @@ test('initialize → tools/list → tools/call round-trip', async () => {
       { jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 't', version: '0' } } },
       { jsonrpc: '2.0', method: 'notifications/initialized' },
       { jsonrpc: '2.0', id: 2, method: 'tools/list' },
-      { jsonrpc: '2.0', id: 3, method: 'tools/call', params: { name: 'graft_callers', arguments: { symbol: 'x.ts', depth: 2 } } },
+      { jsonrpc: '2.0', id: 3, method: 'tools/call', params: { name: 'graft_trace_calls', arguments: { symbol: 'x.ts', depth: 2 } } },
     ],
     dir,
     3,
@@ -46,12 +46,12 @@ test('initialize → tools/list → tools/call round-trip', async () => {
   assert.equal(init.result.serverInfo.name, 'graft');
   const list = rs.find((r) => r.id === 2);
   assert.deepEqual(list.result.tools.map((t: any) => t.name), [
-    'graft_ask',
-    'graft_skeleton',
-    'graft_check',
-    'graft_callers',
-    'graft_grep',
-    'graft_map',
+    'graft_find_code',
+    'graft_file_api',
+    'graft_check_freshness',
+    'graft_trace_calls',
+    'graft_find_all',
+    'graft_repo_map',
   ]);
   const call = rs.find((r) => r.id === 3);
   assert.equal(call.result.isError, true); // unbuilt repo → soft error content
@@ -70,8 +70,8 @@ test('initialize carries instructions — the layer that survives tool deferral'
   // A host that defers graft's schemas shows the model six bare names and nothing
   // else, so this string has to carry both the pitch and the recovery instruction.
   assert.match(instructions, /ONE lookup/, 'tells the agent to batch the schema fetch');
-  assert.match(instructions, /select:mcp__graft__graft_ask,/, 'gives a copy-pasteable query');
-  for (const t of ['graft_ask', 'graft_grep', 'graft_callers', 'graft_skeleton', 'graft_map']) {
+  assert.match(instructions, /select:mcp__graft__graft_find_code,/, 'gives a copy-pasteable query');
+  for (const t of ['graft_find_code', 'graft_find_all', 'graft_trace_calls', 'graft_file_api', 'graft_repo_map']) {
     assert.ok(instructions.includes(t), `names ${t}`);
   }
   // Observed sibling servers sit at 660–984 chars; nothing proves a longer one

--- a/test/mcp-server.test.ts
+++ b/test/mcp-server.test.ts
@@ -58,6 +58,28 @@ test('initialize → tools/list → tools/call round-trip', async () => {
   assert.match(call.result.content[0].text, /graft build/);
 });
 
+test('initialize carries instructions — the layer that survives tool deferral', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'graft-mcpsrv-instr-'));
+  const rs = await rpc(
+    [{ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 't', version: '0' } } }],
+    dir,
+    1,
+  );
+  const { instructions, serverInfo } = rs[0].result;
+  assert.equal(typeof instructions, 'string');
+  // A host that defers graft's schemas shows the model six bare names and nothing
+  // else, so this string has to carry both the pitch and the recovery instruction.
+  assert.match(instructions, /ONE lookup/, 'tells the agent to batch the schema fetch');
+  assert.match(instructions, /select:mcp__graft__graft_ask,/, 'gives a copy-pasteable query');
+  for (const t of ['graft_ask', 'graft_grep', 'graft_callers', 'graft_skeleton', 'graft_map']) {
+    assert.ok(instructions.includes(t), `names ${t}`);
+  }
+  // Observed sibling servers sit at 660–984 chars; nothing proves a longer one
+  // survives un-truncated, so hold the line here rather than discover it later.
+  assert.ok(instructions.length < 1000, `instructions must stay under 1000 chars, got ${instructions.length}`);
+  assert.match(serverInfo.version, /^\d+\.\d+\.\d+$/, 'real version, not the old hardcoded 0');
+});
+
 test('unknown method returns -32601', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'graft-mcpsrv2-'));
   const rs = await rpc([{ jsonrpc: '2.0', id: 9, method: 'resources/list' }], dir, 1);

--- a/test/mcp-tools.test.ts
+++ b/test/mcp-tools.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { execFileSync } from 'node:child_process';
-import { TOOLS, callTool } from '../src/mcp/tools.js';
+import { TOOLS, callTool, canonicalToolName } from '../src/mcp/tools.js';
 
 function builtRepo(): string {
   const d = mkdtempSync(join(tmpdir(), 'graft-mcptools-'));
@@ -60,7 +60,7 @@ function fileScopeRepo(): string {
 }
 
 /** Five top-level dirs, one file each — enough groups that a small `max_dirs`
- * actually drops some, so the `graft_map` `max_dirs` arg has something to
+ * actually drops some, so the `graft_repo_map` `max_dirs` arg has something to
  * prove it's wired through to `buildRepoMap`. */
 function multiDirRepo(): string {
   const d = mkdtempSync(join(tmpdir(), 'graft-mcptools-multidir-'));
@@ -74,62 +74,62 @@ function multiDirRepo(): string {
 
 test('TOOLS lists the six tools with schemas', async () => {
   assert.deepEqual(TOOLS.map((t) => t.name), [
-    'graft_ask',
-    'graft_skeleton',
-    'graft_check',
-    'graft_callers',
-    'graft_grep',
-    'graft_map',
+    'graft_find_code',
+    'graft_file_api',
+    'graft_check_freshness',
+    'graft_trace_calls',
+    'graft_find_all',
+    'graft_repo_map',
   ]);
   for (const t of TOOLS) {
     assert.ok(t.description.length > 0);
     assert.equal((t.inputSchema as { type: string }).type, 'object');
   }
-  // graft_callers absorbed callees (direction) and blast radius (depth) — the
+  // graft_trace_calls absorbed callees (direction) and blast radius (depth) — the
   // schema must document both flags.
-  const callers = TOOLS.find((t) => t.name === 'graft_callers')!;
+  const callers = TOOLS.find((t) => t.name === 'graft_trace_calls')!;
   const props = (callers.inputSchema as { properties: Record<string, unknown> }).properties;
-  assert.ok('direction' in props, 'graft_callers schema should document `direction`');
-  assert.ok('depth' in props, 'graft_callers schema should document `depth`');
+  assert.ok('direction' in props, 'graft_trace_calls schema should document `direction`');
+  assert.ok('depth' in props, 'graft_trace_calls schema should document `depth`');
 });
 
-test('graft_ask returns ranked hits for a built repo', async () => {
+test('graft_find_code returns ranked hits for a built repo', async () => {
   const d = builtRepo();
-  const r = await callTool(d, 'graft_ask', { query: 'how do I add numbers' });
+  const r = await callTool(d, 'graft_find_code', { query: 'how do I add numbers' });
   assert.equal(r.isError, false);
   assert.match(r.text, /add/);
   assert.match(r.text, /src\/math\.ts/);
 });
 
-test('graft_ask: `in` arg round-trips — narrows results to the prefix and is a soft isError on an unknown one', async () => {
+test('graft_find_code: `in` arg round-trips — narrows results to the prefix and is a soft isError on an unknown one', async () => {
   const d = builtRepo();
-  const ok = await callTool(d, 'graft_ask', { query: 'how do I add numbers', in: 'src' });
+  const ok = await callTool(d, 'graft_find_code', { query: 'how do I add numbers', in: 'src' });
   assert.equal(ok.isError, false);
   assert.match(ok.text, /src\/math\.ts/);
 
-  const miss = await callTool(d, 'graft_ask', { query: 'how do I add numbers', in: 'nosuchdir' });
+  const miss = await callTool(d, 'graft_find_code', { query: 'how do I add numbers', in: 'nosuchdir' });
   assert.equal(miss.isError, true);
   assert.match(miss.text, /nothing indexed under "nosuchdir\/"/);
   assert.match(miss.text, /or any path prefix/);
 });
 
-test('graft_check reports the wiring state', async () => {
+test('graft_check_freshness reports the wiring state', async () => {
   const d = builtRepo();
-  const r = await callTool(d, 'graft_check', {});
+  const r = await callTool(d, 'graft_check_freshness', {});
   assert.equal(r.isError, false);
   assert.match(r.text, /graph check: OK/);
 });
 
-test('graft_callers with depth names dependents of a file (blast radius)', async () => {
+test('graft_trace_calls with depth names dependents of a file (blast radius)', async () => {
   const d = builtRepo();
-  const r = await callTool(d, 'graft_callers', { symbol: 'src/math.ts', depth: 2 });
+  const r = await callTool(d, 'graft_trace_calls', { symbol: 'src/math.ts', depth: 2 });
   assert.equal(r.isError, false);
   assert.ok(r.text.length > 0);
 });
 
 test('unbuilt repo and unknown tool are soft errors', async () => {
   const bare = mkdtempSync(join(tmpdir(), 'graft-mcptools-bare-'));
-  const r1 = await callTool(bare, 'graft_callers', { symbol: 'x.ts', depth: 2 });
+  const r1 = await callTool(bare, 'graft_trace_calls', { symbol: 'x.ts', depth: 2 });
   assert.equal(r1.isError, true);
   assert.match(r1.text, /graft build/);
   const r2 = await callTool(bare, 'nope', {});
@@ -137,57 +137,57 @@ test('unbuilt repo and unknown tool are soft errors', async () => {
   assert.match(r2.text, /unknown tool/i);
 });
 
-test('graft_callers round-trips a caller on the built fixture', async () => {
+test('graft_trace_calls round-trips a caller on the built fixture', async () => {
   const d = builtRepo();
-  const r = await callTool(d, 'graft_callers', { symbol: 'add' });
+  const r = await callTool(d, 'graft_trace_calls', { symbol: 'add' });
   assert.equal(r.isError, false);
   assert.match(r.text, /add · function · src\/math\.ts:/);
   assert.match(r.text, /calls ← sub \(src\/math\.ts:/);
 });
 
-test('graft_callers: qualified/--in narrowing still resolves through the shared resolver', async () => {
+test('graft_trace_calls: qualified/--in narrowing still resolves through the shared resolver', async () => {
   const d = builtRepo();
-  const r = await callTool(d, 'graft_callers', { symbol: 'add', in: 'math' });
+  const r = await callTool(d, 'graft_trace_calls', { symbol: 'add', in: 'math' });
   assert.equal(r.isError, false);
   assert.match(r.text, /calls ← sub/);
-  const miss = await callTool(d, 'graft_callers', { symbol: 'add', in: 'nowhere' });
+  const miss = await callTool(d, 'graft_trace_calls', { symbol: 'add', in: 'nowhere' });
   assert.equal(miss.isError, true);
   assert.match(miss.text, /no symbol "add" in the graph/);
 });
 
-test('graft_callers direction:out round-trips a callee, and reports a loud note when there are none', async () => {
+test('graft_trace_calls direction:out round-trips a callee, and reports a loud note when there are none', async () => {
   const d = builtRepo();
-  const callee = await callTool(d, 'graft_callers', { symbol: 'sub', direction: 'out' });
+  const callee = await callTool(d, 'graft_trace_calls', { symbol: 'sub', direction: 'out' });
   assert.equal(callee.isError, false);
   assert.match(callee.text, /calls → add \(src\/math\.ts:/);
 
   // `add` calls nothing, so its callees are empty — must be a loud note, not silence.
-  const empty = await callTool(d, 'graft_callers', { symbol: 'add', direction: 'out' });
+  const empty = await callTool(d, 'graft_trace_calls', { symbol: 'add', direction: 'out' });
   assert.equal(empty.isError, false);
   assert.match(empty.text, /no indexed callees/);
   assert.match(empty.text, /graft grep "add"/);
 });
 
-test('graft_callers: unknown symbol / missing symbol are soft isErrors', async () => {
+test('graft_trace_calls: unknown symbol / missing symbol are soft isErrors', async () => {
   const d = builtRepo();
-  const r1 = await callTool(d, 'graft_callers', { symbol: 'noSuchSymbolAnywhere' });
+  const r1 = await callTool(d, 'graft_trace_calls', { symbol: 'noSuchSymbolAnywhere' });
   assert.equal(r1.isError, true);
   assert.match(r1.text, /no symbol "noSuchSymbolAnywhere" in the graph/);
   assert.match(r1.text, /check spelling|graft build/);
 
-  const r2 = await callTool(d, 'graft_callers', {});
+  const r2 = await callTool(d, 'graft_trace_calls', {});
   assert.equal(r2.isError, true);
   assert.match(r2.text, /requires a symbol/);
 });
 
-test('graft_callers: depth param is honored (depth 2 reaches further than depth 1)', async () => {
+test('graft_trace_calls: depth param is honored (depth 2 reaches further than depth 1)', async () => {
   const d = chainRepo();
-  const shallow = await callTool(d, 'graft_callers', { symbol: 'add', depth: 1 });
+  const shallow = await callTool(d, 'graft_trace_calls', { symbol: 'add', depth: 1 });
   assert.equal(shallow.isError, false);
   assert.match(shallow.text, /← sub \(/);
   assert.doesNotMatch(shallow.text, /compute/);
 
-  const deeper = await callTool(d, 'graft_callers', { symbol: 'add', depth: 2 });
+  const deeper = await callTool(d, 'graft_trace_calls', { symbol: 'add', depth: 2 });
   assert.equal(deeper.isError, false);
   assert.match(deeper.text, /← sub \(/);
   assert.match(deeper.text, /\[depth 1\]/);
@@ -195,9 +195,9 @@ test('graft_callers: depth param is honored (depth 2 reaches further than depth 
   assert.match(deeper.text, /\[depth 2\]/);
 });
 
-test('graft_callers depth>1 on a file aggregates dependents that call into a symbol the file defines, not just file-level imports', async () => {
+test('graft_trace_calls depth>1 on a file aggregates dependents that call into a symbol the file defines, not just file-level imports', async () => {
   const d = fileScopeRepo();
-  const r = await callTool(d, 'graft_callers', { symbol: 'src/a.ts', depth: 2 });
+  const r = await callTool(d, 'graft_trace_calls', { symbol: 'src/a.ts', depth: 2 });
   assert.equal(r.isError, false);
   // Walking only the FILE node's incoming edges would find b.ts via `imports`
   // but drop it via `calls`, since a `calls` edge targets the SYMBOL id
@@ -206,66 +206,66 @@ test('graft_callers depth>1 on a file aggregates dependents that call into a sym
   assert.match(r.text, /calls ← useB \(src\/b\.ts/);
 });
 
-test('graft_callers: unknown symbol is a soft isError with the check-spelling message', async () => {
+test('graft_trace_calls: unknown symbol is a soft isError with the check-spelling message', async () => {
   const d = builtRepo();
-  const r = await callTool(d, 'graft_callers', { symbol: 'noSuchSymbolAnywhere', depth: 2 });
+  const r = await callTool(d, 'graft_trace_calls', { symbol: 'noSuchSymbolAnywhere', depth: 2 });
   assert.equal(r.isError, true);
   assert.match(r.text, /no symbol "noSuchSymbolAnywhere" in the graph/);
   assert.match(r.text, /check spelling/);
 });
 
-test('graft_grep round-trips a hit on the built fixture, grouped by enclosing symbol', async () => {
+test('graft_find_all round-trips a hit on the built fixture, grouped by enclosing symbol', async () => {
   const d = builtRepo();
-  const r = await callTool(d, 'graft_grep', { pattern: 'add' });
+  const r = await callTool(d, 'graft_find_all', { pattern: 'add' });
   assert.equal(r.isError, false);
   assert.match(r.text, /"add" — \d+ hits? in \d+ symbols? across \d+ files? \(searched \d+ indexed files\)/);
   assert.match(r.text, /src\/math\.ts/);
 });
 
-test('graft_grep: no hits is a soft (non-error) result with the loud fallback note', async () => {
+test('graft_find_all: no hits is a soft (non-error) result with the loud fallback note', async () => {
   const d = builtRepo();
-  const r = await callTool(d, 'graft_grep', { pattern: 'noSuchPatternAnywhere' });
+  const r = await callTool(d, 'graft_find_all', { pattern: 'noSuchPatternAnywhere' });
   assert.equal(r.isError, false);
   assert.match(r.text, /no hits for "noSuchPatternAnywhere"/);
   assert.match(r.text, /retry graft grep/);
 });
 
-test('graft_grep: missing pattern and unbuilt repo are soft errors', async () => {
+test('graft_find_all: missing pattern and unbuilt repo are soft errors', async () => {
   const d = builtRepo();
-  const r1 = await callTool(d, 'graft_grep', {});
+  const r1 = await callTool(d, 'graft_find_all', {});
   assert.equal(r1.isError, true);
   assert.match(r1.text, /requires a pattern/);
 
   const bare = mkdtempSync(join(tmpdir(), 'graft-mcptools-grep-bare-'));
-  const r2 = await callTool(bare, 'graft_grep', { pattern: 'add' });
+  const r2 = await callTool(bare, 'graft_find_all', { pattern: 'add' });
   assert.equal(r2.isError, true);
   assert.match(r2.text, /graft build/);
 });
 
-test('graft_map round-trips a repo orientation on the built fixture', async () => {
+test('graft_repo_map round-trips a repo orientation on the built fixture', async () => {
   const d = builtRepo();
-  const r = await callTool(d, 'graft_map', {});
+  const r = await callTool(d, 'graft_repo_map', {});
   assert.equal(r.isError, false);
   assert.match(r.text, /^repo map — \d+ files · \d+ symbols · \d+ edges/);
   assert.match(r.text, /src/);
   assert.match(r.text, /hotspots:/);
 });
 
-test('graft_map: unbuilt repo is a soft isError with the no-graph message', async () => {
+test('graft_repo_map: unbuilt repo is a soft isError with the no-graph message', async () => {
   const bare = mkdtempSync(join(tmpdir(), 'graft-mcptools-map-bare-'));
-  const r = await callTool(bare, 'graft_map', {});
+  const r = await callTool(bare, 'graft_repo_map', {});
   assert.equal(r.isError, true);
   assert.match(r.text, /graft build/);
 });
 
-test('graft_map: max_dirs arg is honored — the MCP escape hatch for dropped dirs', async () => {
+test('graft_repo_map: max_dirs arg is honored — the MCP escape hatch for dropped dirs', async () => {
   const d = multiDirRepo();
 
-  const capped = await callTool(d, 'graft_map', { max_dirs: 1 });
+  const capped = await callTool(d, 'graft_repo_map', { max_dirs: 1 });
   assert.equal(capped.isError, false);
   assert.match(capped.text, /\+4 more directories not shown/);
 
-  const raised = await callTool(d, 'graft_map', { max_dirs: 10 });
+  const raised = await callTool(d, 'graft_repo_map', { max_dirs: 10 });
   assert.equal(raised.isError, false);
   assert.doesNotMatch(raised.text, /more directories? not shown/);
 });
@@ -274,27 +274,68 @@ test('callTool honors a dirOverride for a graph built in a non-default dir', asy
   const { repo, graphDir } = customDirRepo();
 
   // With the override pointing at the actual graph location, tools find it.
-  const check = await callTool(repo, 'graft_check', {}, graphDir);
+  const check = await callTool(repo, 'graft_check_freshness', {}, graphDir);
   assert.equal(check.isError, false);
   assert.match(check.text, /graph check: OK/);
 
-  const callers = await callTool(repo, 'graft_callers', { symbol: 'add' }, graphDir);
+  const callers = await callTool(repo, 'graft_trace_calls', { symbol: 'add' }, graphDir);
   assert.equal(callers.isError, false);
   assert.match(callers.text, /calls ← sub \(src\/math\.ts:/);
 
   // Without the override, tools fall back to the default `<repo>/graft`,
   // which doesn't exist here — must report no graph, not silently succeed.
-  const noOverride = await callTool(repo, 'graft_callers', { symbol: 'add' });
+  const noOverride = await callTool(repo, 'graft_trace_calls', { symbol: 'add' });
   assert.equal(noOverride.isError, true);
   assert.match(noOverride.text, /graft build/);
 });
 
-test('graft_skeleton returns signatures for a file, errors on unknown file', async () => {
+test('graft_file_api returns signatures for a file, errors on unknown file', async () => {
   const d = builtRepo();
-  const r = await callTool(d, 'graft_skeleton', { file: 'src/math.ts' });
+  const r = await callTool(d, 'graft_file_api', { file: 'src/math.ts' });
   assert.equal(r.isError, false);
   assert.match(r.text, /graft skeleton — src\/math\.ts/);
   assert.match(r.text, /function add {2}function add\(a: number, b: number\): number/);
-  const miss = await callTool(d, 'graft_skeleton', { file: 'src/nope.ts' });
+  const miss = await callTool(d, 'graft_file_api', { file: 'src/nope.ts' });
   assert.equal(miss.isError, true);
+});
+
+// ── the rename: new names advertised, old names still answered ──
+// A tool name is an API. The rename exists because a host that defers graft's
+// schemas shows the model the names ALONE, so they have to describe themselves —
+// but skills, saved prompts and other people's scripts still say the old ones.
+const RENAMES: Record<string, string> = {
+  graft_ask: 'graft_find_code',
+  graft_grep: 'graft_find_all',
+  graft_callers: 'graft_trace_calls',
+  graft_skeleton: 'graft_file_api',
+  graft_map: 'graft_repo_map',
+  graft_check: 'graft_check_freshness',
+};
+
+test('TOOLS advertises exactly the six new names — the roster does not grow', () => {
+  assert.deepEqual([...TOOLS.map((t) => t.name)].sort(), Object.values(RENAMES).sort());
+});
+
+test('every old tool name still resolves to its replacement', () => {
+  for (const [old, neu] of Object.entries(RENAMES)) {
+    assert.equal(canonicalToolName(old), neu, `${old} → ${neu}`);
+  }
+  assert.equal(canonicalToolName('graft_find_code'), 'graft_find_code', 'new names pass through');
+  assert.equal(canonicalToolName('nope'), 'nope', 'unknown names are left alone for the error path');
+});
+
+test('an old name dispatches for real, not just in the alias map', async () => {
+  const d = builtRepo();
+  const viaOld = await callTool(d, 'graft_ask', { query: 'how do I add numbers' });
+  const viaNew = await callTool(d, 'graft_find_code', { query: 'how do I add numbers' });
+  assert.equal(viaOld.isError, false);
+  assert.match(viaOld.text, /add/);
+  assert.equal(viaOld.text, viaNew.text, 'the alias is the same call, not a near-miss');
+
+  // …including the one tool whose behaviour depends on its name being recognised:
+  // graft_check_freshness must not trigger a pre-query rebuild, or it would always
+  // report the graph it just fixed.
+  const check = await callTool(d, 'graft_check', {});
+  assert.equal(check.isError, false);
+  assert.ok(!check.text.startsWith('[graft] refreshed'), 'old check name still skips the refresh');
 });


### PR DESCRIPTION
Graft was installed, wired, and ignored. Two sessions were traced end to end — 199 tool
calls on the `cli` entrypoint, 18 on `claude-desktop` — and across both, graft's MCP tools
were called **zero** times while the agent ran 38 greps and 41 file reads. This fixes the
four causes that turned out to be measurable.

## What was wrong

| Cause | Evidence |
|---|---|
| The auto-injected hint cleared its own quality bar by 0.015 and shipped three irrelevant test files | `coverage 0.165` vs floor `0.150`, `coverageStrong 0.033` |
| Deferred MCP tools reach the model as **bare names, no descriptions** | `deferred_tools_delta.addedLines` — six raw strings |
| The MCP handshake has a prose channel and graft sent nothing through it | sibling servers use it (660 and 984 chars); graft's `initialize` had no `instructions` |
| The card tree is invisible to the default search tool | `graft/` is gitignored, ripgrep honours that; 0 of 41 reads and 0 of 119 bash calls ever opened a `graft/*.md` |

## What changed

**1 — Gate the injected hint on match strength.** `relevantRetrieval` now requires either a
real name hit (`coverageStrong >= STRONG_FLOOR`) or broad coverage worth trusting
(`coverage >= HIGH_FLOOR`) — the same two-clause rule `ask/fuse.ts` already applies to a
cheaper decision. Failing it emits one line naming the command instead of going silent,
capped at two per session. `AskJson` gains `coverageStrong`, which the CLI always emitted
but the hook's type never declared.

The old gate's comment justified leaning low because "a wrongly-skipped pack is
recoverable — the agent pulls with `graft ask`". The trace falsified that: the agent didn't
pull, it grepped. A borderline pass is the worst of the three outcomes, because it reads as
orientation and suppresses the retrieval it should have triggered.

**2 — Ship `instructions` in the MCP handshake** (`src/mcp/instructions.ts`, 947 chars).
This is the only graft prose that survives tool deferral: the harness delivers it as its
own context layer even when all six schemas are withheld. It leads with the recovery
instruction — one `ToolSearch` with a comma-separated `select:` loads all six for the
session, so the cost is a single round trip rather than two calls per use — then one
decision rule per tool, which is the entire steering budget in a host with no hooks.

**3 — Make the cards findable again.** `ensureSearchable`, a twin of `ensureGitignored`,
writes a three-line root `.ignore` (`!graft/`, minus `.cache/` and `.graph/`). ripgrep reads
`.ignore` at higher precedence than `.gitignore`, so the tree returns to search while git
keeps ignoring it. `cards.ts`'s own docstring says the point of cards is that "a
`grep <symbol>` lands on the card" — that premise has been quietly broken since the graph
became a local cache. Plus one note in `INDEX.md`, and deliberately *not* in the 124 cards:
a pitch containing *ask / grep / callers / search* would make every card match searches for
those words.

**4 — Names that describe themselves.** Since a deferred payload carries names only,
`graft_ask` had to compete with `Grep` on nine characters. `graft_find_code`,
`graft_find_all`, `graft_trace_calls`, `graft_file_api`, `graft_repo_map`,
`graft_check_freshness` — with a `TOOL_ALIASES` map so every old name still dispatches, and
the roster still advertising exactly six. Also: `serverEntry()` prefers a bare `graft`
command over `npx -y` (211 ms → 80 ms handshake, measured, 5 runs each), and the allowlist
covers the forms this repo actually runs. The handshake saving is real but buys less than it
sounds — see *Still open*, where an 80 ms server still misses turn one.

## Deliberately not done

- **Asking users to disable their other connectors.** It would work — 75 of 111 deferred
  tools were unrelated — but graft has to survive whatever tool soup it lands in, so 2 and
  4 make it work *while* deferred instead.
- **Baking absolute paths into MCP configs.** Faster-looking, but these files get committed;
  the repo already carries the scar of a checked-in hook shim with another machine's home
  directory in it. `serverEntry()` returns a bare command name and probes PATH at init,
  overridable with `GRAFT_MCP_NPX=1`.

## Verification

492 tests pass (478 before). New coverage: the traced `0.165 / 0.033` pair as a regression
fixture; `initialize` carrying `instructions` under the 1,000-char ceiling with all five
retrieval tools named; `ensureSearchable` idempotency and its no-op cases; every old tool
name dispatching through the alias map, including that `graft_check` still skips the
pre-query refresh.

Tests only prove the server *emits* `instructions`, not that the harness *delivers* them —
so 2 and 3 were also checked against live sessions on this build.

**2, end to end.** A two-turn headless session (`e10c482b`, `--mcp-config` pointed at the
local `dist`) logs an `mcp_instructions_delta` attachment with `addedNames: ["graft"]`,
carrying the block verbatim, alongside all six new names in `deferred_tools_delta`. The
strongest signal is unprompted: asked which graft tools it could see, the model volunteered
that *"the server's own instructions list only the first five for bulk loading"* — it had
read the text and reasoned about a detail inside it. (That observation is correct;
`graft_check_freshness` is left out of the `select:` line on purpose, since the same
paragraph says the graph refreshes itself.) The direct stdio handshake returns 953 chars and
`serverInfo.version 0.8.0`, replacing the hardcoded `'0'`.

**3, end to end.** In this repo, a default `rg -l` now returns `graft/src/claude/format.md`
where it previously could not; **0** `.cache/` or `.graph/` files leak into results;
`git check-ignore` still ignores `graft/`; `git status` stays clean. Worth recording that the
first attempt at this check used `rg -g 'graft/**'`, which overrides ignore rules and made
the exclusions look broken — the result above is without the glob.

## Still open

The 13.9 s roster gap is **not** boot cost, which is the one thing now ruled out. A
single-turn probe (`7a9ac6d4`, 4.8 s) recorded `pendingMcpServers: ["graft"]` — the server
had not finished connecting when the request was assembled, so no tools and no instructions
reached the model at all. Measured against that, the handshake is **80 ms** over three runs.
An 80 ms server still misses turn one, because the harness assembles turn one before MCP
connection resolves; the boot-path change in 4 is a cheap win that cannot buy that turn.
Whether the 13.9 s case is the same effect at larger scale, or something else, is still
unknown.

This is the premise 1 and 3 were built on, now measured rather than inferred: turn one
belongs to the hook and the file tree, not to MCP.

What remains unproven is the only thing that matters — whether any of this changes
behaviour. No session has yet run on the fixed build against the baseline of 199 calls / 38
greps / 0 retrievals. `bench/` is where that gets settled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

