### PR TITLE
Fix false map hubs from unresolved member calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Fixed
 
+- **`graft map` no longer promotes unrelated methods into hubs and hotspots.**
+  A member call with an unknown receiver could be wired to the repository's
+  only method with the same bare name, so built-ins such as `Map.set()` inflated
+  an unrelated user-defined `set` method. Member calls now require an
+  owner-qualified receiver-type match; unresolved calls are dropped rather
+  than guessed ([#35]).
+
 - **Indexing now respects `.gitignore`.** In Git repositories, graft indexes
   tracked files plus untracked files that Git does not ignore, so generated
   output such as `Scripts/bundles/` and `Scripts/transpiled/` is no longer

--- a/src/graph/resolve.ts
+++ b/src/graph/resolve.ts
@@ -5,10 +5,12 @@
  * Confidence mirrors the SCIP/Graphify model:
  *   - `extracted`: the target is certain — a match within the same file, an
  *     import specifier, or a structural containment.
- *   - `inferred`: the target was resolved by a unique name match across files,
- *     which name-shadowing could in principle fool.
+ *   - `inferred`: a bare function target was resolved by a unique name match
+ *     across files, which name-shadowing could in principle fool.
  * Ambiguous cross-file matches (a name defined in several files) are dropped
- * rather than guessed, so we never wire an edge to the wrong symbol.
+ * rather than guessed. Member calls are stricter: they require a receiver type
+ * and owner-qualified method match because a unique bare method name says
+ * nothing about the receiver.
  */
 import { posix } from "node:path";
 import { toPosixPath } from "../util/paths.js";
@@ -16,22 +18,6 @@ import type { EdgeV1, Kind, NodeV1, Relation } from "./types.js";
 import type { RawEdge } from "./extract.js";
 
 const IMPORT_EXTS = [".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs", ".py"];
-
-// Builtin container/value types whose methods are never user-defined symbols in the
-// repo. A typed member call on one of these receivers (`deg.set(...)` where
-// `recvType` is `Map`) must never fall back to the untyped unique-bare-name path —
-// doing so wires it to whatever repo symbol happens to share the method's name
-// (e.g. a class's own `.set` method), which is always wrong. RawEdge carries no
-// language tag, so this is the union of the TS/TSX and Python builtin lists rather
-// than a per-language check; a repo class legitimately named e.g. `dict` colliding
-// with the Python builtin is vanishingly rare, and the failure mode in that case is
-// just a dropped edge (safe), not a wrong one.
-const BUILTIN_CONTAINER_TYPES = new Set([
-  // TS/TSX
-  "Map", "Set", "WeakMap", "WeakSet", "Array", "Promise", "Object", "Date", "RegExp", "Error",
-  // Python
-  "dict", "list", "set", "tuple", "str", "frozenset", "bytes",
-]);
 
 /** A Go module discovered in the repo: its `module` path from `go.mod` and the repo
  * directory that `go.mod` lives in (posix, `.` for the repo root). A monorepo may hold
@@ -124,23 +110,16 @@ export function resolveEdges(
       const candidates = perFileName.get(targetFile)?.get(e.name) ?? [];
       if (candidates.length === 1) add(e.source, candidates[0].id, "references", "extracted");
     } else if (e.relation === "calls") {
-      if (e.viaMember && e.recvType) {
+      if (e.viaMember) {
+        if (!e.recvType) continue;
         const hit = resolveTypedMember(e.recvType, e.name!, e.file, ownerMethod, classParents);
         if (hit === "ambiguous") continue; // drop — never guess past an ambiguous owner
         if (hit) add(e.source, hit.id, "calls", hit.confidence);
-        else if (!BUILTIN_CONTAINER_TYPES.has(e.recvType)) {
-          // chain exhausted with zero candidates at every level → fall back to the
-          // existing untyped path (unique bare-name match), unchanged.
-          const fallback = resolveName(e.name!, e.file, ["method"], perFileName, globalName);
-          if (fallback) add(e.source, fallback.id, "calls", fallback.confidence);
-        }
-        // else: recvType is a known builtin container (Map/dict/etc) — its methods
-        // are never user-defined repo symbols, so drop rather than wire a bare-name
-        // fallback to an unrelated same-named method.
+        // No owner-qualified match means the call is unresolved. A unique bare
+        // method name is not evidence that this receiver has that method.
         continue;
       }
-      const kinds: Kind[] = e.viaMember ? ["method"] : ["function"];
-      const hit = resolveName(e.name!, e.file, kinds, perFileName, globalName);
+      const hit = resolveName(e.name!, e.file, ["function"], perFileName, globalName);
       if (hit) add(e.source, hit.id, "calls", hit.confidence); // drop unresolved calls (too noisy)
     }
   }
@@ -182,8 +161,7 @@ function resolveName(
  *     per the inviolable philosophy we drop and stop rather than guess, and we do
  *     NOT continue up the chain past this level.
  *   - `null` — the whole chain (recvType + ancestors, breadth-first, depth ≤ 3,
- *     cycle-guarded) had zero candidates at every level; caller may fall back to
- *     the untyped bare-name path.
+ *     cycle-guarded) had zero candidates at every level.
  */
 function resolveTypedMember(
   recvType: string,

--- a/test/graph-resolve-typed.test.ts
+++ b/test/graph-resolve-typed.test.ts
@@ -1,5 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { buildRepoMap } from "../src/graph/map.js";
 import { resolveEdges } from "../src/graph/resolve.js";
 import type { NodeV1 } from "../src/graph/types.js";
 
@@ -59,12 +60,20 @@ test("same-file owner wins among duplicates, confidence extracted", () => {
   assert.equal(call?.confidence, "extracted");
 });
 
-test("unknown recvType falls back to unique bare-name path", () => {
+test("unknown receiver type does not guess from a unique bare method name", () => {
   const nodes = [n("a.py", "file"), n("a.py#Only", "class"), n("a.py#Only.solo", "method"), n("b.py", "file"), n("b.py#f", "function")];
   const edges = resolveEdges(nodes, [
     { source: "b.py#f", relation: "calls", name: "solo", viaMember: true, recvType: "Ghost", file: "b.py" },
   ]);
-  assert.equal(edges.find((e) => e.relation === "calls")?.target, "a.py#Only.solo");
+  assert.equal(edges.filter((e) => e.relation === "calls").length, 0);
+});
+
+test("untyped member call does not guess from a unique bare method name", () => {
+  const nodes = [n("a.py", "file"), n("a.py#Only", "class"), n("a.py#Only.solo", "method"), n("b.py", "file"), n("b.py#f", "function")];
+  const edges = resolveEdges(nodes, [
+    { source: "b.py#f", relation: "calls", name: "solo", viaMember: true, file: "b.py" },
+  ]);
+  assert.equal(edges.filter((e) => e.relation === "calls").length, 0);
 });
 
 test("builtin-container receiver drops instead of bare-name fallback", () => {
@@ -89,4 +98,29 @@ test("Go NewServer()→Server recall still resolves (regression guard, non-built
     { source: "m.go#f", relation: "calls", name: "Start", viaMember: true, recvType: "Server", file: "m.go" },
   ]);
   assert.equal(edges.find((e) => e.relation === "calls")?.target, "srv.go#Server.Start");
+});
+
+test("unresolved member calls cannot inflate map hubs and hotspots (#35)", () => {
+  const nodes = [
+    n("bindings.ts", "file"),
+    n("bindings.ts#FileBindings", "class"),
+    n("bindings.ts#FileBindings.set", "method"),
+    n("consumer.ts", "file"),
+    n("consumer.ts#write", "function"),
+    n("real.ts", "file"),
+    n("real.ts#writeBinding", "function"),
+  ];
+  const edges = resolveEdges(nodes, [
+    { source: "consumer.ts#write", relation: "calls", name: "set", viaMember: true, file: "consumer.ts" },
+    { source: "consumer.ts#write", relation: "calls", name: "set", viaMember: true, recvType: "Map", file: "consumer.ts" },
+    { source: "real.ts#writeBinding", relation: "calls", name: "set", viaMember: true, recvType: "FileBindings", file: "real.ts" },
+  ]);
+
+  const map = buildRepoMap({
+    meta: { version: 1, nodeCount: nodes.length, edgeCount: edges.length, languages: ["typescript"] },
+    nodes,
+    edges,
+  });
+  const set = map.hotspots.find((h) => h.name === "set");
+  assert.equal(set?.inDegree, 1, "only the owner-qualified FileBindings.set call contributes");
 });


### PR DESCRIPTION
## Summary
- require owner-qualified receiver matches before resolving member calls
- prevent unresolved calls such as `Map.set()` from inflating unrelated map hubs and hotspots
- add resolver and map regression coverage for #35

## Test plan
- [x] Run focused resolver, map, and binding tests
- [x] Run `npm run build`
- [x] Run the full test suite (536 passing)

Closes #35