### PR TITLE
fix: unique node ids, UTF-16 read coherence, clearer ambiguous-callers messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,32 @@
   matches. Pass a real prefix (`--in server/src/gpu`), a full file path
   (`--in src/a.ts`), or use `grep`'s pattern to match on content.
 
+- **Duplicate-named definitions no longer silently collide onto one graph node
+  id.** A branch-guarded redeclaration, a reopened class, or any other same-name
+  definition within a file used to mint the exact same node id as an earlier
+  definition, so the second one silently overwrote the first in every id-keyed
+  lookup (`callers`, `ask`, MCP tools). Every definition now mints a unique id
+  (`~2`, `~3`, ... on a document-order duplicate), and a qualified query
+  (`Class.method`) now matches every duplicate, not just the first.
+
+- **UTF-16LE source is now decoded consistently everywhere graft reads repo
+  source.** `graft build`'s parse, `check`'s and `fingerprint`'s drift hashes,
+  the context summarizer's input, `ask --source`'s span slicer, and `grep` each
+  read files with their own `readFileSync(file, "utf8")` — hashing what the
+  parser actually sees wasn't guaranteed, and a UTF-16LE file (the common
+  encoding Windows tooling writes) got silently mojibake'd by some readers and
+  not others. All of them now share one `readSourceFile`, so a file decodes
+  identically no matter which command reads it. UTF-16BE, unsupported by
+  Node's built-in decoders, is a clean skip (an empty entry) rather than a
+  mojibake read.
+
+- **`graft callers`'s zero-hit note now says when the query name itself is
+  ambiguous.** When a symbol name is defined more than once, name resolution
+  drops a cross-file call to it rather than guessing which definition it means
+  — so a zero-hit result could really mean "something calls this, but the edge
+  was dropped for being ambiguous." The note now states how many definitions
+  share the name.
+
 [#33]: https://github.com/NanoNets/Graft/issues/33
 [#35]: https://github.com/NanoNets/Graft/issues/35
 [#36]: https://github.com/NanoNets/Graft/issues/36

--- a/src/ask/ask.ts
+++ b/src/ask/ask.ts
@@ -32,6 +32,7 @@ import { resolveSymbol } from "../graph/traverse.js";
 import type { EdgeV1, GraphV1, NodeV1, Relation } from "../graph/types.js";
 import { rankScopesAndFuse } from "./fuse.js";
 import { personalizedPageRank } from "./graphrank.js";
+import { readSourceFile } from "../util/source.js";
 import { counts, tokenize, type AskIndex, type AskIndexDoc } from "./index-file.js";
 
 export interface AskHit {
@@ -744,7 +745,9 @@ function parseSpan(pointer: string): { path: string; from: number; to: number } 
  * capped at {@link MAX_SPAN_LINES}. Returns null if the file can't be read. */
 function sliceSpan(root: string, path: string, from: number, to: number): string | null {
   try {
-    const lines = readFileSync(join(root, path), "utf8").split("\n");
+    const source = readSourceFile(join(root, path));
+    if (source === null) return null; // unsupported encoding (e.g. UTF-16BE)
+    const lines = source.split("\n");
     const start = Math.max(1, from);
     const end = Math.min(lines.length, to);
     const slice = lines.slice(start - 1, end);

--- a/src/context/build.ts
+++ b/src/context/build.ts
@@ -16,6 +16,7 @@ import { join, resolve } from "node:path";
 import { walkDir } from "../ingest/fs.js";
 import { contentHash } from "../util/id.js";
 import { relPosix } from "../util/paths.js";
+import { readSourceFile } from "../util/source.js";
 import type { Summarizer } from "../ai/summarize.js";
 import type { FileSummary, SynthNode, Synthesizer } from "../ai/synthesize.js";
 import {
@@ -123,7 +124,9 @@ export async function buildContext(dir: string, opts: BuildOptions): Promise<Bui
     opts.onProgress?.({ phase: "summarize", index: i, total: files.length, file: rel });
     let code: string;
     try {
-      code = readFileSync(file, "utf8");
+      const decoded = readSourceFile(file);
+      if (decoded === null) return undefined; // unsupported encoding (e.g. UTF-16BE) — skip, not an error
+      code = decoded;
     } catch (err) {
       result.errors.push(`${rel}: ${errMsg(err)}`);
       return undefined;

--- a/src/context/check.ts
+++ b/src/context/check.ts
@@ -12,11 +12,12 @@
  *   coverage    a code file exists that no node was built from (new/uningested)
  *   index       a node's frontmatter disagrees with the manifest (hand-edited)
  */
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { walkDir } from "../ingest/fs.js";
 import { contentHash } from "../util/id.js";
 import { relPosix } from "../util/paths.js";
+import { readSourceFile } from "../util/source.js";
 import { CODE_EXTENSIONS } from "./build.js";
 import { contextDirFor, readManifest, readNodes } from "./node-file.js";
 
@@ -61,7 +62,9 @@ export function checkContext(dir: string, opts: CheckOptions = {}): CheckResult 
     if (file.startsWith(outDir)) continue;
     if (!exts.some((e) => file.toLowerCase().endsWith(e))) continue;
     try {
-      current.set(relPosix(root, file), contentHash(readFileSync(file, "utf8")));
+      const source = readSourceFile(file);
+      if (source === null) continue; // unsupported encoding (e.g. UTF-16BE) → treat as removed below
+      current.set(relPosix(root, file), contentHash(source));
     } catch {
       // Unreadable now → treat as removed below (it won't be in `current`).
     }

--- a/src/graph/build.ts
+++ b/src/graph/build.ts
@@ -20,6 +20,7 @@ import { contextDirFor, ensureGitignored, ensureSearchable } from "../context/no
 import { extractFile, languageLabelOf, languageOf, type RawEdge } from "./extract.js";
 import { contentHash } from "../util/id.js";
 import { relPosix } from "../util/paths.js";
+import { readSourceFile } from "../util/source.js";
 import {
   emptyExtractCache,
   readExtractCache,
@@ -182,15 +183,21 @@ export async function buildGraph(
     // may decide whether a *query* bothers rebuilding; it may not decide what the
     // rebuild itself looks at. Reading is ~0.05ms/file against the ~4.6ms parse
     // this still skips.
-    let source: string;
+    let source: string | null;
     try {
-      source = readFileSync(f.abs, "utf8");
+      source = readSourceFile(f.abs);
     } catch (err) {
       const message = `${rel}: ${err instanceof Error ? err.message : String(err)}`;
       errors.push(message);
       // Record it anyway (with the stat we do have) so the freshness probe's
       // fast path doesn't report this file as new on every single query.
       entries[rel] = { size: f.size, mtimeMs: f.mtimeMs, hash: "", nodes: [], rawEdges: [], error: message };
+      return;
+    }
+    if (source === null) {
+      // Unsupported encoding (UTF-16BE) — a skip, never an error: recorded with
+      // an empty entry so the freshness probe doesn't treat it as new every run.
+      entries[rel] = { size: f.size, mtimeMs: f.mtimeMs, hash: "", nodes: [], rawEdges: [] };
       return;
     }
 

--- a/src/graph/check.ts
+++ b/src/graph/check.ts
@@ -17,13 +17,13 @@
  * code. `stale` is a meaning-layer signal the last build already recorded.
  * `pending` (never summarized) is not drift — it's a deliberate Tier-1-only build.
  */
-import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { relPosix } from "../util/paths.js";
 import { contextDirFor } from "../context/node-file.js";
 import { extractFile, languageOf } from "./extract.js";
 import { listSourceFiles } from "./build.js";
 import { readGraph, wiringPath } from "./write.js";
+import { readSourceFile } from "../util/source.js";
 
 export interface GraphCheckResult {
   ok: boolean;
@@ -65,12 +65,13 @@ export function checkGraph(dir: string, opts: GraphCheckOptions = {}): GraphChec
   const current = new Map<string, string>(); // id → body_hash
   for (const file of listSourceFiles(root, outDir)) {
     const lang = languageOf(file)!;
-    let source: string;
+    let source: string | null;
     try {
-      source = readFileSync(file, "utf8");
+      source = readSourceFile(file);
     } catch {
       continue; // unreadable now → its nodes show up as `removed` below
     }
+    if (source === null) continue; // unsupported encoding (e.g. UTF-16BE)
     try {
       const { nodes } = extractFile(relPosix(root, file), source, lang);
       for (const n of nodes) current.set(n.id, n.body_hash);

--- a/src/graph/extract.ts
+++ b/src/graph/extract.ts
@@ -242,20 +242,41 @@ export function extractFile(rel: string, source: string, lang: Language): Extrac
     goReceiverVar: null,
     importedSymbols,
   };
-  for (const child of root.namedChildren) walk(child, ctx, nodes, rawEdges);
+  // Every id minted this file, seeded with the file node's own id (`rel`) so a
+  // top-level definition can never collide with it. Threaded as its own
+  // parameter rather than living on WalkCtx — WalkCtx is spread into every
+  // childCtx, so a by-ref Set there would read as ordinary inherited context
+  // when it's actually accidental shared mutable state across the whole walk.
+  const minted = new Set<string>([rel]);
+  for (const child of root.namedChildren) walk(child, ctx, nodes, rawEdges, minted);
   // nodes[0] is the file node; the rest are its symbols. Index the module-level
   // residual on the file node so a term outside every symbol still surfaces it.
   nodes[0].body_text = fileResidual(source, nodes.slice(1));
   return { nodes, rawEdges };
 }
 
-function walk(node: Parser.SyntaxNode, ctx: WalkCtx, out: NodeV1[], edges: RawEdge[]): void {
+/** Mint-time uniqueness: a document-order duplicate (same name reopened, or two
+ * sibling defs that happen to collide) gets `~2`, `~3`, ... instead of silently
+ * shadowing the first. The while-loop (not a single `~2` guess) is what makes
+ * this collision-proof: a source name that itself ends in ~N would collide
+ * with a single-guess suffix, so this keeps incrementing until it finds a
+ * truly free id rather than trusting one candidate suffix is unused. */
+export function mintId(base: string, minted: Set<string>): string {
+  let id = base;
+  let k = 2;
+  while (minted.has(id)) id = `${base}~${k++}`;
+  minted.add(id);
+  return id;
+}
+
+function walk(node: Parser.SyntaxNode, ctx: WalkCtx, out: NodeV1[], edges: RawEdge[], minted: Set<string>): void {
   const desc = describe(node, ctx);
   if (desc) {
     // `idName` scopes the id (e.g. a Go method under its receiver: `#DB.Count`) while
     // `name` stays the bare symbol name so member-call resolution matches it.
     const idPart = desc.idName ?? desc.name;
-    const id = `${ctx.rel}#${[...ctx.scope, idPart].join(".")}`;
+    const base = `${ctx.rel}#${[...ctx.scope, idPart].join(".")}`;
+    const id = mintId(base, minted);
     const isGoMethod = ctx.lang === "go" && node.type === "method_declaration";
     // The bare name of this node's OWN immediate enclosing class/receiver — for a
     // Go method that's its receiver type (methods aren't nested, so ctx.enclosingClass
@@ -303,7 +324,7 @@ function walk(node: Parser.SyntaxNode, ctx: WalkCtx, out: NodeV1[], edges: RawEd
           ? withoutShadowedImports(ctx.importedSymbols, node)
           : ctx.importedSymbols,
     };
-    for (const child of node.namedChildren) walk(child, childCtx, out, edges);
+    for (const child of node.namedChildren) walk(child, childCtx, out, edges, minted);
     return;
   }
 
@@ -345,7 +366,7 @@ function walk(node: Parser.SyntaxNode, ctx: WalkCtx, out: NodeV1[], edges: RawEd
     }
   }
 
-  for (const child of node.namedChildren) walk(child, ctx, out, edges);
+  for (const child of node.namedChildren) walk(child, ctx, out, edges, minted);
 }
 
 /**

--- a/src/graph/extract.ts
+++ b/src/graph/extract.ts
@@ -256,6 +256,14 @@ function walk(node: Parser.SyntaxNode, ctx: WalkCtx, out: NodeV1[], edges: RawEd
     // `name` stays the bare symbol name so member-call resolution matches it.
     const idPart = desc.idName ?? desc.name;
     const id = `${ctx.rel}#${[...ctx.scope, idPart].join(".")}`;
+    const isGoMethod = ctx.lang === "go" && node.type === "method_declaration";
+    // The bare name of this node's OWN immediate enclosing class/receiver — for a
+    // Go method that's its receiver type (methods aren't nested, so ctx.enclosingClass
+    // wouldn't see it); for every other method it's simply what the nearest ancestor
+    // class already set as ctx.enclosingClass. Only method nodes carry it — resolve.ts's
+    // ownerMethod index is the sole consumer (see NodeV1.owner's doc comment).
+    const owner: string | undefined =
+      desc.kind === "method" ? (isGoMethod ? (goReceiverType(node) ?? undefined) : (ctx.enclosingClass ?? undefined)) : undefined;
     out.push({
       id,
       name: desc.name,
@@ -275,13 +283,13 @@ function walk(node: Parser.SyntaxNode, ctx: WalkCtx, out: NodeV1[], edges: RawEd
       summary_state: "pending",
       summary: null,
       crux: null,
+      ...(owner !== undefined ? { owner } : {}),
     });
     // structural containment
     edges.push({ source: ctx.parentId, relation: "contains", targetId: id, file: ctx.rel });
     // class heritage
     if (desc.kind === "class") edges.push(...heritageEdges(node, id, ctx));
 
-    const isGoMethod = ctx.lang === "go" && node.type === "method_declaration";
     const enclosingClass = desc.kind === "class" ? desc.name : isGoMethod ? goReceiverType(node) : ctx.enclosingClass;
     const childCtx: WalkCtx = {
       ...ctx,

--- a/src/graph/fingerprint.ts
+++ b/src/graph/fingerprint.ts
@@ -18,10 +18,10 @@
  * degrade safely: no fingerprint → "unknown, rebuild"; no parse cache → the
  * rebuild is just cold.
  */
-import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { CACHE_DIR } from "../context/node-file.js";
 import { contentHash } from "../util/id.js";
+import { readSourceFile } from "../util/source.js";
 import { readJson, writeJsonAtomic } from "../util/state.js";
 import { extractorStamp, pruneSidecars, type ExtractEntry } from "./extract-cache.js";
 import { listSourceStats } from "./source-files.js";
@@ -158,7 +158,9 @@ export function probeDrift(root: string, outDir: string): Drift | null {
     // the only way to learn it's readable again is to try.
     let now: string;
     try {
-      now = contentHash(readFileSync(f.abs, "utf8"));
+      const source = readSourceFile(f.abs);
+      if (source === null) continue; // unsupported encoding (e.g. UTF-16BE)
+      now = contentHash(source);
     } catch {
       continue; // unreadable right now — leave it to the next probe
     }

--- a/src/graph/resolve.ts
+++ b/src/graph/resolve.ts
@@ -60,10 +60,8 @@ export function resolveEdges(
     let fileMap = perFileName.get(n.path);
     if (!fileMap) perFileName.set(n.path, (fileMap = new Map()));
     push(fileMap, n.name, n);
-    if (n.kind === "method") {
-      const post = n.id.slice(n.id.indexOf("#") + 1);
-      const segs = post.split(".");
-      if (segs.length >= 2) push(ownerMethod, `${segs[segs.length - 2]}.${segs[segs.length - 1]}`, n);
+    if (n.kind === "method" && n.owner) {
+      push(ownerMethod, `${n.owner}.${n.name}`, n);
     }
   }
 
@@ -73,8 +71,11 @@ export function resolveEdges(
   const classParents = new Map<string, string[]>();
   for (const e of rawEdges) {
     if (e.relation !== "extends" || !e.name) continue;
-    const post = e.source.slice(e.source.indexOf("#") + 1);
-    const ownName = post.split(".").pop()!;
+    // The declaring class's own bare name — read from its node (keyed by n.name, set
+    // once at mint time) rather than re-derived by slicing e.source, which breaks once
+    // ids can carry a dedup ordinal (A3's `Cache~2`).
+    const ownName = byId.get(e.source)?.name;
+    if (!ownName) continue;
     push(classParents, ownName, e.name);
   }
 

--- a/src/graph/scopes.ts
+++ b/src/graph/scopes.ts
@@ -23,7 +23,7 @@
  */
 import { existsSync, readdirSync, readFileSync, type Dirent } from "node:fs";
 import { join, resolve } from "node:path";
-import { SKIP_DIRS, walkDir } from "../ingest/fs.js";
+import { shouldSkipDir, walkDir } from "../ingest/fs.js";
 import { relPosix } from "../util/paths.js";
 import type { GraphV1, ScopeV1 } from "./types.js";
 
@@ -327,13 +327,7 @@ export function discoverWorkspaceChildren(root: string): string[] {
     return [];
   }
   return entries
-    .filter(
-      (e) =>
-        e.isDirectory() &&
-        !e.name.startsWith(".") &&
-        !SKIP_DIRS.has(e.name) &&
-        existsSync(join(absRoot, e.name, ".git")),
-    )
+    .filter((e) => e.isDirectory() && !shouldSkipDir(e.name) && existsSync(join(absRoot, e.name, ".git")))
     .map((e) => e.name);
 }
 

--- a/src/graph/traverse-cli.ts
+++ b/src/graph/traverse-cli.ts
@@ -64,11 +64,21 @@ export function callersSavings(
   return savingsFor(graph, paths);
 }
 
-/** Loud, actionable empty-result note — never a bare empty list. */
-export function looseNoteFor(direction: Direction, name: string): string {
+/** Loud, actionable empty-result note — never a bare empty list. `candidateCount`
+ * is how many nodes {@link resolveSymbol} matched for this query (both call
+ * sites already hold it as `matches.length`) — when it's >1, the query name is
+ * itself ambiguous (several definitions share it), which is exactly the case
+ * `resolve.ts` drops a cross-file call/reference for rather than guessing which
+ * one it means. Without saying so, a zero-hit result here reads as "nothing
+ * calls this" when it may really be "something does, but the edge was dropped". */
+export function looseNoteFor(direction: Direction, name: string, candidateCount: number): string {
   const label = direction === "out" ? "callees" : "callers";
   const dir = direction === "out" ? "outgoing" : "incoming";
-  return `  no indexed ${label} — the graph has no ${dir} call/reference edges for this symbol as written. Check the name (try the bare symbol, or "Type.method"), or find its uses with graft grep "${name}". Fall back to raw grep -rn only for unindexed files`;
+  const ambiguity =
+    candidateCount > 1
+      ? ` ${candidateCount} definitions share the name "${name}"; a cross-file caller of an ambiguous name is dropped rather than guessed, so this may undercount.`
+      : "";
+  return `  no indexed ${label} — the graph has no ${dir} call/reference edges for this symbol as written.${ambiguity} Check the name (try the bare symbol, or "Type.method"), or find its uses with graft grep "${name}". Fall back to raw grep -rn only for unindexed files`;
 }
 
 interface SymbolJson {
@@ -179,7 +189,7 @@ export function runCallersCommand(query: string, dir: string, opts: CallersCliOp
       matches: results.map((r): MatchJson => {
         const m: MatchJson = { symbol: symbolJson(r.symbol), hits: r.hits.map(hitJson) };
         if (r.hits.length === 0) {
-          m.note = looseNoteFor(direction, r.symbol.name);
+          m.note = looseNoteFor(direction, r.symbol.name, matches.length);
         }
         return m;
       }),
@@ -192,7 +202,7 @@ export function runCallersCommand(query: string, dir: string, opts: CallersCliOp
   const lines: string[] = [];
   for (const { symbol, hits } of results) {
     lines.push(headerOf(symbol));
-    if (hits.length === 0) lines.push(looseNoteFor(direction, symbol.name));
+    if (hits.length === 0) lines.push(looseNoteFor(direction, symbol.name, matches.length));
     else for (const h of hits) lines.push(hitLine(direction, h, showDepth));
     lines.push("");
   }

--- a/src/graph/traverse.ts
+++ b/src/graph/traverse.ts
@@ -85,6 +85,19 @@ export function resolveSymbol(graph: GraphV1, query: string, opts: ResolveSymbol
   return matches;
 }
 
+/** Strips extract.ts's mint-time disambiguation ordinals (`~2`, `~3`, ...)
+ * from segment ends in a dotted id-tail — the same shape extract.ts mints
+ * when a document-order duplicate definition would otherwise collide with an
+ * already-minted id (see extract.ts's mint-time uniqueness comment). Without
+ * this, a qualified query like `C.m` only ever matches the bare id (`#C.m`),
+ * silently hiding the `~2` duplicate from callers/ask/MCP lookups. The
+ * ordinal can land on any segment, not just the tail (a reopened class shows
+ * up as `C~2.m`), so this strips at every segment boundary (`.` or end of
+ * string), not just the very end of the string. */
+function stripOrdinals(idTail: string): string {
+  return idTail.replace(/~\d+(?=\.|$)/g, "");
+}
+
 function symbolMatches(nodes: NodeV1[], lowerQuery: string): NodeV1[] {
   const suffixHash = "#" + lowerQuery;
   const suffixDot = "." + lowerQuery;
@@ -92,7 +105,9 @@ function symbolMatches(nodes: NodeV1[], lowerQuery: string): NodeV1[] {
     if (n.kind === "file") return false;
     if (n.name.toLowerCase() === lowerQuery) return true;
     const lowerId = n.id.toLowerCase();
-    return lowerId.endsWith(suffixHash) || lowerId.endsWith(suffixDot);
+    const hashIdx = lowerId.indexOf("#");
+    const candidateId = hashIdx === -1 ? lowerId : lowerId.slice(0, hashIdx + 1) + stripOrdinals(lowerId.slice(hashIdx + 1));
+    return candidateId.endsWith(suffixHash) || candidateId.endsWith(suffixDot);
   });
 }
 

--- a/src/graph/types.ts
+++ b/src/graph/types.ts
@@ -40,6 +40,11 @@ export interface NodeV1 {
   id: string; // path-scoped: "src/cache.ts#Cache.get"
   name: string; // the symbol's own name: "get"
   kind: Kind;
+  // method nodes only: the bare name of the immediate enclosing class/receiver
+  // ("Cache" for "get"). Lets owner-qualified lookups (resolve.ts's ownerMethod
+  // index) key off a stored field instead of re-deriving it by slicing `id`,
+  // which breaks once ids can carry a dedup ordinal (`Cache.get~2`).
+  owner?: string;
 
   // location (Tier-1, deterministic)
   path: string; // repo-relative: "src/cache.ts"

--- a/src/graph/workspace.ts
+++ b/src/graph/workspace.ts
@@ -425,7 +425,7 @@ export function federateCallers(
     const lines = [`## ${child}/`];
     for (const { symbol: sym, hits } of results) {
       lines.push(headerOf(sym));
-      if (hits.length === 0) lines.push(looseNoteFor(direction, sym.name));
+      if (hits.length === 0) lines.push(looseNoteFor(direction, sym.name, matches.length));
       else for (const h of hits) lines.push(hitLine(direction, h, showDepth));
     }
     const body = lines.join("\n");

--- a/src/ingest/fs.ts
+++ b/src/ingest/fs.ts
@@ -22,6 +22,22 @@ export const SKIP_DIRS = new Set([
 export const MAX_FILE_BYTES = 1_000_000;
 
 /**
+ * Whether a directory named `name` should be skipped when walking a repo tree:
+ * any dot-prefixed directory (`.git`, `.github`, `.vscode`, ...) or one of
+ * {@link SKIP_DIRS}. The single source of truth for "is this dir source" —
+ * `skippedPath` and `walkFilesystem` below and the git-child discovery in
+ * `graph/scopes.ts` share it, so they can never independently drift on what
+ * counts as skippable.
+ *
+ * KNOWN LIMITATION: a dot-directory is skipped WHOLESALE — there is no
+ * override for a dot-prefixed directory. A repo that keeps real,
+ * hand-written source under one is out of scope.
+ */
+export function shouldSkipDir(name: string): boolean {
+  return name.startsWith(".") || SKIP_DIRS.has(name);
+}
+
+/**
  * Recursively list all files under a directory. Skips dot-directories,
  * dependency/build directories (node_modules, dist, …), and files over 1 MB.
  * In a Git worktree, tracked files plus untracked, non-ignored files come from
@@ -67,20 +83,22 @@ function gitVisibleFiles(dir: string): string[] | null {
   return out;
 }
 
+/** A path (git-relative, either separator) is skipped when any of its
+ * segments is a skippable directory name — the final segment doubles as the
+ * dot-FILE check (`.eslintrc.js` and friends are not source either). */
 function skippedPath(path: string): boolean {
-  const segments = path.replace(/\\/g, "/").split("/");
-  return segments.some((segment) => segment.startsWith(".") || SKIP_DIRS.has(segment));
+  return path.replace(/\\/g, "/").split("/").some(shouldSkipDir);
 }
 
 function walkFilesystem(dir: string): string[] {
   const out: string[] = [];
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    if (entry.name.startsWith(".")) continue;
     const full = join(dir, entry.name);
     if (entry.isDirectory()) {
-      if (SKIP_DIRS.has(entry.name)) continue;
+      if (shouldSkipDir(entry.name)) continue;
       out.push(...walkFilesystem(full));
     } else if (entry.isFile()) {
+      if (entry.name.startsWith(".")) continue; // dot-files are not source either
       try {
         if (statSync(full).size > MAX_FILE_BYTES) continue;
       } catch {

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -137,7 +137,7 @@ function renderMatches(
     .map((m) => {
       const hits = hitsFor(m);
       const lines = [headerOf(m)];
-      if (hits.length === 0) lines.push(looseNoteFor(direction, m.name));
+      if (hits.length === 0) lines.push(looseNoteFor(direction, m.name, matches.length));
       else for (const h of hits) lines.push(hitLine(direction, h, showDepth));
       return lines.join('\n');
     })

--- a/src/search/grep.ts
+++ b/src/search/grep.ts
@@ -9,13 +9,13 @@
  * human text and wires the CLI command; `mcp/tools.ts` renders the same
  * shape for the `graft_find_all` tool.
  */
-import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { GraphV1, NodeV1 } from "../graph/types.js";
 import { WALK_RELATIONS } from "../graph/relations.js";
 import { assertPrefixIndexed, pathUnderPrefix } from "../graph/scopes.js";
 import { normalizePathPrefix } from "../util/paths.js";
 import { savingsFor, type Savings } from "../context/savings.js";
+import { readSourceFile } from "../util/source.js";
 
 export interface GrepHit {
   line: number;
@@ -160,7 +160,12 @@ export function grepGraph(graph: GraphV1, repoRoot: string, pattern: string, opt
   for (const file of fileNodes) {
     let text: string;
     try {
-      text = readFileSync(join(repoRoot, file.path), "utf8");
+      const decoded = readSourceFile(join(repoRoot, file.path));
+      if (decoded === null) {
+        truncatedFiles++; // unsupported encoding (e.g. UTF-16BE) — same posture as unreadable
+        continue;
+      }
+      text = decoded;
     } catch {
       truncatedFiles++;
       continue;

--- a/src/util/source.ts
+++ b/src/util/source.ts
@@ -1,0 +1,10 @@
+import { readFileSync } from "node:fs";
+
+/** Read source text, decoding Windows tooling's common UTF-16LE output. UTF-16BE
+ * is rare and unsupported by Node's built-in decoders, so callers silently skip it. */
+export function readSourceFile(path: string): string | null {
+  const bytes = readFileSync(path);
+  if (bytes[0] === 0xfe && bytes[1] === 0xff) return null;
+  if (bytes[0] === 0xff && bytes[1] === 0xfe) return bytes.subarray(2).toString("utf16le");
+  return bytes.toString("utf8");
+}

--- a/test/ask-index.test.ts
+++ b/test/ask-index.test.ts
@@ -221,6 +221,36 @@ test("an unparseable sidecar file falls back to live tokenization", async () => 
   }
 });
 
+test("A3: a duplicate-named definition still gets its own ask-index doc (unique ids -> docs.length === nodes.length)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-ask-index-dup-"));
+  try {
+    writeFileSync(
+      join(dir, "dup.ts"),
+      `export function helper(): void {\n  console.log("first");\n}\n\n` +
+        `export function helper(): void {\n  console.log("second");\n}\n`,
+    );
+    await buildGraph(dir);
+    const outDir = contextDirFor(dir);
+    const graph = readGraph(wiringPath(outDir));
+    assert.ok(graph, "wiring graph should exist after build");
+    const ids = graph!.nodes.map((n) => n.id);
+    assert.equal(new Set(ids).size, ids.length, "sanity: node ids are unique");
+    assert.ok(
+      ids.includes("dup.ts#helper") && ids.includes("dup.ts#helper~2"),
+      "sanity: the dup actually minted an ordinal id",
+    );
+
+    const index = readAskIndex(outDir);
+    assert.ok(index, "sidecar should exist after build");
+    assert.equal(index!.docCount, graph!.nodes.length);
+    assert.equal(index!.docs.length, graph!.nodes.length);
+    const docIds = new Set(index!.docs.map((d) => d.id));
+    for (const id of ids) assert.ok(docIds.has(id), `sidecar missing doc for ${id}`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("readAskIndex returns null when the sidecar is simply missing", () => {
   const dir = mkdtempSync(join(tmpdir(), "graft-ask-index-missing-"));
   try {

--- a/test/graph-extract-dedup.test.ts
+++ b/test/graph-extract-dedup.test.ts
@@ -1,0 +1,114 @@
+/**
+ * A3 — mint-time unique node ids.
+ *
+ * extract.ts used to mint a node's id purely from its scope + own name, so two
+ * definitions that happen to share a name (a branch-guarded redeclaration, a
+ * duplicated class, ...) collided onto the SAME id — the second definition's
+ * node silently overwrote the first's in every id-keyed lookup.
+ *
+ * `walk()` now mints ids against a per-file `minted` Set via the extracted
+ * `mintId(base, minted)` helper: the first occurrence keeps its bare id, and
+ * every later document-order duplicate gets the next free `~2`, `~3`, ...
+ * suffix — collision-proof even against a source name that itself ends in
+ * `~N` (which would collide with a single-guess `~2` suffix), because the
+ * loop keeps incrementing until it finds a truly free id rather than trusting
+ * one guessed candidate.
+ *
+ * These tests assert the ACTUAL minted ids (not a guessed shape) — the hard
+ * invariants are: every id unique, the first occurrence keeps the bare id, and
+ * ordinals follow document order.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { extractFile, mintId } from "../src/graph/extract.js";
+
+function assertUniqueIds(nodes: { id: string }[], label: string): void {
+  const ids = nodes.map((n) => n.id);
+  assert.equal(new Set(ids).size, ids.length, `${label}: every node id must be unique, got ${JSON.stringify(ids)}`);
+}
+
+test("A3 mintId: the while-loop finds the next truly free ordinal, not a single-guess ~2", () => {
+  // Pre-seeding both the bare id AND its ~2 ordinal simulates two prior mints
+  // (occurrences 1 and 2) already having claimed them; a THIRD occurrence of
+  // the same base must skip the taken ~2 and land on ~3 — proving the loop
+  // (not a single `~2` guess) is what finds a truly free id.
+  const base = "dup.ts#helper";
+  const minted = new Set<string>([base, `${base}~2`]);
+  const id = mintId(base, minted);
+  assert.equal(id, `${base}~3`, "the third occurrence must land on ~3, skipping the already-taken ~2");
+  assert.ok(minted.has(`${base}~3`));
+});
+
+test("A3 mintId: an unclaimed base id is returned bare (no suffix) and gets added to the set", () => {
+  const minted = new Set<string>();
+  const id = mintId("solo.ts#f", minted);
+  assert.equal(id, "solo.ts#f");
+  assert.ok(minted.has("solo.ts#f"));
+});
+
+test("A3 ts: branch-guarded duplicate function + duplicate class w/ method mint distinct, unique ids", () => {
+  const src = `
+if (true) {
+  function f() { return 1; }
+} else {
+  function f() { return 2; }
+}
+
+class C {
+  m(): void {}
+}
+class C {
+  m(): void {}
+}
+`;
+  const { nodes } = extractFile("mix.ts", src, "typescript");
+  assertUniqueIds(nodes, "ts dup fn/class");
+
+  const ids = nodes.map((n) => n.id);
+  // Document order: first `f` bare, second gets ~2; same for the two `C` classes.
+  assert.deepEqual(
+    ids,
+    ["mix.ts", "mix.ts#f", "mix.ts#f~2", "mix.ts#C", "mix.ts#C.m", "mix.ts#C~2", "mix.ts#C.m~2"],
+  );
+});
+
+test("A3 py: duplicate def + duplicate class/method mint distinct, unique ids", () => {
+  const src = `
+def f():
+    return 1
+
+def f():
+    return 2
+
+class C:
+    def m(self):
+        pass
+
+class C:
+    def m(self):
+        pass
+`;
+  const { nodes } = extractFile("dup.py", src, "python");
+  assertUniqueIds(nodes, "py dup def/class");
+
+  const ids = nodes.map((n) => n.id);
+  assert.deepEqual(
+    ids,
+    ["dup.py", "dup.py#f", "dup.py#f~2", "dup.py#C", "dup.py#C.m", "dup.py#C~2", "dup.py#C.m~2"],
+  );
+});
+
+test("A3 go: two same-name methods on one receiver mint distinct, unique ids", () => {
+  const src = `package pkg
+
+type Worker struct{}
+
+func (w *Worker) Run() {}
+func (w *Worker) Run() {}
+`;
+  const { nodes } = extractFile("dup.go", src, "go");
+  assertUniqueIds(nodes, "go dup receiver method");
+
+  const ids = nodes.map((n) => n.id);
+  assert.deepEqual(ids, ["dup.go", "dup.go#Worker", "dup.go#Worker.Run", "dup.go#Worker.Run~2"]);
+});

--- a/test/graph-incremental.test.ts
+++ b/test/graph-incremental.test.ts
@@ -49,6 +49,25 @@ test("an incremental rebuild writes byte-identical wiring.json to a cold one", a
   assert.equal(wiringOf(d), cold, "replaying cached parses must not change a single byte of the graph");
 });
 
+test("A3: an incremental rebuild is still byte-identical to a cold one on a duplicate-name-bearing fixture", async () => {
+  const d = mkdtempSync(join(tmpdir(), "graft-incr-dup-"));
+  mkdirSync(join(d, "src"), { recursive: true });
+  writeFileSync(join(d, "src", "dup.ts"), "export function helper(): void {}\nexport function helper(): void {}\n");
+
+  await buildGraph(d, { reuse: false });
+  const cold = wiringOf(d);
+  await buildGraph(d);
+  assert.equal(wiringOf(d), cold, "replaying cached parses must not change a single byte, even with minted ordinal ids");
+
+  const g = readGraph(wiringPath(outOf(d))) as GraphV1;
+  const ids = g.nodes.map((n) => n.id);
+  assert.equal(new Set(ids).size, ids.length, "ids stay unique across cold/incremental");
+  assert.ok(
+    ids.includes("src/dup.ts#helper") && ids.includes("src/dup.ts#helper~2"),
+    "sanity: the dup actually minted an ordinal id",
+  );
+});
+
 test("unchanged files are replayed, not re-parsed", async () => {
   const d = repo();
   const first = await buildGraph(d);

--- a/test/graph-resolve-typed.test.ts
+++ b/test/graph-resolve-typed.test.ts
@@ -2,11 +2,19 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { buildRepoMap } from "../src/graph/map.js";
 import { resolveEdges } from "../src/graph/resolve.js";
+import { extractFile } from "../src/graph/extract.js";
+import type { RawEdge } from "../src/graph/extract.js";
 import type { NodeV1 } from "../src/graph/types.js";
 
+// `owner` mirrors what extractFile now stamps on a method node: the bare name of
+// its immediate enclosing class (the segment just before its own name in the
+// dotted id) — set here so these hand-built fixtures match real extraction output.
 function n(id: string, kind: NodeV1["kind"]): NodeV1 {
-  const name = id.includes("#") ? id.split("#")[1].split(".").pop()! : id;
-  return { id, name, kind, path: id.split("#")[0], span: "L1-L1", signature: null,
+  const post = id.includes("#") ? id.split("#")[1] : id;
+  const segs = post.split(".");
+  const name = segs[segs.length - 1];
+  const owner = kind === "method" && segs.length >= 2 ? segs[segs.length - 2] : undefined;
+  return { id, name, kind, owner, path: id.split("#")[0], span: "L1-L1", signature: null,
     exported: true, origin: "ast", body_hash: "h", summary_state: "pending", summary: null, crux: null } as NodeV1;
 }
 
@@ -123,4 +131,63 @@ test("unresolved member calls cannot inflate map hubs and hotspots (#35)", () =>
   });
   const set = map.hotspots.find((h) => h.name === "set");
   assert.equal(set?.inDegree, 1, "only the owner-qualified FileBindings.set call contributes");
+});
+
+// A2: resolve.ts used to derive ownerMethod/classParents keys by slicing `n.id`,
+// which breaks once ids can carry a dedup ordinal (A3). extract.ts now stamps a
+// `owner` field at mint time instead; these tests pin the field's contract and
+// prove the owner-keyed lookups it feeds still resolve exactly as the old
+// slicing did.
+
+test("A2: extractFile sets NodeV1.owner to the immediate enclosing class/receiver on method nodes only", () => {
+  const tsNodes = extractFile("a.ts", "class Cache {\n  get(): void {}\n}\n", "typescript").nodes;
+  assert.equal(tsNodes.find((x) => x.id === "a.ts#Cache.get")?.owner, "Cache");
+  assert.equal(tsNodes.find((x) => x.id === "a.ts#Cache")?.owner, undefined, "a class node itself carries no owner");
+
+  const pyNodes = extractFile(
+    "b.py",
+    "class Outer:\n    def render(self):\n        pass\n\n\nclass Container:\n    class Inner:\n        def render(self):\n            pass\n",
+    "python",
+  ).nodes;
+  assert.equal(pyNodes.find((x) => x.id === "b.py#Outer.render")?.owner, "Outer");
+  assert.equal(
+    pyNodes.find((x) => x.id === "b.py#Container.Inner.render")?.owner,
+    "Inner",
+    "nested class: owner is the immediate parent, not the outer container",
+  );
+
+  const goNodes = extractFile("c.go", "package c\n\ntype Server struct{}\n\nfunc (s *Server) Start() {}\n", "go").nodes;
+  assert.equal(goNodes.find((x) => x.id === "c.go#Server.Start")?.owner, "Server");
+});
+
+test("A2: owner-keyed ownerMethod/classParents resolve identically to the old id-slicing scheme (mixed fixture: sibling classes + inheritance)", () => {
+  const src = [
+    "class Base {",
+    "  render(): void {}",
+    "}",
+    "class Widget extends Base {",
+    "  render(): void {}",
+    "}",
+    "class Other {",
+    "  render(): void {}",
+    "}",
+    "class Sub extends Other {}",
+    "function use(): void {}",
+    "",
+  ].join("\n");
+  const { nodes, rawEdges } = extractFile("mixed.ts", src, "typescript");
+
+  const callWidget: RawEdge = { source: "mixed.ts#use", relation: "calls", name: "render", viaMember: true, recvType: "Widget", file: "mixed.ts" };
+  const callSub: RawEdge = { source: "mixed.ts#use", relation: "calls", name: "render", viaMember: true, recvType: "Sub", file: "mixed.ts" };
+  const edges = resolveEdges(nodes, [...rawEdges, callWidget, callSub]);
+
+  const targets = edges
+    .filter((e) => e.relation === "calls" && e.source === "mixed.ts#use")
+    .map((e) => e.target)
+    .sort();
+  assert.deepEqual(
+    targets,
+    ["mixed.ts#Other.render", "mixed.ts#Widget.render"],
+    "Widget's own render must win over Base's/Other's (owner-scoped), and Sub inherits Other's via classParents",
+  );
 });

--- a/test/graph-traverse-cli.test.ts
+++ b/test/graph-traverse-cli.test.ts
@@ -109,6 +109,42 @@ test('graft callers --direction out --json: zero-edge symbol includes a note fie
   assert.match(m.note, /graft grep "add"/);
 });
 
+function ambiguousRepo(): string {
+  const d = mkdtempSync(join(tmpdir(), 'graft-traversecli-ambiguous-'));
+  mkdirSync(join(d, 'src'), { recursive: true });
+  writeFileSync(join(d, 'src', 'a.ts'), 'export function shared(): number {\n  return 1;\n}\n');
+  writeFileSync(join(d, 'src', 'b.ts'), 'export function shared(): number {\n  return 2;\n}\n');
+  // A cross-file call to the ambiguous name — resolve.ts drops it rather than
+  // guessing which `shared` it means, so NEITHER definition gets a caller edge.
+  writeFileSync(join(d, 'src', 'user.ts'), 'import { shared } from "./a.js";\nexport function use(): number {\n  return shared();\n}\n');
+  execFileSync(process.execPath, ['--import', 'tsx', 'src/cli.ts', 'build', d], { stdio: 'pipe' });
+  return d;
+}
+
+test('A6: an ambiguous name (2 definitions) states the candidate count in the zero-hit note', () => {
+  const d = ambiguousRepo();
+  const r = runCli(['callers', 'shared', d]);
+  assert.equal(r.status, 0);
+  // Both candidates are reported (resolveSymbol returns every match).
+  assert.equal((r.stdout.match(/shared · function · src\//g) ?? []).length, 2);
+  // Each zero-hit block states 2 definitions share the name.
+  assert.equal((r.stdout.match(/2 definitions share the name/g) ?? []).length, 2);
+  assert.match(r.stdout, /dropped rather than guessed/);
+});
+
+test('A6 --json: the ambiguous-name note includes the candidate count', () => {
+  const d = ambiguousRepo();
+  const r = runCli(['callers', 'shared', d, '--json']);
+  assert.equal(r.status, 0);
+  const parsed = JSON.parse(r.stdout);
+  assert.equal(parsed.matches.length, 2);
+  for (const m of parsed.matches) {
+    assert.equal(m.hits.length, 0, 'the ambiguity drop leaves no caller edges for either candidate');
+    assert.match(m.note, /2 definitions share the name/);
+    assert.match(m.note, /dropped rather than guessed/);
+  }
+});
+
 test('graft callers --depth: depth flag walks the BFS transitively (blast radius)', () => {
   const d = builtRepo();
   // compute -> sub -> add: callers of `add` at depth 1 is just `sub`;

--- a/test/graph-traverse.test.ts
+++ b/test/graph-traverse.test.ts
@@ -156,6 +156,35 @@ test("resolveSymbol: unknown symbol returns empty array", () => {
   assert.deepEqual(resolveSymbol(g, "NoSuchSymbol"), []);
 });
 
+test("resolveSymbol: qualified query matches both the bare and ordinal-suffixed ids of a duplicated definition (A3)", () => {
+  // extract.ts mints `~2`, `~3`, ... on a document-order duplicate definition
+  // (same name reopened) rather than shadowing the first — see extract.ts's
+  // mint-time uniqueness comment. Before this fix, a qualified query like
+  // "C.m" only ever matched the bare id (`#C.m`), silently hiding the `~2`
+  // duplicate from callers/ask/MCP lookups.
+  const dupFirst = nodeStub({ id: "src/dup.ts#C.m", name: "m", kind: "method", path: "src/dup.ts" });
+  const dupSecond = nodeStub({ id: "src/dup.ts#C.m~2", name: "m", kind: "method", path: "src/dup.ts" });
+  const g = graphOf([dupFirst, dupSecond], []);
+  const matches = resolveSymbol(g, "C.m");
+  assert.deepEqual(
+    matches.map((n) => n.id).sort(),
+    ["src/dup.ts#C.m", "src/dup.ts#C.m~2"].sort(),
+  );
+});
+
+test("resolveSymbol: ordinal suffix stripped mid-path too, so a qualified query stays precise rather than falling back to an over-broad bare-name match", () => {
+  // The ordinal can land on any segment, not only the tail — a class itself
+  // reopened would put `~2` on the scope segment (`C~2.m`), not the method
+  // name. Without stripping it there, the direct id-suffix check finds
+  // nothing and resolveSymbol falls through to its last-segment bare-name
+  // fallback, which would incorrectly sweep in every unrelated `m` method
+  // (here, D.m) instead of precisely matching only the C-scoped one.
+  const cScoped = nodeStub({ id: "src/dup.ts#C~2.m", name: "m", kind: "method", path: "src/dup.ts" });
+  const dScoped = nodeStub({ id: "src/dup.ts#D.m", name: "m", kind: "method", path: "src/dup.ts" });
+  const g = graphOf([cScoped, dScoped], []);
+  assert.deepEqual(resolveSymbol(g, "C.m").map((n) => n.id), ["src/dup.ts#C~2.m"]);
+});
+
 // ── callersOf / calleesOf ────────────────────────────────────────────────
 
 test("calleesOf: walks outgoing walk-relation edges, keeping unresolved targets", () => {

--- a/test/graph-write.test.ts
+++ b/test/graph-write.test.ts
@@ -34,6 +34,19 @@ function makeNode(overrides: Partial<NodeV1> = {}): NodeV1 {
   };
 }
 
+// ── PERMANENT gate: every graph this file builds must have unique node ids ──
+//
+// Mint-time id collisions used to be silent — a duplicate definition's node
+// simply overwrote the first's in every id-keyed lookup (see extract.ts's
+// mint-time uniqueness comment). Checked against every fixture this file
+// builds — hand-built (writeGraph) AND real (buildGraph) alike — as a
+// standing regression gate. A hand-built fixture that trips this has a bug in
+// the fixture, not a false positive: the invariant IS the point.
+function assertUniqueIds(nodes: NodeV1[]): void {
+  const ids = nodes.map((n) => n.id);
+  assert.equal(new Set(ids).size, ids.length, `node ids must be unique, got ${JSON.stringify(ids)}`);
+}
+
 test("writeGraph strips body_text from the serialized node but keeps every other field", () => {
   const dir = mkdtempSync(join(tmpdir(), "graft-write-"));
   try {
@@ -56,6 +69,7 @@ test("writeGraph strips body_text from the serialized node but keeps every other
 
     const reread = readGraph(path);
     assert.equal(reread!.nodes[0].body_text, undefined);
+    assertUniqueIds(graph.nodes);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -73,6 +87,7 @@ test("writeGraph does not mutate the in-memory node — build.ts's sidecar pass 
     writeGraph(graph, dir);
     assert.equal(node.body_text, "untouched body text", "original node object must be unchanged");
     assert.equal(graph.nodes[0].body_text, "untouched body text", "graph.nodes must still reference the live object");
+    assertUniqueIds(graph.nodes);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -91,6 +106,7 @@ test("a node with no body_text (e.g. a file node) round-trips unchanged", () => 
     const raw = JSON.parse(readFileSync(path, "utf8"));
     assert.ok(!("body_text" in raw.nodes[0]));
     assert.equal(raw.nodes[0].kind, "file");
+    assertUniqueIds(graph.nodes);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -126,16 +142,6 @@ test("buildGraph: the serialized wiring.json has no body_text key on ANY node", 
     rmSync(dir, { recursive: true, force: true });
   }
 });
-
-// ── A3 PERMANENT gate: every graph this file builds must have unique node ids ──
-
-/** Mint-time id collisions used to be silent — a duplicate definition's node
- * simply overwrote the first's in every id-keyed lookup. This is checked
- * against every fixture this file builds, as a standing regression gate. */
-function assertUniqueIds(nodes: NodeV1[]): void {
-  const ids = nodes.map((n) => n.id);
-  assert.equal(new Set(ids).size, ids.length, `node ids must be unique, got ${JSON.stringify(ids)}`);
-}
 
 test("A3 PERMANENT gate: duplicate-named definitions still produce unique node ids in the written wiring.json", async () => {
   const dir = mkdtempSync(join(tmpdir(), "graft-write-dup-"));

--- a/test/graph-write.test.ts
+++ b/test/graph-write.test.ts
@@ -121,6 +121,36 @@ test("buildGraph: the serialized wiring.json has no body_text key on ANY node", 
     for (const n of parsed.nodes) {
       assert.ok(!("body_text" in n), `node ${n.id} must not carry body_text in the serialized graph`);
     }
+    assertUniqueIds(parsed.nodes);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── A3 PERMANENT gate: every graph this file builds must have unique node ids ──
+
+/** Mint-time id collisions used to be silent — a duplicate definition's node
+ * simply overwrote the first's in every id-keyed lookup. This is checked
+ * against every fixture this file builds, as a standing regression gate. */
+function assertUniqueIds(nodes: NodeV1[]): void {
+  const ids = nodes.map((n) => n.id);
+  assert.equal(new Set(ids).size, ids.length, `node ids must be unique, got ${JSON.stringify(ids)}`);
+}
+
+test("A3 PERMANENT gate: duplicate-named definitions still produce unique node ids in the written wiring.json", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-write-dup-"));
+  try {
+    writeFileSync(
+      join(dir, "dup.ts"),
+      "export function helper(): void {}\n\nexport function helper(): void {}\n",
+    );
+    await buildGraph(dir);
+    const outDir = contextDirFor(dir);
+    const graph = readGraph(wiringPath(outDir));
+    assert.ok(graph);
+    assertUniqueIds(graph!.nodes);
+    const ids = graph!.nodes.map((n) => n.id);
+    assert.ok(ids.includes("dup.ts#helper") && ids.includes("dup.ts#helper~2"), "sanity: the dup actually minted an ordinal id");
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/test/ingest-fs.test.ts
+++ b/test/ingest-fs.test.ts
@@ -4,7 +4,8 @@ import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, relative } from "node:path";
-import { walkDir } from "../src/ingest/fs.js";
+import { shouldSkipDir, walkDir, SKIP_DIRS } from "../src/ingest/fs.js";
+import { discoverScopes, discoverWorkspaceChildren } from "../src/graph/scopes.js";
 
 function fixture(tag: string): string {
   const dir = mkdtempSync(join(tmpdir(), `graft-walk-${tag}-`));
@@ -68,6 +69,98 @@ test("walkDir retains fixed skips and filesystem fallback outside Git", () => {
     write(dir, ".hidden/secret.ts");
 
     assert.deepEqual(walked(dir), ["src/app.ts"]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+/**
+ * A4 — shouldSkipDir consolidation.
+ *
+ * "Is this name dot-prefixed or in SKIP_DIRS" is re-implemented by hand in
+ * three places: `skippedPath`'s per-segment predicate and `walkFilesystem`'s
+ * directory check (both src/ingest/fs.ts), and `discoverWorkspaceChildren`'s
+ * git-child filter (src/graph/scopes.ts). `shouldSkipDir` is the single
+ * source of truth now; these tests pin the predicate's contract and prove
+ * every consumer — the file walk, marker-scope discovery and workspace-glob
+ * resolution (both derived from the walked file set), and git-child
+ * discovery — agrees on exactly the same skip set.
+ */
+
+test("shouldSkipDir: every SKIP_DIRS name and any dot-prefixed name is skipped; an ordinary name is not", () => {
+  for (const name of SKIP_DIRS) assert.equal(shouldSkipDir(name), true, `${name} should be skipped`);
+  assert.equal(shouldSkipDir(".git"), true);
+  assert.equal(shouldSkipDir(".github"), true);
+  assert.equal(shouldSkipDir("."), true);
+  assert.equal(shouldSkipDir("src"), false);
+  assert.equal(shouldSkipDir("app"), false);
+});
+
+/** One subdirectory per SKIP_DIRS name, plus a dot-directory and a normal
+ * directory — each holding a package.json marker, a source file, and a
+ * nested .git, so every check under test (file walk, marker-scope discovery,
+ * workspace-glob resolution, git-child discovery) has something to find IF
+ * it fails to skip. Deliberately not a git repo, so walkDir exercises the
+ * filesystem fallback where the built-in skip list is the only guard. */
+function buildSkipFixture(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graft-skipdirs-"));
+  const seed = (relDir: string, sourceName: string) => {
+    const sub = join(dir, relDir);
+    mkdirSync(sub, { recursive: true });
+    writeFileSync(join(sub, "package.json"), "{}");
+    writeFileSync(join(sub, sourceName), "export const X = 1;\n");
+    mkdirSync(join(sub, ".git"));
+  };
+  for (const name of SKIP_DIRS) seed(name, "junk.ts");
+  seed(".hidden", "junk.ts");
+  seed("app", "real.ts");
+  return dir;
+}
+
+test("walkDir and every scopes.ts consumer agree on the skip set: SKIP_DIRS + a dot-dir are all skipped, a normal dir survives", () => {
+  const dir = buildSkipFixture();
+  try {
+    // walkDir (fs.ts)
+    const files = walkDir(dir);
+    const rels = files.map((f) => f.slice(dir.length + 1));
+    assert.ok(rels.includes(join("app", "real.ts")), "walkDir must still find the normal dir's file");
+    for (const name of SKIP_DIRS) {
+      assert.ok(!rels.some((r) => r.startsWith(`${name}${"/"}`) || r.startsWith(join(name, ""))), `walkDir must skip ${name}/`);
+    }
+    assert.ok(!rels.some((r) => r.startsWith(".hidden")), "walkDir must skip the dot-dir");
+
+    // discoverScopes (scopes.ts) — its candidate dirs derive from the walked
+    // file set, so a skipped dir's package.json must never surface as a scope.
+    const scopes = discoverScopes(dir);
+    const prefixes = scopes.map((s) => s.prefix);
+    assert.ok(prefixes.includes("app"), "discoverScopes must still find the normal dir's marker");
+    for (const name of SKIP_DIRS) assert.ok(!prefixes.includes(name), `discoverScopes must not surface ${name} as a scope`);
+    assert.ok(!prefixes.includes(".hidden"), "discoverScopes must not surface the dot-dir as a scope");
+
+    // discoverWorkspaceChildren (scopes.ts)
+    const children = discoverWorkspaceChildren(dir);
+    assert.ok(children.includes("app"), "discoverWorkspaceChildren must still find the normal git child");
+    for (const name of SKIP_DIRS) assert.ok(!children.includes(name), `discoverWorkspaceChildren must skip ${name}`);
+    assert.ok(!children.includes(".hidden"), "discoverWorkspaceChildren must skip the dot-dir");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("workspace-glob resolution (scopes.ts's resolveGlob over visible-file dirs) also honors the skip set", () => {
+  const dir = buildSkipFixture();
+  try {
+    // A `packages: ['*']` intent resolves every immediate subdir as a workspace
+    // match UNLESS it's absent from the visible-file dir set — if that set
+    // stopped agreeing with shouldSkipDir, a SKIP_DIRS name or the dot-dir
+    // would show up here as its own scope (workspace matches become candidates
+    // even without a marker).
+    writeFileSync(join(dir, "pnpm-workspace.yaml"), "packages:\n  - '*'\n");
+    const scopes = discoverScopes(dir);
+    const prefixes = scopes.map((s) => s.prefix);
+    assert.ok(prefixes.includes("app"), "the normal dir must still resolve as a workspace match");
+    for (const name of SKIP_DIRS) assert.ok(!prefixes.includes(name), `the glob must not resolve into ${name}`);
+    assert.ok(!prefixes.includes(".hidden"), "the glob must not resolve into the dot-dir");
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/test/search-grep.test.ts
+++ b/test/search-grep.test.ts
@@ -161,6 +161,30 @@ test('grepGraph: a hit outside every symbol span groups as file-level (symbol: n
   assert.match(moduleLevel!.hits[0].text, /NEEDLE at module level/);
 });
 
+test('A3: a duplicate-named definition displays its minted ordinal in the grouped symbol name', () => {
+  const d = mkdtempSync(join(tmpdir(), 'graft-grep-dup-'));
+  mkdirSync(join(d, 'src'), { recursive: true });
+  writeFileSync(
+    join(d, 'src', 'dup.ts'),
+    [
+      'export function helper(): void {',
+      '  console.log("NEEDLE first");',
+      '}',
+      '',
+      'export function helper(): void {',
+      '  console.log("NEEDLE second");',
+      '}',
+      '',
+    ].join('\n'),
+  );
+  execFileSync(process.execPath, ['--import', 'tsx', 'src/cli.ts', 'build', d], { stdio: 'pipe' });
+  const graph = loadBuiltGraph(d);
+  const r = grepGraph(graph, d, 'NEEDLE');
+
+  const names = r.groups.map((g) => g.symbol?.name).sort();
+  assert.deepEqual(names, ['helper', 'helper~2'], 'the second definition displays its minted ordinal, not a bare duplicate name');
+});
+
 test('grepGraph: `in` filter narrows to matching file paths only', () => {
   const repo = needleRepo();
   const graph = loadBuiltGraph(repo);

--- a/test/utf16-source.test.ts
+++ b/test/utf16-source.test.ts
@@ -1,0 +1,164 @@
+/**
+ * A1 — UTF-16-aware source reading, routed through every repo-source reader.
+ *
+ * `util/source.ts`'s `readSourceFile` decodes UTF-16LE (BOM `FF FE`) and treats
+ * UTF-16BE (BOM `FE FF`) as unsupported (null — never a silent mojibake read).
+ * Every reader that walks real repo source — graph/build.ts, graph/fingerprint.ts,
+ * graph/check.ts, context/build.ts, context/check.ts, ask.ts's `--source` span
+ * slicer, and search/grep.ts — routes through it, so a UTF-16LE file (the common
+ * shape written by Windows tooling generally, not just one language's toolchain)
+ * decodes identically everywhere it is read: hash-what-you-parse consistency
+ * across build/fingerprint/check/grep/ask, not a fresh mojibake bug per reader.
+ *
+ * These fixtures deliberately use plain .ts/.py files — no PowerShell grammar on
+ * this branch — to prove the routing is general-purpose, not tied to any one
+ * source language.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readSourceFile } from "../src/util/source.js";
+import { buildGraph } from "../src/graph/build.js";
+import { checkGraph } from "../src/graph/check.js";
+import { probeDrift } from "../src/graph/fingerprint.js";
+import { buildContext } from "../src/context/build.js";
+import { checkContext } from "../src/context/check.js";
+import { grepGraph } from "../src/search/grep.js";
+import { ask } from "../src/ask/ask.js";
+import { readGraph, wiringPath } from "../src/graph/write.js";
+import { contextDirFor } from "../src/context/node-file.js";
+import { fakeProviders } from "./helpers.js";
+
+/** BOM + UTF-16LE bytes — the shape Windows tooling in general actually writes. */
+function utf16le(text: string): Buffer {
+  return Buffer.concat([Buffer.from([0xff, 0xfe]), Buffer.from(text, "utf16le")]);
+}
+
+/** BOM + UTF-16BE bytes — unsupported; readSourceFile must return null, never
+ * mojibake, for this encoding. */
+function utf16be(text: string): Buffer {
+  return Buffer.concat([Buffer.from([0xfe, 0xff]), Buffer.from(text, "utf16le").swap16()]);
+}
+
+test("readSourceFile: decodes a UTF-16LE BOM, returns null for UTF-16BE, and reads plain UTF-8 unchanged", () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-utf16-unit-"));
+  try {
+    writeFileSync(join(dir, "le.ts"), utf16le("export const x = 1;\n"));
+    writeFileSync(join(dir, "be.ts"), utf16be("export const x = 1;\n"));
+    writeFileSync(join(dir, "plain.ts"), "export const x = 1;\n", "utf8");
+
+    assert.equal(readSourceFile(join(dir, "le.ts")), "export const x = 1;\n");
+    assert.equal(readSourceFile(join(dir, "be.ts")), null);
+    assert.equal(readSourceFile(join(dir, "plain.ts")), "export const x = 1;\n");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("A1 graph/build.ts: a UTF-16LE .ts file is decoded at graph ingest, not mojibake-parsed", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-utf16-build-"));
+  try {
+    writeFileSync(join(dir, "legacy.ts"), utf16le("export function fromLegacy(): void {}\n"));
+    const r = await buildGraph(dir);
+    assert.deepEqual(r.errors, []);
+    const graph = readGraph(wiringPath(join(dir, "graft")))!;
+    assert.ok(graph.nodes.some((n) => n.id === "legacy.ts#fromLegacy"), "the UTF-16LE file's function must be extracted");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("A1 graph/build.ts: a UTF-16BE file is an empty entry, not a build error (null → empty-entry posture)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-utf16be-build-"));
+  try {
+    writeFileSync(join(dir, "legacy.ts"), utf16be("export function fromLegacy(): void {}\n"));
+    const r = await buildGraph(dir);
+    assert.deepEqual(r.errors, [], "an unsupported encoding is a skip, never an error");
+    const graph = readGraph(wiringPath(join(dir, "graft")))!;
+    assert.ok(!graph.nodes.some((n) => n.path === "legacy.ts"), "no nodes minted for the undecodable file");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("A1 hash-what-you-parse consistency: build/check/fingerprint agree on a UTF-16LE file", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-utf16-consistency-"));
+  try {
+    writeFileSync(join(dir, "legacy.py"), utf16le("def from_legacy():\n    return 42\n"));
+    await buildGraph(dir);
+
+    const check = checkGraph(dir);
+    assert.equal(check.ok, true, "checkGraph must decode the same way build.ts did — no added/removed/changed");
+    assert.deepEqual(check.added, []);
+    assert.deepEqual(check.removed, []);
+    assert.deepEqual(check.changed, []);
+
+    const drift = probeDrift(join(dir), join(dir, "graft"));
+    assert.deepEqual(drift, { changed: [], added: [], removed: [] }, "fingerprint's probe must agree too — no drift");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("A1 context/build.ts + check.ts: a UTF-16LE file's summarizer input decodes cleanly, and the two tiers' content hash stays consistent", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-utf16-context-"));
+  try {
+    writeFileSync(
+      join(dir, "legacy.ts"),
+      utf16le("// [[Utf16Widget]]\nexport const widget = 1;\n"),
+    );
+    const r = await buildContext(dir, { model: "fake", ...fakeProviders() });
+    assert.deepEqual(r.errors, [], "the file must be readable, not treated as an error");
+    // PassthroughSummarizer hands the (post-decode) code straight to
+    // BracketSynthesizer, which only matches [[Name]] in CLEAN text — a
+    // mojibake decode (NUL bytes between every ASCII char) would never match.
+    assert.equal(r.nodes, 1, "the [[Utf16Widget]] marker must survive decoding to be synthesized as a node");
+
+    const check = checkContext(dir);
+    assert.equal(check.ok, true, "content hash must agree between build and check for the same UTF-16LE file");
+    assert.deepEqual(check.contentDrift, []);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("A1 search/grep.ts: finds a pattern inside a UTF-16LE file", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-utf16-grep-"));
+  try {
+    writeFileSync(
+      join(dir, "legacy.ts"),
+      utf16le("export function fromLegacy(): void {\n  console.log(\"NEEDLE hit\");\n}\n"),
+    );
+    await buildGraph(dir);
+    const graph = readGraph(wiringPath(join(dir, "graft")))!;
+    assert.ok(graph.nodes.some((n) => n.id === "legacy.ts#fromLegacy"), "sanity: the file parses (extract already routes through readSourceFile)");
+
+    const r = grepGraph(graph, dir, "NEEDLE");
+    assert.equal(r.totalHits, 1, "grep must find the pattern in the UTF-16LE file's decoded text");
+    assert.match(r.groups[0]!.hits[0]!.text, /NEEDLE hit/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("A1 ask.ts --source: inlines clean (non-garbled) source sliced from a UTF-16LE file", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-utf16-ask-"));
+  try {
+    writeFileSync(
+      join(dir, "legacy.ts"),
+      utf16le("export function fromLegacyAsk(): number {\n  return 42;\n}\n"),
+    );
+    await buildGraph(dir);
+
+    const r = ask(dir, "fromLegacyAsk", { source: true });
+    const hit = r.hits.find((h) => h.title.startsWith("fromLegacyAsk"));
+    assert.ok(hit, "expected a hit for the UTF-16LE-defined function");
+    assert.ok(hit!.code, "expected inlined source");
+    assert.match(hit!.code!, /return 42/, "the sliced span must decode cleanly, not as mojibake");
+    assert.ok(!hit!.code!.includes("\u0000"), "no stray NUL bytes from a mis-decoded UTF-16LE read");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Three engine correctness fixes, independent of each other's motivation but shipped together as they were found together (surfaced while testing new-language extraction at scale; all reproduce on TypeScript/Python today).

## 1. Unique node ids

Same-file same-name redefinitions — branch-guarded defs, Python `@overload` stacks, duplicate methods — mint colliding `path#name` ids. `wiring.json` preserves the duplicates, but every consumer builds last-write-wins `Map`s over them: enrich can attach a stale summary to the wrong symbol, `graft check` drift detection goes quiet on the shadowed copy, callers/impact attribution is arbitrary, and ask-index docs collapse. Real-world scale: psf/requests has 9 colliding groups (20 shadowed nodes) today.

Fix: ids are minted collision-free per file via a small loop-until-free helper (`path#name`, `path#name~2`, … in document order; first occurrence keeps the bare id). A prerequisite refactor carries a method's owner as a `NodeV1.owner` field instead of re-parsing id strings in resolution (behavior-identical, verified). Qualified symbol queries strip ordinals so duplicates stay findable. A standing all-ids-unique test gate prevents regression.

Evidence: semantic before/after diff on psf/requests — 20 duplicate copies → 0, exactly 20 previously-swallowed `contains` edges recovered 1:1, zero edge losses, zero node changes. spf13/afero (no duplicates) — normalized edge multiset EQUAL, proving the change is a no-op where nothing was broken. Cold-vs-incremental builds remain byte-identical on duplicate-bearing fixtures.

## 2. UTF-16 read coherence (hash-what-you-parse)

Repo-source readers each did their own `readFileSync(path, "utf8")` — tier-1 extraction, fingerprint, check, the tier-2 concept pipeline, ask's snippet slicing, and grep. A UTF-16LE source file decodes to NUL-interleaved mojibake, differently consumed at each site. All readers now route through one BOM-aware `readSourceFile` (UTF-16LE decoded; unsupported UTF-16BE yields a clean skip — an empty entry instead of a mojibake read; UTF-8 byte-identical to before), so what is hashed is always what is parsed/summarized/searched.

## 3. Ambiguity in the callers zero-hit note

When several definitions share a queried name, `graft callers` printed "no indexed callers" per match with no hint that ambiguity (cross-file matches are deliberately dropped rather than guessed) is the cause. The note now states the candidate count, at all four surfaces (CLI human + JSON, MCP, workspace federation).

Also included: the dot-dir/skip-dir predicate duplicated across `fs.ts` and three `scopes.ts` sites is consolidated into one shared `shouldSkipDir` (no behavior change).

25 new tests; suite green; `NodeV1.owner` is additive so the graph format version is unchanged, and the extractor stamp self-invalidates caches — no migration needed.
