### PR TITLE
Added Dart & Kotlin support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,25 @@
 {
   "name": "@nanonets/graft",
-  "version": "0.8.0",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nanonets/graft",
-      "version": "0.8.0",
+      "version": "0.8.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.113.0",
+        "@driftlog/tree-sitter-dart": "^1.0.4",
         "commander": "^15.0.0",
         "dotenv": "^17.4.2",
         "gray-matter": "^4.0.3",
         "openai": "^6.45.0",
-        "tree-sitter": "^0.21.1",
-        "tree-sitter-go": "^0.23.4",
-        "tree-sitter-python": "^0.21.0",
+        "tree-sitter": "^0.25.1",
+        "tree-sitter-go": "^0.25.0",
+        "tree-sitter-kotlin": "^0.3.8",
+        "tree-sitter-python": "^0.25.0",
         "tree-sitter-typescript": "^0.23.2"
       },
       "bin": {
@@ -63,6 +65,31 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@driftlog/tree-sitter-dart": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@driftlog/tree-sitter-dart/-/tree-sitter-dart-1.0.4.tgz",
+      "integrity": "sha512-QaTUyrcXZtiOtdvfcJWH41mCQi82Ri5QLYXFsaK34gpny6ZdhCCiW+sSMMxgIe62eFtrchGfEY/nBJkm7eC+Ew==",
+      "hasInstallScript": true,
+      "license": "ISC",
+      "dependencies": {
+        "node-gyp-build": "^4.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "node-addon-api": "^7.1.0",
+        "tree-sitter": ">=0.22.0"
+      },
+      "peerDependenciesMeta": {
+        "node-addon-api": {
+          "optional": false
+        },
+        "tree-sitter": {
+          "optional": true
+        }
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -759,13 +786,10 @@
       }
     },
     "node_modules/node-addon-api": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.0.tgz",
-      "integrity": "sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==",
-      "license": "MIT",
-      "engines": {
-        "node": "^18 || ^20 || >= 21"
-      }
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
     },
     "node_modules/node-gyp-build": {
       "version": "4.8.4",
@@ -841,33 +865,42 @@
       }
     },
     "node_modules/tree-sitter": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
-      "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.25.1.tgz",
+      "integrity": "sha512-mrcEdkYtHfrK1A6fs3O6FxkBo0Qig5XUXqHhxUOQu0bmPo00QF4XaSx4edpazdHwxnSCjlGKGgIqWdaN4dvTLA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "node-addon-api": "^8.0.0",
-        "node-gyp-build": "^4.8.0"
+        "node-addon-api": "^8.5.0",
+        "node-gyp-build": "^4.8.4"
       }
     },
     "node_modules/tree-sitter-go": {
-      "version": "0.23.4",
-      "resolved": "https://registry.npmjs.org/tree-sitter-go/-/tree-sitter-go-0.23.4.tgz",
-      "integrity": "sha512-iQaHEs4yMa/hMo/ZCGqLfG61F0miinULU1fFh+GZreCRtKylFLtvn798ocCZjO2r/ungNZgAY1s1hPFyAwkc7w==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-go/-/tree-sitter-go-0.25.0.tgz",
+      "integrity": "sha512-APBc/Dq3xz/e35Xpkhb1blu5UgW+2E3RyGWawZSCNcbGwa7jhSQPS8KsUupuzBla8PCo8+lz9W/JDJjmfRa2tw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "node-addon-api": "^8.2.1",
-        "node-gyp-build": "^4.8.2"
+        "node-addon-api": "^8.3.1",
+        "node-gyp-build": "^4.8.4"
       },
       "peerDependencies": {
-        "tree-sitter": "^0.21.1"
+        "tree-sitter": "^0.25.0"
       },
       "peerDependenciesMeta": {
         "tree-sitter": {
           "optional": true
         }
+      }
+    },
+    "node_modules/tree-sitter-go/node_modules/node-addon-api": {
+      "version": "8.9.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.1.tgz",
+      "integrity": "sha512-4eUQWVPCUUUiBjLnHS3cXWeC6ryoPUc0U3rP7IuzapoGbzMqd/r6KKO0clr0b+snQhsrueFEhCZDdK+LK7hxKg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
       }
     },
     "node_modules/tree-sitter-javascript": {
@@ -889,10 +922,19 @@
         }
       }
     },
-    "node_modules/tree-sitter-python": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/tree-sitter-python/-/tree-sitter-python-0.21.0.tgz",
-      "integrity": "sha512-IUKx7JcTVbByUx1iHGFS/QsIjx7pqwTMHL9bl/NGyhyyydbfNrpruo2C7W6V4KZrbkkCOlX8QVrCoGOFW5qecg==",
+    "node_modules/tree-sitter-javascript/node_modules/node-addon-api": {
+      "version": "8.9.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.1.tgz",
+      "integrity": "sha512-4eUQWVPCUUUiBjLnHS3cXWeC6ryoPUc0U3rP7IuzapoGbzMqd/r6KKO0clr0b+snQhsrueFEhCZDdK+LK7hxKg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/tree-sitter-kotlin": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/tree-sitter-kotlin/-/tree-sitter-kotlin-0.3.8.tgz",
+      "integrity": "sha512-A4obq6bjzmYrA+F0JLLoheFPcofFkctNaZSpnDd+GPn1SfVZLY4/GG4C0cYVBTOShuPBGGAOPLM1JWLZQV4m1g==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -908,11 +950,33 @@
         }
       }
     },
+    "node_modules/tree-sitter-python": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-python/-/tree-sitter-python-0.25.0.tgz",
+      "integrity": "sha512-eCmJx6zQa35GxaCtQD+wXHOhYqBxEL+bp71W/s3fcDMu06MrtzkVXR437dRrCrbrDbyLuUDJpAgycs7ncngLXw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.5.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.25.0"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tree-sitter-python/node_modules/node-addon-api": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "license": "MIT"
+      "version": "8.9.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.1.tgz",
+      "integrity": "sha512-4eUQWVPCUUUiBjLnHS3cXWeC6ryoPUc0U3rP7IuzapoGbzMqd/r6KKO0clr0b+snQhsrueFEhCZDdK+LK7hxKg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
     },
     "node_modules/tree-sitter-typescript": {
       "version": "0.23.2",
@@ -932,6 +996,24 @@
         "tree-sitter": {
           "optional": true
         }
+      }
+    },
+    "node_modules/tree-sitter-typescript/node_modules/node-addon-api": {
+      "version": "8.9.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.1.tgz",
+      "integrity": "sha512-4eUQWVPCUUUiBjLnHS3cXWeC6ryoPUc0U3rP7IuzapoGbzMqd/r6KKO0clr0b+snQhsrueFEhCZDdK+LK7hxKg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/tree-sitter/node_modules/node-addon-api": {
+      "version": "8.9.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.1.tgz",
+      "integrity": "sha512-4eUQWVPCUUUiBjLnHS3cXWeC6ryoPUc0U3rP7IuzapoGbzMqd/r6KKO0clr0b+snQhsrueFEhCZDdK+LK7hxKg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
       }
     },
     "node_modules/ts-algebra": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "commander": "^15.0.0",
         "dotenv": "^17.4.2",
         "gray-matter": "^4.0.3",
+        "ignore": "^7.0.6",
         "openai": "^6.45.0",
         "tree-sitter": "^0.25.1",
         "tree-sitter-go": "^0.25.0",
@@ -739,6 +740,15 @@
       },
       "engines": {
         "node": ">=6.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/is-extendable": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "commander": "^15.0.0",
     "dotenv": "^17.4.2",
     "gray-matter": "^4.0.3",
+    "ignore": "^7.0.6",
     "openai": "^6.45.0",
     "tree-sitter": "^0.25.1",
     "tree-sitter-go": "^0.25.0",

--- a/package.json
+++ b/package.json
@@ -56,13 +56,15 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.113.0",
+    "@driftlog/tree-sitter-dart": "^1.0.4",
     "commander": "^15.0.0",
     "dotenv": "^17.4.2",
     "gray-matter": "^4.0.3",
     "openai": "^6.45.0",
-    "tree-sitter": "^0.21.1",
-    "tree-sitter-go": "^0.23.4",
-    "tree-sitter-python": "^0.21.0",
+    "tree-sitter": "^0.25.1",
+    "tree-sitter-go": "^0.25.0",
+    "tree-sitter-kotlin": "^0.3.8",
+    "tree-sitter-python": "^0.25.0",
     "tree-sitter-typescript": "^0.23.2"
   },
   "devDependencies": {
@@ -72,5 +74,8 @@
     "esbuild": "^0.28.1",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3"
+  },
+  "overrides": {
+    "tree-sitter": "^0.25.1"
   }
 }

--- a/src/cli-meta.ts
+++ b/src/cli-meta.ts
@@ -6,7 +6,7 @@
  */
 import { existsSync, readFileSync } from "node:fs";
 import { execFileSync, spawnSync } from "node:child_process";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const PKG_NAME = "@nanonets/graft";
@@ -33,7 +33,7 @@ export function readCurrentVersion(moduleUrl: string): string {
 /** True when the running module lives under an npx cache dir (e.g.
  * `~/.npm/_npx/<hash>/node_modules/...`) rather than a regular global install. */
 export function isRunningViaNpx(moduleUrl: string): boolean {
-  return fileURLToPath(moduleUrl).includes("/_npx/");
+  return fileURLToPath(moduleUrl).split(sep).join("/").includes("/_npx/");
 }
 
 export interface NpmViewResult {

--- a/src/cli-picker.ts
+++ b/src/cli-picker.ts
@@ -13,7 +13,9 @@ const amber = (s: string) => `\x1b[38;5;179m${s}\x1b[0m`;
 
 /** `/Users/me/.codex/x` → `~/.codex/x`, for display only. */
 export function tilde(path: string, home: string): string {
-  return path === home || path.startsWith(home + sep) ? `~${path.slice(home.length)}` : path;
+  const p = path.split(sep).join("/");
+  const h = home.split(sep).join("/");
+  return p === h || p.startsWith(h + "/") ? `~${p.slice(h.length)}` : path;
 }
 
 /** Deepest directory containing every given path. */

--- a/src/context/check.ts
+++ b/src/context/check.ts
@@ -13,7 +13,7 @@
  *   index       a node's frontmatter disagrees with the manifest (hand-edited)
  */
 import { existsSync, readFileSync } from "node:fs";
-import { relative, resolve } from "node:path";
+import { relative, resolve, sep } from "node:path";
 import { walkDir } from "../ingest/fs.js";
 import { contentHash } from "../util/id.js";
 import { CODE_EXTENSIONS } from "./build.js";
@@ -60,7 +60,7 @@ export function checkContext(dir: string, opts: CheckOptions = {}): CheckResult 
     if (file.startsWith(outDir)) continue;
     if (!exts.some((e) => file.toLowerCase().endsWith(e))) continue;
     try {
-      current.set(relative(root, file), contentHash(readFileSync(file, "utf8")));
+      current.set(relative(root, file).split(sep).join("/"), contentHash(readFileSync(file, "utf8")));
     } catch {
       // Unreadable now → treat as removed below (it won't be in `current`).
     }

--- a/src/graph/bindings.ts
+++ b/src/graph/bindings.ts
@@ -55,6 +55,14 @@ export function defName(node: Parser.SyntaxNode, lang: Language): string | null 
     }
     return null;
   }
+  if (lang === "dart") {
+    const nameNode = node.childForFieldName("name") ?? node.namedChildren.find((c) => c.type === "identifier" || c.type === "type_identifier");
+    return nameNode?.text ?? null;
+  }
+  if (lang === "kotlin") {
+    const nameNode = node.childForFieldName("name") ?? node.namedChildren.find((c) => c.type === "type_identifier" || c.type === "simple_identifier" || c.type === "identifier");
+    return nameNode ? nameNode.text : (node.type === "companion_object" ? "Companion" : null);
+  }
   const defTypes =
     lang === "python"
       ? new Set(["class_definition", "function_definition"])
@@ -122,6 +130,8 @@ export function resolveRecvType(
 
 function isClassNode(node: Parser.SyntaxNode, lang: Language): boolean {
   if (lang === "python") return node.type === "class_definition";
+  if (lang === "dart") return node.type === "class_definition" || node.type === "mixin_declaration" || node.type === "extension_declaration";
+  if (lang === "kotlin") return node.type === "class_declaration" || node.type === "object_declaration" || node.type === "companion_object";
   if (lang === "typescript" || lang === "tsx") {
     return node.type === "class_declaration" || node.type === "abstract_class_declaration";
   }
@@ -169,6 +179,8 @@ function visit(
 ): void {
   if (lang === "python") handlePy(node, scope, classScope, bindings, aliases);
   else if (lang === "go") handleGo(node, scope, bindings);
+  else if (lang === "dart") handleDart(node, scope, bindings);
+  else if (lang === "kotlin") handleKotlin(node, scope, bindings);
   else handleTs(node, scope, classScope, bindings, aliases);
 
   const name = defName(node, lang);
@@ -318,5 +330,23 @@ function handleGo(node: Parser.SyntaxNode, scope: string[], bindings: FileBindin
       if (fn?.type === "identifier" && /^New[A-Z]/.test(fn.text)) typeName = fn.text.slice(3);
     }
     if (typeName) bindings.set(scopePath, nameNode.text, typeName);
+  }
+}
+
+function handleDart(node: Parser.SyntaxNode, scope: string[], bindings: FileBindings): void {
+  const scopePath = scope.join(".");
+  if (node.type === "declaration" || node.type === "initialized_variable_definition") {
+    const nameNode = node.childForFieldName("name") ?? node.namedChildren.find((c) => c.type === "identifier");
+    const typeNode = node.childForFieldName("type") ?? node.namedChildren.find((c) => c.type === "type_identifier");
+    if (nameNode && typeNode) bindings.set(scopePath, nameNode.text, typeNode.text);
+  }
+}
+
+function handleKotlin(node: Parser.SyntaxNode, scope: string[], bindings: FileBindings): void {
+  const scopePath = scope.join(".");
+  if (node.type === "property_declaration" || node.type === "parameter" || node.type === "variable_declaration") {
+    const nameNode = node.childForFieldName("name") ?? node.namedChildren.find((c) => c.type === "simple_identifier" || c.type === "identifier");
+    const typeNode = node.childForFieldName("type") ?? node.namedChildren.find((c) => c.type === "user_type" || c.type === "type_identifier");
+    if (nameNode && typeNode) bindings.set(scopePath, nameNode.text, typeNode.text);
   }
 }

--- a/src/graph/check.ts
+++ b/src/graph/check.ts
@@ -18,7 +18,7 @@
  * `pending` (never summarized) is not drift — it's a deliberate Tier-1-only build.
  */
 import { readFileSync } from "node:fs";
-import { relative, resolve } from "node:path";
+import { relative, resolve, sep } from "node:path";
 import { contextDirFor } from "../context/node-file.js";
 import { extractFile, languageOf } from "./extract.js";
 import { listSourceFiles } from "./build.js";
@@ -71,7 +71,7 @@ export function checkGraph(dir: string, opts: GraphCheckOptions = {}): GraphChec
       continue; // unreadable now → its nodes show up as `removed` below
     }
     try {
-      const { nodes } = extractFile(relative(root, file), source, lang);
+      const { nodes } = extractFile(relative(root, file).split(sep).join("/"), source, lang);
       for (const n of nodes) current.set(n.id, n.body_hash);
     } catch {
       // parse failure → skip; the committed nodes for this file become `removed`.

--- a/src/graph/extract.ts
+++ b/src/graph/extract.ts
@@ -10,12 +10,14 @@ import Parser from "tree-sitter";
 import TypeScript from "tree-sitter-typescript";
 import Python from "tree-sitter-python";
 import Go from "tree-sitter-go";
+import Dart from "@driftlog/tree-sitter-dart";
+import Kotlin from "tree-sitter-kotlin";
 import { basename } from "node:path";
 import { contentHash } from "../util/id.js";
 import { collectBindings, goReceiverVarOf, resolveRecvType, type FileBindings } from "./bindings.js";
 import type { Kind, NodeV1, Relation } from "./types.js";
 
-export type Language = "typescript" | "tsx" | "python" | "go";
+export type Language = "typescript" | "tsx" | "python" | "go" | "dart" | "kotlin";
 
 /** Map a file path to a supported language, or null if unsupported. */
 export function languageOf(path: string): Language | null {
@@ -24,6 +26,8 @@ export function languageOf(path: string): Language | null {
   if (/\.(ts|mts|cts|js|mjs|cjs)$/.test(p)) return "typescript";
   if (p.endsWith(".py") || p.endsWith(".pyi")) return "python";
   if (p.endsWith(".go")) return "go";
+  if (p.endsWith(".dart")) return "dart";
+  if (p.endsWith(".kt") || p.endsWith(".kts")) return "kotlin";
   return null;
 }
 
@@ -111,11 +115,33 @@ const GO_KINDS: Record<string, Kind> = {
   method_declaration: "method",
 };
 
+const DART_KINDS: Record<string, Kind> = {
+  class_definition: "class",
+  mixin_declaration: "class",
+  extension_declaration: "class",
+  enum_declaration: "enum",
+  function_signature: "function",
+  method_signature: "method",
+  type_alias: "type",
+};
+
+const KOTLIN_KINDS: Record<string, Kind> = {
+  class_declaration: "class",
+  object_declaration: "class",
+  companion_object: "class",
+  interface_declaration: "interface",
+  enum_entry: "enum",
+  function_declaration: "function",
+  property_declaration: "type",
+};
+
 const KINDS_BY_LANG: Record<Language, Record<string, Kind>> = {
   typescript: TS_KINDS,
   tsx: TS_KINDS,
   python: PY_KINDS,
   go: GO_KINDS,
+  dart: DART_KINDS,
+  kotlin: KOTLIN_KINDS,
 };
 
 const FUNCTION_VALUE_TYPES = new Set([
@@ -131,6 +157,8 @@ const GRAMMARS: Record<Language, unknown> = {
   tsx: TypeScript.tsx,
   python: Python,
   go: Go,
+  dart: Dart,
+  kotlin: Kotlin,
 };
 
 export interface WalkCtx {
@@ -281,6 +309,8 @@ function walk(node: Parser.SyntaxNode, ctx: WalkCtx, out: NodeV1[], edges: RawEd
  * TS arrow-consts. */
 function describe(node: Parser.SyntaxNode, ctx: WalkCtx): DefDescriptor | null {
   if (ctx.lang === "go") return describeGo(node, ctx);
+  if (ctx.lang === "dart") return describeDart(node, ctx);
+  if (ctx.lang === "kotlin") return describeKotlin(node, ctx);
 
   const mapped = ctx.kinds[node.type];
   if (mapped) {
@@ -355,6 +385,38 @@ function describeGo(node: Parser.SyntaxNode, _ctx: WalkCtx): DefDescriptor | nul
   return null;
 }
 
+function describeDart(node: Parser.SyntaxNode, ctx: WalkCtx): DefDescriptor | null {
+  const mapped = ctx.kinds[node.type];
+  if (mapped) {
+    const nameNode = node.childForFieldName("name") ?? node.namedChildren.find((c) => c.type === "identifier" || c.type === "type_identifier");
+    if (!nameNode) return null;
+    const name = nameNode.text;
+    let kind = mapped;
+    if (mapped === "function" && ctx.enclosingKind === "class") {
+      kind = "method";
+    }
+    const body = node.childForFieldName("body") ?? node.namedChildren.find((c) => c.type === "block" || c.type === "function_body");
+    return { name, kind, headerEnd: body ? body.startIndex : node.endIndex, hashNode: node };
+  }
+  return null;
+}
+
+function describeKotlin(node: Parser.SyntaxNode, ctx: WalkCtx): DefDescriptor | null {
+  const mapped = ctx.kinds[node.type];
+  if (mapped) {
+    const nameNode = node.childForFieldName("name") ?? node.namedChildren.find((c) => c.type === "type_identifier" || c.type === "simple_identifier" || c.type === "identifier");
+    const name = nameNode ? nameNode.text : (node.type === "companion_object" ? "Companion" : null);
+    if (!name) return null;
+    let kind = mapped;
+    if (mapped === "function" && ctx.enclosingKind === "class") {
+      kind = "method";
+    }
+    const body = node.childForFieldName("body") ?? node.namedChildren.find((c) => c.type === "class_body" || c.type === "function_body" || c.type === "block");
+    return { name, kind, headerEnd: body ? body.startIndex : node.endIndex, hashNode: node };
+  }
+  return null;
+}
+
 /** The receiver's base type name for a Go method, unwrapping a pointer receiver
  * (`func (u *User) …` → `User`). Null if it can't be read. */
 function goReceiverType(node: Parser.SyntaxNode): string | null {
@@ -380,6 +442,32 @@ function heritageEdges(node: Parser.SyntaxNode, classId: string, ctx: WalkCtx): 
     for (const c of supers?.namedChildren ?? []) {
       if (c.type === "identifier") {
         edges.push({ source: classId, relation: "extends", name: c.text, file: ctx.rel });
+      }
+    }
+    return edges;
+  }
+  if (ctx.lang === "dart") {
+    for (const child of node.namedChildren) {
+      if (child.type === "superclass" || child.type === "interfaces" || child.type === "mixins") {
+        const relation: Relation = child.type === "interfaces" ? "implements" : "extends";
+        for (const t of child.namedChildren) {
+          if (t.type === "identifier" || t.type === "type_identifier") {
+            edges.push({ source: classId, relation, name: t.text, file: ctx.rel });
+          }
+        }
+      }
+    }
+    return edges;
+  }
+  if (ctx.lang === "kotlin") {
+    for (const child of node.namedChildren) {
+      if (child.type === "delegation_specifier" || child.type === "delegation_specifiers") {
+        const typeNode = child.namedChildren.find((c) => c.type === "constructor_invocation" || c.type === "user_type" || c.type === "type_identifier" || c.type === "simple_identifier") ?? child;
+        const nameNode = typeNode.namedChildren.find((c) => c.type === "user_type" || c.type === "type_identifier" || c.type === "simple_identifier") ?? typeNode;
+        const name = nameNode.text.replace(/\(.*\)$/, "").trim();
+        if (name) {
+          edges.push({ source: classId, relation: "extends", name, file: ctx.rel });
+        }
       }
     }
     return edges;
@@ -424,6 +512,14 @@ function calleeName(
     const p = fn.childForFieldName("property") ?? fn.namedChildren.at(-1);
     return p ? { name: p.text, viaMember: true, receiver: tsReceiver(fn) } : null;
   }
+  if (lang === "dart") {
+    const p = fn.childForFieldName("method") ?? fn.namedChildren.at(-1);
+    return p ? { name: p.text, viaMember: true } : null;
+  }
+  if (lang === "kotlin") {
+    const p = fn.namedChildren.at(-1);
+    return p ? { name: p.text, viaMember: true } : null;
+  }
   return null;
 }
 
@@ -457,6 +553,8 @@ function isImport(node: Parser.SyntaxNode, lang: Language): boolean {
   // Go: match the per-import leaf, so single (`import "fmt"`) and grouped
   // (`import ( … )`) forms each yield one edge as the walk recurses into the list.
   if (lang === "go") return node.type === "import_spec";
+  if (lang === "dart") return node.type === "import_or_export" || node.type === "import_statement";
+  if (lang === "kotlin") return node.type === "import_header";
   return node.type === "import_statement" || node.type === "import_from_statement";
 }
 
@@ -471,6 +569,14 @@ function importSpecifier(node: Parser.SyntaxNode, lang: Language): string | null
     // import_spec's `path` is an interpreted_string_literal, e.g. `"mymod/pkg/util"`.
     const path = node.childForFieldName("path") ?? node.namedChildren.at(-1);
     return path ? path.text.replace(/^["`]|["`]$/g, "") : null;
+  }
+  if (lang === "dart") {
+    const match = node.text.match(/['"]([^'"]+)['"]/);
+    return match ? match[1] : null;
+  }
+  if (lang === "kotlin") {
+    const id = node.namedChildren.find((c) => c.type === "identifier" || c.type === "dotted_identifier" || c.type === "user_type");
+    return id ? id.text : null;
   }
   const str = node.namedChildren.find((c) => c.type === "string");
   if (!str) return null;

--- a/src/graph/resolve.ts
+++ b/src/graph/resolve.ts
@@ -15,7 +15,7 @@ import { sep } from "node:path";
 import type { EdgeV1, Kind, NodeV1, Relation } from "./types.js";
 import type { RawEdge } from "./extract.js";
 
-const IMPORT_EXTS = [".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs", ".py"];
+const IMPORT_EXTS = [".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs", ".py", ".dart", ".kt", ".kts"];
 
 // Builtin container/value types whose methods are never user-defined symbols in the
 // repo. A typed member call on one of these receivers (`deg.set(...)` where
@@ -31,6 +31,8 @@ const BUILTIN_CONTAINER_TYPES = new Set([
   "Map", "Set", "WeakMap", "WeakSet", "Array", "Promise", "Object", "Date", "RegExp", "Error",
   // Python
   "dict", "list", "set", "tuple", "str", "frozenset", "bytes",
+  // Dart & Kotlin
+  "List", "Map", "Set", "String", "int", "double", "num", "bool", "Future", "Stream", "ArrayList", "HashMap", "HashSet",
 ]);
 
 /** A Go module discovered in the repo: its `module` path from `go.mod` and the repo
@@ -217,10 +219,20 @@ function resolveTypedMember(
  * otherwise return the raw specifier (external package or unresolved path).
  */
 function resolveImport(spec: string, file: string, byId: Map<string, NodeV1>): string {
+  if (spec.startsWith("package:")) {
+    const parts = spec.slice(8).split("/");
+    if (parts.length > 1) {
+      const relPath = posix.join("lib", ...parts.slice(1));
+      for (const id of byId.keys()) {
+        if (id.endsWith(relPath) || id === relPath) return id;
+      }
+    }
+    return spec;
+  }
   if (!spec.startsWith(".")) return spec;
   const dir = posix.dirname(file.split(sep).join("/"));
   const base = posix.normalize(posix.join(dir, spec));
-  const noExt = base.replace(/\.(js|jsx|mjs|cjs|ts|tsx|py)$/, "");
+  const noExt = base.replace(/\.(js|jsx|mjs|cjs|ts|tsx|py|dart|kt|kts)$/, "");
   const candidates = [
     base,
     ...IMPORT_EXTS.map((e) => noExt + e),

--- a/src/graph/scopes.ts
+++ b/src/graph/scopes.ts
@@ -27,7 +27,7 @@ import { SKIP_DIRS } from "../ingest/fs.js";
 import type { GraphV1, ScopeV1 } from "./types.js";
 
 /** Project-marker files, checked in this order (also the order `markers` is built in). */
-const MARKERS = ["package.json", "go.mod", "pyproject.toml", "setup.py", "Cargo.toml"];
+const MARKERS = ["package.json", "go.mod", "pyproject.toml", "setup.py", "Cargo.toml", "pubspec.yaml", "build.gradle.kts", "build.gradle"];
 
 const CANONICAL_ROOT: ScopeV1[] = [{ prefix: "", label: "", markers: [] }];
 

--- a/src/graph/scopes.ts
+++ b/src/graph/scopes.ts
@@ -23,7 +23,7 @@
  */
 import { existsSync, readdirSync, readFileSync, statSync, type Dirent } from "node:fs";
 import { join, resolve } from "node:path";
-import { SKIP_DIRS } from "../ingest/fs.js";
+import { SKIP_DIRS, loadGraftIgnore } from "../ingest/fs.js";
 import type { GraphV1, ScopeV1 } from "./types.js";
 
 /** Project-marker files, checked in this order (also the order `markers` is built in). */
@@ -32,9 +32,10 @@ const MARKERS = ["package.json", "go.mod", "pyproject.toml", "setup.py", "Cargo.
 const CANONICAL_ROOT: ScopeV1[] = [{ prefix: "", label: "", markers: [] }];
 
 /** Recursively collect every directory under `root` (posix rel path, "" = root itself),
- * reusing `walkDir`'s skip rules (dot-dirs, `SKIP_DIRS`) so build-output and dependency
+ * reusing `walkDir`'s skip rules (dot-dirs, `SKIP_DIRS`, `.graftignore`) so build-output and dependency
  * trees are never scanned for markers. */
 function collectDirs(root: string): string[] {
+  const ig = loadGraftIgnore(root);
   const out: string[] = [""];
   const walk = (absDir: string, relDir: string): void => {
     let entries: Dirent[];
@@ -47,6 +48,7 @@ function collectDirs(root: string): string[] {
       if (!entry.isDirectory()) continue;
       if (entry.name.startsWith(".") || SKIP_DIRS.has(entry.name)) continue;
       const rel = relDir === "" ? entry.name : `${relDir}/${entry.name}`;
+      if (ig && (ig.ignores(rel) || ig.ignores(`${rel}/`))) continue;
       out.push(rel);
       walk(join(absDir, entry.name), rel);
     }

--- a/src/graph/source-files.ts
+++ b/src/graph/source-files.ts
@@ -7,7 +7,7 @@
  * {@link listSourceFiles} so its existing importers are unaffected.
  */
 import { statSync } from "node:fs";
-import { relative } from "node:path";
+import { relative, sep } from "node:path";
 import { walkDir } from "../ingest/fs.js";
 import { languageOf } from "./extract.js";
 
@@ -40,7 +40,7 @@ export function listSourceStats(root: string, outDir: string): SourceStat[] {
     } catch {
       continue;
     }
-    out.push({ abs, rel: relative(root, abs), size: s.size, mtimeMs: s.mtimeMs });
+    out.push({ abs, rel: relative(root, abs).split(sep).join("/"), size: s.size, mtimeMs: s.mtimeMs });
   }
   return out;
 }

--- a/src/ingest/fs.ts
+++ b/src/ingest/fs.ts
@@ -1,38 +1,60 @@
 /**
  * Filesystem walking used by `init`/`check` to enumerate a repo's source files.
  */
-import { readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+import { type Ignore } from "ignore";
+import { SKIP_DIRS, createDefaultIgnore } from "./ignore-rules.js";
 
-/** Directories that are dependency/build output, never source. */
-export const SKIP_DIRS = new Set([
-  "node_modules",
-  "dist",
-  "build",
-  "out",
-  "target",
-  "vendor",
-  "coverage",
-  "__pycache__",
-  "venv",
-]);
+export { SKIP_DIRS };
 
 /** Files above this size are generated/vendored in practice, not hand-written code. */
 export const MAX_FILE_BYTES = 1_000_000;
 
 /**
- * Recursively list all files under a directory. Skips dot-directories,
- * dependency/build directories (node_modules, dist, …), and files over 1 MB.
+ * Load default ecosystem ignore rules combined with root `.graftignore` if present.
+ * Only the root directory `.graftignore` is considered.
  */
-export function walkDir(dir: string): string[] {
+export function loadGraftIgnore(rootDir: string): Ignore {
+  const ig = createDefaultIgnore();
+  const path = join(rootDir, ".graftignore");
+  if (existsSync(path)) {
+    try {
+      const content = readFileSync(path, "utf8");
+      ig.add(content);
+    } catch {
+      // Ignore unreadable .graftignore
+    }
+  }
+  return ig;
+}
+
+/**
+ * Recursively list all files under a directory. Skips dot-directories,
+ * dependency/build directories (node_modules, dist, …), files over 1 MB,
+ * and paths ignored by root `.graftignore`.
+ */
+export function walkDir(dir: string, rootDir: string = dir, ig?: Ignore | null): string[] {
+  if (ig === undefined) {
+    ig = loadGraftIgnore(rootDir);
+  }
   const out: string[] = [];
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
     if (entry.name.startsWith(".")) continue;
     const full = join(dir, entry.name);
+    const relPath = relative(rootDir, full).split(sep).join("/");
+
     if (entry.isDirectory()) {
-      if (SKIP_DIRS.has(entry.name)) continue;
-      out.push(...walkDir(full));
+      if (ig && (ig.ignores(relPath) || ig.ignores(`${relPath}/`))) continue;
+      out.push(...walkDir(full, rootDir, ig));
     } else if (entry.isFile()) {
+      if (ig && ig.ignores(relPath)) continue;
       try {
         if (statSync(full).size > MAX_FILE_BYTES) continue;
       } catch {

--- a/src/ingest/ignore-rules.ts
+++ b/src/ingest/ignore-rules.ts
@@ -1,0 +1,118 @@
+/**
+ * Modular ignore rules categorized by ecosystem / language context.
+ *
+ * Used by filesystem walking (`fs.ts`) and scope discovery (`scopes.ts`) to
+ * exclude build outputs, dependency directories, bytecode, and non-source files.
+ */
+import ignore, { type Ignore } from "ignore";
+
+export interface IgnoreGroup {
+  /** Stable identifier for the ecosystem group. */
+  id: string;
+  /** Human-readable display name. */
+  name: string;
+  /** Directory names or relative path patterns to skip. */
+  dirs: ReadonlyArray<string>;
+  /** Non-source file extension or pattern rules to skip. */
+  patterns: ReadonlyArray<string>;
+}
+
+export const GENERAL_IGNORE_GROUP: IgnoreGroup = {
+  id: "general",
+  name: "General & Universal",
+  dirs: [],
+  patterns: [
+    "*.exe", "*.dll", "*.so", "*.dylib",
+    "*.zip", "*.tar", "*.gz", "*.7z", "*.rar",
+    "*.pdf", "*.png", "*.jpg", "*.jpeg", "*.gif", "*.ico", "*.svg",
+    "*.mp3", "*.mp4", "*.mov", "*.db", "*.sqlite",
+  ],
+};
+
+export const NPM_JS_IGNORE_GROUP: IgnoreGroup = {
+  id: "npm",
+  name: "NPM / JavaScript / TypeScript",
+  dirs: [
+    "node_modules", "dist", "build", "out", "coverage",
+    ".next", ".nuxt", ".turbo", ".output", ".parcel-cache",
+  ],
+  patterns: [
+    "node_modules/", "dist/", "build/", "out/", "coverage/",
+    ".next/", ".nuxt/", ".turbo/", ".output/", ".parcel-cache/",
+    "*.min.js", "*.min.css", "*.js.map", "*.css.map",
+  ],
+};
+
+export const PYTHON_IGNORE_GROUP: IgnoreGroup = {
+  id: "python",
+  name: "Python",
+  dirs: [
+    "__pycache__", "venv", ".venv", "env", ".env", "virtualenv",
+    ".pytest_cache", ".mypy_cache", ".ruff_cache", ".tox", "htmlcov",
+    ".eggs", "eggs", "*.egg-info",
+  ],
+  patterns: [
+    "__pycache__/", "venv/", ".venv/", "env/", ".env/", "virtualenv/",
+    ".pytest_cache/", ".mypy_cache/", ".ruff_cache/", ".tox/", "htmlcov/",
+    ".eggs/", "eggs/", "*.egg-info/",
+    "*.pyc", "*.pyo", "*.pyd",
+  ],
+};
+
+export const KOTLIN_GRADLE_IGNORE_GROUP: IgnoreGroup = {
+  id: "kotlin-gradle",
+  name: "Kotlin / Gradle / Java",
+  dirs: [
+    "build", ".gradle", "out", "target", ".idea", ".apt_generated", "bin",
+  ],
+  patterns: [
+    "build/", ".gradle/", "out/", "target/", ".idea/", ".apt_generated/", "bin/",
+    "*.class", "*.jar", "*.aar", "*.war", "*.ear", "*.klib",
+  ],
+};
+
+export const DART_FLUTTER_IGNORE_GROUP: IgnoreGroup = {
+  id: "dart-flutter",
+  name: "Dart / Flutter",
+  dirs: [
+    ".dart_tool", ".pub-cache", ".pub", "build", "ephemeral", "ios/Pods", ".fvm",
+  ],
+  patterns: [
+    ".dart_tool/", ".pub-cache/", ".pub/", "build/", "ephemeral/", "ios/Pods/", ".fvm/",
+    ".flutter-plugins", ".flutter-plugins-dependencies",
+  ],
+};
+
+export const GO_IGNORE_GROUP: IgnoreGroup = {
+  id: "go",
+  name: "Go",
+  dirs: ["vendor", "bin"],
+  patterns: ["vendor/", "bin/", "*.a", "*.o"],
+};
+
+export const ALL_IGNORE_GROUPS: ReadonlyArray<IgnoreGroup> = [
+  GENERAL_IGNORE_GROUP,
+  NPM_JS_IGNORE_GROUP,
+  PYTHON_IGNORE_GROUP,
+  KOTLIN_GRADLE_IGNORE_GROUP,
+  DART_FLUTTER_IGNORE_GROUP,
+  GO_IGNORE_GROUP,
+];
+
+/** Combined directory names set for fast lookup and backward compatibility. */
+export const SKIP_DIRS: Set<string> = new Set<string>(
+  ALL_IGNORE_GROUPS.flatMap((g) => g.dirs),
+);
+
+/**
+ * Returns a new `Ignore` instance pre-loaded with pattern rules from all default ecosystem groups.
+ */
+export function createDefaultIgnore(): Ignore {
+  const ig = ignore();
+  for (const group of ALL_IGNORE_GROUPS) {
+    if (group.patterns.length > 0) {
+      ig.add(group.patterns as string[]);
+    }
+  }
+  return ig;
+}

--- a/test/claude-state.test.ts
+++ b/test/claude-state.test.ts
@@ -50,7 +50,7 @@ test('acquireLock reclaims a stale lock', () => {
 });
 
 test('writeJsonAtomic leaves no scratch file behind when the write fails', (t) => {
-  if (process.getuid?.() === 0) return t.skip('root writes anywhere, so a read-only dir proves nothing');
+  if (process.platform === 'win32' || process.getuid?.() === 0) return t.skip('Windows NTFS / root does not prevent file creation on chmod 500');
   const d = fresh();
   const dir = join(d, 'locked');
   mkdirSync(dir, { recursive: true });

--- a/test/cli-picker.test.ts
+++ b/test/cli-picker.test.ts
@@ -140,7 +140,7 @@ test('describeWrites names out-of-repo writes as machine-wide', () => {
   const agents = planInit(repo, { home, ids: ['agents'] })[0];
   const summary = describeWrites(agents.writes, repo, home);
   assert.match(summary, /AGENTS\.md/);
-  assert.match(summary, /\+ 3 in ~\/\.codex\/ \(machine-wide\)/);
+  assert.match(summary.replace(/\\/g, "/"), /\+ 3 in ~\/\.codex\/ \(machine-wide\)/);
 });
 
 test('describeWrites flags hosts with no MCP target', () => {
@@ -175,7 +175,7 @@ test('formatPlan separates repo writes from machine-wide ones', () => {
   const repoAt = text.indexOf('would write — this repo:');
   const globalAt = text.indexOf('affects ALL repos:');
   assert.ok(repoAt >= 0 && globalAt > repoAt, 'repo section comes first');
-  assert.match(text, /~\/\.codex\/hooks\.json/);
+  assert.match(text.replace(/\\/g, "/"), /~\/\.codex\/hooks\.json/);
   assert.match(text, /PostToolUse: Write\|Edit\|MultiEdit/);
   assert.match(text, /nothing was written \(--dry-run\)/);
   assert.match(text, /--no-global/);

--- a/test/graftignore.test.ts
+++ b/test/graftignore.test.ts
@@ -1,0 +1,98 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { loadGraftIgnore, walkDir } from "../src/ingest/fs.js";
+import { buildGraph } from "../src/graph/build.js";
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "graftignore-test-"));
+}
+
+test("loadGraftIgnore: returns an Ignore instance with default ecosystem rules when no .graftignore exists", () => {
+  const dir = makeTmpDir();
+  try {
+    const ig = loadGraftIgnore(dir);
+    assert.ok(ig);
+    assert.ok(ig.ignores("node_modules/"));
+    assert.ok(ig.ignores(".gradle/"));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadGraftIgnore & walkDir: respects root .graftignore rules", () => {
+  const dir = makeTmpDir();
+  try {
+    writeFileSync(join(dir, ".graftignore"), "ignored_dir/\n*.secret\n");
+    writeFileSync(join(dir, "keep.ts"), "export const keep = 1;");
+    writeFileSync(join(dir, "hide.secret"), "export const hide = 1;");
+    
+    mkdirSync(join(dir, "ignored_dir"));
+    writeFileSync(join(dir, "ignored_dir", "foo.ts"), "export const foo = 1;");
+
+    mkdirSync(join(dir, "included_dir"));
+    writeFileSync(join(dir, "included_dir", "bar.ts"), "export const bar = 1;");
+
+    const files = walkDir(dir).map((f) => f.slice(dir.length + 1).replace(/\\/g, "/"));
+
+    assert.ok(files.includes("keep.ts"));
+    assert.ok(files.includes("included_dir/bar.ts"));
+    assert.ok(!files.includes("hide.secret"));
+    assert.ok(!files.includes("ignored_dir/foo.ts"));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("walkDir: ignores subfolder .graftignore files as rule sources", () => {
+  const dir = makeTmpDir();
+  try {
+    mkdirSync(join(dir, "sub"));
+    // Subfolder has a .graftignore that attempts to ignore sub_hidden.ts
+    writeFileSync(join(dir, "sub", ".graftignore"), "sub_hidden.ts\n");
+    writeFileSync(join(dir, "sub", "sub_hidden.ts"), "export const subHidden = 1;");
+    writeFileSync(join(dir, "sub", "normal.ts"), "export const normal = 1;");
+
+    const files = walkDir(dir).map((f) => f.slice(dir.length + 1).replace(/\\/g, "/"));
+
+    // sub_hidden.ts should NOT be ignored because subfolder .graftignore is ignored as a rule source
+    assert.ok(files.includes("sub/sub_hidden.ts"));
+    assert.ok(files.includes("sub/normal.ts"));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("walkDir: handles negation rules in root .graftignore", () => {
+  const dir = makeTmpDir();
+  try {
+    writeFileSync(join(dir, ".graftignore"), "*.log\n!important.log\n");
+    writeFileSync(join(dir, "debug.log"), "debug log");
+    writeFileSync(join(dir, "important.log"), "important log");
+
+    const files = walkDir(dir).map((f) => f.slice(dir.length + 1).replace(/\\/g, "/"));
+
+    assert.ok(!files.includes("debug.log"));
+    assert.ok(files.includes("important.log"));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("buildGraph: ignores files matching .graftignore", async () => {
+  const dir = makeTmpDir();
+  try {
+    writeFileSync(join(dir, ".graftignore"), "temp/\n");
+    writeFileSync(join(dir, "index.ts"), "export function main() {}");
+    
+    mkdirSync(join(dir, "temp"));
+    writeFileSync(join(dir, "temp", "secret.ts"), "export function secret() {}");
+
+    const result = await buildGraph(dir);
+    assert.ok(result.files === 1, `Expected 1 file parsed, got ${result.files}`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/graph-dart.test.ts
+++ b/test/graph-dart.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for Dart extraction in the Tier-1 code graph.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { buildGraph } from "../src/graph/build.js";
+import { readGraph, wiringPath } from "../src/graph/write.js";
+import type { GraphV1, NodeV1 } from "../src/graph/types.js";
+
+const MAIN_DART = `
+import 'package:my_app/models/user.dart';
+
+class BaseService {}
+
+class UserService extends BaseService {
+  void fetchUser() {
+    print("fetching");
+    helper();
+  }
+}
+
+void helper() {}
+`;
+
+const USER_DART = `
+class User {
+  String name;
+  User(this.name);
+}
+`;
+
+function makeFixture(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graft-dart-"));
+  writeFileSync(join(dir, "pubspec.yaml"), "name: my_app\n");
+  mkdirSync(join(dir, "lib", "models"), { recursive: true });
+  writeFileSync(join(dir, "lib", "main.dart"), MAIN_DART);
+  writeFileSync(join(dir, "lib", "models", "user.dart"), USER_DART);
+  return dir;
+}
+
+function nodeById(graph: GraphV1, id: string): NodeV1 | undefined {
+  return graph.nodes.find((n) => n.id === id);
+}
+
+test("Dart extraction: classes, functions, inheritance, call edges, imports", async () => {
+  const dir = makeFixture();
+  try {
+    const result = await buildGraph(dir);
+    assert.ok(result.languages.includes("dart"), "languages should include dart");
+
+    const graph = readGraph(wiringPath(join(dir, "graft")));
+    assert.ok(graph, "wiring graph should be written");
+
+    const baseService = nodeById(graph!, "lib/main.dart#BaseService");
+    assert.equal(baseService?.kind, "class");
+
+    const userService = nodeById(graph!, "lib/main.dart#UserService");
+    assert.equal(userService?.kind, "class");
+
+    const helper = nodeById(graph!, "lib/main.dart#helper");
+    assert.equal(helper?.kind, "function");
+
+    const user = nodeById(graph!, "lib/models/user.dart#User");
+    assert.equal(user?.kind, "class");
+
+    // Extends relation
+    const extendsEdge = graph!.edges.find(
+      (e) => e.relation === "extends" && e.source === "lib/main.dart#UserService" && e.target === "lib/main.dart#BaseService"
+    );
+    assert.ok(extendsEdge, "UserService should extend BaseService");
+
+    // Import resolution
+    const importEdge = graph!.edges.find(
+      (e) => e.relation === "imports" && e.source === "lib/main.dart" && e.target === "lib/models/user.dart"
+    );
+    assert.ok(importEdge, "package:my_app/models/user.dart should resolve to lib/models/user.dart");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/graph-incremental.test.ts
+++ b/test/graph-incremental.test.ts
@@ -159,7 +159,7 @@ test("every file on disk lands in the fingerprint", async () => {
 });
 
 test("an unreadable file is still recorded, so it can't look new on every probe", async (t) => {
-  if (process.getuid?.() === 0) return t.skip("root reads anything, so chmod 000 proves nothing");
+  if (process.platform === "win32" || process.getuid?.() === 0) return t.skip("Windows NTFS / root does not revoke read access on chmod 000");
   const d = repo();
   const secret = join(d, "src", "secret.ts");
   writeFileSync(secret, "export function secretFn(): number {\n  return 1;\n}\n");

--- a/test/graph-kotlin.test.ts
+++ b/test/graph-kotlin.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for Kotlin extraction in the Tier-1 code graph.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { buildGraph } from "../src/graph/build.js";
+import { readGraph, wiringPath } from "../src/graph/write.js";
+import type { GraphV1, NodeV1 } from "../src/graph/types.js";
+
+const MAIN_KT = `
+package com.example.app
+
+class BaseManager
+
+class UserManager : BaseManager() {
+  fun process() {
+    doWork()
+  }
+}
+
+fun doWork() {}
+`;
+
+const BUILD_KTS = `
+plugins {
+    kotlin("jvm") version "1.9.0"
+}
+
+fun configureProject() {}
+`;
+
+function makeFixture(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graft-kt-"));
+  mkdirSync(join(dir, "src", "main", "kotlin"), { recursive: true });
+  writeFileSync(join(dir, "build.gradle.kts"), BUILD_KTS);
+  writeFileSync(join(dir, "src", "main", "kotlin", "Main.kt"), MAIN_KT);
+  return dir;
+}
+
+function nodeById(graph: GraphV1, id: string): NodeV1 | undefined {
+  return graph.nodes.find((n) => n.id === id);
+}
+
+test("Kotlin extraction: classes, functions, inheritance, .kts script support", async () => {
+  const dir = makeFixture();
+  try {
+    const result = await buildGraph(dir);
+    assert.ok(result.languages.includes("kotlin"), "languages should include kotlin");
+
+    const graph = readGraph(wiringPath(join(dir, "graft")));
+    assert.ok(graph, "wiring graph should be written");
+
+    const baseManager = nodeById(graph!, "src/main/kotlin/Main.kt#BaseManager");
+    assert.equal(baseManager?.kind, "class");
+
+    const userManager = nodeById(graph!, "src/main/kotlin/Main.kt#UserManager");
+    assert.equal(userManager?.kind, "class");
+
+    const doWork = nodeById(graph!, "src/main/kotlin/Main.kt#doWork");
+    assert.equal(doWork?.kind, "function");
+
+    const configureProject = nodeById(graph!, "build.gradle.kts#configureProject");
+    assert.equal(configureProject?.kind, "function");
+
+    // Extends relation
+    const extendsEdge = graph!.edges.find(
+      (e) => e.relation === "extends" && e.source === "src/main/kotlin/Main.kt#UserManager" && e.target === "src/main/kotlin/Main.kt#BaseManager"
+    );
+    assert.ok(extendsEdge, "UserManager should extend BaseManager");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/graph-refresh.test.ts
+++ b/test/graph-refresh.test.ts
@@ -8,7 +8,7 @@ import assert from "node:assert/strict";
 import { chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { spawn } from "node:child_process";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { dirname, join } from "node:path";
 import { buildGraph } from "../src/graph/build.js";
 import { ensureFreshChildren, ensureFreshGraph, refreshNote } from "../src/graph/refresh.js";
@@ -244,7 +244,7 @@ test("GRAFT_REFRESH=hash: drift the probe reports is drift the rebuild repairs",
 });
 
 test("a file that becomes readable again is picked up through the probe", async (t) => {
-  if (process.getuid?.() === 0) return t.skip("root reads anything, so chmod 000 proves nothing");
+  if (process.platform === "win32" || process.getuid?.() === 0) return t.skip("Windows NTFS / root does not revoke read access on chmod 000");
   const d = repo();
   const hidden = join(d, "src", "hidden.ts");
   writeFileSync(hidden, "export function reachable(): number {\n  return 1;\n}\n");
@@ -265,7 +265,7 @@ test("a file that becomes readable again is picked up through the probe", async 
 });
 
 test("an unwritable cache costs reuse, not correctness", async (t) => {
-  if (process.getuid?.() === 0) return t.skip("root writes anywhere, so a read-only dir proves nothing");
+  if (process.platform === "win32" || process.getuid?.() === 0) return t.skip("Windows NTFS / root does not revoke read access on chmod 000");
   const d = repo();
   await buildGraph(d);
 
@@ -419,7 +419,8 @@ test("callTool refreshes before answering — except for graft_check_freshness",
   assert.ok(!again.text.startsWith("[graft] refreshed"), "nothing moved — no note, no rebuild");
 });
 
-test("a process killed while holding the lock releases it", async () => {
+test("a process killed while holding the lock releases it", async (t) => {
+  if (process.platform === "win32") return t.skip("Windows does not dispatch SIGTERM handlers to child processes");
   const d = repo();
   const cache = join(outOf(d), ".cache");
   mkdirSync(cache, { recursive: true });
@@ -431,11 +432,13 @@ test("a process killed while holding the lock releases it", async () => {
   // never ran, and the abandoned lock then blocked the background sync and made every
   // query wait-then-answer-stale until it aged out.
   const src = fileURLToPath(new URL("../src", import.meta.url));
+  const stateUrl = pathToFileURL(join(src, "util", "state.ts")).href;
+  const refreshUrl = pathToFileURL(join(src, "graph", "refresh.ts")).href;
   const child = spawn(
     process.execPath,
     ["--import", "tsx", "-e",
-      `const { acquireLockIn } = await import(${JSON.stringify(`${src}/util/state.ts`)});
-       const { releaseOnSignal } = await import(${JSON.stringify(`${src}/graph/refresh.ts`)});
+      `const { acquireLockIn } = await import(${JSON.stringify(stateUrl)});
+       const { releaseOnSignal } = await import(${JSON.stringify(refreshUrl)});
        const cache = process.argv[1];
        if (!acquireLockIn(cache)) { process.exit(9); }
        releaseOnSignal(cache);

--- a/test/hosts-codex-hooks.test.ts
+++ b/test/hosts-codex-hooks.test.ts
@@ -18,7 +18,7 @@ test('writes shim + hooks.json entry, idempotent on re-run', () => {
   assert.equal(w.length, 2);
   const shim = join(home, '.codex', 'hooks', 'graft', 'graft-hooks.cjs');
   assert.ok(existsSync(shim));
-  assert.ok(statSync(shim).mode & 0o111, 'shim is executable');
+  if (process.platform !== 'win32') assert.ok(statSync(shim).mode & 0o111, 'shim is executable');
   const cfg = JSON.parse(readFileSync(join(home, '.codex', 'hooks.json'), 'utf8'));
   const entries = cfg.hooks.PostToolUse;
   assert.equal(entries.length, 1);
@@ -67,7 +67,8 @@ test('non-array PostToolUse (foreign single object) is never rewritten', () => {
   assert.equal(readFileSync(join(home, '.codex', 'hooks.json'), 'utf8'), original);
 });
 
-test('re-heals shim exec bit when a prior install had its mode stripped', () => {
+test('re-heals shim exec bit when a prior install had its mode stripped', (t) => {
+  if (process.platform === 'win32') return t.skip('Windows does not support file executable mode bits');
   const home = fresh();
   mkdirSync(join(home, '.codex'), { recursive: true });
   installCodexHooks(home);

--- a/test/hosts-init.test.ts
+++ b/test/hosts-init.test.ts
@@ -106,7 +106,7 @@ test('runHostsInit registers MCP configs for selected hosts', () => {
   const home = fresh(); const repo = fresh();
   const r = runHostsInit(repo, { home, agents: ['cursor'] });
   assert.equal(r.mcp.length, 1);
-  assert.match(r.mcp[0].path, /\.cursor\/mcp\.json$/);
+  assert.match(r.mcp[0].path.replace(/\\/g, "/"), /\.cursor\/mcp\.json$/);
   const cfg = JSON.parse(readFileSync(join(repo, '.cursor', 'mcp.json'), 'utf8'));
   assert.equal(cfg.mcpServers.graft.command, 'npx');
 });
@@ -168,7 +168,7 @@ function cliStderr(repo: string, home: string, extra: string[] = []): string {
   const res = spawnSync(
     process.execPath,
     ['--import', 'tsx', 'src/cli.ts', 'init', repo, '--no-build', ...extra],
-    { encoding: 'utf8', env: { ...process.env, HOME: home } },
+    { encoding: 'utf8', env: { ...process.env, HOME: home, USERPROFILE: home, APPDATA: home } },
   );
   assert.equal(res.status, 0, `exited ${res.status}: ${res.stderr}`);
   return res.stderr ?? '';
@@ -190,10 +190,10 @@ test('CLI: --dry-run prints the plan, both sections, and writes nothing', () => 
   const out = cliStderr(repo, home, ['--dry-run']);
 
   assert.match(out, /would write — this repo:/);
-  assert.match(out, /\.claude\/settings\.json/);
+  assert.match(out.replace(/\\/g, "/"), /\.claude\/settings\.json/);
   assert.match(out, /AGENTS\.md/);
   assert.match(out, /affects ALL repos:/);
-  assert.match(out, /~\/\.codex\/hooks\.json/);
+  assert.match(out.replace(/\\/g, "/"), /~\/\.codex\/hooks\.json/);
   assert.match(out, /nothing was written/);
 
   assert.deepEqual(readdirSync(repo), []);
@@ -241,7 +241,7 @@ test('CLI: --dry-run respects an explicit --agents list', () => {
   const home = fresh(); const repo = fresh();
   mkdirSync(join(home, '.codex'), { recursive: true });
   const out = cliStderr(repo, home, ['--agents', 'adal', '--dry-run']);
-  assert.match(out, /\.adal\/skills\/graft\/SKILL\.md/);
+  assert.match(out.replace(/\\/g, "/"), /\.adal\/skills\/graft\/SKILL\.md/);
   assert.doesNotMatch(out, /AGENTS\.md/);
   assert.doesNotMatch(out, /affects ALL repos/);
 });

--- a/test/hosts-plan.test.ts
+++ b/test/hosts-plan.test.ts
@@ -48,7 +48,7 @@ test('the three ~/.codex writes are scoped global', () => {
   const globals = agents.writes.filter((w) => w.scope === 'global');
   assert.equal(globals.length, 3);
   assert.deepEqual(
-    globals.map((w) => w.path.slice(home.length)).sort(),
+    globals.map((w) => w.path.slice(home.length).replace(/\\/g, "/")).sort(),
     ['/.codex/config.toml', '/.codex/hooks.json', '/.codex/hooks/graft/graft-hooks.cjs'],
   );
 });
@@ -72,7 +72,7 @@ test('adal is an instruction-only host — no MCP target', () => {
   const adal = planInit(fresh(), { home: fullHome(), ids: ['adal'] })[0];
   assert.equal(adal.writes.length, 1);
   assert.equal(adal.writes[0].kind, 'instruction');
-  assert.match(adal.writes[0].path, /\.adal\/skills\/graft\/SKILL\.md$/);
+  assert.match(adal.writes[0].path.replace(/\\/g, "/"), /\.adal\/skills\/graft\/SKILL\.md$/);
 });
 
 // The assertion that keeps the plan honest: whatever a real run writes must be

--- a/test/ignore-rules.test.ts
+++ b/test/ignore-rules.test.ts
@@ -1,0 +1,106 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  ALL_IGNORE_GROUPS,
+  KOTLIN_GRADLE_IGNORE_GROUP,
+  DART_FLUTTER_IGNORE_GROUP,
+  createDefaultIgnore,
+} from "../src/ingest/ignore-rules.js";
+import { loadGraftIgnore, walkDir, SKIP_DIRS } from "../src/ingest/fs.js";
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "ignore-rules-test-"));
+}
+
+test("ALL_IGNORE_GROUPS: contains all modular ecosystem groups", () => {
+  const ids = ALL_IGNORE_GROUPS.map((g) => g.id);
+  assert.ok(ids.includes("general"));
+  assert.ok(ids.includes("npm"));
+  assert.ok(ids.includes("python"));
+  assert.ok(ids.includes("kotlin-gradle"));
+  assert.ok(ids.includes("dart-flutter"));
+  assert.ok(ids.includes("go"));
+});
+
+test("SKIP_DIRS: includes directories from all ecosystem groups", () => {
+  assert.ok(SKIP_DIRS.has("node_modules"));
+  assert.ok(SKIP_DIRS.has("__pycache__"));
+  assert.ok(SKIP_DIRS.has(".gradle"));
+  assert.ok(SKIP_DIRS.has(".dart_tool"));
+  assert.ok(SKIP_DIRS.has("vendor"));
+});
+
+test("createDefaultIgnore: evaluates pattern rules for Kotlin/Gradle and Dart/Flutter", () => {
+  const ig = createDefaultIgnore();
+  assert.ok(ig.ignores("build/"));
+  assert.ok(ig.ignores("build/outputs/app.apk"));
+  assert.ok(ig.ignores("App.class"));
+  assert.ok(ig.ignores("library.aar"));
+
+  assert.ok(ig.ignores(".dart_tool/package_config.json"));
+  assert.ok(ig.ignores(".pub-cache/hosted/pub.dev/foo"));
+
+  assert.ok(ig.ignores("__pycache__/foo.pyc"));
+  assert.ok(ig.ignores("bundle.min.js"));
+});
+
+test("walkDir: excludes Kotlin/Gradle build outputs and bytecode files", () => {
+  const dir = makeTmpDir();
+  try {
+    mkdirSync(join(dir, "src", "main", "kotlin"), { recursive: true });
+    mkdirSync(join(dir, "build", "classes"), { recursive: true });
+
+    writeFileSync(join(dir, "src", "main", "kotlin", "Main.kt"), "fun main() {}");
+    writeFileSync(join(dir, "build", "classes", "Main.class"), "bytecode");
+    writeFileSync(join(dir, "src", "main", "kotlin", "Main.class"), "compiled bytecode");
+
+    const files = walkDir(dir).map((f) => f.slice(dir.length + 1).replace(/\\/g, "/"));
+
+    assert.ok(files.includes("src/main/kotlin/Main.kt"));
+    assert.ok(!files.includes("build/classes/Main.class"));
+    assert.ok(!files.includes("src/main/kotlin/Main.class"));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("walkDir: excludes Dart/Flutter build output and tool caches", () => {
+  const dir = makeTmpDir();
+  try {
+    mkdirSync(join(dir, "lib"));
+    mkdirSync(join(dir, ".dart_tool"));
+    mkdirSync(join(dir, ".pub-cache"));
+
+    writeFileSync(join(dir, "lib", "main.dart"), "void main() {}");
+    writeFileSync(join(dir, ".dart_tool", "package_config.json"), "{}");
+    writeFileSync(join(dir, ".pub-cache", "cached.dart"), "// cached");
+
+    const files = walkDir(dir).map((f) => f.slice(dir.length + 1).replace(/\\/g, "/"));
+
+    assert.ok(files.includes("lib/main.dart"));
+    assert.ok(!files.includes(".dart_tool/package_config.json"));
+    assert.ok(!files.includes(".pub-cache/cached.dart"));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadGraftIgnore: supports user .graftignore negated rules", () => {
+  const dir = makeTmpDir();
+  try {
+    mkdirSync(join(dir, "vendor"));
+    writeFileSync(join(dir, ".graftignore"), "!vendor/\nvendor/*\n!vendor/custom.go\n");
+    writeFileSync(join(dir, "vendor", "ignored.go"), "package vendor");
+    writeFileSync(join(dir, "vendor", "custom.go"), "package custom");
+
+    const files = walkDir(dir).map((f) => f.slice(dir.length + 1).replace(/\\/g, "/"));
+
+    assert.ok(files.includes("vendor/custom.go"));
+    assert.ok(!files.includes("vendor/ignored.go"));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
- Added Dart and Kotlin parsing support and tree-sitter upgrades.
- Introduced new dependencies (@driftlog/tree-sitter-dart, tree-sitter-kotlin), bumped tree-sitter versions.
- Implemented Dart & Kotlin language handling across graph: kinds, describe(), heritage/callee/import parsing, binding collectors, and import resolution (including package: style for Dart).
- Normalized file paths to POSIX style internally.
- Added tests for Dart and Kotlin support.
- Adjusted existing tests for Windows (path separators, platform-specific behavior, exec-bit expectations).
- Updated package.json/package-lock accordingly.

> [!IMPORTANT]
> All tests are passing, including the newly added ones for Kotlin and Dart extraction. 
> Project is building cleanly.
> Have run both `graft build` and `graft build --deep` (using Gemini 3.6 Flash [Medium]) each on one Dart and one Kotlin project
> All runs finished successfully 
> Results assessed through `graft viz` were compelling, from a cursory look
> Haven't tested in development yet

Right now, support for Dart and Kotlin has been added by just adding further conditional branches to existing code without changing the code structure, and of course by adding the relevant `tree-sitter-*` dependencies. This was done out of personal need for Graft in Dart and Kotlin projects specifically.

Later, however, it might be a good idea to refactor the functionality to make this project's language support more extensible, so that people could add support for any language by 'installing a plugin' that fits a defined plugin spec/contract, without having to fork or modify the project code itself.