### PR TITLE
feat: --include-dir override for the built-in skip list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+### Added
+
+- **`graft build --include-dir <name>`** — an explicit, persisted override for
+  `SKIP_DIRS` (repeatable: `--include-dir build --include-dir tools`). Some
+  ecosystems keep genuine hand-written source under a directory name graft
+  otherwise treats as build output (e.g. a `build/` that isn't generated).
+  The override is persisted per repo: set it once and every later no-flag
+  `graft build`, plus the hooks/refresh path (which never sees CLI flags at
+  all), include it identically. It lifts only graft's own skip list — in a
+  Git repository, Git's ignore rules stay authoritative, so a directory that
+  is both skip-listed and gitignored needs un-ignoring (or `git add -f`) too,
+  the same contract indexing already applies to tracked-but-ignored files.
+  Dot-directories are never overridable. Reaches the wiring graph, the Tier-2
+  markdown/concept pipeline, Go module discovery, and workspace child builds
+  alike, and is validated up front (a bare directory name only — no paths, no
+  dot-prefixes).
+
 ### Fixed
 
 - **`graft map` no longer promotes unrelated methods into hubs and hotspots.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@
   `SKIP_DIRS` (repeatable: `--include-dir build --include-dir tools`). Some
   ecosystems keep genuine hand-written source under a directory name graft
   otherwise treats as build output (e.g. a `build/` that isn't generated).
-  The override is persisted per repo: set it once and every later no-flag
-  `graft build`, plus the hooks/refresh path (which never sees CLI flags at
-  all), include it identically. It lifts only graft's own skip list — in a
+  The override is persisted per repo in Git-ignored `.graft/config.json`: set
+  it once and every later no-flag `graft build`, plus the hooks/refresh path
+  (which never sees CLI flags at all), include it identically. It lifts only
+  graft's own skip list — in a
   Git repository, Git's ignore rules stay authoritative, so a directory that
   is both skip-listed and gitignored needs un-ignoring (or `git add -f`) too,
   the same contract indexing already applies to tracked-but-ignored files.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,6 +33,7 @@ import { planInit, selectedWrites } from "./hosts/plan.js";
 import { formatNonInteractiveHelp, formatPlan, runPicker } from "./cli-picker.js";
 import { homedir } from "node:os";
 import { formatUpgradeReport, formatVersionReport, getNpmViewVersion, readCurrentVersion, runUpgrade } from "./cli-meta.js";
+import { writeBuildConfig } from "./util/state.js";
 
 const program = new Command();
 const currentVersion = readCurrentVersion(import.meta.url);
@@ -119,11 +120,39 @@ program
   .option("-e, --extensions <exts...>", 'code extensions to include (e.g. ".ts" ".py")')
   .option("-j, --concurrency <n>", "files summarized in parallel during --deep (default 5)")
   .option("--no-reuse", "re-parse every file instead of replaying unchanged ones from the extraction cache")
-  .action(async (dir: string, opts: { deep?: boolean; extensions?: string[]; concurrency?: string; reuse?: boolean }) => {
+  .option(
+    "--include-dir <name>",
+    "override SKIP_DIRS for this repo's walks — repeatable (e.g. --include-dir build --include-dir tools); " +
+      "persisted, so a later build (and the hooks/refresh path) include it without the flag; dot-dirs are never overridable",
+    (val: string, prev: string[]) => [...prev, val],
+    [] as string[],
+  )
+  .action(async (dir: string, opts: { deep?: boolean; extensions?: string[]; concurrency?: string; reuse?: boolean; includeDir?: string[] }) => {
     const concurrency = opts.concurrency ? Math.max(1, Number(opts.concurrency)) : undefined;
     if (opts.concurrency && !Number.isFinite(concurrency)) {
       console.error(`✗ --concurrency must be a number, got "${opts.concurrency}"`);
       process.exit(1);
+    }
+    // Persisted BEFORE the build itself runs, so this invocation's walks (and
+    // every later no-flag build / hooks refresh) see it identically — the
+    // walkDir call sites read it from state, not from a threaded option.
+    if (opts.includeDir && opts.includeDir.length > 0) {
+      // --include-dir takes bare SKIP_DIRS-style directory NAMES (shouldSkipDir
+      // compares a single path segment), never paths, and dot-dirs are never
+      // overridable at all (see the option's own help text) — reject anything
+      // else up front instead of silently persisting a value that can never
+      // match a real directory name.
+      for (const name of opts.includeDir) {
+        if (name.startsWith(".")) {
+          console.error(`✗ --include-dir "${name}": dot-directories are never overridable`);
+          process.exit(1);
+        }
+        if (name.includes("/") || name.includes("\\")) {
+          console.error(`✗ --include-dir "${name}": expected a bare directory name, not a path`);
+          process.exit(1);
+        }
+      }
+      writeBuildConfig(resolve(dir), { includeDirs: opts.includeDir });
     }
     const engine = engineFrom();
     const fmt = (o: Record<string, number>) =>
@@ -159,6 +188,7 @@ program
         concurrency,
         childConfig: cliConfig(),
         override: buildGlobalDir,
+        includeDirs: opts.includeDir,
       });
       return;
     }

--- a/src/context/build.ts
+++ b/src/context/build.ts
@@ -17,6 +17,7 @@ import { walkDir } from "../ingest/fs.js";
 import { contentHash } from "../util/id.js";
 import { relPosix } from "../util/paths.js";
 import { readSourceFile } from "../util/source.js";
+import { readIncludeDirs } from "../util/state.js";
 import type { Summarizer } from "../ai/summarize.js";
 import type { FileSummary, SynthNode, Synthesizer } from "../ai/synthesize.js";
 import {
@@ -102,7 +103,10 @@ export async function buildContext(dir: string, opts: BuildOptions): Promise<Bui
   const root = resolve(dir);
   const outDir = contextDirFor(root, opts.contextDir);
   const exts = opts.extensions ?? CODE_EXTENSIONS;
-  const files = walkDir(root)
+  // Read root's persisted `--include-dir` override (same lookup source-files.ts
+  // does for the Tier-1 wiring graph) so an included dir like `build/` isn't
+  // invisible to the Tier-2 concept pipeline while the wiring graph sees it.
+  const files = walkDir(root, readIncludeDirs(root))
     .filter((f) => exts.some((e) => f.toLowerCase().endsWith(e)))
     .filter((f) => !f.startsWith(outDir));
 

--- a/src/context/check.ts
+++ b/src/context/check.ts
@@ -18,6 +18,7 @@ import { walkDir } from "../ingest/fs.js";
 import { contentHash } from "../util/id.js";
 import { relPosix } from "../util/paths.js";
 import { readSourceFile } from "../util/source.js";
+import { readIncludeDirs } from "../util/state.js";
 import { CODE_EXTENSIONS } from "./build.js";
 import { contextDirFor, readManifest, readNodes } from "./node-file.js";
 
@@ -56,9 +57,12 @@ export function checkContext(dir: string, opts: CheckOptions = {}): CheckResult 
     return result;
   }
 
-  // Current code files on disk (same rules `init` used).
+  // Current code files on disk (same rules `init` used) — including root's
+  // persisted `--include-dir` override, so this freshness check never
+  // disagrees with buildContext about what "current" means (an included
+  // build/ must not silently vanish from one side and not the other).
   const current = new Map<string, string>(); // rel → hash
-  for (const file of walkDir(root)) {
+  for (const file of walkDir(root, readIncludeDirs(root))) {
     if (file.startsWith(outDir)) continue;
     if (!exts.some((e) => file.toLowerCase().endsWith(e))) continue;
     try {

--- a/src/graph/build.ts
+++ b/src/graph/build.ts
@@ -21,6 +21,7 @@ import { extractFile, languageLabelOf, languageOf, type RawEdge } from "./extrac
 import { contentHash } from "../util/id.js";
 import { relPosix } from "../util/paths.js";
 import { readSourceFile } from "../util/source.js";
+import { readIncludeDirs } from "../util/state.js";
 import {
   emptyExtractCache,
   readExtractCache,
@@ -138,8 +139,9 @@ export async function buildGraph(
   const root = resolve(dir);
   const outDir = contextDirFor(root, opts.contextDir);
   // Enumerate once: source extraction, scope discovery, and Go module
-  // resolution must agree on the same Git-ignore-aware working-tree view.
-  const repoFiles = walkDir(root);
+  // resolution must agree on the same Git-ignore-aware working-tree view —
+  // including the repo's persisted `--include-dir` override.
+  const repoFiles = walkDir(root, readIncludeDirs(root));
   const files = listSourceStats(root, outDir, repoFiles);
   const discoveredScopes = discoverScopes(root, repoFiles);
 

--- a/src/graph/build.ts
+++ b/src/graph/build.ts
@@ -115,7 +115,12 @@ export interface GraphBuildResult {
 /** Every Go module in the repo: each `go.mod`'s declared `module` path and the repo
  * directory it lives in (posix, `.` for the root). Found anywhere in the tree, so a
  * monorepo whose module is in a subdir (e.g. `backend/go.mod`) resolves too. Lets edge
- * resolution map Go import paths to in-repo files. */
+ * resolution map Go import paths to in-repo files.
+ *
+ * `repoFiles` is buildGraph's single enumeration, which already carries root's
+ * persisted `--include-dir` override — so a `go.mod` living under an included
+ * dir (e.g. `build/go.mod`) is found here exactly when its `.go` files are
+ * indexed, and its intra-module imports resolve. */
 function readGoModules(root: string, repoFiles: string[]): GoModule[] {
   const mods: GoModule[] = [];
   for (const f of repoFiles) {

--- a/src/graph/scopes.ts
+++ b/src/graph/scopes.ts
@@ -25,6 +25,7 @@ import { existsSync, readdirSync, readFileSync, type Dirent } from "node:fs";
 import { join, resolve } from "node:path";
 import { shouldSkipDir, walkDir } from "../ingest/fs.js";
 import { relPosix } from "../util/paths.js";
+import { readIncludeDirs } from "../util/state.js";
 import type { GraphV1, ScopeV1 } from "./types.js";
 
 /** Project-marker files, checked in this order (also the order `markers` is built in). */
@@ -127,8 +128,12 @@ interface Candidate {
   isWorkspace: boolean;
 }
 
-/** Walk the tree (reusing `walkDir`'s skip rules) and find project-marker dirs. */
-export function discoverScopes(root: string, repoFiles: string[] = walkDir(root)): ScopeV1[] {
+/** Walk the tree (reusing `walkDir`'s skip rules, including the repo's persisted
+ * `--include-dir` override) and find project-marker dirs. */
+export function discoverScopes(
+  root: string,
+  repoFiles: string[] = walkDir(root, readIncludeDirs(resolve(root))),
+): ScopeV1[] {
   const absRoot = resolve(root);
   const dirs = collectDirs(absRoot, repoFiles);
 
@@ -320,6 +325,7 @@ export function assertPrefixIndexed(graph: GraphV1, prefix: string): void {
  * Used by workspace federation (Task 5). */
 export function discoverWorkspaceChildren(root: string): string[] {
   const absRoot = resolve(root);
+  const includes = readIncludeDirs(absRoot);
   let entries: Dirent[];
   try {
     entries = readdirSync(absRoot, { withFileTypes: true });
@@ -327,7 +333,7 @@ export function discoverWorkspaceChildren(root: string): string[] {
     return [];
   }
   return entries
-    .filter((e) => e.isDirectory() && !shouldSkipDir(e.name) && existsSync(join(absRoot, e.name, ".git")))
+    .filter((e) => e.isDirectory() && !shouldSkipDir(e.name, includes) && existsSync(join(absRoot, e.name, ".git")))
     .map((e) => e.name);
 }
 

--- a/src/graph/source-files.ts
+++ b/src/graph/source-files.ts
@@ -7,12 +7,25 @@
  * {@link listSourceFiles} so its existing importers are unaffected.
  */
 import { statSync } from "node:fs";
+import { resolve } from "node:path";
 import { walkDir } from "../ingest/fs.js";
 import { relPosix } from "../util/paths.js";
+import { readIncludeDirs } from "../util/state.js";
 import { languageOf } from "./extract.js";
 
-/** The source files a graph build parses: supported languages, minus the output dir. */
-export function listSourceFiles(root: string, outDir: string, repoFiles: string[] = walkDir(root)): string[] {
+/**
+ * The source files a graph build parses: supported languages, minus the
+ * output dir. When no pre-enumerated `repoFiles` is passed, the walk reads
+ * `root`'s persisted `--include-dir` override (if any) directly from state —
+ * so every caller that enumerates through here (the fingerprint probe, the
+ * hooks/refresh path, none of which ever see a CLI flag) behaves identically
+ * to the `graft build --include-dir` invocation that set it.
+ */
+export function listSourceFiles(
+  root: string,
+  outDir: string,
+  repoFiles: string[] = walkDir(root, readIncludeDirs(resolve(root))),
+): string[] {
   return repoFiles.filter((f) => !f.startsWith(outDir) && languageOf(f) !== null);
 }
 

--- a/src/graph/workspace-cli.ts
+++ b/src/graph/workspace-cli.ts
@@ -33,9 +33,8 @@ export interface WorkspaceBuildOptions {
   override?: string;
   /** The CLI's `--include-dir` override, if any. Persisted into EACH CHILD's
    * own state (not the parent's) before that child builds: children are
-   * independent repos with their own graft state, and the parent's `graft/`
-   * (including any state it briefly held) is deleted by `splitWorkspace`
-   * right after the children build — see `clearParentGraft`'s doc comment. */
+   * independent repos with their own local settings and can later be rebuilt
+   * directly without seeing the parent invocation's flags. */
   includeDirs?: string[];
 }
 

--- a/src/graph/workspace-cli.ts
+++ b/src/graph/workspace-cli.ts
@@ -7,6 +7,7 @@
  */
 import { Graft } from "../engine.js";
 import { contextDirFor, ensureGitignored } from "../context/node-file.js";
+import { writeBuildConfig } from "../util/state.js";
 import type { EngineConfig } from "../ai/providers.js";
 import { formatAsk } from "../ask/ask.js";
 import type { Direction } from "./traverse.js";
@@ -30,6 +31,12 @@ export interface WorkspaceBuildOptions {
    * override, so each child writes to its own `<child>/graft/`. */
   childConfig: EngineConfig;
   override?: string;
+  /** The CLI's `--include-dir` override, if any. Persisted into EACH CHILD's
+   * own state (not the parent's) before that child builds: children are
+   * independent repos with their own graft state, and the parent's `graft/`
+   * (including any state it briefly held) is deleted by `splitWorkspace`
+   * right after the children build — see `clearParentGraft`'s doc comment. */
+  includeDirs?: string[];
 }
 
 /** Build every git child into its own committable `graft/`, then replace the
@@ -37,6 +44,12 @@ export interface WorkspaceBuildOptions {
  * first when migrating away from a mega-graph. */
 export async function runWorkspaceBuild(root: string, opts: WorkspaceBuildOptions): Promise<void> {
   const buildChild = async (childDir: string, childName: string): Promise<void> => {
+    // Persisted BEFORE the child build itself runs, same as the single-repo
+    // `graft build --include-dir` path in cli.ts — so this child's walks (and
+    // every later no-flag build of it) see the override identically.
+    if (opts.includeDirs && opts.includeDirs.length > 0) {
+      writeBuildConfig(childDir, { includeDirs: opts.includeDirs });
+    }
     const engine = new Graft({ ...opts.childConfig, contextDir: undefined });
     if (opts.deep) await engine.init(childDir, { extensions: opts.extensions });
     const g = await engine.graph(childDir, { llm: opts.deep, concurrency: opts.concurrency });

--- a/src/ingest/fs.ts
+++ b/src/ingest/fs.ts
@@ -24,35 +24,48 @@ export const MAX_FILE_BYTES = 1_000_000;
 /**
  * Whether a directory named `name` should be skipped when walking a repo tree:
  * any dot-prefixed directory (`.git`, `.github`, `.vscode`, ...) or one of
- * {@link SKIP_DIRS}. The single source of truth for "is this dir source" —
- * `skippedPath` and `walkFilesystem` below and the git-child discovery in
- * `graph/scopes.ts` share it, so they can never independently drift on what
- * counts as skippable.
+ * {@link SKIP_DIRS} not named in `includes`. The single source of truth for
+ * "is this dir source" — `skippedPath` and `walkFilesystem` below and the
+ * git-child discovery in `graph/scopes.ts` share it, so they can never
+ * independently drift on what counts as skippable.
  *
- * KNOWN LIMITATION: a dot-directory is skipped WHOLESALE — there is no
- * override for a dot-prefixed directory. A repo that keeps real,
- * hand-written source under one is out of scope.
+ * `includes` is the explicit, per-repo `graft build --include-dir` override
+ * (persisted via `util/state.ts`'s `readIncludeDirs`, threaded in by each
+ * caller) — a name in it is removed from the effective skip set for THIS
+ * repo's walks. Absent/empty ≡ today's default behavior. It lifts only
+ * graft's own skip list: in a Git repo, Git's ignore rules stay authoritative
+ * (see {@link walkDir}).
+ *
+ * KNOWN LIMITATION: a dot-directory is skipped WHOLESALE and is NEVER
+ * overridable, even via `includes` — unlike `SKIP_DIRS`, there is no path to
+ * un-skip one. A repo that keeps real, hand-written source under a
+ * dot-prefixed directory is out of scope.
  */
-export function shouldSkipDir(name: string): boolean {
-  return name.startsWith(".") || SKIP_DIRS.has(name);
+export function shouldSkipDir(name: string, includes?: ReadonlySet<string>): boolean {
+  if (name.startsWith(".")) return true;
+  if (includes?.has(name)) return false;
+  return SKIP_DIRS.has(name);
 }
 
 /**
  * Recursively list all files under a directory. Skips dot-directories,
- * dependency/build directories (node_modules, dist, …), and files over 1 MB.
+ * dependency/build directories (node_modules, dist, …) not named in
+ * `includes`, and files over 1 MB.
  * In a Git worktree, tracked files plus untracked, non-ignored files come from
  * `git ls-files`; this gives indexing exactly Git's nested `.gitignore`,
  * negation, and global-exclude semantics. Non-Git directories retain the plain
- * filesystem walk.
+ * filesystem walk. `includes` lifts only the built-in skip list — it never
+ * overrides Git's ignore rules (un-ignore or `git add -f` a directory to
+ * index it, the same contract as tracked-but-ignored files).
  */
-export function walkDir(dir: string): string[] {
-  return gitVisibleFiles(dir) ?? walkFilesystem(dir);
+export function walkDir(dir: string, includes?: ReadonlySet<string>): string[] {
+  return gitVisibleFiles(dir, includes) ?? walkFilesystem(dir, includes);
 }
 
 /** Git's canonical working-tree file set, relative to `dir`. Tracked files are
  * deliberately included even when a later ignore rule matches them; `.gitignore`
  * only controls untracked files in Git, and graft follows the same contract. */
-function gitVisibleFiles(dir: string): string[] | null {
+function gitVisibleFiles(dir: string, includes?: ReadonlySet<string>): string[] | null {
   const root = resolve(dir);
   const result = spawnSync(
     "git",
@@ -68,7 +81,7 @@ function gitVisibleFiles(dir: string): string[] | null {
 
   const out: string[] = [];
   for (const rel of result.stdout.split("\0")) {
-    if (!rel || skippedPath(rel)) continue;
+    if (!rel || skippedPath(rel, includes)) continue;
     const abs = resolve(root, rel);
     try {
       const stat = lstatSync(abs);
@@ -86,17 +99,17 @@ function gitVisibleFiles(dir: string): string[] | null {
 /** A path (git-relative, either separator) is skipped when any of its
  * segments is a skippable directory name — the final segment doubles as the
  * dot-FILE check (`.eslintrc.js` and friends are not source either). */
-function skippedPath(path: string): boolean {
-  return path.replace(/\\/g, "/").split("/").some(shouldSkipDir);
+function skippedPath(path: string, includes?: ReadonlySet<string>): boolean {
+  return path.replace(/\\/g, "/").split("/").some((segment) => shouldSkipDir(segment, includes));
 }
 
-function walkFilesystem(dir: string): string[] {
+function walkFilesystem(dir: string, includes?: ReadonlySet<string>): string[] {
   const out: string[] = [];
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const full = join(dir, entry.name);
     if (entry.isDirectory()) {
-      if (shouldSkipDir(entry.name)) continue;
-      out.push(...walkFilesystem(full));
+      if (shouldSkipDir(entry.name, includes)) continue;
+      out.push(...walkFilesystem(full, includes));
     } else if (entry.isFile()) {
       if (entry.name.startsWith(".")) continue; // dot-files are not source either
       try {

--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -62,6 +62,34 @@ export function writeJsonAtomic(p: string, value: unknown, compact = false): voi
 
 export function readStats(d: string): Stats | null { return readJson<Stats>(statsPath(d)); }
 export function writeStats(d: string, s: Stats): void { writeJsonAtomic(statsPath(d), s); }
+
+/**
+ * Persisted per-repo build configuration — currently just `graft build
+ * --include-dir`'s override. An explicit input like the graph itself: absent
+ * or empty `includeDirs` means today's default (every `SKIP_DIRS` name stays
+ * skipped), so a repo that never used the flag is entirely unaffected.
+ */
+export interface BuildConfig {
+  /** SKIP_DIRS names to include in this repo's walks, persisted so a LATER
+   * no-flag build — and the fingerprint/refresh path, which never sees CLI
+   * flags at all — behave identically to the invocation that set it. */
+  includeDirs?: string[];
+}
+
+function configPath(d: string): string { return join(cacheDir(d), 'config.json'); }
+
+export function readBuildConfig(d: string): BuildConfig | null { return readJson<BuildConfig>(configPath(d)); }
+export function writeBuildConfig(d: string, c: BuildConfig): void { writeJsonAtomic(configPath(d), c); }
+
+/** The persisted `--include-dir` override for repo `d`, as a Set — `undefined`
+ * when nothing was ever persisted (or the persisted list is empty), which every
+ * `shouldSkipDir`/`walkDir` caller treats as "today's default behavior". Shared
+ * by every walkDir-driven entry point (source-files.ts, scopes.ts) so a build,
+ * a later no-flag rebuild, and the hooks/refresh path all agree. */
+export function readIncludeDirs(d: string): Set<string> | undefined {
+  const dirs = readBuildConfig(d)?.includeDirs;
+  return dirs && dirs.length ? new Set(dirs) : undefined;
+}
 // Best-effort read-modify-write; not atomic across concurrent processes, but acceptable
 // for episodic hook writes (worst case is a lost update, not corruption).
 export function patchStats(d: string, patch: Partial<Stats>): Stats {

--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -76,10 +76,34 @@ export interface BuildConfig {
   includeDirs?: string[];
 }
 
-function configPath(d: string): string { return join(cacheDir(d), 'config.json'); }
+/** Local, Git-ignored repository configuration. Kept outside generated
+ * `graft/` output so deleting/replacing that cache, workspace federation, and
+ * custom `--dir` builds cannot erase or redirect the persisted choice. */
+export const BUILD_CONFIG_DIR = '.graft';
 
-export function readBuildConfig(d: string): BuildConfig | null { return readJson<BuildConfig>(configPath(d)); }
-export function writeBuildConfig(d: string, c: BuildConfig): void { writeJsonAtomic(configPath(d), c); }
+export function buildConfigPath(d: string): string { return join(d, BUILD_CONFIG_DIR, 'config.json'); }
+
+/** Keep local build configuration out of Git without coupling it to the
+ * generated graph directory. Best-effort, matching graph-cache ignore setup. */
+function ensureBuildConfigIgnored(d: string): void {
+  const path = join(d, '.gitignore');
+  let current = '';
+  try { current = readFileSync(path, 'utf8'); } catch { /* no .gitignore yet */ }
+  const present = current.split('\n').some((line) => {
+    const value = line.trim();
+    return value === BUILD_CONFIG_DIR || value === `${BUILD_CONFIG_DIR}/` || value === `/${BUILD_CONFIG_DIR}/`;
+  });
+  if (present) return;
+  const gap = current === '' ? '' : current.endsWith('\n') ? '\n' : '\n\n';
+  const block = `${gap}# graft's local repository settings — not committed.\n/${BUILD_CONFIG_DIR}/\n`;
+  try { writeFileSync(path, current + block); } catch { /* best-effort */ }
+}
+
+export function readBuildConfig(d: string): BuildConfig | null { return readJson<BuildConfig>(buildConfigPath(d)); }
+export function writeBuildConfig(d: string, c: BuildConfig): void {
+  ensureBuildConfigIgnored(d);
+  writeJsonAtomic(buildConfigPath(d), c);
+}
 
 /** The persisted `--include-dir` override for repo `d`, as a Set — `undefined`
  * when nothing was ever persisted (or the persisted list is empty), which every

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -4,13 +4,14 @@
  */
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 import { buildContext } from "../src/context/build.js";
 import { checkContext, indexFreshness, staleBanner } from "../src/context/check.js";
 import { contextDirFor, ensureGitignored, ensureSearchable } from "../src/context/node-file.js";
+import { writeBuildConfig } from "../src/util/state.js";
 import { fakeProviders } from "./helpers.js";
 
 // CLI-spawn helper (same pattern as test/graph-traverse-cli.test.ts) — these tests
@@ -156,6 +157,47 @@ test("check detects a new file not yet in the graph (coverage drift)", async () 
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+// A5 — a persisted `--include-dir` override must reach the Tier-2 markdown
+// pipeline (context/build.ts) and its freshness check (context/check.ts), not
+// just the Tier-1 wiring graph (graph/build.ts, via source-files.ts). Both
+// sides must agree, in both directions: build/ shows up in buildContext's
+// file listing, and checkContext neither reports it removed (disagreeing
+// about what "current" means) nor as new coverage.
+test("A5: a persisted --include-dir override reaches context/build.ts's file listing and context/check.ts's freshness check", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "ctxgraph-include-dir-"));
+  try {
+    writeFileSync(
+      join(dir, "auth.ts"),
+      `// [[Auth Service]]\nexport const auth = 1;\n`,
+    );
+    mkdirSync(join(dir, "build"), { recursive: true });
+    writeFileSync(
+      join(dir, "build", "gen.ts"),
+      `// [[Generated Widget]]\nexport const genWidget = 1;\n`,
+    );
+    writeBuildConfig(dir, { includeDirs: ["build"] });
+
+    const r = await buildContext(dir, buildOpts());
+    assert.deepEqual(r.errors, [], "build should not error");
+    assert.ok(
+      manifestFiles(dir).includes("build/gen.ts"),
+      "build/gen.ts must be walked and recorded once --include-dir is persisted",
+    );
+
+    const check = checkContext(dir);
+    assert.equal(check.ok, true, `expected no drift, got ${JSON.stringify(check)}`);
+    assert.deepEqual(check.removed, [], "build/ must not be reported removed — check.ts must see it too");
+    assert.deepEqual(check.coverage, [], "build/ must not be reported as new/uncovered — it's already in the manifest");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function manifestFiles(dir: string): string[] {
+  const manifest = JSON.parse(readFileSync(join(dir, "graft", "manifest.json"), "utf8"));
+  return manifest.files.map((f: { path: string }) => f.path);
+}
 
 test("re-running init clears drift", async () => {
   const dir = makeFixture();

--- a/test/graph-go.test.ts
+++ b/test/graph-go.test.ts
@@ -10,6 +10,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { buildGraph } from "../src/graph/build.js";
 import { readGraph, wiringPath } from "../src/graph/write.js";
+import { writeBuildConfig } from "../src/util/state.js";
 import type { GraphV1, NodeV1 } from "../src/graph/types.js";
 
 const MAIN_GO = `package main
@@ -161,6 +162,43 @@ test("Go extraction: go.mod in a subdirectory resolves intra-module imports", as
       ),
       "fmt should remain an external package string",
     );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("A5: a go.mod under a persisted --include-dir override is found, so imports inside it resolve internally", async () => {
+  // build/ is in SKIP_DIRS by default — readGoModules must honor the same
+  // persisted include-dir override source-files.ts already reads, or a
+  // go.mod living under an included dir is missed while its .go files (which
+  // DO go through source-files.ts) are indexed just fine.
+  const dir = mkdtempSync(join(tmpdir(), "graft-go-include-dir-"));
+  try {
+    mkdirSync(join(dir, "build", "store"), { recursive: true });
+    writeFileSync(join(dir, "build", "go.mod"), "module example.com/app\n\ngo 1.21\n");
+    writeFileSync(
+      join(dir, "build", "main.go"),
+      `package main\n\nimport (\n\t"fmt"\n\t"example.com/app/store"\n)\n\nfunc main() {\n\tfmt.Println(store.New())\n}\n`,
+    );
+    writeFileSync(join(dir, "build", "store", "store.go"), "package store\n\nfunc New() int { return 0 }\n");
+    writeBuildConfig(dir, { includeDirs: ["build"] });
+
+    await buildGraph(dir);
+    const graph = readGraph(wiringPath(join(dir, "graft")))!;
+
+    // Sanity: the .go files under build/ are indexed at all (source-files.ts
+    // already reads the persisted include list correctly).
+    assert.ok(graph.nodes.some((n) => n.id === "build/main.go#main"), "build/main.go should be indexed");
+
+    const internal = graph.edges.find(
+      (e) => e.relation === "imports" && e.source === "build/main.go" && e.target === "build/store/store.go",
+    );
+    assert.ok(internal, "example.com/app/store should resolve internally once build/go.mod is found");
+
+    const external = graph.edges.find(
+      (e) => e.relation === "imports" && e.source === "build/main.go" && e.target === "example.com/app/store",
+    );
+    assert.ok(!external, "must not be left as an unresolved external package string once the module is found");
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/test/graph-include-dir.test.ts
+++ b/test/graph-include-dir.test.ts
@@ -1,0 +1,139 @@
+/**
+ * A5 — `graft build --include-dir <name>` end-to-end through the real CLI.
+ *
+ * SKIP_DIRS eats real source in some ecosystems (e.g. a build/ directory that
+ * genuinely holds hand-written code). This is the explicit, persisted
+ * override: no git-awareness (graft's documented no-git invariant), just a
+ * per-repo state file that later no-flag builds — and the fingerprint probe,
+ * which never sees CLI flags at all — read identically.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { readGraph, wiringPath } from "../src/graph/write.js";
+import { probeDrift, isClean } from "../src/graph/fingerprint.js";
+import type { GraphV1 } from "../src/graph/types.js";
+
+function repoWithBuildDir(): string {
+  const d = mkdtempSync(join(tmpdir(), "graft-include-dir-"));
+  mkdirSync(join(d, "build"), { recursive: true });
+  writeFileSync(join(d, "build", "util.ts"), "export function fromBuild(): number {\n  return 1;\n}\n");
+  writeFileSync(join(d, "main.ts"), "export function main(): number {\n  return 2;\n}\n");
+  return d;
+}
+
+function runCli(args: string[]): void {
+  execFileSync(process.execPath, ["--import", "tsx", "src/cli.ts", ...args], { stdio: "pipe" });
+}
+
+/** Like {@link runCli}, but captures a non-zero exit instead of throwing —
+ * for the --include-dir validation tests, which expect `graft build` to
+ * reject bad input rather than run to completion. */
+function runCliCapture(args: string[]): { stdout: string; stderr: string; status: number } {
+  try {
+    const stdout = execFileSync(process.execPath, ["--import", "tsx", "src/cli.ts", ...args], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { stdout, stderr: "", status: 0 };
+  } catch (err) {
+    const e = err as { stdout?: string; stderr?: string; status?: number };
+    return { stdout: e.stdout ?? "", stderr: e.stderr ?? "", status: e.status ?? 1 };
+  }
+}
+
+function graphOf(d: string): GraphV1 | null {
+  return readGraph(wiringPath(join(d, "graft")));
+}
+
+test("A5: build/ is absent by default, present with --include-dir build, persists across a no-flag rebuild, and the fingerprint probe agrees (no drift loop)", () => {
+  const d = repoWithBuildDir();
+
+  runCli(["build", d]);
+  const cold = graphOf(d);
+  assert.ok(cold, "expected a built graph.json");
+  assert.ok(!cold!.nodes.some((n) => n.path.startsWith("build/")), "build/ must be absent by default (SKIP_DIRS)");
+  assert.ok(cold!.nodes.some((n) => n.id === "main.ts#main"), "sanity: the non-skipped file is indexed");
+
+  runCli(["build", d, "--include-dir", "build"]);
+  const withFlag = graphOf(d);
+  assert.ok(withFlag);
+  assert.ok(
+    withFlag!.nodes.some((n) => n.id === "build/util.ts#fromBuild"),
+    "build/ must be included this run, with the flag",
+  );
+
+  // No flag this time — the persisted state must still include it.
+  runCli(["build", d]);
+  const persisted = graphOf(d);
+  assert.ok(persisted);
+  assert.ok(
+    persisted!.nodes.some((n) => n.id === "build/util.ts#fromBuild"),
+    "a follow-up NO-FLAG rebuild must still include build/ (state-persisted)",
+  );
+
+  // The fingerprint probe (the fast path `ensureFreshGraph`/hooks use, which
+  // never sees CLI flags) must read the same persisted include set — so it
+  // recognizes build/util.ts as already-tracked, not perpetually "added".
+  const drift = probeDrift(d, join(d, "graft"));
+  assert.ok(drift, "expected a fingerprint to probe against");
+  assert.ok(isClean(drift!), `probe must report clean, got ${JSON.stringify(drift)}`);
+});
+
+// --include-dir takes bare SKIP_DIRS-style directory NAMES, never paths, and
+// dot-dirs are (per the option's own help text) never overridable at all.
+// Without validation, a value like ".github" or "foo/bar" would silently
+// persist and then just never match any real directory name walkDir compares
+// against (shouldSkipDir compares against a single path segment), so the flag
+// would look accepted while doing nothing.
+
+test("A5: --include-dir rejects a dot-prefixed name", () => {
+  const d = repoWithBuildDir();
+  try {
+    const r = runCliCapture(["build", d, "--include-dir", ".github"]);
+    assert.equal(r.status, 1, `expected exit 1, got ${r.status}\nstdout: ${r.stdout}\nstderr: ${r.stderr}`);
+    assert.match(r.stderr, /--include-dir/);
+    assert.match(r.stderr, /\.github/);
+    assert.equal(existsSync(join(d, "graft", ".cache", "config.json")), false, "must not persist an invalid value");
+  } finally {
+    rmSync(d, { recursive: true, force: true });
+  }
+});
+
+test("A5: --include-dir rejects a value containing a path separator", () => {
+  const d = repoWithBuildDir();
+  try {
+    const r = runCliCapture(["build", d, "--include-dir", "foo/bar"]);
+    assert.equal(r.status, 1, `expected exit 1, got ${r.status}\nstdout: ${r.stdout}\nstderr: ${r.stderr}`);
+    assert.match(r.stderr, /--include-dir/);
+    assert.match(r.stderr, /foo\/bar/);
+    assert.equal(existsSync(join(d, "graft", ".cache", "config.json")), false, "must not persist an invalid value");
+  } finally {
+    rmSync(d, { recursive: true, force: true });
+  }
+});
+
+test("A5: --include-dir rejects a value containing a backslash", () => {
+  const d = repoWithBuildDir();
+  try {
+    const r = runCliCapture(["build", d, "--include-dir", "foo\\bar"]);
+    assert.equal(r.status, 1, `expected exit 1, got ${r.status}\nstdout: ${r.stdout}\nstderr: ${r.stderr}`);
+    assert.match(r.stderr, /--include-dir/);
+  } finally {
+    rmSync(d, { recursive: true, force: true });
+  }
+});
+
+test("A5: a later valid --include-dir still works (validation isn't over-eager)", () => {
+  const d = repoWithBuildDir();
+  try {
+    runCli(["build", d, "--include-dir", "build"]);
+    const g = graphOf(d);
+    assert.ok(g && g.nodes.some((n) => n.id === "build/util.ts#fromBuild"));
+  } finally {
+    rmSync(d, { recursive: true, force: true });
+  }
+});

--- a/test/graph-include-dir.test.ts
+++ b/test/graph-include-dir.test.ts
@@ -83,6 +83,39 @@ test("A5: build/ is absent by default, present with --include-dir build, persist
   assert.ok(isClean(drift!), `probe must report clean, got ${JSON.stringify(drift)}`);
 });
 
+test("A5: deleting the generated graft cache does not delete the persisted include-dir setting", () => {
+  const d = repoWithBuildDir();
+  try {
+    runCli(["build", d, "--include-dir", "build"]);
+    rmSync(join(d, "graft"), { recursive: true, force: true });
+
+    runCli(["build", d]);
+    const rebuilt = graphOf(d);
+    assert.ok(rebuilt?.nodes.some((n) => n.id === "build/util.ts#fromBuild"));
+    assert.equal(existsSync(join(d, ".graft", "config.json")), true);
+  } finally {
+    rmSync(d, { recursive: true, force: true });
+  }
+});
+
+test("A5: custom --dir builds keep repository config outside both output directories", () => {
+  const d = repoWithBuildDir();
+  const out = mkdtempSync(join(tmpdir(), "graft-include-dir-output-"));
+  try {
+    writeFileSync(join(d, "graft"), "a regular file that must not receive config\n");
+    runCli(["--dir", out, "build", d, "--include-dir", "build"]);
+
+    const graph = readGraph(wiringPath(out));
+    assert.ok(graph?.nodes.some((n) => n.id === "build/util.ts#fromBuild"));
+    assert.equal(existsSync(join(d, ".graft", "config.json")), true);
+    assert.equal(existsSync(join(d, "graft", ".cache", "config.json")), false);
+    assert.equal(existsSync(join(out, ".cache", "config.json")), false);
+  } finally {
+    rmSync(d, { recursive: true, force: true });
+    rmSync(out, { recursive: true, force: true });
+  }
+});
+
 // --include-dir takes bare SKIP_DIRS-style directory NAMES, never paths, and
 // dot-dirs are (per the option's own help text) never overridable at all.
 // Without validation, a value like ".github" or "foo/bar" would silently
@@ -97,7 +130,7 @@ test("A5: --include-dir rejects a dot-prefixed name", () => {
     assert.equal(r.status, 1, `expected exit 1, got ${r.status}\nstdout: ${r.stdout}\nstderr: ${r.stderr}`);
     assert.match(r.stderr, /--include-dir/);
     assert.match(r.stderr, /\.github/);
-    assert.equal(existsSync(join(d, "graft", ".cache", "config.json")), false, "must not persist an invalid value");
+    assert.equal(existsSync(join(d, ".graft", "config.json")), false, "must not persist an invalid value");
   } finally {
     rmSync(d, { recursive: true, force: true });
   }
@@ -110,7 +143,7 @@ test("A5: --include-dir rejects a value containing a path separator", () => {
     assert.equal(r.status, 1, `expected exit 1, got ${r.status}\nstdout: ${r.stdout}\nstderr: ${r.stderr}`);
     assert.match(r.stderr, /--include-dir/);
     assert.match(r.stderr, /foo\/bar/);
-    assert.equal(existsSync(join(d, "graft", ".cache", "config.json")), false, "must not persist an invalid value");
+    assert.equal(existsSync(join(d, ".graft", "config.json")), false, "must not persist an invalid value");
   } finally {
     rmSync(d, { recursive: true, force: true });
   }

--- a/test/graph-scopes.test.ts
+++ b/test/graph-scopes.test.ts
@@ -13,6 +13,7 @@ import {
 import { buildGraph } from "../src/graph/build.js";
 import { readGraph, wiringPath, writeGraph } from "../src/graph/write.js";
 import { loadGraphCached } from "../src/graph/load.js";
+import { writeBuildConfig } from "../src/util/state.js";
 import type { GraphV1 } from "../src/graph/types.js";
 
 function fx(layout: Record<string, string>): string {
@@ -167,6 +168,16 @@ test("discoverWorkspaceChildren finds immediate git children only", () => {
   mkdirSync(join(d, "repoB/.git"), { recursive: true });
   mkdirSync(join(d, "repoB/vendored/.git"), { recursive: true }); // nested: not a child of d
   assert.deepEqual(discoverWorkspaceChildren(d).sort(), ["repoA", "repoB"]);
+  rmSync(d, { recursive: true, force: true });
+});
+
+test("A5: discoverScopes finds a marker under a SKIP_DIRS name once persisted via --include-dir state, absent otherwise", () => {
+  const d = fx({ "build/package.json": "{}" });
+  assert.deepEqual(discoverScopes(d), [{ prefix: "", label: "", markers: [] }], "build/ is skipped by default — no scope found");
+
+  writeBuildConfig(d, { includeDirs: ["build"] });
+  const prefixes = discoverScopes(d).map((s) => s.prefix);
+  assert.deepEqual(prefixes, ["build"], "once persisted, build/'s own marker is discovered as a scope");
   rmSync(d, { recursive: true, force: true });
 });
 

--- a/test/graph-workspace-include-dir.test.ts
+++ b/test/graph-workspace-include-dir.test.ts
@@ -1,0 +1,68 @@
+/**
+ * A5 (V4) — a workspace build's `--include-dir` must reach the children.
+ *
+ * `runWorkspaceBuild` builds each child through its own `Graft` engine
+ * (`workspace-cli.ts`), then `splitWorkspace` deletes the PARENT's entire
+ * `graft/` (including any just-persisted include-dir state — see
+ * `clearParentGraft`'s doc comment) and replaces it with `workspace.json`.
+ * Without threading the CLI's `--include-dir` value into
+ * `runWorkspaceBuild`/`buildChild`, a workspace build had no way to see it —
+ * and even if it had persisted state at the parent, that state is exactly
+ * what gets deleted moments later. Children are independent repos with their
+ * own graft state, so the fix persists the include list in EACH CHILD's own
+ * state instead.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runWorkspaceBuild } from "../src/graph/workspace-cli.js";
+import { buildGraph } from "../src/graph/build.js";
+import { readGraph, wiringPath } from "../src/graph/write.js";
+import type { GraphV1 } from "../src/graph/types.js";
+
+function workspaceWithBuildDirs(): string {
+  const parent = mkdtempSync(join(tmpdir(), "ws-include-dir-"));
+  for (const child of ["repoA", "repoB"]) {
+    mkdirSync(join(parent, child, ".git"), { recursive: true });
+    mkdirSync(join(parent, child, "build"), { recursive: true });
+    writeFileSync(join(parent, child, "build", "util.ts"), "export function fromBuild(): number {\n  return 1;\n}\n");
+    writeFileSync(join(parent, child, "main.ts"), "export function main(): number {\n  return 2;\n}\n");
+  }
+  return parent;
+}
+
+function graphOf(childDir: string): GraphV1 | null {
+  return readGraph(wiringPath(join(childDir, "graft")));
+}
+
+test("A5: --include-dir on a workspace build reaches every child, which persists it for a later no-flag rebuild", async () => {
+  const parent = workspaceWithBuildDirs();
+  try {
+    await runWorkspaceBuild(parent, { deep: false, childConfig: {}, includeDirs: ["build"] });
+
+    for (const child of ["repoA", "repoB"]) {
+      const g = graphOf(join(parent, child));
+      assert.ok(g, `expected a built graph for ${child}`);
+      assert.ok(
+        g!.nodes.some((n) => n.id === "build/util.ts#fromBuild"),
+        `${child}'s build/ file must be indexed with --include-dir`,
+      );
+    }
+
+    // A later no-flag rebuild of a single child (never sees the parent's CLI
+    // invocation at all, let alone its flags) must still include build/ —
+    // proof the child persisted the override in ITS OWN state, not the
+    // parent's (which splitWorkspace deletes right after the build).
+    await buildGraph(join(parent, "repoA"));
+    const rebuilt = graphOf(join(parent, "repoA"));
+    assert.ok(rebuilt);
+    assert.ok(
+      rebuilt!.nodes.some((n) => n.id === "build/util.ts#fromBuild"),
+      "child's own persisted include-dir state must survive a no-flag rebuild",
+    );
+  } finally {
+    rmSync(parent, { recursive: true, force: true });
+  }
+});

--- a/test/graph-workspace-include-dir.test.ts
+++ b/test/graph-workspace-include-dir.test.ts
@@ -2,24 +2,22 @@
  * A5 (V4) — a workspace build's `--include-dir` must reach the children.
  *
  * `runWorkspaceBuild` builds each child through its own `Graft` engine
- * (`workspace-cli.ts`), then `splitWorkspace` deletes the PARENT's entire
- * `graft/` (including any just-persisted include-dir state — see
- * `clearParentGraft`'s doc comment) and replaces it with `workspace.json`.
+ * (`workspace-cli.ts`), then `splitWorkspace` replaces the PARENT's generated
+ * `graft/` with `workspace.json`.
  * Without threading the CLI's `--include-dir` value into
  * `runWorkspaceBuild`/`buildChild`, a workspace build had no way to see it —
- * and even if it had persisted state at the parent, that state is exactly
- * what gets deleted moments later. Children are independent repos with their
- * own graft state, so the fix persists the include list in EACH CHILD's own
- * state instead.
+ * children are independent repos with their own graft state, so the fix
+ * persists the include list in EACH CHILD's own state too.
  */
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runWorkspaceBuild } from "../src/graph/workspace-cli.js";
 import { buildGraph } from "../src/graph/build.js";
 import { readGraph, wiringPath } from "../src/graph/write.js";
+import { writeBuildConfig } from "../src/util/state.js";
 import type { GraphV1 } from "../src/graph/types.js";
 
 function workspaceWithBuildDirs(): string {
@@ -53,8 +51,7 @@ test("A5: --include-dir on a workspace build reaches every child, which persists
 
     // A later no-flag rebuild of a single child (never sees the parent's CLI
     // invocation at all, let alone its flags) must still include build/ —
-    // proof the child persisted the override in ITS OWN state, not the
-    // parent's (which splitWorkspace deletes right after the build).
+    // proof the child persisted the override in ITS OWN state.
     await buildGraph(join(parent, "repoA"));
     const rebuilt = graphOf(join(parent, "repoA"));
     assert.ok(rebuilt);
@@ -62,6 +59,26 @@ test("A5: --include-dir on a workspace build reaches every child, which persists
       rebuilt!.nodes.some((n) => n.id === "build/util.ts#fromBuild"),
       "child's own persisted include-dir state must survive a no-flag rebuild",
     );
+  } finally {
+    rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+test("A5: a skipped-name workspace child remains discoverable on a later no-flag rebuild", async () => {
+  const parent = mkdtempSync(join(tmpdir(), "ws-include-child-"));
+  try {
+    for (const child of ["app", "build"]) {
+      mkdirSync(join(parent, child, ".git"), { recursive: true });
+      writeFileSync(join(parent, child, "main.ts"), `export const ${child}Value = 1;\n`);
+    }
+
+    writeBuildConfig(parent, { includeDirs: ["build"] });
+    await runWorkspaceBuild(parent, { deep: false, childConfig: {}, includeDirs: ["build"] });
+    await runWorkspaceBuild(parent, { deep: false, childConfig: {} });
+
+    const workspace = JSON.parse(readFileSync(join(parent, "graft", "workspace.json"), "utf8")) as { children: string[] };
+    assert.deepEqual(workspace.children, ["app", "build"]);
+    assert.equal(readFileSync(join(parent, ".graft", "config.json"), "utf8").includes("build"), true);
   } finally {
     rmSync(parent, { recursive: true, force: true });
   }

--- a/test/ingest-fs.test.ts
+++ b/test/ingest-fs.test.ts
@@ -18,8 +18,8 @@ function write(root: string, path: string, content = "export const value = 1;\n"
   writeFileSync(join(root, path), content);
 }
 
-function walked(root: string): string[] {
-  return walkDir(root)
+function walked(root: string, includes?: ReadonlySet<string>): string[] {
+  return walkDir(root, includes)
     .map((path) => relative(root, path).replace(/\\/g, "/"))
     .sort();
 }
@@ -75,16 +75,21 @@ test("walkDir retains fixed skips and filesystem fallback outside Git", () => {
 });
 
 /**
- * A4 — shouldSkipDir consolidation.
+ * A5 — `shouldSkipDir` and its `--include-dir` override.
  *
  * "Is this name dot-prefixed or in SKIP_DIRS" is re-implemented by hand in
  * three places: `skippedPath`'s per-segment predicate and `walkFilesystem`'s
  * directory check (both src/ingest/fs.ts), and `discoverWorkspaceChildren`'s
- * git-child filter (src/graph/scopes.ts). `shouldSkipDir` is the single
- * source of truth now; these tests pin the predicate's contract and prove
- * every consumer — the file walk, marker-scope discovery and workspace-glob
- * resolution (both derived from the walked file set), and git-child
- * discovery — agrees on exactly the same skip set.
+ * git-child filter (src/graph/scopes.ts). This introduces `shouldSkipDir` as
+ * the single source of truth, with an optional `includes` param: a name in it
+ * is removed from the effective skip set for this repo's walks (persisted via
+ * `graft build --include-dir`), while a dot-directory stays non-overridable
+ * regardless.
+ *
+ * `--include-dir` lifts only graft's OWN skip list. In a Git repo, Git's
+ * ignore rules stay authoritative: an ignored directory remains excluded even
+ * when named — un-ignore it (or `git add -f`) to index it, the same contract
+ * the walker already applies to tracked-but-ignored files.
  */
 
 test("shouldSkipDir: every SKIP_DIRS name and any dot-prefixed name is skipped; an ordinary name is not", () => {
@@ -94,6 +99,59 @@ test("shouldSkipDir: every SKIP_DIRS name and any dot-prefixed name is skipped; 
   assert.equal(shouldSkipDir("."), true);
   assert.equal(shouldSkipDir("src"), false);
   assert.equal(shouldSkipDir("app"), false);
+});
+
+test("A5: shouldSkipDir(name, includes) removes a SKIP_DIRS name from the skip set, but never a dot-dir", () => {
+  const includes = new Set(["build", ".git"]);
+  assert.equal(shouldSkipDir("build", includes), false, "an included SKIP_DIRS name is no longer skipped");
+  assert.equal(shouldSkipDir("vendor", includes), true, "a SKIP_DIRS name NOT in includes is still skipped");
+  assert.equal(shouldSkipDir(".git", includes), true, "a dot-dir is never overridable, even if explicitly included");
+  assert.equal(shouldSkipDir("src", includes), false);
+});
+
+test("A5: walkDir(dir, includes) descends into an included SKIP_DIRS-named directory (filesystem fallback)", () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-walkdir-include-"));
+  try {
+    mkdirSync(join(dir, "build"), { recursive: true });
+    writeFileSync(join(dir, "build", "real.ts"), "export const X = 1;\n");
+    mkdirSync(join(dir, "vendor"), { recursive: true });
+    writeFileSync(join(dir, "vendor", "other.ts"), "export const Y = 1;\n");
+
+    const withoutIncludes = walkDir(dir).map((f) => f.slice(dir.length + 1));
+    assert.ok(!withoutIncludes.some((f) => f.startsWith("build")), "default: build/ is skipped");
+
+    const withIncludes = walkDir(dir, new Set(["build"])).map((f) => f.slice(dir.length + 1));
+    assert.ok(withIncludes.some((f) => f.startsWith("build")), "build/ is walked once included");
+    assert.ok(!withIncludes.some((f) => f.startsWith("vendor")), "vendor/ stays skipped — only the named dir is included");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("A5: in a Git repo, --include-dir lifts the built-in skip for git-visible files", () => {
+  const dir = fixture("include-git");
+  try {
+    write(dir, "src/app.ts");
+    write(dir, "vendor/lib.ts"); // vendored dep committed to the repo — visible to git, skipped by the built-in list
+
+    assert.ok(!walked(dir).includes("vendor/lib.ts"), "default: vendor/ is skipped by the built-in list");
+    assert.deepEqual(walked(dir, new Set(["vendor"])), ["src/app.ts", "vendor/lib.ts"]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("A5: --include-dir does not override gitignore — an ignored directory stays excluded even when named", () => {
+  const dir = fixture("include-ignored");
+  try {
+    write(dir, ".gitignore", "build/\n");
+    write(dir, "src/app.ts");
+    write(dir, "build/gen.ts");
+
+    assert.deepEqual(walked(dir, new Set(["build"])), [".gitignore", "src/app.ts"]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 /** One subdirectory per SKIP_DIRS name, plus a dot-directory and a normal

--- a/test/ingest-fs.test.ts
+++ b/test/ingest-fs.test.ts
@@ -148,7 +148,7 @@ test("A5: --include-dir does not override gitignore — an ignored directory sta
     write(dir, "src/app.ts");
     write(dir, "build/gen.ts");
 
-    assert.deepEqual(walked(dir, new Set(["build"])), [".gitignore", "src/app.ts"]);
+    assert.deepEqual(walked(dir, new Set(["build"])), ["src/app.ts"]);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/test/util-state.test.ts
+++ b/test/util-state.test.ts
@@ -1,0 +1,41 @@
+/**
+ * A5 — persisted --include-dir override.
+ *
+ * `graft build --include-dir <name>` needs a per-repo, persisted record of
+ * which SKIP_DIRS names to include, so a LATER no-flag build (or the hooks/
+ * refresh path, which never sees CLI flags at all) behaves identically to the
+ * invocation that set it. These tests pin the round-trip contract directly,
+ * independent of the CLI wiring (covered end-to-end in
+ * test/graph-include-dir.test.ts).
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readBuildConfig, writeBuildConfig, readIncludeDirs } from "../src/util/state.js";
+
+function fresh(): string {
+  return mkdtempSync(join(tmpdir(), "graft-buildconfig-"));
+}
+
+test("readBuildConfig returns null when nothing was ever persisted", () => {
+  const d = fresh();
+  assert.equal(readBuildConfig(d), null);
+  assert.equal(readIncludeDirs(d), undefined, "no persisted config -> today's default (no includes)");
+});
+
+test("writeBuildConfig + readBuildConfig round-trip includeDirs", () => {
+  const d = fresh();
+  writeBuildConfig(d, { includeDirs: ["build", "vendor"] });
+  assert.deepEqual(readBuildConfig(d), { includeDirs: ["build", "vendor"] });
+});
+
+test("readIncludeDirs turns a persisted list into a Set; an empty persisted list reads as undefined (default behavior)", () => {
+  const d = fresh();
+  writeBuildConfig(d, { includeDirs: ["build"] });
+  assert.deepEqual(readIncludeDirs(d), new Set(["build"]));
+
+  writeBuildConfig(d, { includeDirs: [] });
+  assert.equal(readIncludeDirs(d), undefined, "an empty list must read exactly like no list at all");
+});

--- a/test/util-state.test.ts
+++ b/test/util-state.test.ts
@@ -10,10 +10,10 @@
  */
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { readBuildConfig, writeBuildConfig, readIncludeDirs } from "../src/util/state.js";
+import { buildConfigPath, readBuildConfig, writeBuildConfig, readIncludeDirs } from "../src/util/state.js";
 
 function fresh(): string {
   return mkdtempSync(join(tmpdir(), "graft-buildconfig-"));
@@ -29,6 +29,9 @@ test("writeBuildConfig + readBuildConfig round-trip includeDirs", () => {
   const d = fresh();
   writeBuildConfig(d, { includeDirs: ["build", "vendor"] });
   assert.deepEqual(readBuildConfig(d), { includeDirs: ["build", "vendor"] });
+  assert.equal(buildConfigPath(d), join(d, ".graft", "config.json"));
+  assert.equal(existsSync(join(d, "graft", ".cache", "config.json")), false);
+  assert.match(readFileSync(join(d, ".gitignore"), "utf8"), /^\/\.graft\/$/m);
 });
 
 test("readIncludeDirs turns a persisted list into a Set; an empty persisted list reads as undefined (default behavior)", () => {


### PR DESCRIPTION
## Summary
- rebases and continues external contributor PR #42 on the latest `main`
- adds repeatable, persisted `graft build --include-dir <name>` overrides for built-in skipped directory names
- stores local settings in Git-ignored `.graft/config.json`, independent of generated output and custom `--dir`
- keeps Git ignore rules authoritative and propagates the same file set through refresh, scopes, context, Go modules, and workspace children

All original feature commits retain Alex Matthews as their author. Supersedes #42 only because the contributor fork does not permit maintainer pushes.

## Test plan
- [x] persistence regressions: generated-cache deletion, custom `--dir`, and workspace parent rebuild
- [x] `npm run build`
- [x] `npm test` (583 passing)