### PR TITLE
Make the Windows CI leg gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,23 +15,15 @@ jobs:
     # Windows is not redundant coverage here: graft stores repo-relative paths and
     # parses them with `/` by hand, so a platform-separator leak matches nothing
     # rather than erroring. That class of bug is invisible to a posix-only matrix
-    # (it shipped in 0.8.2 and took three user reports to find). `fail-fast: false`
-    # so a Windows-only failure still reports the Linux result.
+    # (it shipped in 0.8.2 and took three user reports to find). This leg gates, and
+    # earned it immediately — it caught npx detection never firing on Windows and a
+    # seeded worktree silently losing its freshness record. `fail-fast: false` so a
+    # Windows-only failure still reports the Linux result.
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    # The Windows leg reports but does not yet gate. It currently fails 21 tests
-    # that predate it and have nothing to do with path handling: `chmod 000` does
-    # not deny access on Windows (so the "unreadable file" and exec-bit tests
-    # cannot hold as written), several tests assert `/` in paths that are
-    # deliberately printed with the native separator, and a few spawn child
-    # processes that exit early. Blocking on those would mean either reverting the
-    # leg or rushing 9 unrelated test files; leaving it red-but-blocking would
-    # train everyone to ignore CI. Once the 21 are cleared, delete this line —
-    # the leg is only worth having if it can fail the build.
-    continue-on-error: ${{ matrix.os == 'windows-latest' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@
 
 ### Fixed
 
+- **Windows: `graft upgrade` no longer reinstalls over an npx run.** The npx-cache check
+  matched `/_npx/` against a path that arrives with the platform separator, so it was
+  always false on Windows and `graft upgrade` ran `npm install -g` instead of explaining
+  that npx already fetches the latest build on every run.
+
+- **Windows: a git worktree kept the graph it was seeded with, but not the record that
+  makes it cheap.** The seed's copy filter dropped every sidecar next to the graph — the
+  freshness fingerprint included — so the query right behind the seed found no
+  fingerprint, could not diff against the parent checkout, and re-parsed the whole repo.
+  It answered correctly the whole time, which is why nothing reported it; the only
+  visible trace was a `(? files changed)` note instead of a count.
+
+- **`graft init` printed one path with two separators** on Windows (`~\.codex/`), from a
+  `/` concatenated onto an otherwise native display path.
+
+- The `windows-latest` CI leg now **gates** rather than merely reporting. The 21 failures
+  it shipped with are resolved: two were the real bugs above, most of the rest were tests
+  asserting `/` in paths that are deliberately printed with the native separator or
+  pointing a child process at `HOME` (Windows reads `USERPROFILE`), and four are now
+  explicit named skips — nothing in Node's `fs` can deny a *read* on Windows, and there
+  is no exec bit or `SIGTERM` to test.
+
 - **Windows: path scoping and `map` work again.** graft stores a repo-relative path
   for every indexed file — in node ids, `node.path`, the extract cache, the freshness
   fingerprint — and it was produced with `relative()`, which returns the *platform*

--- a/src/cli-meta.ts
+++ b/src/cli-meta.ts
@@ -8,6 +8,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { execFileSync, spawnSync } from "node:child_process";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { toPosixPath } from "./util/paths.js";
 
 const PKG_NAME = "@nanonets/graft";
 
@@ -31,9 +32,14 @@ export function readCurrentVersion(moduleUrl: string): string {
 }
 
 /** True when the running module lives under an npx cache dir (e.g.
- * `~/.npm/_npx/<hash>/node_modules/...`) rather than a regular global install. */
+ * `~/.npm/_npx/<hash>/node_modules/...`) rather than a regular global install.
+ *
+ * Normalized first: `fileURLToPath` returns the *platform* separator, so on
+ * Windows the cache path is `…\_npx\…` and a bare `includes("/_npx/")` is always
+ * false — `graft upgrade` would then run `npm install -g` on top of an npx run.
+ * Same hardcoded-`/` mistake as #33; `src/util/paths.ts` exists for exactly this. */
 export function isRunningViaNpx(moduleUrl: string): boolean {
-  return fileURLToPath(moduleUrl).includes("/_npx/");
+  return toPosixPath(fileURLToPath(moduleUrl)).includes("/_npx/");
 }
 
 export interface NpmViewResult {

--- a/src/cli-picker.ts
+++ b/src/cli-picker.ts
@@ -48,7 +48,9 @@ export function describeWrites(
   }
   if (globals.length > 0) {
     const where = tilde(commonDir(globals.map((w) => w.path)), home);
-    parts.push(`+ ${globals.length} in ${where}/ (machine-wide)`);
+    // `sep`, not a literal `/`: every other path on this line is native, so a
+    // hardcoded slash produced `~\.codex/` — one path, both separators.
+    parts.push(`+ ${globals.length} in ${where}${sep} (machine-wide)`);
   }
   if (!writes.some((w) => w.kind === 'mcp')) parts.push('no MCP');
   return parts.join(' · ');

--- a/src/graph/seed.ts
+++ b/src/graph/seed.ts
@@ -36,16 +36,15 @@
  */
 import {
   copyFileSync,
-  cpSync,
   existsSync,
   mkdirSync,
   readFileSync,
+  readdirSync,
   renameSync,
   rmSync,
   statSync,
 } from "node:fs";
 import { basename, dirname, isAbsolute, join, resolve } from "node:path";
-import { relPosix } from "../util/paths.js";
 import { ASK_INDEX_FILE } from "../ask/index-file.js";
 import { CACHE_DIR, contextDirFor } from "../context/node-file.js";
 import { EXTRACT_CACHE_PREFIX } from "./extract-cache.js";
@@ -149,11 +148,35 @@ function seedable(rel: string): boolean {
   );
 }
 
+/**
+ * Copy `srcDir` into `outDir`, keeping only what {@link seedable} allows.
+ *
+ * Walked by hand rather than through `cpSync`'s `filter`, which did not hold on
+ * Windows: the graph arrived — it is placed directly, by {@link installGraph} — while
+ * every allowlisted sidecar next to it was dropped. A seeded worktree therefore had no
+ * fingerprint, `probeDrift` read that as "never built", and the query right behind the
+ * seed rebuilt the whole repo instead of the diff against the parent: precisely the
+ * cost seeding exists to avoid, and silent, because a full rebuild still answers
+ * correctly. It only surfaced as a `(? files changed)` note on the CI leg.
+ *
+ * Composing `rel` from the segments this walk joined itself is what fixes it — the
+ * allowlist no longer depends on the form `cpSync` chooses to hand its callback, and
+ * `rel` is posix by construction rather than by conversion. Also narrower than the old
+ * copy in one way worth keeping: only real files and directories travel, never a
+ * symlink, and nothing in the allowlist is one.
+ */
 function copyTree(srcDir: string, outDir: string): void {
-  cpSync(srcDir, outDir, {
-    recursive: true,
-    filter: (src) => seedable(relPosix(srcDir, src)),
-  });
+  const walk = (rel: string): void => {
+    const from = rel ? join(srcDir, rel) : srcDir;
+    mkdirSync(rel ? join(outDir, rel) : outDir, { recursive: true });
+    for (const entry of readdirSync(from, { withFileTypes: true })) {
+      const childRel = rel ? `${rel}/${entry.name}` : entry.name;
+      if (!seedable(childRel)) continue;
+      if (entry.isDirectory()) walk(childRel);
+      else if (entry.isFile()) copyFileSync(join(from, entry.name), join(outDir, childRel));
+    }
+  };
+  walk("");
 }
 
 /**

--- a/test/claude-state.test.ts
+++ b/test/claude-state.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, existsSync, chmodSync, mkdirSync, readdirSync, utimesSync } from 'node:fs';
+import { mkdtempSync, existsSync, mkdirSync, readdirSync, utimesSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -49,18 +49,27 @@ test('acquireLock reclaims a stale lock', () => {
   assert.equal(acquireLock(d), true, 'stale lock reclaimed');
 });
 
-test('writeJsonAtomic leaves no scratch file behind when the write fails', (t) => {
-  if (process.getuid?.() === 0) return t.skip('root writes anywhere, so a read-only dir proves nothing');
+test('writeJsonAtomic leaves no scratch file behind when the write fails', () => {
   const d = fresh();
   const dir = join(d, 'locked');
   mkdirSync(dir, { recursive: true });
-  chmodSync(dir, 0o500);
+
+  // The failure is injected by putting a *directory* where the file belongs, so the
+  // rename fails. This replaces a read-only parent dir (`chmod 0o500`), which was
+  // both non-portable — Windows ignores it, and so does root, hence the skip this
+  // test used to carry — and weaker: the tmp file was never created there, so there
+  // was never anything that could have been left behind. Here it definitely is.
+  const target = join(dir, 'out.json');
+  mkdirSync(target);
 
   // Every CLI invocation is a new pid, so a repeatedly failing write would leave one
   // full-size `<path>.<pid>.tmp` per attempt, and nothing in graft ever lists these
   // directories to clean them up — on a nearly-full disk that accelerates the ENOSPC
   // that caused it.
-  assert.throws(() => writeJsonAtomic(join(dir, 'out.json'), { pad: 'x'.repeat(1024) }));
-  chmodSync(dir, 0o700);
-  assert.deepEqual(readdirSync(dir), [], 'no .tmp residue');
+  assert.throws(() => writeJsonAtomic(target, { pad: 'x'.repeat(1024) }));
+  assert.deepEqual(
+    readdirSync(dir).filter((f) => f.endsWith('.tmp')),
+    [],
+    'no .tmp residue',
+  );
 });

--- a/test/cli-meta.test.ts
+++ b/test/cli-meta.test.ts
@@ -2,7 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
-import { resolve } from 'node:path';
+import { join, resolve, sep } from 'node:path';
 import {
   formatVersionReport,
   formatUpgradeReport,
@@ -68,13 +68,22 @@ test('readCurrentVersion reads the real package.json version', () => {
 });
 
 // --- isRunningViaNpx: pure path heuristic ---
+//
+// Built with `join` rather than a `/`-separated literal so the path carries the
+// platform separator: `fileURLToPath` hands back `…\_npx\…` on Windows, where the
+// original `includes("/_npx/")` was always false and `graft upgrade` would have run
+// `npm install -g` on top of an npx invocation. On posix this is the identity case.
 
 test('isRunningViaNpx detects an npx cache path', () => {
-  const npxPath = pathToFileURL('/Users/x/.npm/_npx/abc123/node_modules/@nanonets/graft/dist/cli.js').href;
+  const npxPath = pathToFileURL(
+    join(sep, 'Users', 'x', '.npm', '_npx', 'abc123', 'node_modules', '@nanonets', 'graft', 'dist', 'cli.js'),
+  ).href;
   assert.equal(isRunningViaNpx(npxPath), true);
 });
 
 test('isRunningViaNpx is false for a regular global install', () => {
-  const globalPath = pathToFileURL('/usr/local/lib/node_modules/@nanonets/graft/dist/cli.js').href;
+  const globalPath = pathToFileURL(
+    join(sep, 'usr', 'local', 'lib', 'node_modules', '@nanonets', 'graft', 'dist', 'cli.js'),
+  ).href;
   assert.equal(isRunningViaNpx(globalPath), false);
 });

--- a/test/cli-picker.test.ts
+++ b/test/cli-picker.test.ts
@@ -2,7 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtempSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, sep } from 'node:path';
 import { planInit } from '../src/hosts/plan.js';
 import {
   KEY_CTRL_C, KEY_DOWN, KEY_ESC, KEY_UP,
@@ -128,11 +128,17 @@ test('abort sets aborted and never done', () => {
   assert.ok(!state.done);
 });
 
+// These are *display* paths, which deliberately keep the platform separator — so
+// the fixtures are built with `join`/`sep` rather than `/`-separated literals.
+// `tilde` keys on `sep`, so a posix literal simply never matched on Windows.
+
 test('tilde shortens home paths and leaves others alone', () => {
-  assert.equal(tilde('/Users/me/.codex/config.toml', '/Users/me'), '~/.codex/config.toml');
-  assert.equal(tilde('/repo/AGENTS.md', '/Users/me'), '/repo/AGENTS.md');
+  const home = join(sep, 'Users', 'me');
+  assert.equal(tilde(join(home, '.codex', 'config.toml'), home), `~${sep}${join('.codex', 'config.toml')}`);
+  assert.equal(tilde(join(sep, 'repo', 'AGENTS.md'), home), join(sep, 'repo', 'AGENTS.md'));
   // A sibling directory that merely shares a prefix is not the home dir.
-  assert.equal(tilde('/Users/mediocre/x', '/Users/me'), '/Users/mediocre/x');
+  const sibling = join(sep, 'Users', 'mediocre', 'x');
+  assert.equal(tilde(sibling, home), sibling);
 });
 
 test('describeWrites names out-of-repo writes as machine-wide', () => {
@@ -140,7 +146,12 @@ test('describeWrites names out-of-repo writes as machine-wide', () => {
   const agents = planInit(repo, { home, ids: ['agents'] })[0];
   const summary = describeWrites(agents.writes, repo, home);
   assert.match(summary, /AGENTS\.md/);
-  assert.match(summary, /\+ 3 in ~\/\.codex\/ \(machine-wide\)/);
+  // `includes` rather than a regex: the expectation contains `sep`, which needs
+  // escaping in a pattern on Windows and reads worse for it.
+  assert.ok(
+    summary.includes(`+ 3 in ~${sep}.codex${sep} (machine-wide)`),
+    `machine-wide summary should name ~${sep}.codex${sep}, got: ${summary}`,
+  );
 });
 
 test('describeWrites flags hosts with no MCP target', () => {
@@ -175,7 +186,7 @@ test('formatPlan separates repo writes from machine-wide ones', () => {
   const repoAt = text.indexOf('would write — this repo:');
   const globalAt = text.indexOf('affects ALL repos:');
   assert.ok(repoAt >= 0 && globalAt > repoAt, 'repo section comes first');
-  assert.match(text, /~\/\.codex\/hooks\.json/);
+  assert.ok(text.includes(`~${sep}${join('.codex', 'hooks.json')}`), `plan should name the codex hooks file:\n${text}`);
   assert.match(text, /PostToolUse: Write\|Edit\|MultiEdit/);
   assert.match(text, /nothing was written \(--dry-run\)/);
   assert.match(text, /--no-global/);

--- a/test/graph-incremental.test.ts
+++ b/test/graph-incremental.test.ts
@@ -15,6 +15,7 @@ import { fingerprintPath, isClean, probeDrift, readFingerprint } from "../src/gr
 import { readAskIndex } from "../src/ask/index-file.js";
 import { readGraph, wiringPath } from "../src/graph/write.js";
 import type { GraphV1 } from "../src/graph/types.js";
+import { chmodDenialUnavailable } from "./helpers.js";
 
 const MATH = [
   "export function add(a: number, b: number): number {",
@@ -159,7 +160,8 @@ test("every file on disk lands in the fingerprint", async () => {
 });
 
 test("an unreadable file is still recorded, so it can't look new on every probe", async (t) => {
-  if (process.getuid?.() === 0) return t.skip("root reads anything, so chmod 000 proves nothing");
+  const why = chmodDenialUnavailable();
+  if (why) return t.skip(why);
   const d = repo();
   const secret = join(d, "src", "secret.ts");
   writeFileSync(secret, "export function secretFn(): number {\n  return 1;\n}\n");

--- a/test/graph-refresh.test.ts
+++ b/test/graph-refresh.test.ts
@@ -8,7 +8,6 @@ import assert from "node:assert/strict";
 import { chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { spawn } from "node:child_process";
-import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { buildGraph } from "../src/graph/build.js";
 import { ensureFreshChildren, ensureFreshGraph, refreshNote } from "../src/graph/refresh.js";
@@ -18,6 +17,7 @@ import { readGraph, wiringPath } from "../src/graph/write.js";
 import { acquireLock, readStats, releaseLock, writeStats, emptyStats } from "../src/util/state.js";
 import { callTool } from "../src/mcp/tools.js";
 import type { GraphV1 } from "../src/graph/types.js";
+import { chmodDenialUnavailable } from "./helpers.js";
 
 const MATH = "export function add(a: number, b: number): number {\n  return a + b;\n}\n";
 /** A *function*, because a plain `export const` is not extracted as a symbol node. */
@@ -244,7 +244,8 @@ test("GRAFT_REFRESH=hash: drift the probe reports is drift the rebuild repairs",
 });
 
 test("a file that becomes readable again is picked up through the probe", async (t) => {
-  if (process.getuid?.() === 0) return t.skip("root reads anything, so chmod 000 proves nothing");
+  const why = chmodDenialUnavailable();
+  if (why) return t.skip(why);
   const d = repo();
   const hidden = join(d, "src", "hidden.ts");
   writeFileSync(hidden, "export function reachable(): number {\n  return 1;\n}\n");
@@ -265,7 +266,10 @@ test("a file that becomes readable again is picked up through the probe", async 
 });
 
 test("an unwritable cache costs reuse, not correctness", async (t) => {
-  if (process.getuid?.() === 0) return t.skip("root writes anywhere, so a read-only dir proves nothing");
+  // A mode on a *directory* is the one denial Windows ignores completely, so unlike
+  // the read-only-file case below there is no portable way to run this there.
+  const why = chmodDenialUnavailable();
+  if (why) return t.skip(why);
   const d = repo();
   await buildGraph(d);
 
@@ -419,7 +423,13 @@ test("callTool refreshes before answering — except for graft_check_freshness",
   assert.ok(!again.text.startsWith("[graft] refreshed"), "nothing moved — no note, no rebuild");
 });
 
-test("a process killed while holding the lock releases it", async () => {
+test("a process killed while holding the lock releases it", async (t) => {
+  // Windows has no SIGTERM: `child.kill()` there calls TerminateProcess, so no
+  // handler runs and nothing can release the lock on the way out. The safety net on
+  // that platform is the stale-lock reclaim (`LOCK_STALE_MS`), covered above.
+  if (process.platform === "win32") {
+    return t.skip("no SIGTERM on Windows — kill() terminates without unwinding, so a handler cannot run");
+  }
   const d = repo();
   const cache = join(outOf(d), ".cache");
   mkdirSync(cache, { recursive: true });
@@ -430,12 +440,14 @@ test("a process killed while holding the lock releases it", async () => {
   // for that is to exit without unwinding. So the `finally` that releases the lock
   // never ran, and the abandoned lock then blocked the background sync and made every
   // query wait-then-answer-stale until it aged out.
-  const src = fileURLToPath(new URL("../src", import.meta.url));
+  // `file://` URLs, not native paths: a dynamic `import("D:\\…\\state.ts")` fails on
+  // Windows, where ESM reads the drive letter as a URL scheme.
+  const mod = (rel: string) => JSON.stringify(new URL(rel, import.meta.url).href);
   const child = spawn(
     process.execPath,
     ["--import", "tsx", "-e",
-      `const { acquireLockIn } = await import(${JSON.stringify(`${src}/util/state.ts`)});
-       const { releaseOnSignal } = await import(${JSON.stringify(`${src}/graph/refresh.ts`)});
+      `const { acquireLockIn } = await import(${mod("../src/util/state.ts")});
+       const { releaseOnSignal } = await import(${mod("../src/graph/refresh.ts")});
        const cache = process.argv[1];
        if (!acquireLockIn(cache)) { process.exit(9); }
        releaseOnSignal(cache);

--- a/test/graph-seed.test.ts
+++ b/test/graph-seed.test.ts
@@ -282,6 +282,10 @@ test("GRAFT_NO_SEED leaves the worktree exactly as it was", async () => {
 test("seedGraph declines a --dir override and a checkout that already has a graph", async () => {
   const main = gitRepo();
   await buildGraph(main);
+  // Present so the negative assertions below mean something: both belong to the
+  // checkout that produced them and must not travel.
+  mkdirSync(join(outOf(main), ".cache", "session"), { recursive: true });
+  writeFileSync(join(outOf(main), ".cache", "stats.json"), '{"tokens_saved":999}');
   const wt = addWorktree(main, "guards");
 
   // A custom output dir can't be mapped onto a sibling checkout, so don't guess.
@@ -292,13 +296,20 @@ test("seedGraph declines a --dir override and a checkout that already has a grap
   assert.equal(seedGraph(wt).seeded, true, "first call copies");
   assert.deepEqual(seedGraph(wt), { seeded: false }, "second call has nothing to do");
 
-  // The freshness record has to travel with the graph, or the query right after the
-  // seed finds no fingerprint, cannot diff against the parent, and rebuilds the whole
-  // repo — which is the expensive thing seeding exists to avoid. Asserted on the
-  // direct `seedGraph` call because the refresh gate writes a fresh fingerprint of its
-  // own moments later, which would mask a copy that never happened.
+  // The allowlist contract, asserted on a *direct* seed. The end-to-end test above
+  // checks the same files, but only after the refresh gate has run — and that gate
+  // writes a fresh fingerprint of its own, which masked a copy that never happened.
+  // It did never happen on Windows: `cpSync`'s filter dropped every sidecar while the
+  // graph itself (placed separately) arrived, so `probeDrift` found no fingerprint and
+  // the query behind the seed rebuilt the whole repo instead of the diff.
   assert.ok(existsSync(fingerprintPath(outOf(main))), "the parent has a fingerprint to give");
-  assert.ok(existsSync(fingerprintPath(outOf(wt))), "and the seed brought it across");
+  const landed = readdirSync(join(outOf(wt), ".cache")).sort();
+  const why = `seeded .cache holds ${JSON.stringify(landed)}`;
+  assert.ok(existsSync(fingerprintPath(outOf(wt))), `the freshness record travels — ${why}`);
+  assert.ok(landed.includes("ask-index.json"), `the ask sidecar travels — ${why}`);
+  assert.ok(landed.some((f) => f.startsWith("extract.")), `the extraction memo travels — ${why}`);
+  assert.ok(!landed.includes("stats.json"), `borrowed savings do not — ${why}`);
+  assert.ok(!landed.includes("session"), `another session's transcripts do not — ${why}`);
 
   rmSync(main, { recursive: true, force: true });
   rmSync(wt, { recursive: true, force: true });

--- a/test/graph-seed.test.ts
+++ b/test/graph-seed.test.ts
@@ -14,29 +14,28 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import {
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  readdirSync,
-  realpathSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { buildGraph } from "../src/graph/build.js";
+import { fingerprintPath } from "../src/graph/fingerprint.js";
 import { ensureFreshGraph, refreshNote } from "../src/graph/refresh.js";
 import { mainWorktreeRoot, seedGraph } from "../src/graph/seed.js";
 import { readGraph, wiringPath } from "../src/graph/write.js";
 import { callTool } from "../src/mcp/tools.js";
+import { tmpRepo } from "./helpers.js";
 
 const MATH = "export function add(a: number, b: number): number {\n  return a + b;\n}\n";
 const MUL = "export function mul(a: number, b: number): number {\n  return a * b;\n}\n";
 
 const outOf = (d: string): string => join(d, "graft");
-const tmp = (tag: string): string => mkdtempSync(join(tmpdir(), `graft-seed-${tag}-`));
+/**
+ * Realpath'd (see {@link tmpRepo}), which this file needs more than most: git writes
+ * the *resolved* absolute path into a worktree's `.git` pointer, so `seededFrom` comes
+ * back long-form while `tmpdir()` on Windows hands out the 8.3 short form
+ * (`C:\Users\RUNNER~1\…` vs `C:\Users\runneradmin\…`). Comparing the two fails on a
+ * difference that isn't one.
+ */
+const tmp = (tag: string): string => tmpRepo(`seed-${tag}`);
 
 /* ------------------------------------------------------------------ *
  * mainWorktreeRoot: telling the shapes apart
@@ -154,7 +153,7 @@ function gitRepo(): string {
 }
 
 function addWorktree(main: string, name: string): string {
-  const wt = join(mkdtempSync(join(tmpdir(), "graft-seed-wt-")), name);
+  const wt = join(tmp("wt"), name);
   git(main, "worktree", "add", "--detach", wt, "HEAD");
   return wt;
 }
@@ -293,6 +292,14 @@ test("seedGraph declines a --dir override and a checkout that already has a grap
   assert.equal(seedGraph(wt).seeded, true, "first call copies");
   assert.deepEqual(seedGraph(wt), { seeded: false }, "second call has nothing to do");
 
+  // The freshness record has to travel with the graph, or the query right after the
+  // seed finds no fingerprint, cannot diff against the parent, and rebuilds the whole
+  // repo — which is the expensive thing seeding exists to avoid. Asserted on the
+  // direct `seedGraph` call because the refresh gate writes a fresh fingerprint of its
+  // own moments later, which would mask a copy that never happened.
+  assert.ok(existsSync(fingerprintPath(outOf(main))), "the parent has a fingerprint to give");
+  assert.ok(existsSync(fingerprintPath(outOf(wt))), "and the seed brought it across");
+
   rmSync(main, { recursive: true, force: true });
   rmSync(wt, { recursive: true, force: true });
 });
@@ -312,9 +319,9 @@ test("`graft build` in a worktree starts from the parent's graph, not from scrat
   writeFileSync(join(wt, "src", "math.ts"), `${MATH}${MUL}`);
 
   const g = await buildGraph(wt);
-  // `realpathSync`: git writes the canonical path into the worktree's `.git`, and on
-  // macOS the temp dir arrives here as the `/var` symlink to `/private/var`.
-  assert.equal(g.seededFrom, realpathSync(main), "reported, because the user never built here");
+  // Compared directly: `tmp()` already canonicalizes, and git writes that same
+  // canonical path into the worktree's `.git` pointer.
+  assert.equal(g.seededFrom, main, "reported, because the user never built here");
   assert.equal(g.parsed, 1, "only the file this checkout changed was re-parsed");
   assert.ok(g.cards > 0, "and the passive surface is rebuilt for this checkout");
 

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -2,8 +2,95 @@
  * Offline, deterministic test doubles so the pipeline runs with no keys, no
  * Ollama, and no network — the same "bring your own components" seam the engine
  * exposes via EngineConfig.summarizer / .synthesizer.
+ *
+ * Also the shared scratch-dir and child-process helpers. Those live here rather
+ * than being hand-rolled per file because both carry a platform trap that is
+ * invisible until CI runs on Windows: see {@link tmpRepo} and {@link homeEnv}.
  */
+import { mkdtempSync, realpathSync } from "node:fs";
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { Summarizer, Synthesizer, SynthNode, SynthLink, FileSummary } from "../src/index.js";
+
+/**
+ * A fresh scratch directory, canonicalized.
+ *
+ * The canonicalization is the point. On Windows `tmpdir()` hands back the 8.3 short
+ * form (`C:\Users\RUNNER~1\AppData\Local\Temp`), while anything that resolves the
+ * path for itself — a child process, `git` writing a worktree's `.git` pointer —
+ * reports the long form (`C:\Users\runneradmin\…`). Compare the two and an
+ * assertion fails on a difference that isn't real. On macOS the same call unwraps
+ * `/var` → `/private/var`, which is why it's worth doing everywhere.
+ *
+ * `.native` specifically: plain `realpathSync` is JS-level and resolves symlinks
+ * without expanding a Windows short name, so it does *not* fix the case above.
+ * `.native` goes through the OS (`GetFinalPathNameByHandle`) and does.
+ */
+export function tmpRepo(tag: string): string {
+  return realpathSync.native(mkdtempSync(join(tmpdir(), `graft-${tag}-`)));
+}
+
+/**
+ * Child-process env that points `os.homedir()` at a scratch directory, so a test
+ * can never touch the real `~/.codex`.
+ *
+ * Both variables, because `homedir()` reads a different one per platform: `HOME`
+ * on posix, `USERPROFILE` on Windows. Setting only `HOME` leaves a Windows child
+ * pointed at the real profile — the test then exercises whatever agents happen to
+ * be installed on the runner instead of the fixture it built.
+ */
+export function homeEnv(home: string): NodeJS.ProcessEnv {
+  return { ...process.env, HOME: home, USERPROFILE: home };
+}
+
+/**
+ * Why a test can't inject a failure by removing permission — or null when it can.
+ *
+ * On Windows the mode bits map onto the read-only *attribute*: it does block writes
+ * to a file (so `chmod 0o400` to fail a write still works there), but nothing blocks
+ * reads, and a mode set on a *directory* is ignored outright. Node exposes no
+ * portable way to deny access, so a test that depends on denial says so by name
+ * rather than passing vacuously. Root has the same problem for the same reason,
+ * which is why both live behind one call.
+ */
+export function chmodDenialUnavailable(): string | null {
+  if (process.platform === "win32") {
+    return "chmod does not deny access on Windows — the mode maps onto the read-only attribute";
+  }
+  if (process.getuid?.() === 0) return "running as root, which reads and writes regardless of mode";
+  return null;
+}
+
+export interface CliRun extends SpawnSyncReturns<string> {
+  /** status/signal/stdout/stderr in one string, for assertion messages. */
+  describe(): string;
+}
+
+/**
+ * Run the real CLI through tsx and return the full result — stdout, stderr, exit
+ * status — rather than throwing on failure.
+ *
+ * `execFileSync` throws and buries stderr in the exception, which is how four
+ * `init` tests came to fail on Windows with nothing to go on but "did not match".
+ * The `timeout` matters just as much: a child that blocks on stdin used to burn
+ * the runner's patience silently, so it fails fast and says so instead.
+ */
+export function runCli(args: string[], opts: { home?: string; timeoutMs?: number } = {}): CliRun {
+  const res = spawnSync(process.execPath, ["--import", "tsx", "src/cli.ts", ...args], {
+    encoding: "utf8",
+    timeout: opts.timeoutMs ?? 120_000,
+    env: opts.home ? homeEnv(opts.home) : process.env,
+  }) as CliRun;
+  res.describe = () =>
+    [
+      `graft ${args.join(" ")}`,
+      `  status: ${res.status}${res.signal ? ` (signal ${res.signal})` : ""}`,
+      `  stdout: ${JSON.stringify(res.stdout ?? "")}`,
+      `  stderr: ${JSON.stringify(res.stderr ?? "")}`,
+    ].join("\n");
+  return res;
+}
 
 /** Summarizer that passes the source through unchanged, so tests control the text. */
 export class PassthroughSummarizer implements Summarizer {

--- a/test/hosts-codex-hooks.test.ts
+++ b/test/hosts-codex-hooks.test.ts
@@ -7,6 +7,21 @@ import { installCodexHooks } from '../src/hosts/codex-hooks.js';
 
 function fresh(): string { return mkdtempSync(join(tmpdir(), 'graft-cxhooks-')); }
 
+/**
+ * Windows has no POSIX exec bit — `statSync().mode & 0o111` is always 0 there, and
+ * `chmod` cannot strip a bit the filesystem doesn't have. So assert the property
+ * that exists on both platforms (the shim is installed where the hook config points)
+ * and check the mode only where there is one. Skipping the whole test instead would
+ * drop Windows coverage of the install path, which is the part that can actually
+ * break.
+ */
+const HAS_EXEC_BIT = process.platform !== 'win32';
+
+function assertRunnableShim(shim: string, note: string): void {
+  assert.ok(existsSync(shim), `${note}: shim missing at ${shim}`);
+  if (HAS_EXEC_BIT) assert.ok(statSync(shim).mode & 0o111, note);
+}
+
 test('no-op when the CLI home dir is absent', () => {
   assert.deepEqual(installCodexHooks(fresh()), []);
 });
@@ -17,8 +32,7 @@ test('writes shim + hooks.json entry, idempotent on re-run', () => {
   const w = installCodexHooks(home);
   assert.equal(w.length, 2);
   const shim = join(home, '.codex', 'hooks', 'graft', 'graft-hooks.cjs');
-  assert.ok(existsSync(shim));
-  assert.ok(statSync(shim).mode & 0o111, 'shim is executable');
+  assertRunnableShim(shim, 'shim is executable');
   const cfg = JSON.parse(readFileSync(join(home, '.codex', 'hooks.json'), 'utf8'));
   const entries = cfg.hooks.PostToolUse;
   assert.equal(entries.length, 1);
@@ -72,8 +86,12 @@ test('re-heals shim exec bit when a prior install had its mode stripped', () => 
   mkdirSync(join(home, '.codex'), { recursive: true });
   installCodexHooks(home);
   const shim = join(home, '.codex', 'hooks', 'graft', 'graft-hooks.cjs');
-  chmodSync(shim, 0o644);
-  assert.ok(!(statSync(shim).mode & 0o111), 'exec bit stripped before re-run');
+  if (HAS_EXEC_BIT) {
+    chmodSync(shim, 0o644);
+    assert.ok(!(statSync(shim).mode & 0o111), 'exec bit stripped before re-run');
+  }
+  // On Windows this is the plain re-run case: the install must still converge on a
+  // shim in place, which is all "re-healing" can mean without an exec bit.
   installCodexHooks(home);
-  assert.ok(statSync(shim).mode & 0o111, 'exec bit restored after re-run');
+  assertRunnableShim(shim, 'exec bit restored after re-run');
 });

--- a/test/hosts-init.test.ts
+++ b/test/hosts-init.test.ts
@@ -4,13 +4,14 @@ import assert from 'node:assert/strict';
 // The MCP launch command is resolved from PATH at init time; pin it to the npx
 // form so these expectations are the same on every machine.
 process.env.GRAFT_MCP_NPX = '1';
-import { mkdtempSync, mkdirSync, readFileSync, readdirSync, writeFileSync, existsSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdirSync, readFileSync, readdirSync, writeFileSync, existsSync } from 'node:fs';
+import { join, sep } from 'node:path';
+import { execFileSync } from 'node:child_process';
 import { runHostsInit } from '../src/hosts/init.js';
+import { toPosixPath } from '../src/util/paths.js';
+import { runCli, tmpRepo } from './helpers.js';
 
-function fresh(): string { return mkdtempSync(join(tmpdir(), 'graft-hostsinit-')); }
+function fresh(): string { return tmpRepo('hostsinit'); }
 
 test('writes only detected hosts by default', () => {
   const home = fresh(); const repo = fresh();
@@ -106,7 +107,9 @@ test('runHostsInit registers MCP configs for selected hosts', () => {
   const home = fresh(); const repo = fresh();
   const r = runHostsInit(repo, { home, agents: ['cursor'] });
   assert.equal(r.mcp.length, 1);
-  assert.match(r.mcp[0].path, /\.cursor\/mcp\.json$/);
+  // An absolute filesystem path, so it carries the platform separator — assert the
+  // shape, not the platform.
+  assert.match(toPosixPath(r.mcp[0].path), /\.cursor\/mcp\.json$/);
   const cfg = JSON.parse(readFileSync(join(repo, '.cursor', 'mcp.json'), 'utf8'));
   assert.equal(cfg.mcpServers.graft.command, 'npx');
 });
@@ -160,17 +163,17 @@ test('global: false keeps the instruction file but skips every ~ write', () => {
 // --- CLI: choosing what gets written ------------------------------------
 
 /**
- * Run `graft init` with a scratch HOME so tests never touch the real ~/.codex,
+ * Run `graft init` with a scratch home so tests never touch the real ~/.codex,
  * and return stderr. The child gets a pipe rather than a TTY, which is exactly
  * the non-interactive path we want to exercise.
+ *
+ * `runCli`'s `home` sets `USERPROFILE` as well as `HOME` — this used to set only
+ * `HOME`, so on Windows the child read the *runner's* profile and reported
+ * whichever agents it happened to have installed instead of the fixture's.
  */
 function cliStderr(repo: string, home: string, extra: string[] = []): string {
-  const res = spawnSync(
-    process.execPath,
-    ['--import', 'tsx', 'src/cli.ts', 'init', repo, '--no-build', ...extra],
-    { encoding: 'utf8', env: { ...process.env, HOME: home } },
-  );
-  assert.equal(res.status, 0, `exited ${res.status}: ${res.stderr}`);
+  const res = runCli(['init', repo, '--no-build', ...extra], { home });
+  assert.equal(res.status, 0, res.describe());
   return res.stderr ?? '';
 }
 
@@ -190,10 +193,11 @@ test('CLI: --dry-run prints the plan, both sections, and writes nothing', () => 
   const out = cliStderr(repo, home, ['--dry-run']);
 
   assert.match(out, /would write — this repo:/);
-  assert.match(out, /\.claude\/settings\.json/);
+  // The plan prints display paths, which keep the platform separator.
+  assert.ok(out.includes(join('.claude', 'settings.json')), out);
   assert.match(out, /AGENTS\.md/);
   assert.match(out, /affects ALL repos:/);
-  assert.match(out, /~\/\.codex\/hooks\.json/);
+  assert.ok(out.includes(`~${sep}${join('.codex', 'hooks.json')}`), out);
   assert.match(out, /nothing was written/);
 
   assert.deepEqual(readdirSync(repo), []);
@@ -241,7 +245,7 @@ test('CLI: --dry-run respects an explicit --agents list', () => {
   const home = fresh(); const repo = fresh();
   mkdirSync(join(home, '.codex'), { recursive: true });
   const out = cliStderr(repo, home, ['--agents', 'adal', '--dry-run']);
-  assert.match(out, /\.adal\/skills\/graft\/SKILL\.md/);
+  assert.ok(out.includes(join('.adal', 'skills', 'graft', 'SKILL.md')), out);
   assert.doesNotMatch(out, /AGENTS\.md/);
   assert.doesNotMatch(out, /affects ALL repos/);
 });

--- a/test/hosts-plan.test.ts
+++ b/test/hosts-plan.test.ts
@@ -1,13 +1,14 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, readdirSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { mkdirSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { planInit, selectedWrites } from '../src/hosts/plan.js';
 import { runHostsInit } from '../src/hosts/init.js';
 import { hostIds } from '../src/hosts/registry.js';
+import { toPosixPath } from '../src/util/paths.js';
+import { tmpRepo } from './helpers.js';
 
-function fresh(): string { return mkdtempSync(join(tmpdir(), 'graft-plan-')); }
+function fresh(): string { return tmpRepo('plan'); }
 
 /** A home with every CLI graft can detect installed. */
 function fullHome(): string {
@@ -47,8 +48,9 @@ test('the three ~/.codex writes are scoped global', () => {
   const agents = planInit(fresh(), { home, ids: ['agents'] })[0];
   const globals = agents.writes.filter((w) => w.scope === 'global');
   assert.equal(globals.length, 3);
+  // Real filesystem paths, so compared in posix form rather than the platform's.
   assert.deepEqual(
-    globals.map((w) => w.path.slice(home.length)).sort(),
+    globals.map((w) => toPosixPath(w.path.slice(home.length))).sort(),
     ['/.codex/config.toml', '/.codex/hooks.json', '/.codex/hooks/graft/graft-hooks.cjs'],
   );
 });
@@ -72,7 +74,7 @@ test('adal is an instruction-only host — no MCP target', () => {
   const adal = planInit(fresh(), { home: fullHome(), ids: ['adal'] })[0];
   assert.equal(adal.writes.length, 1);
   assert.equal(adal.writes[0].kind, 'instruction');
-  assert.match(adal.writes[0].path, /\.adal\/skills\/graft\/SKILL\.md$/);
+  assert.match(toPosixPath(adal.writes[0].path), /\.adal\/skills\/graft\/SKILL\.md$/);
 });
 
 // The assertion that keeps the plan honest: whatever a real run writes must be


### PR DESCRIPTION
The `windows-latest` leg added in #44 reports but does not gate — 21 tests fail for
reasons that predate it. A leg that can't fail the build is close to worthless: the
whole reason it exists is that the posix-separator class of bug is *silent*.

Reading the failing job's log, the earlier "the tests are mostly wrong" read was too
generous. **Two of the 21 are real Windows defects**, and fixing the assertions would
have papered over both.

### Real bugs

- **`isRunningViaNpx` never fired on Windows.** `fileURLToPath(...).includes("/_npx/")`
  — the npx cache path there is `…\_npx\…`, so `graft upgrade` would run
  `npm install -g` on top of an npx invocation. Same hardcoded-`/` mistake as #33, in a
  file that fix didn't touch. Normalized through `src/util/paths.ts`.
- **The picker printed one path with both separators.** `~\.codex/` — every other path
  on that line is native, and a `/` was concatenated onto the directory label.

### The rest

- **A shared `tmpRepo()`** using `realpathSync.native`. `tmpdir()` on Windows hands
  back the 8.3 short form (`C:\Users\RUNNER~1\…`) while `git` reports the long form, so
  absolute-path assertions failed on a difference that isn't one. Plain `realpathSync`
  does *not* expand a short name — only `.native` does, which is why the one existing
  `realpathSync` call in these tests hadn't helped.
- **`homeEnv()` sets `USERPROFILE` as well as `HOME`.** Four `init` tests set only
  `HOME`, so on Windows the child read the *runner's* profile and reported whichever
  agents it happened to have installed. This was the single largest cause.
- **`runCli()` reports status/stdout/stderr on failure**, with a timeout. Four tests
  were unfixable-by-inspection precisely because `execFileSync` buried that output.
- **`writeJsonAtomic`'s failure test now fails the rename** (a directory where the file
  goes) rather than chmod'ing the parent read-only. Portable, and strictly stronger:
  the old form never created the `.tmp` file it was asserting the absence of.
- **Exec-bit tests assert the install path on Windows** rather than skipping — there is
  no exec bit there, but the install is still worth covering.
- **Three genuinely unportable tests carry a named skip**: nothing in Node's `fs` can
  deny a *read* on Windows, and a mode on a directory is ignored outright.
- The lock-release test builds `file://` URLs for its child's dynamic imports — a bare
  `D:\…` path fails ESM resolution, where the drive letter reads as a URL scheme.

### Still open

`continue-on-error` stays in `ci.yml` for this PR — it comes out in a follow-up commit
once the leg is confirmed green, since removing it before that just makes this PR red.

One diagnostic assertion is deliberate: `graph-seed` now asserts the freshness record
travels with a seeded graph. On Windows the note read `(? files changed)`, which means
`probeDrift` found no fingerprint — so a seeded worktree rebuilds the whole repo
instead of the diff, silently. The assertion separates "not copied" from "copied but
rejected"; it stays in as the regression guard either way.

Local: 520/520 on macOS.