### PR TITLE
Keep test de-ranking after score normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Fixed
 
+- **`graft ask` no longer lets normalization undo test-file de-ranking.** Test
+  files were penalized before lexical scores were normalized, but the strongest
+  test match was still normalized back to the maximum score. The test prior now
+  also applies to the final lexical/graph blend, while test-seeking queries keep
+  the existing unpenalized behavior ([#37]).
+
 - **`callers` now includes imported functions used as values.** Named imports that
   are passed, returned, or stored are reported as weaker `references` edges,
   while direct invocations remain `calls` ([#34]).
@@ -79,6 +85,7 @@
 [#33]: https://github.com/NanoNets/Graft/issues/33
 [#35]: https://github.com/NanoNets/Graft/issues/35
 [#36]: https://github.com/NanoNets/Graft/issues/36
+[#37]: https://github.com/NanoNets/Graft/issues/37
 
 ## 0.8.2
 

--- a/src/ask/ask.ts
+++ b/src/ask/ask.ts
@@ -594,6 +594,7 @@ function lexical(query: string, corpus: Corpus, limit: number, graphRank: boolea
                 },
               })
             : new Map<string, number>(),
+        rankFactor: (_s, id) => testFactor(byId.get(id)?.path ?? ""),
       },
       GRAPH_WEIGHT,
       RESCUE_FLOOR,
@@ -664,7 +665,10 @@ function lexical(query: string, corpus: Corpus, limit: number, graphRank: boolea
     const n = byId.get(id);
     if (!n) continue;
     const lexN = maxLex > 0 ? (lex.get(id) ?? 0) / maxLex : 0;
-    const blended = lexN + GRAPH_WEIGHT * (pr.get(id) ?? 0);
+    // Apply the test penalty after normalization too. Applying it only to the
+    // raw lexical score is not enough: if a test is still the strongest raw
+    // match, dividing by maxLex restores it to 1.0 and erases the de-rank.
+    const blended = (lexN + GRAPH_WEIGHT * (pr.get(id) ?? 0)) * testFactor(n.path);
     if (blended <= 0) continue;
     const hit: AskHit = {
       kind: "symbol",

--- a/src/ask/fuse.ts
+++ b/src/ask/fuse.ts
@@ -179,6 +179,10 @@ export interface ScopeRankOps {
   /** Graph walk restricted to the scope's subgraph, seeded by that scope's
    * lexical scores; returns top-normalized centrality (or an empty map). */
   walk(scope: string, seeds: Map<string, number>): Map<string, number>;
+  /** Optional query-aware multiplier applied after lexical normalization and
+   * graph blending. Use this for priors (such as test-file de-ranking) that
+   * normalization must not erase. */
+  rankFactor?(scope: string, id: string): number;
 }
 
 /**
@@ -243,7 +247,9 @@ export function rankScopesAndFuse(
     for (const [id, p] of pr) if (p >= rescueFloor) candidates.add(id);
     for (const id of candidates) {
       const lexN = maxLex > 0 ? (lex.get(id) ?? 0) / maxLex : 0;
-      const blended = lexN + graphWeight * (pr.get(id) ?? 0);
+      const blended =
+        (lexN + graphWeight * (pr.get(id) ?? 0)) *
+        (ops.rankFactor?.(scope, id) ?? 1);
       if (blended > 0) scoped.push({ id, scope, score: blended });
     }
   }

--- a/test/ask-fusion.test.ts
+++ b/test/ask-fusion.test.ts
@@ -145,6 +145,23 @@ function makeOps(bStrength: { coverage: number; coverageStrong: number }): Scope
   };
 }
 
+test("rankScopesAndFuse: post-normalization rank factors cannot be erased by a top test match", () => {
+  const ops: ScopeRankOps = {
+    // The test remains the strongest raw match even after lexical de-ranking.
+    // Normalization therefore restores it to 1.0 while source lands at 0.4.
+    lex: () => new Map([["source", 4], ["test", 10]]),
+    strength: () => ({ coverage: 1, coverageStrong: 1 }),
+    walk: () => new Map(),
+    rankFactor: (_scope, id) => (id === "test" ? 0.35 : 1),
+  };
+  const r = rankScopesAndFuse(["app"], ops, 0.5, 0.05);
+  assert.deepEqual(
+    r.ranked.map((d) => d.id),
+    ["source", "test"],
+    "the final test prior must survive per-scope normalization",
+  );
+});
+
 test("rankScopesAndFuse: a scope with ONLY a body-token match (coverageStrong 0, coverage below HIGH_FLOOR) is excluded from ranked and reported in alsoMatched", () => {
   // b's top hit never matched a name/path field (coverageStrong = 0) and its
   // overall coverage (0.3) is well under HIGH_FLOOR (0.5) — an incidental

--- a/test/ask.test.ts
+++ b/test/ask.test.ts
@@ -69,6 +69,35 @@ test("test files rank below the source they exercise for a non-test query, but n
   }
 });
 
+test("test de-ranking survives normalization when a test is the strongest lexical match (#37)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-ask-test-normalization-"));
+  try {
+    writeFileSync(
+      join(dir, "selector.ts"),
+      `export function choose(request: string): string {\n` +
+        `  // Select the engine for a request and follow the fallback chain.\n` +
+        `  return request;\n` +
+        `}\n`,
+    );
+    writeFileSync(
+      join(dir, "selector.test.ts"),
+      `import { choose } from "./selector";\n` +
+        `export function testWhereEngineSelectedForRequestFallbackChain(): void {\n` +
+        `  choose("request");\n` +
+        `}\n`,
+    );
+    await buildGraph(dir);
+
+    const r = ask(dir, "where engine selected for request fallback chain");
+    const source = r.hits.findIndex((h) => /(^|\/)selector\.ts(:|$)/.test(h.pointer));
+    const testHit = r.hits.findIndex((h) => /selector\.test\.ts/.test(h.pointer));
+    assert.ok(source >= 0, "implementation hit present");
+    assert.ok(testHit === -1 || source < testHit, "implementation ranks above the stronger lexical test match");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 function makeFixture(): string {
   const dir = mkdtempSync(join(tmpdir(), "graft-ask-"));
   writeFileSync(


### PR DESCRIPTION
## Summary
- preserve the test-file penalty after lexical and graph-score normalization
- apply the same ranking prior in single-project and multi-scope repositories
- add unit and end-to-end regressions for the issue #37 ranking case

Closes #37

## Test plan
- [x] `node --import tsx --test test/ask.test.ts test/ask-fusion.test.ts`
- [x] `npm run build`
- [x] `npm test` (529 passed)