### PR TITLE
Report imported function references in callers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Fixed
 
+- **`callers` now includes imported functions used as values.** Named imports that
+  are passed, returned, or stored are reported as weaker `references` edges,
+  while direct invocations remain `calls` ([#34]).
+
 - **The build banner and repo map now name the language, not its parser.** JavaScript
   files (`.js`, `.mjs`, `.cjs`) use the TypeScript grammar internally, and `.jsx`
   uses the TSX grammar, but reporting those parser names made indexed files look

--- a/src/graph/extract.ts
+++ b/src/graph/extract.ts
@@ -74,7 +74,7 @@ export interface RawEdge {
   relation: Relation;
   file: string; // the file this edge originates in (scopes name resolution)
   targetId?: string; // already-resolved target (contains)
-  specifier?: string; // module path to resolve (imports)
+  specifier?: string; // module path to resolve (imports / imported-symbol references)
   name?: string; // symbol name to resolve (extends/implements/calls)
   viaMember?: boolean; // calls: was it `obj.foo()` (→ prefer method targets)?
   /** calls with viaMember: the receiver's resolved type name (from bindings /
@@ -182,6 +182,7 @@ export interface WalkCtx {
   bindings: FileBindings; // variable/field -> type, for receiver-type lookups
   enclosingClass: string | null; // nearest enclosing class (py/ts `self`/`this`)
   goReceiverVar: string | null; // Go receiver var, e.g. `w` in `func (w *Worker)`
+  importedSymbols: ReadonlyMap<string, { name: string; specifier: string }>;
 }
 
 /** A definition we're about to emit, normalized across the shapes we handle. */
@@ -207,6 +208,7 @@ export function extractFile(rel: string, source: string, lang: Language): Extrac
   parser.setLanguage(GRAMMARS[lang] as never);
   const root = parseSource(source);
   const bindings = collectBindings(root, lang);
+  const importedSymbols = collectImportedSymbols(root, lang);
 
   const nodes: NodeV1[] = [
     {
@@ -238,6 +240,7 @@ export function extractFile(rel: string, source: string, lang: Language): Extrac
     bindings,
     enclosingClass: null,
     goReceiverVar: null,
+    importedSymbols,
   };
   for (const child of root.namedChildren) walk(child, ctx, nodes, rawEdges);
   // nodes[0] is the file node; the rest are its symbols. Index the module-level
@@ -287,12 +290,16 @@ function walk(node: Parser.SyntaxNode, ctx: WalkCtx, out: NodeV1[], edges: RawEd
       parentId: id,
       enclosingClass,
       goReceiverVar: isGoMethod ? goReceiverVarOf(node) : ctx.goReceiverVar,
+      importedSymbols:
+        desc.kind === "function" || desc.kind === "method"
+          ? withoutShadowedImports(ctx.importedSymbols, node)
+          : ctx.importedSymbols,
     };
     for (const child of node.namedChildren) walk(child, childCtx, out, edges);
     return;
   }
 
-  // not a definition — capture calls/imports, then descend with the same context
+  // not a definition — capture calls/imports/references, then descend with the same context
   const callType = ctx.lang === "python" ? "call" : "call_expression";
   if (node.type === callType) {
     const callee = calleeName(node, ctx.lang);
@@ -310,9 +317,123 @@ function walk(node: Parser.SyntaxNode, ctx: WalkCtx, out: NodeV1[], edges: RawEd
   } else if (isImport(node, ctx.lang)) {
     const spec = importSpecifier(node, ctx.lang);
     if (spec) edges.push({ source: ctx.rel, relation: "imports", specifier: spec, file: ctx.rel });
+    // Imported identifiers are declarations, not uses. The import-binding pass
+    // above already recorded them, so do not descend and emit false references.
+    return;
+  } else if (
+    node.type === "identifier" &&
+    !isDirectCallee(node, callType) &&
+    !isDeclarationName(node)
+  ) {
+    const imported = ctx.importedSymbols.get(node.text);
+    if (imported) {
+      edges.push({
+        source: ctx.parentId,
+        relation: "references",
+        name: imported.name,
+        specifier: imported.specifier,
+        file: ctx.rel,
+      });
+    }
   }
 
   for (const child of node.namedChildren) walk(child, ctx, out, edges);
+}
+
+/**
+ * Named imports whose local binding can be recognized later as a symbol use.
+ * Namespace/default imports are intentionally excluded: they do not tell us
+ * the exported symbol name, so wiring them would require guessing.
+ */
+function collectImportedSymbols(
+  root: Parser.SyntaxNode,
+  lang: Language,
+): Map<string, { name: string; specifier: string }> {
+  const out = new Map<string, { name: string; specifier: string }>();
+  if (lang !== "typescript" && lang !== "tsx") return out;
+
+  const visit = (node: Parser.SyntaxNode): void => {
+    if (node.type === "import_statement") {
+      const specifier = importSpecifier(node, lang);
+      if (!specifier) return;
+      collectTsImportBindings(node, specifier, out);
+      return;
+    }
+    for (const child of node.namedChildren) visit(child);
+  };
+  visit(root);
+  return out;
+}
+
+function collectTsImportBindings(
+  node: Parser.SyntaxNode,
+  specifier: string,
+  out: Map<string, { name: string; specifier: string }>,
+): void {
+  if (node.type === "import_specifier") {
+    const name = node.childForFieldName("name")?.text;
+    const local = node.childForFieldName("alias")?.text ?? name;
+    if (name && local) out.set(local, { name, specifier });
+    return;
+  }
+  for (const child of node.namedChildren) collectTsImportBindings(child, specifier, out);
+}
+
+/**
+ * A parameter or local declaration wins over an import inside that function.
+ * Drop that imported binding for the whole function rather than create a false
+ * dependency. Nested functions are separate scopes and filter themselves.
+ */
+function withoutShadowedImports(
+  imports: ReadonlyMap<string, { name: string; specifier: string }>,
+  definition: Parser.SyntaxNode,
+): ReadonlyMap<string, { name: string; specifier: string }> {
+  if (imports.size === 0) return imports;
+  const shadowed = new Set<string>();
+  const definitionValue = definition.childForFieldName("value");
+  const visit = (node: Parser.SyntaxNode): void => {
+    if (node !== definition && node !== definitionValue && isFunctionBoundary(node)) {
+      const name = node.childForFieldName("name");
+      if (name?.type === "identifier") shadowed.add(name.text);
+      return;
+    }
+    if (node.type === "variable_declarator") {
+      const name = node.childForFieldName("name");
+      if (name?.type === "identifier") shadowed.add(name.text);
+    } else if (node.type === "required_parameter" || node.type === "optional_parameter") {
+      const pattern = node.childForFieldName("pattern");
+      if (pattern?.type === "identifier") shadowed.add(pattern.text);
+    } else if (node.type === "identifier" && node.parent?.type === "formal_parameters") {
+      shadowed.add(node.text);
+    }
+    for (const child of node.namedChildren) visit(child);
+  };
+  visit(definition);
+  if (![...shadowed].some((name) => imports.has(name))) return imports;
+  return new Map([...imports].filter(([local]) => !shadowed.has(local)));
+}
+
+function isFunctionBoundary(node: Parser.SyntaxNode): boolean {
+  return (
+    node.type === "function_declaration" ||
+    node.type === "generator_function_declaration" ||
+    node.type === "method_definition" ||
+    node.type === "arrow_function" ||
+    node.type === "function_expression" ||
+    node.type === "function"
+  );
+}
+
+/** A direct invocation already emits a stronger `calls` edge. */
+function isDirectCallee(node: Parser.SyntaxNode, callType: string): boolean {
+  const parent = node.parent;
+  return parent?.type === callType && parent.childForFieldName("function") === node;
+}
+
+/** Definition/declaration identifiers name a new binding; they do not use one. */
+function isDeclarationName(node: Parser.SyntaxNode): boolean {
+  const parent = node.parent;
+  return parent?.childForFieldName("name") === node;
 }
 
 /** Recognize the definition shapes: mapped node types, Go's type/method forms, and

--- a/src/graph/resolve.ts
+++ b/src/graph/resolve.ts
@@ -115,6 +115,14 @@ export function resolveEdges(
       const hit = resolveName(e.name!, e.file, kinds, perFileName, globalName);
       // an unresolved base is usually an external/imported type — keep the name.
       add(e.source, hit?.id ?? e.name!, e.relation, hit?.confidence ?? "inferred");
+    } else if (e.relation === "references" && e.name && e.specifier) {
+      // A named import gives both halves needed for sound resolution: the module
+      // it came from and the exported name. Resolve inside that file only, so a
+      // same-named symbol elsewhere in the repo cannot become a false edge.
+      const targetFile = resolveImport(e.specifier, e.file, byId);
+      if (!byId.has(targetFile)) continue; // external or unresolved module
+      const candidates = perFileName.get(targetFile)?.get(e.name) ?? [];
+      if (candidates.length === 1) add(e.source, candidates[0].id, "references", "extracted");
     } else if (e.relation === "calls") {
       if (e.viaMember && e.recvType) {
         const hit = resolveTypedMember(e.recvType, e.name!, e.file, ownerMethod, classParents);

--- a/test/graph-references.test.ts
+++ b/test/graph-references.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Regression coverage for issue #34: imported functions used as values must
+ * remain visible to `callers`, but as weaker `references` edges rather than
+ * being mislabeled as direct calls.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { buildGraph } from "../src/graph/build.js";
+import { callersOf } from "../src/graph/traverse.js";
+import { readGraph, wiringPath } from "../src/graph/write.js";
+import { tmpRepo } from "./helpers.js";
+
+test("callers includes an imported function passed as a value (#34)", async () => {
+  const root = tmpRepo("graft-references-");
+  mkdirSync(join(root, "src"), { recursive: true });
+  writeFileSync(
+    join(root, "src", "gate.ts"),
+    ["export function isActive(): boolean {", "  return true;", "}", ""].join("\n"),
+  );
+  writeFileSync(
+    join(root, "src", "direct.ts"),
+    [
+      'import { isActive } from "./gate.js";',
+      "export function callsItDirectly(): boolean {",
+      "  return isActive();",
+      "}",
+      "",
+    ].join("\n"),
+  );
+  writeFileSync(
+    join(root, "src", "consumer.ts"),
+    [
+      'import { isActive } from "./gate.js";',
+      "interface Opts { _isActive?: typeof isActive }",
+      "export function run(opts: Opts = {}): boolean {",
+      "  const check = opts._isActive ?? isActive;",
+      "  return check();",
+      "}",
+      "",
+    ].join("\n"),
+  );
+
+  await buildGraph(root, { reuse: false });
+  const graph = readGraph(wiringPath(join(root, "graft")))!;
+  const target = graph.nodes.find((node) => node.id === "src/gate.ts#isActive");
+  assert.ok(target, "fixture target was not indexed");
+
+  const hits = callersOf(graph, target);
+  assert.deepEqual(
+    hits.map(({ id, relation }) => ({ id, relation })).sort((a, b) => a.id.localeCompare(b.id)),
+    [
+      { id: "src/consumer.ts#Opts", relation: "references" },
+      { id: "src/direct.ts#callsItDirectly", relation: "calls" },
+      { id: "src/consumer.ts#run", relation: "references" },
+    ].sort((a, b) => a.id.localeCompare(b.id)),
+  );
+});
+
+test("aliased named imports resolve references to the exported symbol", async () => {
+  const root = tmpRepo("graft-reference-alias-");
+  mkdirSync(join(root, "src"), { recursive: true });
+  writeFileSync(join(root, "src", "gate.ts"), "export function isActive(): boolean { return true; }\n");
+  writeFileSync(
+    join(root, "src", "consumer.ts"),
+    [
+      'import { isActive as defaultCheck } from "./gate.js";',
+      "export function choose(): typeof defaultCheck {",
+      "  return defaultCheck;",
+      "}",
+      "",
+    ].join("\n"),
+  );
+
+  await buildGraph(root, { reuse: false });
+  const graph = readGraph(wiringPath(join(root, "graft")))!;
+  assert.ok(
+    graph.edges.some(
+      (edge) =>
+        edge.source === "src/consumer.ts#choose" &&
+        edge.target === "src/gate.ts#isActive" &&
+        edge.relation === "references",
+    ),
+  );
+});
+
+test("a local binding that shadows an import does not create a false reference", async () => {
+  const root = tmpRepo("graft-reference-shadow-");
+  mkdirSync(join(root, "src"), { recursive: true });
+  writeFileSync(join(root, "src", "gate.ts"), "export function isActive(): boolean { return true; }\n");
+  writeFileSync(
+    join(root, "src", "consumer.ts"),
+    [
+      'import { isActive } from "./gate.js";',
+      "export function choose(isActive: () => boolean): boolean {",
+      "  return isActive();",
+      "}",
+      "",
+    ].join("\n"),
+  );
+
+  await buildGraph(root, { reuse: false });
+  const graph = readGraph(wiringPath(join(root, "graft")))!;
+  assert.equal(
+    graph.edges.some(
+      (edge) =>
+        edge.source === "src/consumer.ts#choose" &&
+        edge.target === "src/gate.ts#isActive" &&
+        edge.relation === "references",
+    ),
+    false,
+  );
+});


### PR DESCRIPTION
## Summary
- record named imports used as values as weaker `references` edges
- resolve references within their imported module and avoid shadowed local bindings
- add end-to-end coverage for direct calls, value references, aliases, and shadowing

Closes #34

## Test plan
- [x] `npm run build`
- [x] focused graph reference/traversal tests (34 passed)
- [x] full local suite (527 passed)