### PR TITLE
Gate the pull channel on match strength; rule-built crux for keyless builds

### DIFF
--- a/src/ask/ask.ts
+++ b/src/ask/ask.ts
@@ -30,7 +30,7 @@ import {
 import { normalizePathPrefix } from "../util/paths.js";
 import { resolveSymbol } from "../graph/traverse.js";
 import type { EdgeV1, GraphV1, NodeV1, Relation } from "../graph/types.js";
-import { rankScopesAndFuse } from "./fuse.js";
+import { rankScopesAndFuse, HIGH_FLOOR, STRONG_FLOOR } from "./fuse.js";
 import { personalizedPageRank } from "./graphrank.js";
 import { readSourceFile } from "../util/source.js";
 import { counts, tokenize, type AskIndex, type AskIndexDoc } from "./index-file.js";
@@ -922,8 +922,53 @@ function toTokens(chars: number): number {
   return Math.round(chars / 4);
 }
 
-/** Render an {@link AskResult} as a compact markdown context pack. */
-export function formatAsk(r: AskResult): string {
+/** How many pointers a weak pack shows. Three is enough to be a lead and few
+ * enough that a wrong lead is cheap to discard. */
+const WEAK_HIT_CAP = 3;
+
+/**
+ * Does this result fall below the strength floor the push channel already
+ * enforces (`relevantRetrieval` in claude/format.ts)?
+ *
+ * The floors were only ever applied to injected packs. A pull — `graft ask` from
+ * the CLI, or `graft_find_code` over MCP — returned its full top-N with source
+ * inlined at any score, so a query the retriever scored 0.05 came back looking
+ * exactly as authoritative as one it scored 0.9. That asymmetry is what made
+ * django-13121 possible: a forced ask on a no-strong-match prompt injected 6,289
+ * chars of the wrong code, +28% tokens, +31% cost, and the episode timed out.
+ *
+ * Structural results carry neither score and are never weak — a resolved
+ * "callers of X" IS the answer, not a guess about it.
+ */
+export function isWeakMatch(r: AskResult): boolean {
+  if (r.mode !== "lexical") return false;
+  // Absent scores mean "not measured" (older/federated shapes), not "weak".
+  if (r.coverage === undefined && r.coverageStrong === undefined) return false;
+  return (r.coverageStrong ?? 0) < STRONG_FLOOR && (r.coverage ?? 0) < HIGH_FLOOR;
+}
+
+/** The line a weak pack carries instead of inlined source. Says what happened,
+ * how sure it isn't, and which tool to reach for — silence or a bare hedge both
+ * leave the agent to fall back on the grep loop this is meant to prevent. */
+function weakMatchNote(r: AskResult, shown: number, total: number): string {
+  const strong = (r.coverageStrong ?? 0).toFixed(2);
+  const more = total > shown ? ` (${total - shown} more suppressed)` : "";
+  return (
+    `\n\n[graft] LOW CONFIDENCE — the query matched no symbol name well ` +
+    `(name match ${strong}). Showing ${shown} pointer${shown === 1 ? "" : "s"}${more} ` +
+    `without source: at this score the inlined code is as likely to mislead as help.\n` +
+    `[graft] Better move: pull an identifier out of the error/traceback/snippet and ` +
+    "run `graft grep \"<identifier>\"`, or `graft skeleton <file>` if you know the file. " +
+    "Re-run with `--full` to inline anyway."
+  );
+}
+
+/** Render an {@link AskResult} as a compact markdown context pack.
+ *
+ * `force` bypasses the weak-match gate — an explicit `--full` / `full: true` is
+ * the caller overruling the score on purpose, which is theirs to do. */
+export function formatAsk(r: AskResult, opts: { force?: boolean } = {}): string {
+  const weak = !opts.force && isWeakMatch(r);
   const head = `graft ask — "${r.query}"  (${r.mode})`;
   // The note prints as its own prominent line(s) right under the header —
   // above every hit — so a loud structural-fallthrough note (or the
@@ -950,7 +995,8 @@ export function formatAsk(r: AskResult): string {
       if (h.code) lines.push("", "```", h.code, "```", "");
     }
   } else {
-    r.hits.forEach((h, i) => {
+    const shown = weak ? r.hits.slice(0, WEAK_HIT_CAP) : r.hits;
+    shown.forEach((h, i) => {
       // Multi-scope results label each hit with its sub-project (root scope
       // "" stays unlabeled) so a reviewer can tell WHICH codebase answered.
       const label = r.scopes && h.scope ? `[${h.scope}/] ` : "";
@@ -958,12 +1004,16 @@ export function formatAsk(r: AskResult): string {
       lines.push(`   ${h.pointer}`);
       if (h.snippet) lines.push(`   ${h.snippet}`);
       if (h.related?.length) lines.push(`   related: ${h.related.join(", ")}`);
-      if (h.code) lines.push("", "```", h.code, "```");
+      if (h.code && !weak) lines.push("", "```", h.code, "```");
       lines.push("");
     });
     lines.push(...scopeFooterLines(r));
   }
   const body = lines.join("\n").trimEnd();
+  // No savings footer on a weak pack: the estimate is "this pack vs reading
+  // those files whole", and with the source withheld it would claim a large
+  // saving for having answered less. Weak output should not look like a win.
+  if (weak) return body + weakMatchNote(r, Math.min(WEAK_HIT_CAP, r.hits.length), r.hits.length) + "\n";
   return body + askSavingsFooter(r, body) + escalationNudge(r) + "\n";
 }
 

--- a/src/ask/ask.ts
+++ b/src/ask/ask.ts
@@ -762,16 +762,116 @@ function sliceSpan(root: string, path: string, from: number, to: number): string
   }
 }
 
+/** Lines a rule-built crux shows for a function-like node before it truncates. */
+const RULE_CRUX_LINES = 8;
+/** Member signatures a rule-built crux shows for a class-like node. */
+const RULE_CRUX_MEMBERS = 8;
+
+/** Node kinds whose useful summary is their MEMBER LIST, not their first lines.
+ * A long class opens with `__init__` boilerplate; what it does is the set of
+ * methods it exposes. */
+const CONTAINER_KINDS = new Set(["class", "interface", "struct", "trait", "enum"]);
+
+/** Rule-built crux for a container: the declaration line plus its members'
+ * signatures, found by span containment (same file, span nested inside). This
+ * is the same view `graft skeleton` gives for a whole file, narrowed to one
+ * type — and for a container it is arguably better than an LLM excerpt, because
+ * it is the complete API rather than a chosen fragment. */
+function containerCrux(node: NodeV1, graph: GraphV1, declLine: string): string | null {
+  const outer = spanRange(node.span);
+  if (!outer) return null;
+  const members = graph.nodes
+    .filter((n) => {
+      if (n === node || n.path !== node.path || n.kind === "file") return false;
+      const r = spanRange(n.span);
+      return !!r && r.from >= outer.from && r.to <= outer.to;
+    })
+    .sort((a, b) => (spanRange(a.span)?.from ?? 0) - (spanRange(b.span)?.from ?? 0));
+  if (!members.length) return null;
+  const shown = members.slice(0, RULE_CRUX_MEMBERS);
+  const lines = [declLine.trimEnd()];
+  for (const m of shown) lines.push(`    ${m.signature?.trim() || `${m.kind} ${m.name}`}`);
+  const rest = members.length - shown.length;
+  lines.push(
+    `… (${rest > 0 ? `${rest} more member${rest === 1 ? "" : "s"}; ` : ""}` +
+      `full definition at ${node.path}:${node.span}; rerun with --full)`,
+  );
+  return lines.join("\n");
+}
+
+/** `Lx-Ly` → numeric range. */
+function spanRange(span: string): { from: number; to: number } | null {
+  const m = span?.match(/^L(\d+)-L(\d+)$/);
+  return m ? { from: Number(m[1]), to: Number(m[2]) } : null;
+}
+
+/**
+ * Rule-built crux — the $0 stand-in for the LLM-chosen one.
+ *
+ * Without a key there is no `crux`, and the fallback was the whole definition
+ * capped at {@link MAX_SPAN_LINES} = 80. So the free build inlined up to 10× more
+ * per hit than the paid one, and at 5-8 hits a single `ask` could return several
+ * hundred lines. That is the bulk of what the SWE-bench graft arm was paying for.
+ *
+ * The rule is kind-aware, because "first N lines" is the wrong answer for a
+ * container: functions get their opening (signature, docstring, first
+ * statements — where the contract lives), containers get their member
+ * signatures. Both truncate to a marker naming the pointer and `--full`.
+ *
+ * It is deterministic and structural, so it can be honestly worse than the LLM
+ * crux on one shape: a long function whose interesting branch is far down. The
+ * 80-line cap did not reach that either.
+ */
+function ruleCrux(
+  root: string,
+  node: NodeV1 | undefined,
+  graph: GraphV1,
+  s: { path: string; from: number; to: number },
+): string | null {
+  const full = sliceSpanRaw(root, s.path, s.from, s.to);
+  if (!full) return null;
+  const lines = full.split("\n");
+  if (node && CONTAINER_KINDS.has(node.kind)) {
+    const c = containerCrux(node, graph, lines[0] ?? "");
+    if (c) return c;
+  }
+  if (lines.length <= RULE_CRUX_LINES) return full;
+  const head = lines.slice(0, RULE_CRUX_LINES);
+  head.push(
+    `… (+${lines.length - RULE_CRUX_LINES} more lines; full definition at ` +
+      `${s.path}:L${s.from}-L${s.to}; rerun with --full)`,
+  );
+  return head.join("\n");
+}
+
+/** Read span lines with no cap — the rule crux does its own truncation. */
+function sliceSpanRaw(root: string, path: string, from: number, to: number): string | null {
+  try {
+    const source = readSourceFile(join(root, path));
+    if (source === null) return null;
+    const lines = source.split("\n");
+    return lines.slice(Math.max(1, from) - 1, Math.min(lines.length, to)).join("\n");
+  } catch {
+    return null;
+  }
+}
+
 /** Attach inlined source to every hit whose pointer is a real `path:span`.
  * Crux-first: when the graph carries an LLM-chosen crux for the hit's node and
  * `full` is off, inline that ≤8-line excerpt (with an escalation marker) rather
  * than the whole definition — most hits only need the decision point, and the
- * marker tells the agent exactly how to get the rest when this one doesn't. */
+ * marker tells the agent exactly how to get the rest when this one doesn't.
+ * With no LLM crux, {@link ruleCrux} builds one from structure at the same size,
+ * so a keyless build is not silently 10× more expensive per hit. */
 function inlineSource(root: string, hits: AskHit[], graph: GraphV1 | null, full: boolean): void {
   const cruxByPointer = new Map<string, string>();
+  const nodeByPointer = new Map<string, NodeV1>();
   if (!full && graph) {
-    for (const n of graph.nodes)
-      if (n.crux?.code) cruxByPointer.set(`${n.path}:${n.span}`, n.crux.code);
+    for (const n of graph.nodes) {
+      const key = `${n.path}:${n.span}`;
+      if (n.crux?.code) cruxByPointer.set(key, n.crux.code);
+      if (!nodeByPointer.has(key)) nodeByPointer.set(key, n);
+    }
   }
   for (const h of hits) {
     const s = parseSpan(h.pointer);
@@ -780,6 +880,13 @@ function inlineSource(root: string, hits: AskHit[], graph: GraphV1 | null, full:
     if (crux) {
       h.code = `${crux}\n… (crux — full definition at ${h.pointer}; rerun with --full)`;
       continue;
+    }
+    if (!full && graph) {
+      const rule = ruleCrux(root, nodeByPointer.get(h.pointer), graph, s);
+      if (rule) {
+        h.code = rule;
+        continue;
+      }
     }
     const code = sliceSpan(root, s.path, s.from, s.to);
     if (code) h.code = code;

--- a/src/cli-meta.ts
+++ b/src/cli-meta.ts
@@ -147,3 +147,28 @@ export function runUpgrade(moduleUrl: string): UpgradeResult {
   const newVersion = readGlobalInstalledVersion(PKG_NAME) ?? getNpmViewVersion(PKG_NAME).version ?? oldVersion;
   return { ran: true, ok: true, oldVersion, newVersion };
 }
+
+/** Which LLM layers a `graft build` invocation should actually run.
+ *
+ * There are two, with very different economics, and they were previously
+ * conflated under one `--deep` boolean resolved inline in the action handler:
+ *
+ *   concepts — the prose map in `graft/*.md`. One summarize call per file plus a
+ *              synthesis pass over batches. The most expensive layer.
+ *   meaning  — per-symbol summary + crux on the wiring nodes. One call per file,
+ *              and the crux is what caps an `ask` hit at ~8 lines instead of the
+ *              whole definition span.
+ *
+ * Only the second one pays off per token, so `--crux` buys it alone. Neither can
+ * run without a key; a keyless build still gets a rule-built crux at `ask` time,
+ * which is close in size but not in judgement — hence the wording of the warning.
+ */
+export function resolveBuildLayers(opts: {
+  deep?: boolean;
+  crux?: boolean;
+  hasApiKey: boolean;
+}): { concepts: boolean; llm: boolean; degraded: boolean } {
+  const wanted = !!(opts.deep || opts.crux);
+  if (wanted && !opts.hasApiKey) return { concepts: false, llm: false, degraded: true };
+  return { concepts: !!opts.deep, llm: wanted, degraded: false };
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,7 +32,7 @@ import { formatInitEpilogue } from "./cli-epilogue.js";
 import { planInit, selectedWrites } from "./hosts/plan.js";
 import { formatNonInteractiveHelp, formatPlan, runPicker } from "./cli-picker.js";
 import { homedir } from "node:os";
-import { formatUpgradeReport, formatVersionReport, getNpmViewVersion, readCurrentVersion, runUpgrade } from "./cli-meta.js";
+import { formatUpgradeReport, formatVersionReport, getNpmViewVersion, readCurrentVersion, resolveBuildLayers, runUpgrade } from "./cli-meta.js";
 import { writeBuildConfig } from "./util/state.js";
 
 const program = new Command();
@@ -117,6 +117,13 @@ program
   )
   .argument("[dir]", "repository root", ".")
   .option("--deep", "run the LLM pass: concept nodes (graft/*.md) + per-symbol summary/crux")
+  .option(
+    "--crux",
+    "the LLM pass WITHOUT the prose concept map: per-symbol summary/crux only. " +
+      "Roughly half the calls of --deep (no per-file concept summaries, no synthesis) " +
+      "and it buys the thing that shrinks `ask` output most — an 8-line excerpt per hit " +
+      "instead of the whole span. Implied by --deep.",
+  )
   .option("-e, --extensions <exts...>", 'code extensions to include (e.g. ".ts" ".py")')
   .option("-j, --concurrency <n>", "files summarized in parallel during --deep (default 5)")
   .option("--no-reuse", "re-parse every file instead of replaying unchanged ones from the extraction cache")
@@ -127,7 +134,7 @@ program
     (val: string, prev: string[]) => [...prev, val],
     [] as string[],
   )
-  .action(async (dir: string, opts: { deep?: boolean; extensions?: string[]; concurrency?: string; reuse?: boolean; includeDir?: string[] }) => {
+  .action(async (dir: string, opts: { deep?: boolean; crux?: boolean; extensions?: string[]; concurrency?: string; reuse?: boolean; includeDir?: string[] }) => {
     const concurrency = opts.concurrency ? Math.max(1, Number(opts.concurrency)) : undefined;
     if (opts.concurrency && !Number.isFinite(concurrency)) {
       console.error(`✗ --concurrency must be a number, got "${opts.concurrency}"`);
@@ -161,18 +168,27 @@ program
         .map(([k, n]) => `${n} ${k}`)
         .join(", ");
 
-    // --deep needs a key; without one, degrade to the $0 structural build.
-    let deep = opts.deep;
+    // Two independent LLM layers. `--deep` is both; `--crux` is only the second.
+    //   concepts — the prose map in graft/*.md (one summarize call per file, plus
+    //               a synthesis pass). Expensive, and its output is prose.
+    //   meaning   — per-symbol summary + crux on the wiring nodes. One call per
+    //               file, and the crux is what caps `ask` at ~8 lines per hit.
+    // Splitting them exists because the second is what pays off per token: a
+    // keyless build falls back to a rule-built crux, which is close in size but
+    // not in judgement.
     const resolved = resolveConfig(cliConfig());
-    if (deep && !resolved.apiKey) {
-      deep = false;
+    const layers = resolveBuildLayers({ deep: opts.deep, crux: opts.crux, hasApiKey: !!resolved.apiKey });
+    const deep = layers.concepts;
+    const llm = layers.llm;
+    if (layers.degraded) {
       console.error(
         "⚠ no API key set — falling back to the structural build (no LLM summaries).\n" +
+          "  `ask` still truncates each hit to a rule-built crux, so the pack stays small.\n" +
           "  Set GRAFT_API_KEY (and GRAFT_PROVIDER / GRAFT_BASE_URL / GRAFT_MODEL for your\n" +
-          "  provider) and re-run `graft build --deep` to add concept nodes and summaries.",
+          "  provider) and re-run to add LLM-chosen cruxes.",
       );
     }
-    if (deep && resolved.usedLegacyEnv) {
+    if (llm && resolved.usedLegacyEnv) {
       console.error(
         "⚠ using OPENROUTER_API_KEY (deprecated) — prefer GRAFT_API_KEY + GRAFT_BASE_URL.",
       );
@@ -184,6 +200,7 @@ program
     if (isWorkspaceBuildRoot(buildRoot, buildGlobalDir)) {
       await runWorkspaceBuild(buildRoot, {
         deep: !!deep,
+        llm,
         extensions: opts.extensions,
         concurrency,
         childConfig: cliConfig(),
@@ -211,7 +228,7 @@ program
 
     // Wiring graph — always; LLM meaning only with --deep.
     const g = await engine.graph(dir, {
-      llm: deep,
+      llm,
       concurrency,
       reuse: opts.reuse,
       onProgress: ({ phase, index, total, file }) =>
@@ -224,7 +241,7 @@ program
     console.log(`  parsed: ${g.parsed} of ${g.files} files (${g.reused} replayed from cache)`);
     // Worth one line: this build started from a graph the user never built *here*.
     if (g.seededFrom) console.log(`  seeded: copied a starting graph from ${g.seededFrom} (git worktree)`);
-    if (deep) {
+    if (llm) {
       const m = g.meaning;
       console.log(`  meaning: ${m.computed} computed, ${m.cached} cached, ${m.stale} stale, ${m.pending} pending`);
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -268,7 +268,7 @@ program
       console.log(JSON.stringify(r, null, 2));
     } else {
       const { formatAsk } = await import("./ask/ask.js");
-      process.stdout.write(formatAsk(r));
+      process.stdout.write(formatAsk(r, { force: !!opts.full }));
     }
   });
 

--- a/src/graph/workspace-cli.ts
+++ b/src/graph/workspace-cli.ts
@@ -80,7 +80,7 @@ export function runWorkspaceAsk(
 ): void {
   const r = federateAsk(root, override, query, { limit: opts.limit, source: opts.source, full: opts.full, in: opts.in });
   if (opts.json) console.log(JSON.stringify(r, null, 2));
-  else process.stdout.write(formatAsk(r));
+  else process.stdout.write(formatAsk(r, { force: !!opts.full }));
 }
 
 export function runWorkspaceGrep(

--- a/src/graph/workspace-cli.ts
+++ b/src/graph/workspace-cli.ts
@@ -24,7 +24,11 @@ import {
 } from "./workspace.js";
 
 export interface WorkspaceBuildOptions {
+  /** Run the prose concept pass (graft/*.md) on each child. `--deep` only. */
   deep: boolean;
+  /** Run the per-symbol summary/crux pass on each child. Set by `--deep` OR
+   * `--crux`; kept separate so `--crux` does not drag the prose pass along. */
+  llm?: boolean;
   extensions?: string[];
   concurrency?: number;
   /** Provider/model/key config for child builds — WITHOUT any contextDir
@@ -51,7 +55,7 @@ export async function runWorkspaceBuild(root: string, opts: WorkspaceBuildOption
     }
     const engine = new Graft({ ...opts.childConfig, contextDir: undefined });
     if (opts.deep) await engine.init(childDir, { extensions: opts.extensions });
-    const g = await engine.graph(childDir, { llm: opts.deep, concurrency: opts.concurrency });
+    const g = await engine.graph(childDir, { llm: opts.llm ?? opts.deep, concurrency: opts.concurrency });
     console.log(`✓ ${childName}/: ${g.nodes} nodes, ${g.edges} edges, ${g.cards} cards [${g.languages.join(", ")}]`);
     for (const e of g.errors) console.error(`✗ ${childName}/: ${e}`);
   };

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -161,7 +161,7 @@ function callWorkspaceTool(
       const limit = typeof args.limit === 'number' ? args.limit : 5;
       const inArg = typeof args.in === 'string' && args.in ? args.in : undefined;
       const r = federateAsk(root, dirOverride, query, { limit, source: true, full: args.full === true, in: inArg });
-      return { text: formatAsk(r), isError: false };
+      return { text: formatAsk(r, { force: args.full === true }), isError: false };
     }
     case 'graft_trace_calls': {
       const symbol = String(args.symbol ?? args.file ?? '');
@@ -267,7 +267,7 @@ function callSingleTool(
         const engine = new Graft({ contextDir: dirOverride });
         const inArg = typeof args.in === 'string' && args.in ? args.in : undefined;
         const r = engine.ask(root, query, { limit, source: true, full: args.full === true, in: inArg });
-        return { text: formatAsk(r), isError: false };
+        return { text: formatAsk(r, { force: args.full === true }), isError: false };
       }
       case 'graft_file_api': {
         const file = String(args.file ?? '');

--- a/test/ask.test.ts
+++ b/test/ask.test.ts
@@ -12,7 +12,7 @@ import { tmpdir } from "node:os";
 import { readFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { buildGraph } from "../src/graph/build.js";
-import { ask, formatAsk, skeleton, formatSkeleton, isTestPath } from "../src/ask/ask.js";
+import { ask, formatAsk, isWeakMatch, skeleton, formatSkeleton, isTestPath } from "../src/ask/ask.js";
 
 test("isTestPath: de-ranks test files, not real source", () => {
   for (const p of ["server/download_test.go", "packages/x/tests/foo.test.tsx", "a/__tests__/b.ts", "src/api.spec.ts", "pkg/foo/bar_test.go"])
@@ -809,6 +809,75 @@ test("ask with source inlines the actual span from disk", async () => {
     assert.match(hit.code, /return a \+ b;/, "inlined code is the real definition body");
     // formatAsk renders it as a fenced block so it drops into agent context.
     assert.match(formatAsk(r), /```[\s\S]*return a \+ b;[\s\S]*```/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+/**
+ * The pull-channel strength gate.
+ *
+ * `relevantRetrieval` (claude/format.ts) has gated the PUSH channel on
+ * STRONG_FLOOR / HIGH_FLOOR for a while. The pull channel had no such gate: a
+ * query the retriever scored 0.05 came back with its full top-N and source
+ * inlined, rendered identically to a 0.9 match. That is what made the
+ * django-13121 SWE-bench regression possible — a forced `graft ask` on a
+ * no-strong-match problem statement inlined 6,289 chars of the wrong code and
+ * the episode timed out at +28% tokens.
+ *
+ * The fixture query below shares no term with any symbol NAME, so it lands
+ * under both floors while still producing hits.
+ */
+test("weak lexical match: pointers only, no inlined source, and a named next move", async () => {
+  const dir = makeFixture();
+  try {
+    await buildGraph(dir);
+    const r = ask(dir, "intermittent flakiness during nightly deployment windows", { source: true });
+    if (!r.hits.length) return; // nothing matched at all; the empty path covers that
+    assert.ok(isWeakMatch(r), "this query should score under both floors");
+    const out = formatAsk(r);
+    assert.doesNotMatch(out, /```/, "a weak pack must not inline source");
+    assert.match(out, /LOW CONFIDENCE/, "the pack must say it is unsure");
+    assert.match(out, /graft grep/, "and must name the productive next tool");
+    assert.doesNotMatch(out, /tokens saved/, "a weak pack must not claim a saving for answering less");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("weak lexical match: --full/force overrules the gate and inlines source", async () => {
+  const dir = makeFixture();
+  try {
+    await buildGraph(dir);
+    const r = ask(dir, "intermittent flakiness during nightly deployment windows", { source: true });
+    if (!r.hits.length || !r.hits.some((h) => h.code)) return;
+    const out = formatAsk(r, { force: true });
+    assert.match(out, /```/, "an explicit --full is the caller overruling the score on purpose");
+    assert.doesNotMatch(out, /LOW CONFIDENCE/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("strong lexical match is untouched by the gate: source still inlined", async () => {
+  const dir = makeFixture();
+  try {
+    await buildGraph(dir);
+    const r = ask(dir, "addNumbers", { source: true });
+    assert.ok(!isWeakMatch(r), "an exact symbol-name hit is not weak");
+    assert.match(formatAsk(r), /```[\s\S]*return a \+ b;[\s\S]*```/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("structural results are never gated — a resolved who-calls IS the answer", async () => {
+  const dir = makeFixture();
+  try {
+    await buildGraph(dir);
+    const r = ask(dir, "callers of addNumbers", { source: true });
+    if (r.mode !== "structural") return;
+    assert.ok(!isWeakMatch(r), "structural mode carries no coverage score and must never be weak");
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/test/ask.test.ts
+++ b/test/ask.test.ts
@@ -882,3 +882,94 @@ test("structural results are never gated — a resolved who-calls IS the answer"
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+/** Fixture with the two shapes the rule crux treats differently: a container
+ * whose value is its member list, and a function far longer than the crux
+ * budget but still under the old 80-line span cap — i.e. a definition the old
+ * fallback inlined in full. */
+function ruleCruxFixture(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graft-rulecrux-"));
+  const body = Array.from({ length: 60 }, (_, i) => `    step_${i} = compute(value, ${i})`).join("\n");
+  writeFileSync(
+    join(dir, "engine.py"),
+    `class DurationEngine:\n` +
+      `    """Handles duration arithmetic across backends."""\n\n` +
+      `    def __init__(self, connection):\n        self.connection = connection\n\n` +
+      `    def as_sqlite(self, compiler, connection):\n        return "sqlite"\n\n` +
+      `    def as_mysql(self, compiler, connection):\n        return "mysql"\n\n\n` +
+      `def temporal_subtraction(value, connection):\n` +
+      `    """Subtract two temporal values."""\n` +
+      `    if value is None:\n        return None\n${body}\n    return step_59\n`,
+  );
+  return dir;
+}
+
+/**
+ * Without an API key there is no LLM crux, and the fallback used to be the whole
+ * definition capped at MAX_SPAN_LINES = 80 — so a keyless build inlined up to 10x
+ * more per hit than a paid one. That gap is most of what the SWE-bench graft arm
+ * was paying for, since its container builds structurally on purpose.
+ */
+test("rule crux: a long function inlines its opening, not the whole span", async () => {
+  const dir = ruleCruxFixture();
+  try {
+    await buildGraph(dir); // structural: no summarizer, so no LLM crux
+    const r = ask(dir, "temporal_subtraction", { source: true });
+    const hit = r.hits.find((h) => h.title.startsWith("temporal_subtraction"));
+    assert.ok(hit?.code, "source should be inlined");
+    assert.match(hit.code, /def temporal_subtraction/, "keeps the signature");
+    assert.match(hit.code, /Subtract two temporal values/, "keeps the docstring");
+    assert.match(hit.code, /more lines; full definition at/, "marks the truncation and the pointer");
+    assert.doesNotMatch(hit.code, /step_59/, "must not reach the end of a 60-line body");
+    assert.ok(hit.code.split("\n").length <= 10, `crux stayed small (got ${hit.code.split("\n").length} lines)`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("rule crux: a class inlines its member signatures, not its first lines", async () => {
+  const dir = ruleCruxFixture();
+  try {
+    await buildGraph(dir);
+    const r = ask(dir, "DurationEngine", { source: true });
+    const hit = r.hits.find((h) => h.title.startsWith("DurationEngine · class"));
+    assert.ok(hit?.code, "source should be inlined");
+    // The whole API, which is what a container is FOR — not the __init__ body.
+    for (const m of ["__init__", "as_sqlite", "as_mysql"])
+      assert.ok(hit.code.includes(m), `member ${m} should be listed`);
+    assert.doesNotMatch(hit.code, /self\.connection = connection/, "member bodies are not inlined");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("rule crux: --full still returns the whole span", async () => {
+  const dir = ruleCruxFixture();
+  try {
+    await buildGraph(dir);
+    const r = ask(dir, "temporal_subtraction", { source: true, full: true });
+    const hit = r.hits.find((h) => h.title.startsWith("temporal_subtraction"));
+    assert.ok(hit?.code, "source should be inlined");
+    assert.match(hit.code, /step_59/, "--full is the escape hatch and must not be truncated to a crux");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("rule crux never overrides an LLM crux when the graph carries one", async () => {
+  const dir = ruleCruxFixture();
+  try {
+    await buildGraph(dir);
+    const p = join(dir, "graft", ".graph", "wiring.json");
+    const g = JSON.parse(readFileSync(p, "utf8"));
+    const node = g.nodes.find((n: { name: string }) => n.name === "temporal_subtraction");
+    assert.ok(node, "fixture node should exist");
+    node.crux = { code: "LLM_CHOSEN_EXCERPT" };
+    writeFileSync(p, JSON.stringify(g));
+    const r = ask(dir, "temporal_subtraction", { source: true });
+    const hit = r.hits.find((h) => h.title.startsWith("temporal_subtraction"));
+    assert.match(hit!.code!, /LLM_CHOSEN_EXCERPT/, "a paid crux still wins over the rule");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/cli-meta.test.ts
+++ b/test/cli-meta.test.ts
@@ -9,6 +9,7 @@ import {
   resolvePackageJsonPath,
   readCurrentVersion,
   isRunningViaNpx,
+  resolveBuildLayers,
 } from '../src/cli-meta.js';
 
 // --- formatVersionReport: pure formatting, injected npm-view results (no network) ---
@@ -86,4 +87,35 @@ test('isRunningViaNpx is false for a regular global install', () => {
     join(sep, 'usr', 'local', 'lib', 'node_modules', '@nanonets', 'graft', 'dist', 'cli.js'),
   ).href;
   assert.equal(isRunningViaNpx(globalPath), false);
+});
+
+
+// --- resolveBuildLayers: which LLM passes a build actually runs ---
+
+test('resolveBuildLayers: default build runs neither LLM layer', () => {
+  assert.deepEqual(resolveBuildLayers({ hasApiKey: true }), { concepts: false, llm: false, degraded: false });
+});
+
+test('resolveBuildLayers: --deep runs both layers', () => {
+  assert.deepEqual(resolveBuildLayers({ deep: true, hasApiKey: true }), { concepts: true, llm: true, degraded: false });
+});
+
+/** The whole point of the flag: the crux without the prose bill. */
+test('resolveBuildLayers: --crux runs meaning only, never the concept pass', () => {
+  assert.deepEqual(resolveBuildLayers({ crux: true, hasApiKey: true }), { concepts: false, llm: true, degraded: false });
+});
+
+test('resolveBuildLayers: --deep --crux is still --deep, not an error', () => {
+  assert.deepEqual(resolveBuildLayers({ deep: true, crux: true, hasApiKey: true }), { concepts: true, llm: true, degraded: false });
+});
+
+/** No key degrades to the structural build rather than failing: `ask` still
+ * truncates with a rule-built crux, so the pack stays small either way. */
+test('resolveBuildLayers: no API key degrades both layers off and flags it', () => {
+  assert.deepEqual(resolveBuildLayers({ deep: true, hasApiKey: false }), { concepts: false, llm: false, degraded: true });
+  assert.deepEqual(resolveBuildLayers({ crux: true, hasApiKey: false }), { concepts: false, llm: false, degraded: true });
+});
+
+test('resolveBuildLayers: no key with no flags is not a degradation', () => {
+  assert.equal(resolveBuildLayers({ hasApiKey: false }).degraded, false);
 });


### PR DESCRIPTION
Two changes to what `graft ask` returns.

**`4ff0873` — gate the pull channel on match strength**

`isWeakMatch()` in `src/ask/ask.ts` suppresses the source pack when a lexical
result is below both floors (`coverageStrong < STRONG_FLOOR`, `coverage <
HIGH_FLOOR`). A weak pack now returns 3 pointers and no inlined source instead
of a full pack with a savings footer. `--full` bypasses the gate.

**`abdb043` — rule-built crux for keyless builds**

`ruleCrux()` builds a <=8-line crux deterministically, with no LLM and no API
key: signature plus the first meaningful lines for a function, a member
signature list for a class/interface/struct/trait/enum. `inlineSource()` falls
back to it before `sliceSpan`. Measured on one long function: 2848 -> 1071
chars (-62%). Adds `--crux` to build the LLM crux layer without concept nodes,
and `resolveBuildLayers()` in `src/cli-meta.ts` so layer selection is testable.

Tests: 13 new (7 in `test/ask.test.ts`, 6 in `test/cli-meta.test.ts`).

---

**On the benchmark numbers in README.md**

This branch does not change README.md. The SWE-bench table on main (commit
`00c9cc4`) covers 20 instances, and they were not all measured on this code:

- 11 instances ran on this branch's build (`graft-fix12-abdb043.tgz`, v0.9.0)
- 9 instances ran 2026-08-04 on npm 0.8.2, two days before these commits
  existed, under the older harness that still had web access enabled

Merging this makes the 11 the current behaviour. The 9 would need re-running to
put the whole table on one version.