### PR TITLE
fix: detect unsupported source encoding drift

### DIFF
--- a/src/graph/fingerprint.ts
+++ b/src/graph/fingerprint.ts
@@ -159,7 +159,13 @@ export function probeDrift(root: string, outDir: string): Drift | null {
     let now: string;
     try {
       const source = readSourceFile(f.abs);
-      if (source === null) continue; // unsupported encoding (e.g. UTF-16BE)
+      if (source === null) {
+        // A previously indexed file becoming undecodable is real drift: rebuild
+        // once to remove its stale nodes. Empty-hash entries were already skipped
+        // by the last build, so they remain clean and avoid rebuild churn.
+        if (hash) drift.changed.push(f.rel);
+        continue;
+      }
       now = contentHash(source);
     } catch {
       continue; // unreadable right now — leave it to the next probe

--- a/test/utf16-source.test.ts
+++ b/test/utf16-source.test.ts
@@ -102,6 +102,36 @@ test("A1 hash-what-you-parse consistency: build/check/fingerprint agree on a UTF
   }
 });
 
+test("A1 fingerprint reports drift when indexed UTF-16LE becomes unsupported UTF-16BE", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-utf16-drift-"));
+  const previousRefresh = process.env.GRAFT_REFRESH;
+  try {
+    const file = join(dir, "legacy.ts");
+    const source = "export function fromLegacy(): void {}\n";
+    writeFileSync(file, utf16le(source));
+    await buildGraph(dir);
+
+    writeFileSync(file, utf16be(source));
+    process.env.GRAFT_REFRESH = "hash";
+    assert.deepEqual(
+      probeDrift(dir, join(dir, "graft")),
+      { changed: ["legacy.ts"], added: [], removed: [] },
+      "becoming undecodable must rebuild once instead of serving stale UTF-16LE nodes",
+    );
+
+    await buildGraph(dir);
+    assert.deepEqual(
+      probeDrift(dir, join(dir, "graft")),
+      { changed: [], added: [], removed: [] },
+      "after the rebuild records an unsupported file, the probe must not churn",
+    );
+  } finally {
+    if (previousRefresh === undefined) delete process.env.GRAFT_REFRESH;
+    else process.env.GRAFT_REFRESH = previousRefresh;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("A1 context/build.ts + check.ts: a UTF-16LE file's summarizer input decodes cleanly, and the two tiers' content hash stays consistent", async () => {
   const dir = mkdtempSync(join(tmpdir(), "graft-utf16-context-"));
   try {


### PR DESCRIPTION
## Summary
- mark previously indexed files as changed when their encoding becomes unsupported
- rebuild once to remove stale nodes, while keeping already-skipped files clean
- add regression coverage for UTF-16LE to UTF-16BE transitions

## Test plan
- [x] `node --import tsx --test test/utf16-source.test.ts`
- [x] `npm run build`
- [x] `npm test` (564 passing)