### PR TITLE
fix(llm): fall back to string tool_choice for servers that reject the object form (LM Studio)

### DIFF
--- a/src/ai/llm/openai.ts
+++ b/src/ai/llm/openai.ts
@@ -70,6 +70,20 @@ function toChatTool(t: ToolSpec): OpenAI.Chat.Completions.ChatCompletionTool {
   return { type: "function", function: { name: t.name, description: t.description, parameters: t.parameters } };
 }
 
+/**
+ * Some OpenAI-compatible servers — LM Studio's local server, at least as of
+ * 2026 — reject the object form of `tool_choice` outright with a 400
+ * ("Invalid tool_choice type: 'object'. Supported string values: none, auto,
+ * required"), even though the upstream OpenAI spec allows it.
+ */
+function isRejectedObjectToolChoice(err: unknown): boolean {
+  return (
+    err instanceof OpenAI.APIError &&
+    err.status === 400 &&
+    /tool_choice/i.test(String((err as { message?: string }).message ?? ""))
+  );
+}
+
 export class OpenAIChatModel implements ChatModel {
   readonly label: string;
   private client: OpenAI;
@@ -110,8 +124,29 @@ export class OpenAIChatModel implements ChatModel {
       params.tools = tools;
     }
 
-    const resp = await this.client.chat.completions.create(params);
+    const resp = await this.createChatCompletion(params);
     return this.fromResponse(resp, fmt.kind);
+  }
+
+  /**
+   * Wraps `chat.completions.create` with a narrow, safe fallback: if the
+   * server rejects an object-form `tool_choice` and exactly one tool was
+   * offered, "required" is behaviorally identical (the model has nothing
+   * else to pick), so retry once with the string form instead of failing
+   * the whole build. Left alone when more than one tool is offered, since
+   * "required" would then let the model choose freely instead of the
+   * caller-specified tool — that ambiguity isn't safe to paper over
+   * automatically.
+   */
+  private async createChatCompletion(params: ChatParams): Promise<OpenAI.Chat.Completions.ChatCompletion> {
+    try {
+      return await this.client.chat.completions.create(params);
+    } catch (err) {
+      if (isRejectedObjectToolChoice(err) && typeof params.tool_choice === "object" && params.tools?.length === 1) {
+        return this.client.chat.completions.create({ ...params, tool_choice: "required" });
+      }
+      throw err;
+    }
   }
 
   private fromResponse(

--- a/test/llm-adapters.test.ts
+++ b/test/llm-adapters.test.ts
@@ -6,7 +6,7 @@
  */
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import type OpenAI from "openai";
+import OpenAI from "openai";
 import type Anthropic from "@anthropic-ai/sdk";
 import { OpenAIChatModel } from "../src/ai/llm/openai.js";
 import { AnthropicChatModel } from "../src/ai/llm/anthropic.js";
@@ -29,6 +29,8 @@ function openAiResp(over: Partial<any> = {}): any {
     ...over,
   };
 }
+
+const REJECTED_OBJECT_TOOL_CHOICE = "Invalid tool_choice type: 'object'. Supported string values: none, auto, required";
 
 test("openai: plain text — system/user map to strings, usage is uncached-only", async () => {
   const { client, box } = fakeOpenAI(openAiResp());
@@ -112,6 +114,69 @@ test("openai: assistant providerRaw replays verbatim", async () => {
     ],
   });
   assert.deepEqual(box.params.messages[1], raw);
+});
+
+test("openai: retries with tool_choice \"required\" when the server rejects the object form (single tool)", async () => {
+  const calls: any[] = [];
+  const resp = openAiResp({
+    choices: [
+      {
+        message: {
+          content: null,
+          tool_calls: [{ id: "c1", type: "function", function: { name: "emit_json", arguments: '{"correct":true}' } }],
+        },
+        finish_reason: "tool_calls",
+      },
+    ],
+  });
+  const client = {
+    chat: {
+      completions: {
+        create: async (params: any) => {
+          calls.push(params);
+          if (calls.length === 1) {
+            throw new OpenAI.APIError(400, { message: REJECTED_OBJECT_TOOL_CHOICE }, REJECTED_OBJECT_TOOL_CHOICE, new Headers());
+          }
+          return resp;
+        },
+      },
+    },
+  } as unknown as OpenAI;
+  const m = new OpenAIChatModel({ apiKey: "x", model: "local-model", client });
+  const res = await m.create({ messages: [{ role: "user", content: "grade" }], responseFormat: { kind: "json" } });
+
+  assert.equal(calls.length, 2); // first attempt (object form) + retry (string form)
+  assert.deepEqual(calls[0].tool_choice, { type: "function", function: { name: "emit_json" } });
+  assert.equal(calls[1].tool_choice, "required");
+  assert.equal(res.text, '{"correct":true}');
+});
+
+test("openai: does NOT paper over a rejected object tool_choice when multiple tools are offered", async () => {
+  let callCount = 0;
+  const client = {
+    chat: {
+      completions: {
+        create: async () => {
+          callCount++;
+          throw new OpenAI.APIError(400, { message: REJECTED_OBJECT_TOOL_CHOICE }, REJECTED_OBJECT_TOOL_CHOICE, new Headers());
+        },
+      },
+    },
+  } as unknown as OpenAI;
+  const m = new OpenAIChatModel({ apiKey: "x", model: "local-model", client });
+  await assert.rejects(
+    () =>
+      m.create({
+        messages: [{ role: "user", content: "go" }],
+        tools: [
+          { name: "a", description: "d", parameters: { type: "object" } },
+          { name: "b", description: "d", parameters: { type: "object" } },
+        ],
+        responseFormat: { kind: "tool", name: "a" },
+      }),
+    OpenAI.APIError,
+  );
+  assert.equal(callCount, 1); // no ambiguous retry — the caller asked for "a" specifically
 });
 
 // --- Anthropic adapter ------------------------------------------------------


### PR DESCRIPTION
## Problem

`graft build --deep` fails completely against a local LM Studio server (`GRAFT_PROVIDER=openai`, `GRAFT_BASE_URL=http://localhost:1234/v1`), regardless of which model is loaded:

```
400 "Invalid tool_choice type: 'object'. Supported string values: none, auto, required"
```

The "reading concepts" per-file summary pass forces structured JSON output by sending `tool_choice` as an object (`{type:"function", function:{name:"emit_json"}}`) — this is valid per the OpenAI spec, but LM Studio's OpenAI-compatible server only accepts the string form (`none`/`auto`/`required`) and rejects the object form outright. Every request 400s, so nothing gets built.

Confirmed this isn't a version-specific quirk on either side: LM Studio's own [API changelog](https://lmstudio.ai/docs/developer/api-changelog) has only ever documented string `tool_choice` values, and it's a [known, previously-reported issue](https://github.com/lmstudio-ai/lmstudio-bug-tracker/issues/670) in their tracker.

## Fix

In `src/ai/llm/openai.ts`, when `chat.completions.create` throws a 400 whose message mentions `tool_choice` **and** exactly one tool was offered in the request, retry once with `tool_choice: "required"` instead of the object form. This is behaviorally identical in that case — the model has no other tool to pick — so it's a safe, transparent fallback.

When more than one tool is offered, the fix intentionally does *not* retry: `"required"` would let the model choose freely instead of calling the specific tool the caller asked for, which isn't safe to paper over automatically. That case still throws, same as before.

## Testing

Added two adapter tests in `test/llm-adapters.test.ts` (network-free, using the existing stub-client pattern):
- single tool offered + 400 on object `tool_choice` → retries with `"required"`, succeeds
- multiple tools offered + same 400 → propagates instead of guessing, only one call made

Also manually verified end-to-end: reproduced the failure locally against LM Studio with `qwen/qwen3.5-9b`, applied this exact fix, and confirmed `graft build --deep` now produces correct concept nodes against that same local server.

No changes to behavior against providers that accept the object form (OpenAI, OpenRouter, Anthropic-via-native-adapter, etc.) — the object form is still tried first and used as before whenever the server accepts it.
