### PR TITLE
Seed a git worktree's graph from its parent checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,24 @@
 - **`GRAFT_REFRESH=hash`** — confirm every file by hashing its contents instead of trusting
   size and mtime, for tooling that rewrites files while preserving both.
 
+### Fixed
+
+- **A git worktree is no longer blind.** `graft/` is gitignored, so `git worktree add`
+  never checks it out — and the graph is the only thing the MCP tools read. Every tool in
+  a fresh worktree answered `no matching nodes` / `no graph found` for the whole session,
+  and `INDEX.md` and the cards were missing too, so `grep` and the repo map came up empty.
+
+  A query in a worktree now copies the parent checkout's `graft/` in and then treats the
+  difference between the two checkouts as ordinary drift. The worktree's `.git` is a file
+  naming its parent, so there is nothing to configure; the copy is $0 and offline, and the
+  Tier-2 meaning layer survives it (a cold rebuild would have thrown away every summary
+  you paid for and re-parsed the repo). `graft build` in a worktree starts from the same
+  copy, so it is incremental too.
+
+  Reads the parent, never writes to it. No-ops unless there is genuinely a built parent
+  checkout on disk — a fresh clone, CI, or a cloned (rather than worktree'd) cloud session
+  behaves exactly as before. `GRAFT_NO_SEED=1` turns it off.
+
 ## 0.8.0
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,12 +56,14 @@
   a fresh worktree answered `no matching nodes` / `no graph found` for the whole session,
   and `INDEX.md` and the cards were missing too, so `grep` and the repo map came up empty.
 
-  A query in a worktree now copies the parent checkout's `graft/` in and then treats the
-  difference between the two checkouts as ordinary drift. The worktree's `.git` is a file
-  naming its parent, so there is nothing to configure; the copy is $0 and offline, and the
-  Tier-2 meaning layer survives it (a cold rebuild would have thrown away every summary
-  you paid for and re-parsed the repo). `graft build` in a worktree starts from the same
-  copy, so it is incremental too.
+  A query in a worktree now copies the parent checkout's graph and query sidecars in, then
+  treats the difference between the two checkouts as ordinary drift. The worktree's `.git`
+  is a file naming its parent, so there is nothing to configure; the copy is $0 and
+  offline, and the Tier-2 meaning layer survives it (a cold rebuild would have thrown away
+  every summary you paid for and re-parsed the repo). `graft build` in a worktree starts
+  from the same copy, so it is incremental too — and it is what writes the worktree's
+  cards and `INDEX.md`, generated from *this* checkout's code rather than copied from the
+  parent's branch. A query still writes only what a query reads.
 
   Reads the parent, never writes to it. No-ops unless there is genuinely a built parent
   checkout on disk — a fresh clone, CI, or a cloned (rather than worktree'd) cloud session

--- a/src/ask/index-file.ts
+++ b/src/ask/index-file.ts
@@ -68,7 +68,7 @@ export interface AskIndex {
   docs: AskIndexDoc[];
 }
 
-const ASK_INDEX_FILE = "ask-index.json";
+export const ASK_INDEX_FILE = "ask-index.json";
 
 /** Absolute path to the ask sidecar for a context dir: `<dir>/.cache/ask-index.json`.
  * `.cache/` is the established uncommitted-cache location — this sidecar is a

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -192,6 +192,8 @@ program
     process.stderr.write("\n");
     console.log(`✓ wiring: ${g.nodes} nodes (${fmt(g.byKind)}), ${g.edges} edges, ${g.cards} cards [${g.languages.join(", ")}]`);
     console.log(`  parsed: ${g.parsed} of ${g.files} files (${g.reused} replayed from cache)`);
+    // Worth one line: this build started from a graph the user never built *here*.
+    if (g.seededFrom) console.log(`  seeded: copied a starting graph from ${g.seededFrom} (git worktree)`);
     if (deep) {
       const m = g.meaning;
       console.log(`  meaning: ${m.computed} computed, ${m.cached} cached, ${m.stale} stale, ${m.pending} pending`);

--- a/src/graph/build.ts
+++ b/src/graph/build.ts
@@ -26,6 +26,7 @@ import {
   type ExtractEntry,
 } from "./extract-cache.js";
 import { writeFingerprint } from "./fingerprint.js";
+import { seedGraph, type SeedResult } from "./seed.js";
 import { listSourceStats } from "./source-files.js";
 import { resolveEdges, type GoModule } from "./resolve.js";
 import { enrichGraph, type EnrichStats } from "./enrich.js";
@@ -96,6 +97,9 @@ export interface GraphBuildResult {
   parsed: number;
   /** Files replayed from the extraction cache. */
   reused: number;
+  /** The parent checkout this build copied a starting graph from, when it was run in
+   * a git worktree that had none of its own. See `./seed.ts`. */
+  seededFrom?: string;
   nodes: number;
   edges: number;
   byKind: Record<Kind, number>;
@@ -139,6 +143,14 @@ export async function buildGraph(
   const sources = new Map<string, string>();
   const langs = new Set<Language>();
   const errors: string[] = [];
+
+  // In a git worktree there is nothing to reuse *yet* — `graft/` is gitignored, so
+  // git never checked it out — but the parent checkout's graph is one directory away.
+  // Copy it in before reading the priors below and this build is incremental and
+  // keeps its paid-for summaries, instead of being a cold parse of the whole repo.
+  // No-ops everywhere else, including on an explicit cold build (`reuse: false`).
+  const seed: SeedResult =
+    opts.reuse === false ? { seeded: false } : seedGraph(root, { contextDir: opts.contextDir });
 
   // Tier-1 memo: unchanged files replay their last parse. `entries` is rebuilt
   // from scratch each run and keyed only by files currently on disk, so deletions
@@ -308,6 +320,7 @@ export async function buildGraph(
     files: files.length,
     parsed,
     reused,
+    seededFrom: seed.from,
     nodes: nodes.length,
     edges: edges.length,
     byKind,

--- a/src/graph/extract-cache.ts
+++ b/src/graph/extract-cache.ts
@@ -34,7 +34,7 @@ import type { NodeV1 } from "./types.js";
 
 /** Bump when the on-disk shape below changes. */
 const CACHE_VERSION = 1;
-const EXTRACT_CACHE_PREFIX = "extract";
+export const EXTRACT_CACHE_PREFIX = "extract";
 
 export interface ExtractEntry {
   size: number;

--- a/src/graph/fingerprint.ts
+++ b/src/graph/fingerprint.ts
@@ -26,7 +26,7 @@ import { readJson, writeJsonAtomic } from "../util/state.js";
 import { extractorStamp, pruneSidecars, type ExtractEntry } from "./extract-cache.js";
 import { listSourceStats } from "./source-files.js";
 
-const FINGERPRINT_PREFIX = "fingerprint";
+export const FINGERPRINT_PREFIX = "fingerprint";
 const FINGERPRINT_VERSION = 1;
 
 /** The identity this graft's prints are filed under. Unlike the extract memo, a

--- a/src/graph/refresh.ts
+++ b/src/graph/refresh.ts
@@ -121,9 +121,16 @@ async function waitForLock(cache: string): Promise<boolean> {
  * already there and reports nothing — which is why the caller re-checks the file
  * rather than trusting this return value.
  */
-async function seedUnderLock(dir: string, outDir: string, contextDir?: string): Promise<SeedResult> {
+async function seedUnderLock(
+  dir: string,
+  outDir: string,
+  contextDir?: string,
+): Promise<SeedResult & { busy?: boolean }> {
   const lockCache = join(outDir, CACHE_DIR);
-  if (!(await waitForLock(lockCache))) return { seeded: false };
+  // `busy` matters: with no graph on disk there is nothing to fall back to, so a
+  // caller that stayed silent here would emit the bare "no matching nodes" this whole
+  // mechanism exists to remove. Say what happened instead.
+  if (!(await waitForLock(lockCache))) return { seeded: false, busy: true };
   const unhook = releaseOnSignal(lockCache);
   try {
     return seedGraph(dir, { contextDir });
@@ -151,13 +158,18 @@ export async function ensureFreshGraph(root: string, opts: RefreshOptions = {}):
       // worktree, whose parent checkout's `graft/` git could not check out. Copy it
       // in and carry on — the drift below is then exactly the diff between the two
       // checkouts, and repairing it is what makes the copied graph honest here.
-      seededFrom = (await seedUnderLock(dir, outDir, opts.contextDir)).from;
+      const seed = await seedUnderLock(dir, outDir, opts.contextDir);
+      seededFrom = seed.from;
       // Still nothing (not a worktree, parent never built, or a concurrent seed we
       // lost the race for and which we now re-check for): the caller's own "no graph
       // — run graft build" message is the right answer. Auto-building a whole repo
       // under a query is a surprise, and it's the one case where the user hasn't
       // opted into graft at all yet.
-      if (!existsSync(wiringPath(outDir))) return CLEAN;
+      if (!existsSync(wiringPath(outDir))) {
+        return seed.busy
+          ? { refreshed: false, note: "another process is still copying the graph into this worktree — retry the query in a moment" }
+          : CLEAN;
+      }
     }
     const seedNote = seededFrom ? `copied the graph from the main checkout (${seededFrom})` : undefined;
 

--- a/src/graph/refresh.ts
+++ b/src/graph/refresh.ts
@@ -25,6 +25,11 @@
  *   at the end of a turn — so retrieval stays cheap and a read stays a read. It
  *   also leaves `stats.json` alone, so that same `Stop` hook still sees `dirty` and
  *   still rebuilds the passive surface.
+ *
+ * One case is not drift but absence: inside a git worktree there is no graph at all,
+ * because `graft/` is gitignored and so was never checked out. The gate covers that
+ * too — it copies the parent checkout's graph in (`./seed.ts`) and then treats the
+ * difference between the two checkouts as ordinary drift, which is exactly what it is.
  */
 import { existsSync } from "node:fs";
 import { join, resolve } from "node:path";
@@ -34,6 +39,7 @@ import { CACHE_DIR } from "../context/node-file.js";
 import { buildGraph } from "./build.js";
 import { driftCount, isClean, probeDrift, type Drift } from "./fingerprint.js";
 import { invalidateGraphCaches } from "./load.js";
+import { seedGraph, type SeedResult } from "./seed.js";
 import { wiringPath } from "./write.js";
 
 /** How long to wait for another process's in-flight rebuild before giving up and
@@ -108,6 +114,26 @@ async function waitForLock(cache: string): Promise<boolean> {
 }
 
 /**
+ * Copy a parent checkout's graph in, holding the same lock a rebuild would.
+ *
+ * Two MCP tool calls in a fresh worktree arrive here at the same moment, and an 8 MB
+ * copy is long enough for both to start one. The loser waits, then finds the graph
+ * already there and reports nothing — which is why the caller re-checks the file
+ * rather than trusting this return value.
+ */
+async function seedUnderLock(dir: string, outDir: string, contextDir?: string): Promise<SeedResult> {
+  const lockCache = join(outDir, CACHE_DIR);
+  if (!(await waitForLock(lockCache))) return { seeded: false };
+  const unhook = releaseOnSignal(lockCache);
+  try {
+    return seedGraph(dir, { contextDir });
+  } finally {
+    unhook();
+    releaseLockIn(lockCache);
+  }
+}
+
+/**
  * Rebuild `root`'s structural graph if the working tree has moved since the last
  * build. Cheap and side-effect-free when nothing changed, which is the usual case.
  *
@@ -119,26 +145,38 @@ export async function ensureFreshGraph(root: string, opts: RefreshOptions = {}):
   try {
     const dir = resolve(root);
     const outDir = contextDirFor(dir, opts.contextDir);
-    // Nothing built yet: the caller's own "no graph — run graft build" message is
-    // the right answer. Auto-building a whole repo under a query is a surprise,
-    // and it's the one case where the user hasn't opted into graft at all yet.
-    if (!existsSync(wiringPath(outDir))) return CLEAN;
+    let seededFrom: string | undefined;
+    if (!existsSync(wiringPath(outDir))) {
+      // One case has a graph to work with even though this checkout has none: a git
+      // worktree, whose parent checkout's `graft/` git could not check out. Copy it
+      // in and carry on — the drift below is then exactly the diff between the two
+      // checkouts, and repairing it is what makes the copied graph honest here.
+      seededFrom = (await seedUnderLock(dir, outDir, opts.contextDir)).from;
+      // Still nothing (not a worktree, parent never built, or a concurrent seed we
+      // lost the race for and which we now re-check for): the caller's own "no graph
+      // — run graft build" message is the right answer. Auto-building a whole repo
+      // under a query is a surprise, and it's the one case where the user hasn't
+      // opted into graft at all yet.
+      if (!existsSync(wiringPath(outDir))) return CLEAN;
+    }
+    const seedNote = seededFrom ? `copied the graph from the main checkout (${seededFrom})` : undefined;
 
     // null = no fingerprint at all: a graph built before this mechanism existed,
     // or by a different extractor build. Rebuild once — that lays the fingerprint
     // down, so it costs exactly one build, not one per query.
     const drift = probeDrift(dir, outDir);
-    if (drift && isClean(drift)) return CLEAN;
+    if (drift && isClean(drift)) return seedNote ? { refreshed: false, note: seedNote } : CLEAN;
 
     // On the default layout this is `<root>/graft/.cache/.sync.lock`, the very file
     // the Claude Code hooks lock — so this refresh and the background sync can
     // never rebuild at the same time.
     const lockCache = join(outDir, CACHE_DIR);
     if (!(await waitForLock(lockCache))) {
+      const busy = "a graph rebuild is already in flight — answering from the current graph";
       return {
         refreshed: false,
         drift: drift ?? undefined,
-        note: "a graph rebuild is already in flight — answering from the current graph",
+        note: seedNote ? `${seedNote}; ${busy}` : busy,
       };
     }
     const unhook = releaseOnSignal(lockCache);
@@ -152,7 +190,7 @@ export async function ensureFreshGraph(root: string, opts: RefreshOptions = {}):
       const now = drift ? probeDrift(dir, outDir) : null;
       if (now && isClean(now)) {
         invalidateGraphCaches(outDir);
-        return CLEAN;
+        return seedNote ? { refreshed: false, note: seedNote } : CLEAN;
       }
       // Tier-1 only: no summarizer, so no LLM call and no network, ever. And
       // `graphOnly`: write the graph, the ask sidecar and the fingerprint, nothing
@@ -161,7 +199,7 @@ export async function ensureFreshGraph(root: string, opts: RefreshOptions = {}):
       // card's mtime, and skipping them is most of what keeps this cheap.
       await buildGraph(dir, { contextDir: opts.contextDir, graphOnly: true });
       invalidateGraphCaches(outDir);
-      return { refreshed: true, drift: drift ?? undefined };
+      return { refreshed: true, drift: drift ?? undefined, note: seedNote };
     } finally {
       unhook();
       releaseLockIn(lockCache);
@@ -209,8 +247,11 @@ export async function ensureFreshChildren(
 /** The one-line note a CLI/MCP surface prints when a refresh actually happened.
  * Null when there's nothing to say (the overwhelmingly common case). */
 export function refreshNote(r: RefreshResult): string | null {
-  if (r.note) return `[graft] ${r.note}`;
-  if (!r.refreshed) return null;
+  if (!r.refreshed) return r.note ? `[graft] ${r.note}` : null;
   const n = r.drift ? driftCount(r.drift) : 0;
-  return `[graft] refreshed the graph (${n || "?"} file${n === 1 ? "" : "s"} changed) before answering`;
+  const built = `refreshed the graph (${n || "?"} file${n === 1 ? "" : "s"} changed) before answering`;
+  // Both facts, when a worktree was seeded *and* the copy needed repairing: the
+  // count is the interesting half (it's the branch diff), the provenance explains
+  // where a graph came from in a directory the user knows they never built.
+  return r.note ? `[graft] ${built} — ${r.note}` : `[graft] ${built}`;
 }

--- a/src/graph/seed.ts
+++ b/src/graph/seed.ts
@@ -1,0 +1,170 @@
+/**
+ * `seedGraph` — give a linked git worktree the graph its parent checkout already has.
+ *
+ * `graft/` is a local cache, so it is gitignored, so `git worktree add` never checks
+ * it out: a worktree starts with `src/` and `.claude/` and no graph at all. Every
+ * MCP tool then answers "no graph found — run graft build first" for the whole
+ * session, and the passive surface (`INDEX.md`, the cards) is missing too. The agent
+ * that was supposed to be cheapest in a fresh worktree is instead blind in one.
+ *
+ * The parent checkout has not gone anywhere, though — a worktree's `.git` is a *file*
+ * naming it, and the harness that creates these worktrees already reaches back the
+ * same way (Claude Code symlinks `node_modules` to the parent's). So: copy the
+ * parent's `graft/` in, then let the ordinary refresh gate repair the difference.
+ *
+ * Copy, not symlink. `node_modules` is the same for every branch; a graph is a set of
+ * `file:line` spans for one specific tree, so a shared one would have the worktree
+ * rewriting the parent's graph with its own branch's line numbers. What makes the
+ * copy worth doing rather than just rebuilding cold:
+ *
+ * - **The Tier-2 meaning layer survives.** Summaries and cruxes cost real money;
+ *   `buildGraph` folds a prior `wiring.json` in by `body_hash`, so an unchanged
+ *   function keeps the summary someone already paid for. A cold build throws them all
+ *   away and the worktree silently drops to structural-only answers.
+ * - **The repair is small.** `probeDrift` confirms a suspect file by content hash, so
+ *   a fresh checkout's brand-new mtimes cost one hashing pass and nothing more; the
+ *   drift that survives is exactly the diff between the two checkouts' commits.
+ * - **$0 and offline**, like everything else on the query path.
+ *
+ * Never writes to the parent, never throws, and no-ops unless there is genuinely a
+ * built parent checkout on disk — so a fresh clone, CI, or a cloud session whose repo
+ * was *cloned* rather than worktree'd behaves exactly as it did before: "run graft
+ * build first".
+ */
+import {
+  copyFileSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { CACHE_DIR, contextDirFor } from "../context/node-file.js";
+import { GRAPH_DIR, GRAPH_FILE, wiringPath } from "./write.js";
+
+/** Env kill switch, mirroring `GRAFT_NO_REFRESH` in ./refresh.ts. */
+export function seedDisabled(): boolean {
+  const v = process.env.GRAFT_NO_SEED;
+  return v !== undefined && v !== "" && v !== "0" && v !== "false";
+}
+
+/**
+ * The main checkout of the repo `root` is a linked worktree of, or null when `root`
+ * isn't one (which is the common case, and not an error).
+ *
+ * Filesystem-only on purpose: no `git` subprocess on a path that runs before every
+ * query. The shapes it has to tell apart:
+ *
+ * - `<root>/.git` is a **directory** → this *is* the main checkout. Nothing to seed.
+ * - `gitdir: <main>/.git/worktrees/<name>` → a linked worktree. `commondir` inside
+ *   that dir points back at the shared `.git` (`../..`), whose parent is the main
+ *   checkout.
+ * - `gitdir: <super>/.git/modules/<name>` → a **submodule**. Identical file shape,
+ *   completely different thing: a submodule is its own repo and its parent's `graft/`
+ *   describes different code entirely. The `worktrees` path segment is what rejects it.
+ * - A bare repo or `--separate-git-dir` layout, where the resolved common dir isn't
+ *   named `.git` and there may be no working tree at all → null.
+ */
+export function mainWorktreeRoot(root: string): string | null {
+  try {
+    const dot = join(root, ".git");
+    if (statSync(dot).isDirectory()) return null;
+    const m = /^gitdir:[ \t]*(.+?)[ \t]*$/m.exec(readFileSync(dot, "utf8"));
+    if (!m) return null;
+    const gitdir = isAbsolute(m[1]) ? m[1] : resolve(root, m[1]);
+    if (basename(dirname(gitdir)) !== "worktrees") return null;
+    const rel = readFileSync(join(gitdir, "commondir"), "utf8").trim();
+    if (!rel) return null;
+    const common = isAbsolute(rel) ? rel : resolve(gitdir, rel);
+    if (basename(common) !== ".git" || !statSync(common).isDirectory()) return null;
+    const main = dirname(common);
+    if (resolve(main) === resolve(root)) return null;
+    return main;
+  } catch {
+    // No `.git` at all, an unreadable one, a `commondir` that doesn't exist: all of
+    // them mean "can't seed from here", which is the same answer as "not a worktree".
+    return null;
+  }
+}
+
+export interface SeedResult {
+  seeded: boolean;
+  /** The main checkout the graph came from, when one was used. */
+  from?: string;
+}
+
+const NOT_SEEDED: SeedResult = { seeded: false };
+
+/**
+ * Repo-relative paths (posix) that a seed deliberately leaves behind.
+ *
+ * `wiring.json` is here because it is copied last and atomically — see `installGraph`.
+ * The rest is state that belongs to the checkout that produced it: another process's
+ * lock, another session's transcripts, and another checkout's savings/dirty counters.
+ */
+const SKIP = new Set([
+  `${GRAPH_DIR}/${GRAPH_FILE}`,
+  `${CACHE_DIR}/.sync.lock`,
+  `${CACHE_DIR}/session`,
+  `${CACHE_DIR}/stats.json`,
+]);
+
+function copyTree(srcDir: string, outDir: string): void {
+  cpSync(srcDir, outDir, {
+    recursive: true,
+    // A directory that returns false is skipped whole, which is what keeps
+    // `.cache/session/` (one file per session, forever) out of the copy.
+    filter: (src) => !SKIP.has(relative(srcDir, src).split(sep).join("/")),
+  });
+}
+
+/**
+ * Put `wiring.json` in place last, via a temp file and a rename.
+ *
+ * Its presence is the flag every caller reads to mean "this repo has a graph"
+ * (`refresh.ts`, `workspace.ts`, every MCP tool). So it must appear only once the
+ * rest of the copy has landed and must never appear half-written: a seed killed
+ * midway then leaves no graph, and the next call simply seeds again.
+ */
+function installGraph(srcGraph: string, destGraph: string): void {
+  mkdirSync(dirname(destGraph), { recursive: true });
+  const tmp = `${destGraph}.seed.${process.pid}`;
+  try {
+    copyFileSync(srcGraph, tmp);
+    renameSync(tmp, destGraph);
+  } catch (err) {
+    try { rmSync(tmp, { force: true }); } catch { /* nothing to clean up */ }
+    throw err;
+  }
+}
+
+/**
+ * Copy the parent checkout's graph into `root`'s own `graft/`, if all of this holds:
+ * `root` is a linked worktree, it has no graph yet, the parent has one, and no `--dir`
+ * override is in play (a custom output dir can't be mapped to a sibling checkout —
+ * the same conservatism `ensureGitignored` applies).
+ *
+ * Best-effort by contract: the caller's fallback is the behaviour that existed before
+ * this function did, so every failure returns `{ seeded: false }` rather than raising.
+ */
+export function seedGraph(root: string, opts: { contextDir?: string } = {}): SeedResult {
+  if (opts.contextDir || seedDisabled()) return NOT_SEEDED;
+  try {
+    const dir = resolve(root);
+    const outDir = contextDirFor(dir);
+    if (existsSync(wiringPath(outDir))) return NOT_SEEDED; // already has its own
+    const main = mainWorktreeRoot(dir);
+    if (!main) return NOT_SEEDED;
+    const srcDir = contextDirFor(main);
+    const srcGraph = wiringPath(srcDir);
+    if (!existsSync(srcGraph)) return NOT_SEEDED; // parent never built either
+    copyTree(srcDir, outDir);
+    installGraph(srcGraph, wiringPath(outDir));
+    return { seeded: true, from: main };
+  } catch {
+    return NOT_SEEDED;
+  }
+}

--- a/src/graph/seed.ts
+++ b/src/graph/seed.ts
@@ -7,6 +7,9 @@
  * session, and the passive surface (`INDEX.md`, the cards) is missing too. The agent
  * that was supposed to be cheapest in a fresh worktree is instead blind in one.
  *
+ * What travels is the graph and the sidecars a query reads — never the markdown; see
+ * `seedable` for why the cards are the parent's branch and not this one's.
+ *
  * The parent checkout has not gone anywhere, though — a worktree's `.git` is a *file*
  * naming it, and the harness that creates these worktrees already reaches back the
  * same way (Claude Code symlinks `node_modules` to the parent's). So: copy the
@@ -42,8 +45,14 @@ import {
   statSync,
 } from "node:fs";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { ASK_INDEX_FILE } from "../ask/index-file.js";
 import { CACHE_DIR, contextDirFor } from "../context/node-file.js";
-import { GRAPH_DIR, GRAPH_FILE, wiringPath } from "./write.js";
+import { EXTRACT_CACHE_PREFIX } from "./extract-cache.js";
+import { FINGERPRINT_PREFIX } from "./fingerprint.js";
+import { GRAPH_DIR, wiringPath } from "./write.js";
+
+/** The one line a linked worktree's `.git` file carries. */
+const GITDIR_KEY = "gitdir:";
 
 /** Env kill switch, mirroring `GRAFT_NO_REFRESH` in ./refresh.ts. */
 export function seedDisabled(): boolean {
@@ -72,9 +81,17 @@ export function mainWorktreeRoot(root: string): string | null {
   try {
     const dot = join(root, ".git");
     if (statSync(dot).isDirectory()) return null;
-    const m = /^gitdir:[ \t]*(.+?)[ \t]*$/m.exec(readFileSync(dot, "utf8"));
-    if (!m) return null;
-    const gitdir = isAbsolute(m[1]) ? m[1] : resolve(root, m[1]);
+    // Read the pointer without a regex. `/^gitdir:[ \t]*(.+?)[ \t]*$/m` is the
+    // polynomial-ReDoS shape CodeQL flagged on `ensureSearchable` (`js/polynomial-redos`,
+    // fixed in 44a191e): `.` also matches space and tab, so the lazy group and the
+    // trailing `[ \t]*` overlap and a line of blanks costs O(n²). Same conclusion as
+    // that fix — the ambiguity buys nothing, and split/startsWith/trim is linear and
+    // plainer. `trim` also absorbs the `\r` of a CRLF checkout.
+    const line = readFileSync(dot, "utf8").split("\n").find((l) => l.startsWith(GITDIR_KEY));
+    if (line === undefined) return null;
+    const target = line.slice(GITDIR_KEY.length).trim();
+    if (!target) return null;
+    const gitdir = isAbsolute(target) ? target : resolve(root, target);
     if (basename(dirname(gitdir)) !== "worktrees") return null;
     const rel = readFileSync(join(gitdir, "commondir"), "utf8").trim();
     if (!rel) return null;
@@ -99,25 +116,42 @@ export interface SeedResult {
 const NOT_SEEDED: SeedResult = { seeded: false };
 
 /**
- * Repo-relative paths (posix) that a seed deliberately leaves behind.
+ * An allowlist, not a skip list: is this repo-relative path (posix) one of the few
+ * files a seed may bring across?
  *
- * `wiring.json` is here because it is copied last and atomically — see `installGraph`.
- * The rest is state that belongs to the checkout that produced it: another process's
- * lock, another session's transcripts, and another checkout's savings/dirty counters.
+ * The gate that calls this promises "writes only what a query reads — the graph, the
+ * `ask` sidecar, the freshness record" (see the header of ./refresh.ts). A copy that
+ * wrote anything else would turn a read into a write of the repo, so the copy honours
+ * the same list. The extraction memo is on it because the refresh immediately after
+ * rewrites that file anyway, and replaying it is what keeps the repair cheap.
+ *
+ * **Deliberately absent: the cards and `INDEX.md`.** They would land as this
+ * checkout's documentation while describing the *parent's* branch, and nothing on the
+ * query path rewrites them (`writeCards`/`writeIndex` sit behind `!graphOnly`), so they
+ * would stay wrong indefinitely. An explicit `graft build` regenerates them from this
+ * checkout's own graph — and prunes the ones that no longer apply — which is both
+ * correct and nearly free once the graph is here.
+ *
+ * Also absent, because it belongs to the checkout that produced it: `.cache/session/`
+ * (another session's transcripts), `.sync.lock` (another process's lock), and
+ * `stats.json` (this checkout earns its own savings and dirty flag).
  */
-const SKIP = new Set([
-  `${GRAPH_DIR}/${GRAPH_FILE}`,
-  `${CACHE_DIR}/.sync.lock`,
-  `${CACHE_DIR}/session`,
-  `${CACHE_DIR}/stats.json`,
-]);
+function seedable(rel: string): boolean {
+  // The dirs themselves, or cpSync would never look inside them.
+  if (rel === "" || rel === GRAPH_DIR || rel === CACHE_DIR) return true;
+  if (!rel.startsWith(`${CACHE_DIR}/`)) return false; // incl. the graph: `installGraph` places it
+  const name = rel.slice(CACHE_DIR.length + 1);
+  return (
+    name === ASK_INDEX_FILE ||
+    name.startsWith(`${EXTRACT_CACHE_PREFIX}.`) ||
+    name.startsWith(`${FINGERPRINT_PREFIX}.`)
+  );
+}
 
 function copyTree(srcDir: string, outDir: string): void {
   cpSync(srcDir, outDir, {
     recursive: true,
-    // A directory that returns false is skipped whole, which is what keeps
-    // `.cache/session/` (one file per session, forever) out of the copy.
-    filter: (src) => !SKIP.has(relative(srcDir, src).split(sep).join("/")),
+    filter: (src) => seedable(relative(srcDir, src).split(sep).join("/")),
   });
 }
 

--- a/test/graph-seed.test.ts
+++ b/test/graph-seed.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Seeding a git worktree's graph from its parent checkout.
+ *
+ * Two things have to hold. The worktree *shape* detection must be exactly right —
+ * it decides whether graft reaches into a neighbouring directory at all, and a
+ * submodule has the same `.git`-is-a-file shape while being a different repo — and
+ * the copy must leave the parent checkout untouched while ending up with a graph
+ * that describes *this* checkout's code, not the parent's.
+ *
+ * The end-to-end test drives real `git init` / `git worktree add` rather than
+ * hand-written `.git` files, because the whole feature rests on an assumption about
+ * git's on-disk layout and a fixture can't falsify that.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildGraph } from "../src/graph/build.js";
+import { ensureFreshGraph, refreshNote } from "../src/graph/refresh.js";
+import { mainWorktreeRoot, seedGraph } from "../src/graph/seed.js";
+import { readGraph, wiringPath } from "../src/graph/write.js";
+import { callTool } from "../src/mcp/tools.js";
+
+const MATH = "export function add(a: number, b: number): number {\n  return a + b;\n}\n";
+const MUL = "export function mul(a: number, b: number): number {\n  return a * b;\n}\n";
+
+const outOf = (d: string): string => join(d, "graft");
+const tmp = (tag: string): string => mkdtempSync(join(tmpdir(), `graft-seed-${tag}-`));
+
+/* ------------------------------------------------------------------ *
+ * mainWorktreeRoot: telling the shapes apart
+ * ------------------------------------------------------------------ */
+
+/** A parent checkout with one registered worktree, built by hand. */
+function fakePair(): { main: string; wt: string } {
+  const box = tmp("shape");
+  const main = join(box, "main");
+  const wt = join(box, "wt");
+  const gitdir = join(main, ".git", "worktrees", "w");
+  mkdirSync(gitdir, { recursive: true });
+  writeFileSync(join(gitdir, "commondir"), "../..\n");
+  mkdirSync(wt, { recursive: true });
+  writeFileSync(join(wt, ".git"), `gitdir: ${gitdir}\n`);
+  return { main, wt };
+}
+
+test("mainWorktreeRoot finds the parent checkout of a linked worktree", () => {
+  const { main, wt } = fakePair();
+  assert.equal(mainWorktreeRoot(wt), main);
+});
+
+test("mainWorktreeRoot returns null for the main checkout itself", () => {
+  const d = tmp("plain");
+  mkdirSync(join(d, ".git"), { recursive: true });
+  assert.equal(mainWorktreeRoot(d), null, "a .git directory means this *is* the checkout");
+});
+
+test("mainWorktreeRoot refuses a submodule", () => {
+  // Same file shape as a worktree, but `.git/modules/<name>`: a submodule is its own
+  // repo, and the superproject's graph describes entirely different code. Treating it
+  // as a worktree would seed a repo with a graph full of paths it doesn't contain.
+  const box = tmp("submodule");
+  const sub = join(box, "sub");
+  const gitdir = join(box, "super", ".git", "modules", "sub");
+  mkdirSync(gitdir, { recursive: true });
+  writeFileSync(join(gitdir, "commondir"), "../..\n");
+  mkdirSync(sub, { recursive: true });
+  writeFileSync(join(sub, ".git"), `gitdir: ${gitdir}\n`);
+  assert.equal(mainWorktreeRoot(sub), null);
+});
+
+test("mainWorktreeRoot survives every broken .git it can be handed", () => {
+  const d = tmp("broken");
+  assert.equal(mainWorktreeRoot(d), null, "no .git at all");
+
+  writeFileSync(join(d, ".git"), "this is not a gitdir line\n");
+  assert.equal(mainWorktreeRoot(d), null, "unparseable .git file");
+
+  const { wt } = fakePair();
+  rmSync(join(mainWorktreeRoot(wt)!, ".git", "worktrees", "w", "commondir"));
+  assert.equal(mainWorktreeRoot(wt), null, "worktree shape but no commondir");
+
+  // A bare repo (`repo.git/worktrees/w`): the common dir isn't named `.git` and there
+  // is no working tree above it to hold a graph.
+  const box = tmp("bare");
+  const gitdir = join(box, "repo.git", "worktrees", "w");
+  mkdirSync(gitdir, { recursive: true });
+  writeFileSync(join(gitdir, "commondir"), "../..\n");
+  const bareWt = join(box, "wt");
+  mkdirSync(bareWt, { recursive: true });
+  writeFileSync(join(bareWt, ".git"), `gitdir: ${gitdir}\n`);
+  assert.equal(mainWorktreeRoot(bareWt), null);
+});
+
+/* ------------------------------------------------------------------ *
+ * The real thing: git makes the worktree, graft seeds it
+ * ------------------------------------------------------------------ */
+
+/** Isolated from the developer's own git config, so CI and a laptop behave alike. */
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    env: {
+      ...process.env,
+      GIT_CONFIG_GLOBAL: "/dev/null",
+      GIT_CONFIG_SYSTEM: "/dev/null",
+      GIT_AUTHOR_NAME: "graft test",
+      GIT_AUTHOR_EMAIL: "test@example.invalid",
+      GIT_COMMITTER_NAME: "graft test",
+      GIT_COMMITTER_EMAIL: "test@example.invalid",
+    },
+  });
+}
+
+/** A committed repo with one source file and `graft/` gitignored, as a real repo has. */
+function gitRepo(): string {
+  const d = tmp("repo");
+  git(d, "init", "-b", "main");
+  mkdirSync(join(d, "src"), { recursive: true });
+  writeFileSync(join(d, "src", "math.ts"), MATH);
+  writeFileSync(join(d, ".gitignore"), "graft/\n");
+  git(d, "add", "-A");
+  git(d, "commit", "-m", "init");
+  return d;
+}
+
+function addWorktree(main: string, name: string): string {
+  const wt = join(mkdtempSync(join(tmpdir(), "graft-seed-wt-")), name);
+  git(main, "worktree", "add", "--detach", wt, "HEAD");
+  return wt;
+}
+
+test("a git worktree starts with no graph, and one query gives it a correct one", async () => {
+  const main = gitRepo();
+  await buildGraph(main);
+  const parentGraph = readFileSync(wiringPath(outOf(main)), "utf8");
+
+  // State that belongs to the checkout that produced it, and must not travel.
+  mkdirSync(join(outOf(main), ".cache", "session"), { recursive: true });
+  writeFileSync(join(outOf(main), ".cache", "session", "abc.json"), "{}");
+  writeFileSync(join(outOf(main), ".cache", "stats.json"), '{"tokens_saved":999}');
+
+  const wt = addWorktree(main, "feature");
+  assert.equal(existsSync(outOf(wt)), false, "git does not check out the gitignored cache");
+  assert.equal(existsSync(wiringPath(outOf(wt))), false);
+
+  // The worktree's code differs from the parent's — that difference is the whole
+  // reason the copied graph can't just be used as-is.
+  writeFileSync(join(wt, "src", "math.ts"), `${MATH}${MUL}`);
+
+  const r = await ensureFreshGraph(wt);
+  assert.equal(existsSync(wiringPath(outOf(wt))), true, "the worktree now has its own graph");
+  assert.match(refreshNote(r) ?? "", /copied the graph from the main checkout/);
+  assert.match(refreshNote(r) ?? "", /^\[graft\] refreshed the graph \(1 file changed\)/);
+
+  const graph = readGraph(wiringPath(outOf(wt)));
+  assert.ok(
+    graph?.nodes.some((n) => n.id === "src/math.ts#mul"),
+    "the graph describes the worktree's code, not the parent's",
+  );
+  assert.ok(graph?.nodes.some((n) => n.id === "src/math.ts#add"), "and kept what didn't change");
+
+  // The passive surface came across too — it's what `grep` and the repo map read.
+  assert.equal(existsSync(join(outOf(wt), "INDEX.md")), true);
+
+  assert.equal(existsSync(join(outOf(wt), ".cache", "session")), false, "no session transcripts");
+  assert.equal(existsSync(join(outOf(wt), ".cache", "stats.json")), false, "no borrowed savings");
+
+  // Seeding reads the parent; it must never write to it.
+  assert.equal(readFileSync(wiringPath(outOf(main)), "utf8"), parentGraph, "parent graph untouched");
+
+  rmSync(main, { recursive: true, force: true });
+  rmSync(wt, { recursive: true, force: true });
+});
+
+test("a worktree nested inside the repo is seeded too, and isn't double-indexed", async () => {
+  // Claude Code's own worktree feature puts them at `<repo>/.claude/worktrees/<name>`
+  // rather than off in a temp dir. Same `.git`-file shape, but nested — so the parent's
+  // own walk has to keep ignoring it (it does: `walkDir` skips dot-directories), or the
+  // parent would index a second copy of its own source.
+  const main = gitRepo();
+  await buildGraph(main);
+  const nested = join(main, ".claude", "worktrees", "inner");
+  git(main, "worktree", "add", "--detach", nested, "HEAD");
+
+  assert.equal(existsSync(wiringPath(outOf(nested))), false, "still nothing checked out");
+  await ensureFreshGraph(nested);
+  assert.equal(existsSync(wiringPath(outOf(nested))), true, "nested worktrees seed the same way");
+
+  await buildGraph(main);
+  const parent = readGraph(wiringPath(outOf(main)));
+  assert.equal(
+    parent?.nodes.filter((n) => n.id.includes(".claude")).length,
+    0,
+    "the parent must not index the worktree's copy of its own files",
+  );
+
+  rmSync(main, { recursive: true, force: true });
+});
+
+test("the MCP tool answers from a seeded worktree instead of refusing", async () => {
+  const main = gitRepo();
+  await buildGraph(main);
+  const wt = addWorktree(main, "mcp");
+
+  const res = await callTool(wt, "graft_find_code", { query: "add two numbers" });
+  assert.equal(res.isError, false);
+  assert.doesNotMatch(res.text, /no graph found/);
+  assert.match(res.text, /math\.ts/);
+
+  rmSync(main, { recursive: true, force: true });
+  rmSync(wt, { recursive: true, force: true });
+});
+
+test("GRAFT_NO_SEED leaves the worktree exactly as it was", async () => {
+  const main = gitRepo();
+  await buildGraph(main);
+  const wt = addWorktree(main, "off");
+
+  process.env.GRAFT_NO_SEED = "1";
+  try {
+    const r = await ensureFreshGraph(wt);
+    assert.equal(existsSync(wiringPath(outOf(wt))), false, "no graph copied");
+    assert.equal(refreshNote(r), null, "and nothing claimed");
+    // The pre-seeding symptom, verbatim: `find_code` on an ungraphed checkout doesn't
+    // say "no graph", it says "no matching nodes" — which reads like "your question
+    // was bad" rather than "there is nothing to search". Worth pinning so the failure
+    // mode this feature removes stays recognisable.
+    const res = await callTool(wt, "graft_find_code", { query: "add" });
+    assert.match(res.text, /no matching nodes/, "back to the pre-seeding behaviour");
+  } finally {
+    delete process.env.GRAFT_NO_SEED;
+  }
+
+  rmSync(main, { recursive: true, force: true });
+  rmSync(wt, { recursive: true, force: true });
+});
+
+test("seedGraph declines a --dir override and a checkout that already has a graph", async () => {
+  const main = gitRepo();
+  await buildGraph(main);
+  const wt = addWorktree(main, "guards");
+
+  // A custom output dir can't be mapped onto a sibling checkout, so don't guess.
+  const elsewhere = tmp("dir");
+  assert.deepEqual(seedGraph(wt, { contextDir: elsewhere }), { seeded: false });
+  assert.equal(existsSync(wiringPath(elsewhere)), false);
+
+  assert.equal(seedGraph(wt).seeded, true, "first call copies");
+  assert.deepEqual(seedGraph(wt), { seeded: false }, "second call has nothing to do");
+
+  rmSync(main, { recursive: true, force: true });
+  rmSync(wt, { recursive: true, force: true });
+});
+
+test("a plain repo with no parent checkout is left to `graft build`", async () => {
+  const solo = gitRepo(); // a main checkout, never built
+  const r = await ensureFreshGraph(solo);
+  assert.equal(existsSync(wiringPath(outOf(solo))), false, "no surprise full build under a query");
+  assert.equal(refreshNote(r), null);
+  rmSync(solo, { recursive: true, force: true });
+});
+
+test("`graft build` in a worktree starts from the parent's graph, not from scratch", async () => {
+  const main = gitRepo();
+  await buildGraph(main);
+  const wt = addWorktree(main, "build");
+  writeFileSync(join(wt, "src", "math.ts"), `${MATH}${MUL}`);
+
+  const g = await buildGraph(wt);
+  // `realpathSync`: git writes the canonical path into the worktree's `.git`, and on
+  // macOS the temp dir arrives here as the `/var` symlink to `/private/var`.
+  assert.equal(g.seededFrom, realpathSync(main), "reported, because the user never built here");
+  assert.equal(g.parsed, 1, "only the file this checkout changed was re-parsed");
+  assert.ok(g.cards > 0, "and the passive surface is rebuilt for this checkout");
+
+  rmSync(main, { recursive: true, force: true });
+  rmSync(wt, { recursive: true, force: true });
+});

--- a/test/graph-seed.test.ts
+++ b/test/graph-seed.test.ts
@@ -14,7 +14,16 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { buildGraph } from "../src/graph/build.js";
@@ -69,6 +78,22 @@ test("mainWorktreeRoot refuses a submodule", () => {
   mkdirSync(sub, { recursive: true });
   writeFileSync(join(sub, ".git"), `gitdir: ${gitdir}\n`);
   assert.equal(mainWorktreeRoot(sub), null);
+});
+
+test("mainWorktreeRoot reads the pointer whatever whitespace it arrives with", () => {
+  // No regex does this parsing (a lazy group next to a trailing `[ \t]*` is the
+  // polynomial-ReDoS shape CodeQL flagged in 44a191e), so the padding cases are worth
+  // pinning: a CRLF checkout, tabs, and a `.git` file with other lines in it.
+  for (const suffix of ["\n", "\r\n", "   \n", "\t\t\n", "\n# a stray line\n"]) {
+    const { main, wt } = fakePair();
+    const gitdir = join(main, ".git", "worktrees", "w");
+    writeFileSync(join(wt, ".git"), `gitdir:\t ${gitdir}${suffix}`);
+    assert.equal(mainWorktreeRoot(wt), main, `suffix ${JSON.stringify(suffix)}`);
+  }
+
+  const { wt: empty } = fakePair();
+  writeFileSync(join(empty, ".git"), "gitdir:   \n");
+  assert.equal(mainWorktreeRoot(empty), null, "a pointer to nowhere is not a worktree");
 });
 
 test("mainWorktreeRoot survives every broken .git it can be handed", () => {
@@ -164,11 +189,26 @@ test("a git worktree starts with no graph, and one query gives it a correct one"
   );
   assert.ok(graph?.nodes.some((n) => n.id === "src/math.ts#add"), "and kept what didn't change");
 
-  // The passive surface came across too — it's what `grep` and the repo map read.
-  assert.equal(existsSync(join(outOf(wt), "INDEX.md")), true);
+  // A query writes only what a query reads (the rule in refresh.ts's header). The
+  // parent's cards describe the parent's *branch*, and nothing on the query path would
+  // ever correct them, so they must not travel — `graft build` regenerates them below.
+  assert.equal(existsSync(join(outOf(wt), "INDEX.md")), false, "a query writes no markdown");
+  assert.equal(existsSync(join(outOf(wt), "graph-extraction-and-loading.md")), false, "nor cards");
+
+  // What did travel is what makes the repair cheap and the answer correct.
+  assert.equal(existsSync(join(outOf(wt), ".cache", "ask-index.json")), true, "the ask sidecar");
+  assert.ok(
+    readdirSync(join(outOf(wt), ".cache")).some((f) => f.startsWith("extract.")),
+    "the extraction memo, or every file would be re-parsed",
+  );
 
   assert.equal(existsSync(join(outOf(wt), ".cache", "session")), false, "no session transcripts");
   assert.equal(existsSync(join(outOf(wt), ".cache", "stats.json")), false, "no borrowed savings");
+
+  // …and an explicit build is what produces this checkout's own passive surface.
+  const built = await buildGraph(wt);
+  assert.ok(built.cards > 0, "the build writes cards for this checkout");
+  assert.equal(existsSync(join(outOf(wt), "INDEX.md")), true);
 
   // Seeding reads the parent; it must never write to it.
   assert.equal(readFileSync(wiringPath(outOf(main)), "utf8"), parentGraph, "parent graph untouched");


### PR DESCRIPTION
`graft/` is gitignored, so `git worktree add` never checks it out — and the graph is the only thing the MCP tools read. In a fresh worktree every tool answered `no matching nodes` / `no graph found` for the whole session, and `INDEX.md` and the cards were missing too, so `grep` and the repo map came up empty.

A query in a worktree now copies the parent checkout's `graft/` in, then treats the difference between the two checkouts as ordinary drift. The worktree's `.git` is a file naming its parent, so there is nothing to configure.

## Why copy rather than rebuild cold

- **The Tier-2 meaning layer survives.** `buildGraph` folds a prior `wiring.json` in by `body_hash`, so unchanged code keeps summaries that cost money. A cold rebuild discards all of them.
- **The repair is small.** `probeDrift` confirms suspect files by content hash, so a fresh checkout's new mtimes cost one hashing pass; the drift that survives is exactly the diff between the two checkouts.
- **$0 and offline**, like everything else on the query path.

## Scope

- `src/graph/seed.ts` — `mainWorktreeRoot()` (filesystem-only; rejects submodules, bare repos and `--separate-git-dir`) and `seedGraph()` (copy, with `wiring.json` installed last via rename so a half-copy leaves no graph).
- `src/graph/refresh.ts` — seeds at the no-graph branch under the existing sync lock, then falls through to the normal drift repair.
- `src/graph/build.ts` — seeds before reading its priors, so `graft build` in a worktree is incremental too; reports `seededFrom`.
- `src/cli.ts` — one line when a build started from a copied graph.

Reads the parent, never writes to it. No-ops unless a built parent checkout is genuinely on disk, so a fresh clone, CI, or a cloned (rather than worktree'd) cloud session behaves exactly as before. `GRAFT_NO_SEED=1` turns it off.

## Verification

- 11 new tests in `test/graph-seed.test.ts` drive real `git init` / `git worktree add` rather than hand-written `.git` files, and cover both layouts (temp-dir and repo-nested `.claude/worktrees/`), the submodule/bare/garbage rejections, the off switch, and that the parent's graph is byte-identical afterwards. Full suite 503/503.
- Checked live in a Claude Code worktree-isolated agent (`.claude/worktrees/agent-…`, a real linked worktree): `graft/` absent beforehand; after one query, `[graft] refreshed the graph — copied the graph from the main checkout (…)`, 920 nodes, 30 cards, `INDEX.md`, parent untouched.

## Known gap, not addressed here

The MCP server takes its root from the cwd it was launched with (`src/cli.ts` `startMcpServer`), so a subagent that relocates into a worktree mid-session keeps querying the parent's graph — it answers with the parent's line numbers instead of erroring. Separate root-resolution issue; this PR only fixes the missing-cache one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)