### PR TITLE
Add C/C++ to the Tier-1 symbol extractor; make unsupported languages fail loudly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **C/C++ in the Tier-1 symbol graph (definitions-only)** — `.c`, `.h`, `.cpp`,
+  `.cc`, `.cxx`, `.hpp`, `.hh`, `.hxx` are parsed with `tree-sitter-cpp`, so
+  `skeleton`, `grep` and `ask` now cover C/C++ repos: free functions, inline
+  and out-of-class methods (`Physics::step` → method with owner `Physics`),
+  classes, structs and enums, found through namespaces and template wrappers.
+  Prototypes and forward declarations are not definitions and are skipped.
+  Deliberately definitions-only: C++ has no import bindings (only `#include`,
+  namespaces, overloads, templates), so name-only call resolution would
+  fabricate edges between every same-named method in the repo — `callers` on a
+  C/C++ symbol says "no edge data … definitions-only" instead of answering
+  wrongly, and points at `graft grep` ([#66]).
+
+### Fixed
+
+- **Unsupported languages fail loudly instead of masquerading as answers.**
+  On a repo whose code has no Tier-1 parser, `grep`/`callers`/`skeleton`
+  returned confident false negatives ("no hits … all indexed code was
+  searched", "no symbol — check spelling", "no definitions indexed") that
+  steered callers away from raw grep, the only tool that would have worked.
+  Now: `graft build` prints `skipped: N files (no parser: …) — symbol tools
+  will not cover them` and records the gap in the graph (`meta.unindexed`);
+  zero-hit grep, unknown-symbol callers (single-repo and workspace) and
+  skeleton name the no-parser gap and point at raw grep/read; and the MCP
+  `instructions` scope the "prefer these tools over grep/read" claim to the
+  languages actually indexed ([#66]).
+
+[#66]: https://github.com/NanoNets/Graft/issues/66
+
 ## 0.9.0
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,20 @@
 {
   "name": "@nanonets/graft",
+<<<<<<< HEAD
   "version": "0.9.1",
+=======
+  "version": "0.9.0",
+>>>>>>> 8ef2fa4 (Add C/C++ to the Tier-1 extractor; make unsupported languages fail loudly)
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nanonets/graft",
+<<<<<<< HEAD
       "version": "0.9.1",
+=======
+      "version": "0.9.0",
+>>>>>>> 8ef2fa4 (Add C/C++ to the Tier-1 extractor; make unsupported languages fail loudly)
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16,6 +24,7 @@
         "gray-matter": "^4.0.3",
         "openai": "^6.45.0",
         "tree-sitter": "^0.21.1",
+        "tree-sitter-cpp": "^0.23.4",
         "tree-sitter-go": "^0.23.4",
         "tree-sitter-python": "^0.21.0",
         "tree-sitter-typescript": "^0.23.2"
@@ -849,6 +858,45 @@
       "dependencies": {
         "node-addon-api": "^8.0.0",
         "node-gyp-build": "^4.8.0"
+      }
+    },
+    "node_modules/tree-sitter-c": {
+      "version": "0.23.6",
+      "resolved": "https://registry.npmjs.org/tree-sitter-c/-/tree-sitter-c-0.23.6.tgz",
+      "integrity": "sha512-0dxXKznVyUA0s6PjNolJNs2yF87O5aL538A/eR6njA5oqX3C3vH4vnx3QdOKwuUdpKEcFdHuiDpRKLLCA/tjvQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.22.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-cpp": {
+      "version": "0.23.4",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cpp/-/tree-sitter-cpp-0.23.4.tgz",
+      "integrity": "sha512-qR5qUDyhZ5jJ6V8/umiBxokRbe89bCGmcq/dk94wI4kN86qfdV8k0GHIUEKaqWgcu42wKal5E97LKpLeVW8sKw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.1",
+        "node-gyp-build": "^4.8.2",
+        "tree-sitter-c": "^0.23.1"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
       }
     },
     "node_modules/tree-sitter-go": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "gray-matter": "^4.0.3",
     "openai": "^6.45.0",
     "tree-sitter": "^0.21.1",
+    "tree-sitter-cpp": "^0.23.4",
     "tree-sitter-go": "^0.23.4",
     "tree-sitter-python": "^0.21.0",
     "tree-sitter-typescript": "^0.23.2"

--- a/src/ask/ask.ts
+++ b/src/ask/ask.ts
@@ -18,6 +18,7 @@ import { join, resolve } from "node:path";
 import matter from "gray-matter";
 import { contextDirFor } from "../context/node-file.js";
 import { withSavings, savingsFor, SAVINGS_TURN_NUDGE, type Savings } from "../context/savings.js";
+import { unsupportedFileNote } from "../graph/coverage.js";
 import { loadGraphCached, loadAskIndexCached } from "../graph/load.js";
 import {
   assertPrefixIndexed,
@@ -887,7 +888,12 @@ export function skeleton(dir: string, file: string, opts: { contextDir?: string 
     const [path] = matches;
     if (path) defs = graph.nodes.filter((n) => n.kind !== "file" && n.path === path);
   }
-  if (!defs.length) return { file, entries: [], note: "no definitions indexed for this file" };
+  if (!defs.length) {
+    // "no definitions indexed" on a language with no parser is a confident
+    // false negative — the honest answer is "no parser" (issue #66).
+    const unsupported = unsupportedFileNote(file);
+    return { file, entries: [], note: unsupported ?? "no definitions indexed for this file" };
+  }
 
   const startLine = (span: string) => Number(span.match(/^L(\d+)/)?.[1] ?? 0);
   defs.sort((a, b) => startLine(a.span) - startLine(b.span));

--- a/src/claude/skill-template.ts
+++ b/src/claude/skill-template.ts
@@ -50,7 +50,9 @@ enclosing symbol** and ranked by coupling; it also reports files it couldn't rea
   and signature, keep the bare name) and retry \`graft grep\` — do NOT switch to
   raw \`grep -rn\`, which is slower and unranked.
 - \`-i\` case-insensitive; \`--in <path>\` scopes to a subtree. Raw \`grep -rn\` is
-  only for files graft genuinely doesn't index (docs, configs, brand-new files).
+  for files graft doesn't index: docs, configs, brand-new files — and any
+  language \`graft build\` reported as \`skipped:\` (no parser); a zero-hit graft
+  grep on those is a coverage gap, not an answer.
 
 ### 3 · \`graft skeleton <file>\`: a file's API at a glance
 Signatures-only view of one file (every function / method / type with its span)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,6 +28,7 @@ import {
   runWorkspaceGrep,
   runWorkspaceMap,
 } from "./graph/workspace-cli.js";
+import { skippedLine } from "./graph/coverage.js";
 import { formatInitEpilogue } from "./cli-epilogue.js";
 import { planInit, selectedWrites } from "./hosts/plan.js";
 import { formatNonInteractiveHelp, formatPlan, runPicker } from "./cli-picker.js";
@@ -222,6 +223,10 @@ program
     process.stderr.write("\n");
     console.log(`✓ wiring: ${g.nodes} nodes (${fmt(g.byKind)}), ${g.edges} edges, ${g.cards} cards [${g.languages.join(", ")}]`);
     console.log(`  parsed: ${g.parsed} of ${g.files} files (${g.reused} replayed from cache)`);
+    // Never silent about coverage: code with no parser looks exactly like code
+    // with no matches once queries run (issue #66).
+    const skippedNote = skippedLine(g.skipped);
+    if (skippedNote) console.log(`  ${skippedNote}`);
     // Worth one line: this build started from a graph the user never built *here*.
     if (g.seededFrom) console.log(`  seeded: copied a starting graph from ${g.seededFrom} (git worktree)`);
     if (deep) {

--- a/src/graph/build.ts
+++ b/src/graph/build.ts
@@ -37,6 +37,7 @@ import { readGraph, writeGraph, wiringPath } from "./write.js";
 import { writeCards, writeIndex, writeCovers, type CardStats } from "./cards.js";
 import { writeAskIndex } from "../ask/index-file.js";
 import { discoverScopes, scopeOf } from "./scopes.js";
+import { unindexedCodeStats, type UnindexedStat } from "./coverage.js";
 import type { GraphV1, Kind, NodeV1, Relation, ScopeV1 } from "./types.js";
 import type { CruxSummarizer } from "../ai/crux.js";
 
@@ -108,6 +109,8 @@ export interface GraphBuildResult {
   byKind: Record<Kind, number>;
   byRelation: Record<Relation, number>;
   languages: string[];
+  /** Code-like files no Tier-1 grammar parses — never silent (issue #66). */
+  skipped: UnindexedStat[];
   meaning: EnrichStats;
   errors: string[];
 }
@@ -149,6 +152,9 @@ export async function buildGraph(
   const repoFiles = walkDir(root, readIncludeDirs(root));
   const files = listSourceStats(root, outDir, repoFiles);
   const discoveredScopes = discoverScopes(root, repoFiles);
+  // Code the walk saw but no grammar can parse — reported in the banner and
+  // recorded in the graph so queries can say "no parser" instead of "no hits".
+  const skipped = unindexedCodeStats(repoFiles.filter((f) => !f.startsWith(outDir)));
 
   const nodes: NodeV1[] = [];
   const rawEdges: RawEdge[] = [];
@@ -274,6 +280,7 @@ export async function buildGraph(
       edgeCount: edges.length,
       languages: [...langs].sort(),
       scopes,
+      ...(skipped.length > 0 ? { unindexed: skipped } : {}),
     },
     nodes,
     edges,
@@ -347,6 +354,7 @@ export async function buildGraph(
     byKind,
     byRelation,
     languages: [...langs].sort(),
+    skipped,
     meaning,
     errors,
   };

--- a/src/graph/coverage.ts
+++ b/src/graph/coverage.ts
@@ -1,0 +1,94 @@
+/**
+ * What the Tier-1 symbol graph does NOT cover, and how to say so (issue #66).
+ *
+ * The concept pass (`--deep`) and the symbol pass disagree about which
+ * languages they support: {@link CODE_EXTENSIONS} is what the concept pass
+ * reads as code, while `extract.ts` parses only the extensions it has a
+ * grammar for. On a repo in the gap (Rust, Java, …), the symbol tools used to
+ * return confident false negatives — "no hits", "no symbol", "no definitions"
+ * — and even steered callers away from raw grep, the one tool that would have
+ * worked. This module computes the gap at build time and phrases it honestly
+ * at query time.
+ */
+import { CODE_EXTENSIONS } from "../context/build.js";
+import { languageOf } from "./extract.js";
+
+/** One unparseable code extension and how many files carry it. */
+export interface UnindexedStat {
+  ext: string;
+  files: number;
+}
+
+const CODE_EXT_SET = new Set(CODE_EXTENSIONS);
+
+function codeExtOf(path: string): string | null {
+  const dot = path.lastIndexOf(".");
+  if (dot < 0) return null;
+  const ext = path.slice(dot).toLowerCase();
+  return CODE_EXT_SET.has(ext) ? ext : null;
+}
+
+/**
+ * Count the code-like files (by {@link CODE_EXTENSIONS}) that no Tier-1
+ * grammar parses, grouped by extension, most files first. Docs, configs and
+ * other non-code files are not "skipped" — they were never expected to be in
+ * the symbol graph.
+ */
+export function unindexedCodeStats(files: string[]): UnindexedStat[] {
+  const counts = new Map<string, number>();
+  for (const f of files) {
+    if (languageOf(f) !== null) continue;
+    const ext = codeExtOf(f);
+    if (ext) counts.set(ext, (counts.get(ext) ?? 0) + 1);
+  }
+  return [...counts]
+    .map(([ext, n]) => ({ ext, files: n }))
+    .sort((a, b) => b.files - a.files || a.ext.localeCompare(b.ext));
+}
+
+/** The `graft build` banner line for skipped code, or null when nothing was.
+ * "skipped: 350 files (no parser: .h, .cpp) — symbol tools will not cover them" */
+export function skippedLine(stats: UnindexedStat[]): string | null {
+  if (stats.length === 0) return null;
+  const total = stats.reduce((n, s) => n + s.files, 0);
+  const exts = stats.map((s) => s.ext).join(", ");
+  return `skipped: ${total} file${total === 1 ? "" : "s"} (no parser: ${exts}) — symbol tools will not cover them`;
+}
+
+/**
+ * The sentence a zero-result answer appends so a coverage gap never reads as a
+ * fact about the code. Null when there is no gap (the current messages are
+ * already honest then).
+ */
+export function unindexedNote(stats: UnindexedStat[] | undefined): string | null {
+  if (!stats || stats.length === 0) return null;
+  const total = stats.reduce((n, s) => n + s.files, 0);
+  const exts = stats.map((s) => s.ext).join(", ");
+  const subject = `${total} source file${total === 1 ? "" : "s"} (${exts})`;
+  const clause = total === 1 ? "has no parser and is" : "have no parser and are";
+  return `${subject} ${clause} NOT in the symbol graph — if the target lives there, raw grep -rn / reading the file is the right tool`;
+}
+
+/** Sum per-extension counts across several graphs' `meta.unindexed` — the
+ * workspace-federated view of the same gap, most files first. */
+export function mergeUnindexed(lists: (UnindexedStat[] | undefined)[]): UnindexedStat[] {
+  const counts = new Map<string, number>();
+  for (const list of lists) {
+    for (const s of list ?? []) counts.set(s.ext, (counts.get(s.ext) ?? 0) + s.files);
+  }
+  return [...counts]
+    .map(([ext, files]) => ({ ext, files }))
+    .sort((a, b) => b.files - a.files || a.ext.localeCompare(b.ext));
+}
+
+/**
+ * For a single file the caller named (e.g. `graft skeleton enemy_ai.rs`): when
+ * its extension is code-like but unparseable, the honest answer is "no parser",
+ * not "no definitions". Null for supported or non-code files.
+ */
+export function unsupportedFileNote(path: string): string | null {
+  if (languageOf(path) !== null) return null;
+  const ext = codeExtOf(path);
+  if (!ext) return null;
+  return `this file's language has no parser (${ext}) — the symbol graph does not cover it; read the file or use raw grep -rn`;
+}

--- a/src/graph/extract.ts
+++ b/src/graph/extract.ts
@@ -10,12 +10,26 @@ import Parser from "tree-sitter";
 import TypeScript from "tree-sitter-typescript";
 import Python from "tree-sitter-python";
 import Go from "tree-sitter-go";
+import Cpp from "tree-sitter-cpp";
 import { basename } from "node:path";
 import { contentHash } from "../util/id.js";
 import { collectBindings, goReceiverVarOf, resolveRecvType, type FileBindings } from "./bindings.js";
 import type { Kind, NodeV1, Relation } from "./types.js";
 
-export type Language = "typescript" | "tsx" | "python" | "go";
+export type Language = "typescript" | "tsx" | "python" | "go" | "cpp";
+
+/**
+ * C/C++ is a definitions-only tier: nodes and `contains` edges, but no
+ * call/reference/import edges. Every other language resolves cross-file edges
+ * through import bindings; C++ has none (only #include, namespaces, overloads,
+ * templates), so name-only resolution would fabricate an edge between every
+ * same-named method in the repo (issue #66). Consumers use this to say
+ * honestly that edge data does not exist for a file, rather than answering
+ * "nothing calls this" from a graph that never could have known.
+ */
+export function hasEdgeExtraction(lang: Language): boolean {
+  return lang !== "cpp";
+}
 
 /**
  * Extension → the tree-sitter grammar that parses it, and the label a human expects
@@ -44,6 +58,17 @@ const EXTENSIONS: ReadonlyArray<{ ext: string; grammar: Language; label: string 
   { ext: ".pyi", grammar: "python", label: "python" },
   { ext: ".py", grammar: "python", label: "python" },
   { ext: ".go", grammar: "go", label: "go" },
+  // One grammar and one label for the whole C family: the cpp grammar parses C,
+  // and `.h` can't be attributed to either language from its name alone, so a
+  // split label would misreport every C repo's headers (or every C++ one's).
+  { ext: ".cpp", grammar: "cpp", label: "c/c++" },
+  { ext: ".cxx", grammar: "cpp", label: "c/c++" },
+  { ext: ".cc", grammar: "cpp", label: "c/c++" },
+  { ext: ".hpp", grammar: "cpp", label: "c/c++" },
+  { ext: ".hxx", grammar: "cpp", label: "c/c++" },
+  { ext: ".hh", grammar: "cpp", label: "c/c++" },
+  { ext: ".c", grammar: "cpp", label: "c/c++" },
+  { ext: ".h", grammar: "cpp", label: "c/c++" },
 ];
 
 function entryFor(path: string): (typeof EXTENSIONS)[number] | undefined {
@@ -149,11 +174,16 @@ const GO_KINDS: Record<string, Kind> = {
   method_declaration: "method",
 };
 
+// C/C++: empty on purpose — every definition shape depends on its declarator
+// (or on having a body at all), so describeCpp() resolves them dynamically.
+const CPP_KINDS: Record<string, Kind> = {};
+
 const KINDS_BY_LANG: Record<Language, Record<string, Kind>> = {
   typescript: TS_KINDS,
   tsx: TS_KINDS,
   python: PY_KINDS,
   go: GO_KINDS,
+  cpp: CPP_KINDS,
 };
 
 const FUNCTION_VALUE_TYPES = new Set([
@@ -169,6 +199,7 @@ const GRAMMARS: Record<Language, unknown> = {
   tsx: TypeScript.tsx,
   python: Python,
   go: Go,
+  cpp: Cpp,
 };
 
 export interface WalkCtx {
@@ -192,6 +223,10 @@ interface DefDescriptor {
   kind: Kind;
   headerEnd: number; // char index where the signature ends (body starts)
   hashNode: Parser.SyntaxNode; // node whose text forms body_hash / span
+  /** methods whose owner isn't the enclosing walk context: a C++ out-of-class
+   * definition (`Physics::step`) names its class in the declarator, not in any
+   * ancestor node. */
+  owner?: string;
 }
 
 /** tree-sitter's string `parse()` fails with "Invalid argument" on any input
@@ -284,7 +319,9 @@ function walk(node: Parser.SyntaxNode, ctx: WalkCtx, out: NodeV1[], edges: RawEd
     // class already set as ctx.enclosingClass. Only method nodes carry it — resolve.ts's
     // ownerMethod index is the sole consumer (see NodeV1.owner's doc comment).
     const owner: string | undefined =
-      desc.kind === "method" ? (isGoMethod ? (goReceiverType(node) ?? undefined) : (ctx.enclosingClass ?? undefined)) : undefined;
+      desc.kind === "method"
+        ? (desc.owner ?? (isGoMethod ? (goReceiverType(node) ?? undefined) : (ctx.enclosingClass ?? undefined)))
+        : undefined;
     out.push({
       id,
       name: desc.name,
@@ -297,7 +334,9 @@ function walk(node: Parser.SyntaxNode, ctx: WalkCtx, out: NodeV1[], edges: RawEd
           ? !desc.name.startsWith("_")
           : ctx.lang === "go"
             ? goExported(desc.name)
-            : tsExported(node),
+            : ctx.lang === "cpp"
+              ? true // no module system at Tier-1; linkage analysis is out of scope
+              : tsExported(node),
       origin: "ast",
       body_hash: contentHash(desc.hashNode.text),
       body_text: searchBody(desc.hashNode.text),
@@ -311,7 +350,11 @@ function walk(node: Parser.SyntaxNode, ctx: WalkCtx, out: NodeV1[], edges: RawEd
     // class heritage
     if (desc.kind === "class") edges.push(...heritageEdges(node, id, ctx));
 
-    const enclosingClass = desc.kind === "class" ? desc.name : isGoMethod ? goReceiverType(node) : ctx.enclosingClass;
+    // structs count: a C++ struct is a class with default-public members, and its
+    // inline methods need an owner just like a class's. (Go structs never contain
+    // definitions, so including "struct" here is a no-op for them.)
+    const enclosingClass =
+      desc.kind === "class" || desc.kind === "struct" ? desc.name : isGoMethod ? goReceiverType(node) : ctx.enclosingClass;
     const childCtx: WalkCtx = {
       ...ctx,
       scope: [...ctx.scope, idPart],
@@ -325,6 +368,15 @@ function walk(node: Parser.SyntaxNode, ctx: WalkCtx, out: NodeV1[], edges: RawEd
           : ctx.importedSymbols,
     };
     for (const child of node.namedChildren) walk(child, childCtx, out, edges, minted);
+    return;
+  }
+
+  // Definitions-only language (C/C++): descend for nested definitions but emit no
+  // call/reference/import edges — see hasEdgeExtraction() for why guessing is worse
+  // than abstaining. Without this gate the C++ grammar's `call_expression` nodes
+  // would fall straight into the capture below.
+  if (!hasEdgeExtraction(ctx.lang)) {
+    for (const child of node.namedChildren) walk(child, ctx, out, edges, minted);
     return;
   }
 
@@ -469,6 +521,7 @@ function isDeclarationName(node: Parser.SyntaxNode): boolean {
  * TS arrow-consts. */
 function describe(node: Parser.SyntaxNode, ctx: WalkCtx): DefDescriptor | null {
   if (ctx.lang === "go") return describeGo(node, ctx);
+  if (ctx.lang === "cpp") return describeCpp(node, ctx);
 
   const mapped = ctx.kinds[node.type];
   if (mapped) {
@@ -541,6 +594,82 @@ function describeGo(node: Parser.SyntaxNode, _ctx: WalkCtx): DefDescriptor | nul
   }
 
   return null;
+}
+
+/** C/C++ definition shapes (issue #66, definitions-only): function definitions
+ * (free, inline-in-class, and out-of-class `Type::method`), plus named
+ * class/struct/enum bodies. Declarations without a body — prototypes, forward
+ * declarations, extern declarations — are intentionally NOT definitions: a
+ * header's `void update(float);` would otherwise shadow the one real
+ * definition under the same name in every skeleton/grep result.
+ *
+ * `namespace_definition` and `template_declaration` need no case of their own:
+ * describe() returning null makes the walk descend, so the definitions inside
+ * are found with their own spans (a template symbol's span excludes the
+ * `template<…>` header — a bounded imprecision, traded for never emitting the
+ * same definition twice). */
+function describeCpp(node: Parser.SyntaxNode, ctx: WalkCtx): DefDescriptor | null {
+  if (node.type === "function_definition") {
+    const named = cppDeclaratorName(node.childForFieldName("declarator"));
+    if (!named) return null;
+    const body = node.childForFieldName("body");
+    const headerEnd = body ? body.startIndex : node.endIndex;
+    // A qualifier (`Physics::step`) or an enclosing class/struct body makes it a
+    // method; the qualifier also names the owner the walk context can't see.
+    if (named.qualifier) {
+      return {
+        name: named.name,
+        idName: `${named.qualifier}.${named.name}`,
+        kind: "method",
+        owner: named.qualifier,
+        headerEnd,
+        hashNode: node,
+      };
+    }
+    const inType = ctx.enclosingKind === "class" || ctx.enclosingKind === "struct";
+    return { name: named.name, kind: inType ? "method" : "function", headerEnd, hashNode: node };
+  }
+
+  const kind: Kind | null =
+    node.type === "class_specifier"
+      ? "class"
+      : node.type === "struct_specifier"
+        ? "struct"
+        : node.type === "enum_specifier"
+          ? "enum"
+          : null;
+  if (kind) {
+    // Both name AND body required: `class Physics;` (forward declaration) and an
+    // anonymous `struct { … }` are not definitions we can index.
+    const name = node.childForFieldName("name")?.text;
+    const body = node.childForFieldName("body");
+    if (!name || !body) return null;
+    return { name, kind, headerEnd: body.startIndex, hashNode: node };
+  }
+
+  return null;
+}
+
+/** The defined name inside a C/C++ declarator, unwrapping pointer/reference
+ * wrappers (`int* make_buffer()`) and the function_declarator itself, then
+ * resolving qualified names (`game::Entity::~Entity` → name `~Entity`,
+ * qualifier `Entity` — the innermost scope is the owner). Handles plain
+ * identifiers, class-body `field_identifier`s, `destructor_name` and
+ * `operator_name`. Null when no name can be read (e.g. an abstract declarator). */
+function cppDeclaratorName(decl: Parser.SyntaxNode | null): { name: string; qualifier?: string } | null {
+  let d = decl;
+  while (d && (d.type === "pointer_declarator" || d.type === "reference_declarator" || d.type === "parenthesized_declarator")) {
+    d = d.childForFieldName("declarator") ?? d.namedChildren.at(-1) ?? null;
+  }
+  if (d?.type === "function_declarator") d = d.childForFieldName("declarator");
+  let qualifier: string | undefined;
+  while (d?.type === "qualified_identifier") {
+    qualifier = d.childForFieldName("scope")?.text ?? qualifier;
+    d = d.childForFieldName("name");
+  }
+  const NAME_TYPES = new Set(["identifier", "field_identifier", "destructor_name", "operator_name", "type_identifier"]);
+  if (!d || !NAME_TYPES.has(d.type)) return null;
+  return qualifier ? { name: d.text, qualifier } : { name: d.text };
 }
 
 /** The receiver's base type name for a Go method, unwrapping a pointer receiver

--- a/src/graph/traverse-cli.ts
+++ b/src/graph/traverse-cli.ts
@@ -14,6 +14,8 @@
 import { resolve } from "node:path";
 import { contextDirFor } from "../context/node-file.js";
 import { withSavings, savingsFor, type Savings } from "../context/savings.js";
+import { unindexedNote, type UnindexedStat } from "./coverage.js";
+import { hasEdgeExtraction, languageOf } from "./extract.js";
 import { loadGraphCached } from "./load.js";
 import { resolveSymbol, edgeWalk, type Direction, type EdgeHit } from "./traverse.js";
 import type { GraphV1, NodeV1 } from "./types.js";
@@ -71,14 +73,43 @@ export function callersSavings(
  * `resolve.ts` drops a cross-file call/reference for rather than guessing which
  * one it means. Without saying so, a zero-hit result here reads as "nothing
  * calls this" when it may really be "something does, but the edge was dropped". */
-export function looseNoteFor(direction: Direction, name: string, candidateCount: number): string {
+export function looseNoteFor(
+  direction: Direction,
+  name: string,
+  candidateCount: number,
+  opts: { edgeless?: boolean } = {},
+): string {
   const label = direction === "out" ? "callees" : "callers";
+  // A definitions-only language (C/C++) HAS no edge data — an empty result is
+  // "no data", never "nothing calls this", and must not read like a fact about
+  // the code (issue #66).
+  if (opts.edgeless) {
+    return `  no edge data — this symbol is in a definitions-only language (C/C++): call edges are not extracted, so the graph cannot know its ${label}. Find its uses with graft grep "${name}" or raw grep -rn`;
+  }
   const dir = direction === "out" ? "outgoing" : "incoming";
   const ambiguity =
     candidateCount > 1
       ? ` ${candidateCount} definitions share the name "${name}"; a cross-file caller of an ambiguous name is dropped rather than guessed, so this may undercount.`
       : "";
   return `  no indexed ${label} — the graph has no ${dir} call/reference edges for this symbol as written.${ambiguity} Check the name (try the bare symbol, or "Type.method"), or find its uses with graft grep "${name}". Fall back to raw grep -rn only for unindexed files`;
+}
+
+/** True when a symbol's language is indexed definitions-only (no call edges) —
+ * the case {@link looseNoteFor}'s `edgeless` note phrases honestly. */
+export function symbolEdgeless(node: NodeV1): boolean {
+  const lang = languageOf(node.path);
+  return lang !== null && !hasEdgeExtraction(lang);
+}
+
+/** The unknown-symbol error for `graft callers` and `graft_trace_calls` — one
+ * implementation so CLI and MCP say the same thing. With `unindexed` (the
+ * graph's `meta.unindexed`), it names the coverage gap: on an unsupported
+ * language, "check spelling" sends you chasing a typo that isn't there while
+ * the symbol sits in a file no parser ever read (issue #66). */
+export function unknownSymbolNote(query: string, unindexed?: UnindexedStat[]): string {
+  const base = `no symbol "${query}" in the graph — check spelling or run \`graft build\``;
+  const gap = unindexedNote(unindexed);
+  return gap ? `${base}. Note: ${gap}` : base;
 }
 
 interface SymbolJson {
@@ -155,7 +186,7 @@ export function runCallersCommand(query: string, dir: string, opts: CallersCliOp
     return;
   }
   if (matches.length === 0) {
-    console.error(`✗ no symbol "${query}" in the graph — check spelling or run graft build`);
+    console.error(`✗ ${unknownSymbolNote(query, graph.meta.unindexed)}`);
     process.exit(1);
   }
 
@@ -189,7 +220,7 @@ export function runCallersCommand(query: string, dir: string, opts: CallersCliOp
       matches: results.map((r): MatchJson => {
         const m: MatchJson = { symbol: symbolJson(r.symbol), hits: r.hits.map(hitJson) };
         if (r.hits.length === 0) {
-          m.note = looseNoteFor(direction, r.symbol.name, matches.length);
+          m.note = looseNoteFor(direction, r.symbol.name, matches.length, { edgeless: symbolEdgeless(r.symbol) });
         }
         return m;
       }),
@@ -202,7 +233,7 @@ export function runCallersCommand(query: string, dir: string, opts: CallersCliOp
   const lines: string[] = [];
   for (const { symbol, hits } of results) {
     lines.push(headerOf(symbol));
-    if (hits.length === 0) lines.push(looseNoteFor(direction, symbol.name, matches.length));
+    if (hits.length === 0) lines.push(looseNoteFor(direction, symbol.name, matches.length, { edgeless: symbolEdgeless(symbol) }));
     else for (const h of hits) lines.push(hitLine(direction, h, showDepth));
     lines.push("");
   }

--- a/src/graph/types.ts
+++ b/src/graph/types.ts
@@ -101,6 +101,12 @@ export interface GraphV1 {
     /** Ranking scopes: posix path prefixes relative to the graph root, "" = root scope.
      * Absent (old graphs) ≡ [{ prefix: "", label: "" }]. Sorted by prefix length desc. */
     scopes?: ScopeV1[];
+    /** Code-like files present in the repo that no Tier-1 grammar parses,
+     * grouped by extension (most files first). Recorded so query surfaces can
+     * answer "no parser" instead of a confident "no hits" (issue #66). Absent
+     * when every code file was parseable — and on graphs built before this
+     * field existed. */
+    unindexed?: { ext: string; files: number }[];
   };
   nodes: NodeV1[];
   edges: EdgeV1[];

--- a/src/graph/workspace-cli.ts
+++ b/src/graph/workspace-cli.ts
@@ -8,6 +8,7 @@
 import { Graft } from "../engine.js";
 import { contextDirFor, ensureGitignored } from "../context/node-file.js";
 import { writeBuildConfig } from "../util/state.js";
+import { skippedLine } from "./coverage.js";
 import type { EngineConfig } from "../ai/providers.js";
 import { formatAsk } from "../ask/ask.js";
 import type { Direction } from "./traverse.js";
@@ -53,6 +54,8 @@ export async function runWorkspaceBuild(root: string, opts: WorkspaceBuildOption
     if (opts.deep) await engine.init(childDir, { extensions: opts.extensions });
     const g = await engine.graph(childDir, { llm: opts.deep, concurrency: opts.concurrency });
     console.log(`✓ ${childName}/: ${g.nodes} nodes, ${g.edges} edges, ${g.cards} cards [${g.languages.join(", ")}]`);
+    const skipped = skippedLine(g.skipped);
+    if (skipped) console.log(`  ${childName}/: ${skipped}`);
     for (const e of g.errors) console.error(`✗ ${childName}/: ${e}`);
   };
 
@@ -89,13 +92,14 @@ export function runWorkspaceGrep(
   pattern: string,
   opts: { ignoreCase?: boolean; fixed?: boolean; json?: boolean },
 ): void {
-  const { result, coverage } = federateGrep(root, override, pattern, { ignoreCase: opts.ignoreCase, fixed: opts.fixed });
+  const { result, coverage, unindexed } = federateGrep(root, override, pattern, { ignoreCase: opts.ignoreCase, fixed: opts.fixed });
   if (opts.json) {
     console.log(JSON.stringify(result, null, 2));
     return;
   }
   if (result.totalHits === 0) {
-    console.error(coverage ? `${zeroHitNote(result)}\n${coverage}` : zeroHitNote(result));
+    const note = zeroHitNote(result, unindexed);
+    console.error(coverage ? `${note}\n${coverage}` : note);
     return;
   }
   process.stdout.write(formatGrepResult(result));

--- a/src/graph/workspace.ts
+++ b/src/graph/workspace.ts
@@ -21,6 +21,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import { join } from "node:path";
 import { contextDirFor } from "../context/node-file.js";
 import { checkGraph } from "./check.js";
+import { mergeUnindexed, unindexedNote, type UnindexedStat } from "./coverage.js";
 import { loadGraphCached } from "./load.js";
 import { buildRepoMap, formatRepoMap } from "./map.js";
 import { discoverWorkspaceChildren } from "./scopes.js";
@@ -29,6 +30,7 @@ import {
   headerOf,
   hitLine,
   looseNoteFor,
+  symbolEdgeless,
 } from "./traverse-cli.js";
 import { edgeWalk, resolveSymbol, type Direction } from "./traverse.js";
 import { wiringPath } from "./write.js";
@@ -313,7 +315,7 @@ export function federateGrep(
   override: string | undefined,
   pattern: string,
   opts: { ignoreCase?: boolean; fixed?: boolean } = {},
-): { result: GrepResult; coverage: string } {
+): { result: GrepResult; coverage: string; unindexed: UnindexedStat[] } {
   const wg = loadWorkspaceGraphs(root, override);
   const groups: GrepGroup[] = [];
   let filesSearched = 0;
@@ -347,7 +349,10 @@ export function federateGrep(
   groups.sort((a, b) => b.inDegree - a.inDegree || a.path.localeCompare(b.path));
   const saved: Savings | undefined = savedChars > 0 ? { files: savedFiles, baselineChars: savedChars } : undefined;
   const result: GrepResult = { pattern, filesSearched, totalHits, groups, truncated, saved };
-  return { result, coverage: coverageNote(wg) };
+  // Every child's no-parser gap, merged — so a federated zero-hit note can be
+  // as honest as the single-repo one (issue #66).
+  const unindexed = mergeUnindexed(wg.loaded.map(({ graph }) => graph.meta.unindexed));
+  return { result, coverage: coverageNote(wg), unindexed };
 }
 
 /** One `graft map` section per child (each child's own map, budget split evenly
@@ -425,7 +430,7 @@ export function federateCallers(
     const lines = [`## ${child}/`];
     for (const { symbol: sym, hits } of results) {
       lines.push(headerOf(sym));
-      if (hits.length === 0) lines.push(looseNoteFor(direction, sym.name, matches.length));
+      if (hits.length === 0) lines.push(looseNoteFor(direction, sym.name, matches.length, { edgeless: symbolEdgeless(sym) }));
       else for (const h of hits) lines.push(hitLine(direction, h, showDepth));
     }
     const body = lines.join("\n");
@@ -434,7 +439,11 @@ export function federateCallers(
 
   const cov = coverageNote(wg);
   if (!found) {
-    const base = `no symbol "${symbol}" in any of the ${wg.loaded.length} workspace repo(s) — check spelling or run graft build`;
+    let base = `no symbol "${symbol}" in any of the ${wg.loaded.length} workspace repo(s) — check spelling or run graft build`;
+    // Same honesty as the single-repo path: name the no-parser gap before
+    // blaming spelling (issue #66).
+    const gap = unindexedNote(mergeUnindexed(wg.loaded.map(({ graph }) => graph.meta.unindexed)));
+    if (gap) base += `. Note: ${gap}`;
     return { text: cov ? `${base}\n${cov}` : base, found: false };
   }
   let text = blocks.join("\n\n");

--- a/src/hosts/instructions.ts
+++ b/src/hosts/instructions.ts
@@ -24,7 +24,10 @@ hotspots), no LLM, no key.
   exhaustive tasks ("every occurrence / every caller of this pattern"), ranked
   results are top-N, not complete — run \`graft grep "<literal>"\` instead
   (exhaustive over indexed files, grouped by enclosing symbol), falling back
-  to raw \`grep -rn\` only for unindexed files.
+  to raw \`grep -rn\` for unindexed files: docs, configs, and any language
+  \`graft build\` reported as \`skipped:\` (no parser) — code in those languages
+  is invisible to the symbol tools, so a zero-hit result there is a coverage
+  gap, not an answer.
 - \`graft skeleton <file>\` → every definition's signature + span, ~10× cheaper
   than reading the file; use it to skim an API surface.
 - \`graft callers <symbol>\` gives precomputed, exact edges — who calls this.

--- a/src/mcp/instructions.ts
+++ b/src/mcp/instructions.ts
@@ -38,11 +38,21 @@ export function toolSearchQuery(prefix = 'mcp__graft__'): string {
   return `select:${TOOL_ORDER.map((t) => `${prefix}${t}`).join(',')}`;
 }
 
-export function mcpInstructions(): string {
+export function mcpInstructions(unindexed?: { ext: string; files: number }[]): string {
+  // Scope the "prefer these tools" claim to what the graph actually holds: on a
+  // repo with unparseable code, an agent that trusts it unconditionally will
+  // conclude a symbol doesn't exist when really no parser ever read its file
+  // (issue #66).
+  const total = (unindexed ?? []).reduce((n, s) => n + s.files, 0);
+  const coverage =
+    total > 0
+      ? `CAVEAT: ${total} source files (${(unindexed ?? []).map((s) => s.ext).join(', ')}) have no parser and are NOT in the graph — for those, raw grep/read are the right tools.`
+      : null;
   return [
     'This repo is indexed by graft: a prebuilt graph of every symbol, its file:line',
     'span, and who calls what. Prefer these tools over grep/read — one call usually',
     'replaces several file reads.',
+    ...(coverage ? [coverage] : []),
     '',
     `**If these tools are deferred (names shown, schemas withheld), load them all in ONE lookup:** ToolSearch "${toolSearchQuery()}" — one round trip for the whole session. Never load them one at a time.`,
     '',

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -3,6 +3,9 @@
  * stdout carries protocol messages ONLY; diagnostics go to stderr.
  */
 import { createInterface } from 'node:readline';
+import { resolve } from 'node:path';
+import { contextDirFor } from '../context/node-file.js';
+import { loadGraphCached } from '../graph/load.js';
 import { TOOLS, callTool } from './tools.js';
 import { mcpInstructions } from './instructions.js';
 
@@ -44,7 +47,11 @@ export function startMcpServer(root: string, dirOverride?: string, version = '0'
           capabilities: { tools: {} },
           serverInfo: { name: 'graft', version },
           // The one channel that survives tool deferral — see ./instructions.ts.
-          instructions: mcpInstructions(),
+          // The graph's coverage gap (meta.unindexed) scopes the "prefer these
+          // tools" claim; null graph (not built yet) sends the plain version.
+          instructions: mcpInstructions(
+            loadGraphCached(contextDirFor(resolve(root), dirOverride))?.meta.unindexed,
+          ),
         });
         return;
       case 'notifications/initialized':

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -10,7 +10,7 @@ import { loadGraphCached } from '../graph/load.js';
 import { ensureFreshChildren, ensureFreshGraph, refreshNote } from '../graph/refresh.js';
 import { contextDirFor } from '../context/node-file.js';
 import { resolveSymbol, edgeWalk, type Direction, type EdgeHit } from '../graph/traverse.js';
-import { callersSavings, headerOf, hitLine, looseNoteFor } from '../graph/traverse-cli.js';
+import { callersSavings, headerOf, hitLine, looseNoteFor, symbolEdgeless, unknownSymbolNote } from '../graph/traverse-cli.js';
 import { withSavings } from '../context/savings.js';
 import { grepGraph } from '../search/grep.js';
 import { formatGrepResult, zeroHitNote } from '../search/grep-cli.js';
@@ -32,10 +32,6 @@ export interface ToolDef {
 }
 
 const NO_GRAPH = 'no graph found — run `graft build` first';
-
-function unknownSymbolText(query: string): string {
-  return `no symbol "${query}" in the graph — check spelling or run \`graft build\``;
-}
 
 export const TOOLS: ToolDef[] = [
   {
@@ -137,7 +133,7 @@ function renderMatches(
     .map((m) => {
       const hits = hitsFor(m);
       const lines = [headerOf(m)];
-      if (hits.length === 0) lines.push(looseNoteFor(direction, m.name, matches.length));
+      if (hits.length === 0) lines.push(looseNoteFor(direction, m.name, matches.length, { edgeless: symbolEdgeless(m) }));
       else for (const h of hits) lines.push(hitLine(direction, h, showDepth));
       return lines.join('\n');
     })
@@ -176,11 +172,11 @@ function callWorkspaceTool(
     case 'graft_find_all': {
       const pattern = String(args.pattern ?? '');
       if (!pattern) return { text: 'graft_find_all requires a pattern', isError: true };
-      const { result, coverage } = federateGrep(root, dirOverride, pattern, {
+      const { result, coverage, unindexed } = federateGrep(root, dirOverride, pattern, {
         ignoreCase: typeof args.ignore_case === 'boolean' ? args.ignore_case : undefined,
         fixed: typeof args.fixed === 'boolean' ? args.fixed : undefined,
       });
-      const text = result.totalHits === 0 ? zeroHitNote(result) : formatGrepResult(result);
+      const text = result.totalHits === 0 ? zeroHitNote(result, unindexed) : formatGrepResult(result);
       return { text: coverage ? `${text}\n${coverage}` : text, isError: false };
     }
     case 'graft_repo_map': {
@@ -296,7 +292,7 @@ function callSingleTool(
         if (!w) return { text: NO_GRAPH, isError: true };
         const inOpt = typeof args.in === 'string' && args.in ? { in: args.in } : {};
         const matches = resolveSymbol(w, symbol, inOpt);
-        if (matches.length === 0) return { text: unknownSymbolText(symbol), isError: true };
+        if (matches.length === 0) return { text: unknownSymbolNote(symbol, w.meta.unindexed), isError: true };
         const direction: Direction = args.direction === 'out' ? 'out' : 'in';
         // `depth: "all"` (or a huge number) walks the full transitive closure —
         // every connected source — terminating when no new node is reached.
@@ -322,7 +318,7 @@ function callSingleTool(
           fixed: typeof args.fixed === 'boolean' ? args.fixed : undefined,
           in: typeof args.in === 'string' && args.in ? args.in : undefined,
         });
-        if (result.totalHits === 0) return { text: zeroHitNote(result), isError: false };
+        if (result.totalHits === 0) return { text: zeroHitNote(result, w.meta.unindexed), isError: false };
         return { text: formatGrepResult(result), isError: false };
       }
       case 'graft_repo_map': {

--- a/src/search/grep-cli.ts
+++ b/src/search/grep-cli.ts
@@ -10,6 +10,7 @@
 import { resolve } from "node:path";
 import { contextDirFor } from "../context/node-file.js";
 import { withSavings } from "../context/savings.js";
+import { unindexedNote, type UnindexedStat } from "../graph/coverage.js";
 import { loadGraphCached } from "../graph/load.js";
 import { grepGraph, type GrepGroup, type GrepResult } from "./grep.js";
 
@@ -69,9 +70,18 @@ export function formatGrepResult(result: GrepResult): string {
  * Truncation is never silent, even on the zero-hit path: if some indexed
  * files couldn't be read (`truncated.files > 0`), that's called out too —
  * otherwise a zero-hit result on a stale graph or wrong root reads as "no
- * matches" when really some files were never searched at all. */
-export function zeroHitNote(result: GrepResult): string {
-  const base = `no hits for "${result.pattern}" in ${result.filesSearched} indexed files. The pattern may be too specific — retry graft grep with a bare symbol name or short substring (drop the receiver, full signature, and regex anchors). All indexed code was searched; use raw grep -rn only for genuinely unindexed files (docs, configs, brand-new files)`;
+ * matches" when really some files were never searched at all.
+ *
+ * `unindexed` (the graph's `meta.unindexed`) flips the closing advice: when
+ * code files were never parsed, "all indexed code was searched" is true and
+ * deeply misleading — the pattern may simply live in a language with no
+ * parser, and raw grep -rn is then the RIGHT tool, not a fallback (issue #66). */
+export function zeroHitNote(result: GrepResult, unindexed?: UnindexedStat[]): string {
+  const retry = `no hits for "${result.pattern}" in ${result.filesSearched} indexed files. The pattern may be too specific — retry graft grep with a bare symbol name or short substring (drop the receiver, full signature, and regex anchors).`;
+  const gap = unindexedNote(unindexed);
+  const base = gap
+    ? `${retry} All indexed code was searched, but ${gap}`
+    : `${retry} All indexed code was searched; use raw grep -rn only for genuinely unindexed files (docs, configs, brand-new files)`;
   const { files } = result.truncated;
   if (files === 0) return base;
   return `${base} — note: ${files} indexed file${files === 1 ? "" : "s"} could not be read (stale graph? run graft build)`;
@@ -111,7 +121,7 @@ export function runGrepCommand(pattern: string, dir: string, opts: GrepCliOption
   }
 
   if (result.totalHits === 0) {
-    console.error(zeroHitNote(result));
+    console.error(zeroHitNote(result, graph.meta.unindexed));
     return;
   }
 

--- a/test/graph-coverage.test.ts
+++ b/test/graph-coverage.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Unsupported languages must fail LOUDLY (issue #66).
+ *
+ * On a repo whose code has no Tier-1 parser, "no hits" / "no symbol" /
+ * "no definitions" are confident false negatives: they read as facts about the
+ * code when they're really gaps in coverage — and the old wording even steered
+ * the caller *away* from raw grep, the only tool that would have worked. These
+ * tests pin down the honest versions: the build reports what it skipped, the
+ * graph records it, and every query surface says "no parser" when that's the
+ * real answer.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { buildGraph } from "../src/graph/build.js";
+import { readGraph, wiringPath } from "../src/graph/write.js";
+import { mergeUnindexed, skippedLine, unindexedNote, unsupportedFileNote } from "../src/graph/coverage.js";
+import { looseNoteFor, unknownSymbolNote } from "../src/graph/traverse-cli.js";
+import { zeroHitNote } from "../src/search/grep-cli.js";
+import { skeleton } from "../src/ask/ask.js";
+import { mcpInstructions } from "../src/mcp/instructions.js";
+import type { GrepResult } from "../src/search/grep.js";
+
+function makeFixture(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graft-coverage-"));
+  writeFileSync(join(dir, "a.ts"), "export function hello(): number { return 1; }\n");
+  writeFileSync(join(dir, "engine.rs"), "pub fn snap_entity_to_floor() {}\n");
+  writeFileSync(join(dir, "enemy_ai.rs"), "pub fn think() {}\n");
+  writeFileSync(join(dir, "README.md"), "# not code\n");
+  writeFileSync(join(dir, "notes.txt"), "not code either\n");
+  return dir;
+}
+
+test("build reports code files no parser covers, and records them in the graph", async () => {
+  const dir = makeFixture();
+  const result = await buildGraph(dir);
+
+  // .rs is code the concept pass would read, but no Tier-1 grammar parses it;
+  // .md/.txt are not code and must NOT be counted as skipped.
+  assert.deepEqual(result.skipped, [{ ext: ".rs", files: 2 }]);
+
+  const graph = readGraph(wiringPath(join(dir, "graft")));
+  assert.deepEqual(graph?.meta.unindexed, [{ ext: ".rs", files: 2 }]);
+});
+
+test("a fully supported repo skips nothing and records nothing", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-coverage-clean-"));
+  writeFileSync(join(dir, "a.ts"), "export function hello(): number { return 1; }\n");
+  const result = await buildGraph(dir);
+  assert.deepEqual(result.skipped, []);
+  const graph = readGraph(wiringPath(join(dir, "graft")));
+  assert.equal(graph?.meta.unindexed, undefined);
+});
+
+test("skippedLine says how many files symbol tools will not cover", () => {
+  const line = skippedLine([
+    { ext: ".h", files: 200 },
+    { ext: ".cpp", files: 150 },
+  ]);
+  assert.ok(line?.includes("350 files"), line ?? "(null)");
+  assert.ok(line?.includes("no parser"), line ?? "(null)");
+  assert.ok(line?.includes(".h") && line?.includes(".cpp"), line ?? "(null)");
+  assert.ok(line?.includes("symbol tools will not cover them"), line ?? "(null)");
+  assert.equal(skippedLine([]), null);
+});
+
+function emptyGrep(pattern: string): GrepResult {
+  return { pattern, filesSearched: 33, totalHits: 0, groups: [], truncated: { files: 0, hits: 0 } };
+}
+
+test("zero-hit grep steers TOWARD raw grep when code was never parsed", () => {
+  const note = zeroHitNote(emptyGrep("snapEntityToFloor"), [{ ext: ".cpp", files: 350 }]);
+  assert.ok(note.includes("350"), note);
+  assert.ok(note.includes(".cpp"), note);
+  assert.ok(note.includes("no parser"), note);
+  assert.ok(note.includes("grep -rn"), note);
+  // The old tail told callers indexed search was sufficient — it must not
+  // appear when files were skipped.
+  assert.ok(!note.includes("only for genuinely unindexed files"), note);
+
+  // With full coverage, the original message survives unchanged.
+  const covered = zeroHitNote(emptyGrep("snapEntityToFloor"));
+  assert.ok(covered.includes("All indexed code was searched"), covered);
+});
+
+test("unknown symbol mentions unparsed files instead of blaming spelling alone", () => {
+  const note = unknownSymbolNote("snapEntityToFloor", [{ ext: ".cpp", files: 350 }]);
+  assert.ok(note.includes('no symbol "snapEntityToFloor"'), note);
+  assert.ok(note.includes(".cpp"), note);
+  assert.ok(note.includes("no parser"), note);
+  const base = unknownSymbolNote("snapEntityToFloor", undefined);
+  assert.ok(base.includes("check spelling"), base);
+  assert.ok(!base.includes("no parser"), base);
+});
+
+test("unindexedNote is null when everything is covered", () => {
+  assert.equal(unindexedNote(undefined), null);
+  assert.equal(unindexedNote([]), null);
+});
+
+test("mergeUnindexed sums per-extension counts across workspace children", () => {
+  const merged = mergeUnindexed([
+    [{ ext: ".cpp", files: 2 }],
+    undefined,
+    [
+      { ext: ".cpp", files: 3 },
+      { ext: ".rs", files: 1 },
+    ],
+  ]);
+  assert.deepEqual(merged, [
+    { ext: ".cpp", files: 5 },
+    { ext: ".rs", files: 1 },
+  ]);
+});
+
+test("skeleton on an unsupported-language file says 'no parser', not 'no definitions'", async () => {
+  const dir = makeFixture();
+  await buildGraph(dir);
+
+  const rs = skeleton(dir, "enemy_ai.rs");
+  assert.ok(rs.note?.includes("no parser"), rs.note);
+  assert.equal(rs.entries.length, 0);
+
+  // A supported-language file that simply isn't in the graph keeps the old note.
+  const missing = skeleton(dir, "missing.ts");
+  assert.ok(missing.note?.includes("no definitions indexed"), missing.note);
+});
+
+test("unsupportedFileNote fires only for code-like extensions", () => {
+  assert.ok(unsupportedFileNote("src/game/enemy_ai.cpp".replace(".cpp", ".rs"))?.includes("no parser"));
+  assert.equal(unsupportedFileNote("src/app.ts"), null); // has a parser
+  assert.equal(unsupportedFileNote("README.md"), null); // not code
+});
+
+test("callers on a definitions-only language says 'no edge data', not 'no callers'", () => {
+  const note = looseNoteFor("in", "step", 1, { edgeless: true });
+  assert.ok(note.includes("definitions-only"), note);
+  assert.ok(note.includes("graft grep"), note);
+  assert.ok(!note.includes("no indexed callers"), note);
+
+  const normal = looseNoteFor("in", "step", 1);
+  assert.ok(normal.includes("no indexed callers"), normal);
+});
+
+test("MCP instructions scope the 'prefer these tools' claim to indexed languages", () => {
+  const scoped = mcpInstructions([{ ext: ".cpp", files: 350 }]);
+  assert.ok(scoped.includes(".cpp"), scoped);
+  assert.ok(scoped.includes("no parser"), scoped);
+  assert.ok(scoped.length < 1600, `stay near the ~1k char budget, got ${scoped.length}`);
+
+  const plain = mcpInstructions();
+  assert.ok(!plain.includes("no parser"), plain);
+});

--- a/test/graph-cpp.test.ts
+++ b/test/graph-cpp.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for C/C++ extraction in the Tier-1 code graph (issue #66).
+ *
+ * C/C++ is a *definitions-only* tier: nodes for functions, methods, classes,
+ * structs and enums — but NO call/reference/import edges. C++ has no import
+ * bindings (only #include, namespaces, overloads, templates), so name-only
+ * call resolution would fabricate edges between every same-named method in the
+ * repo. `contains` edges are structural facts and are still emitted.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { buildGraph } from "../src/graph/build.js";
+import { extractFile } from "../src/graph/extract.js";
+import { readGraph, wiringPath } from "../src/graph/write.js";
+import type { GraphV1, NodeV1 } from "../src/graph/types.js";
+
+const ENGINE_H = `#pragma once
+namespace game {
+
+struct Vec3 { float x; float y; float z; };
+
+enum class EntityKind { Player, Monster };
+
+class Entity {
+public:
+  Entity();
+  void update(float dt);
+  float health() const { return hp; }
+private:
+  float hp;
+};
+
+template <typename T>
+class Registry {
+public:
+  void add(T item) { count++; }
+  int count = 0;
+};
+
+}
+
+class Physics;
+
+void snapEntityToFloor(game::Entity* e);
+`;
+
+const PHYSICS_CPP = `#include "engine.h"
+
+float Physics::step(float dt) {
+  return dt * gravity;
+}
+
+Entity::~Entity() { }
+
+bool operator==(const Vec3& a, const Vec3& b) { return a.x == b.x; }
+
+void snapEntityToFloor(game::Entity* e) {
+}
+
+void tick(float dt) {
+  snapEntityToFloor(0);
+}
+`;
+
+const UTIL_C = `int clamp(int v, int lo, int hi) {
+  if (v < lo) return lo;
+  if (v > hi) return hi;
+  return v;
+}
+
+int* make_buffer(void) { return 0; }
+`;
+
+function makeFixture(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graft-cpp-"));
+  writeFileSync(join(dir, "engine.h"), ENGINE_H);
+  writeFileSync(join(dir, "physics.cpp"), PHYSICS_CPP);
+  writeFileSync(join(dir, "util.c"), UTIL_C);
+  return dir;
+}
+
+function nodeById(graph: GraphV1, id: string): NodeV1 | undefined {
+  return graph.nodes.find((n) => n.id === id);
+}
+
+test("C/C++ extraction: functions, methods, classes, structs, enums", async () => {
+  const dir = makeFixture();
+  const result = await buildGraph(dir); // $0, Tier-1 only
+  assert.ok(result.languages.includes("c/c++"), `languages should include c/c++, got [${result.languages}]`);
+
+  const graph = readGraph(wiringPath(join(dir, "graft")));
+  assert.ok(graph, "wiring graph should be written");
+
+  // header: struct / enum / class, found through the namespace wrapper
+  assert.equal(nodeById(graph!, "engine.h#Vec3")?.kind, "struct");
+  assert.equal(nodeById(graph!, "engine.h#EntityKind")?.kind, "enum");
+  assert.equal(nodeById(graph!, "engine.h#Entity")?.kind, "class");
+
+  // inline method inside a class body — kind method, owner set
+  const health = nodeById(graph!, "engine.h#Entity.health");
+  assert.equal(health?.kind, "method");
+  assert.equal(health?.owner, "Entity");
+
+  // template class + its method, found through the template_declaration wrapper
+  assert.equal(nodeById(graph!, "engine.h#Registry")?.kind, "class");
+  assert.equal(nodeById(graph!, "engine.h#Registry.add")?.kind, "method");
+
+  // prototypes and forward declarations are NOT definitions
+  assert.ok(!graph!.nodes.some((n) => n.name === "update"), "method prototype must not be indexed");
+  assert.ok(!nodeById(graph!, "engine.h#Physics"), "forward declaration must not be indexed");
+  assert.ok(
+    !graph!.nodes.some((n) => n.path === "engine.h" && n.name === "snapEntityToFloor"),
+    "function prototype must not be indexed",
+  );
+
+  // out-of-class definition `Physics::step` — method, owner from the qualifier
+  const step = nodeById(graph!, "physics.cpp#Physics.step");
+  assert.equal(step?.kind, "method");
+  assert.equal(step?.name, "step");
+  assert.equal(step?.owner, "Physics");
+  // body_text is stripped from the on-disk graph (it lives in the ask sidecar),
+  // so assert it at the extraction layer, where it's populated.
+  const extracted = extractFile("physics.cpp", PHYSICS_CPP, "cpp");
+  const stepNode = extracted.nodes.find((n) => n.id === "physics.cpp#Physics.step");
+  assert.ok(stepNode?.body_text?.includes("gravity"), "definition body is indexed for search");
+
+  // destructor and operator definitions keep their spelled names
+  const dtor = nodeById(graph!, "physics.cpp#Entity.~Entity");
+  assert.equal(dtor?.kind, "method");
+  assert.equal(dtor?.name, "~Entity");
+  assert.ok(graph!.nodes.some((n) => n.name === "operator==" && n.kind === "function"));
+
+  // free functions, including C and a pointer-returning declarator
+  const snap = nodeById(graph!, "physics.cpp#snapEntityToFloor");
+  assert.equal(snap?.kind, "function");
+  assert.equal(snap?.exported, true);
+  assert.ok(snap?.signature?.includes("snapEntityToFloor"), `signature: ${snap?.signature}`);
+  assert.equal(nodeById(graph!, "util.c#clamp")?.kind, "function");
+  assert.equal(nodeById(graph!, "util.c#make_buffer")?.kind, "function");
+
+  // definitions-only: `tick` calls `snapEntityToFloor` in the same file, and no
+  // calls/references/imports edge may exist — only structural containment.
+  assert.ok(nodeById(graph!, "physics.cpp#tick"), "tick should be indexed");
+  const nonContains = graph!.edges.filter((e) => e.relation !== "contains");
+  assert.deepEqual(nonContains, [], "C/C++ must emit no call/reference/import edges");
+  assert.ok(
+    graph!.edges.some((e) => e.source === "engine.h#Entity" && e.target === "engine.h#Entity.health"),
+    "containment edges are still emitted",
+  );
+});

--- a/test/graph-languages.test.ts
+++ b/test/graph-languages.test.ts
@@ -27,6 +27,9 @@ const INDEXED = [
   "a.tsx", "a.jsx",
   "a.py", "a.pyi",
   "a.go",
+  "a.c", "a.h",
+  "a.cpp", "a.cc", "a.cxx",
+  "a.hpp", "a.hh", "a.hxx",
 ];
 
 test("a file is labelled exactly when it is indexed", () => {
@@ -53,6 +56,11 @@ test("labels name the language, not the grammar that parses it", () => {
   assert.equal(languageLabelOf("api/main.py"), "python");
   assert.equal(languageLabelOf("api/main.pyi"), "python");
   assert.equal(languageLabelOf("cmd/main.go"), "go");
+  // One label for the whole C family: the cpp grammar parses C too, and a `.h`
+  // can't be attributed to either language from its name alone.
+  assert.equal(languageLabelOf("src/game/physics.cpp"), "c/c++");
+  assert.equal(languageLabelOf("src/game/engine.h"), "c/c++");
+  assert.equal(languageLabelOf("vendor/util.c"), "c/c++");
 
   // The grammar is unchanged — extraction, the extract cache and every `Language`
   // switch still see exactly what they saw before.


### PR DESCRIPTION
Fixes #66 — both requests: make the language gap visible, and add C/C++ to the tier-1 extractor.

## 1. C/C++ in the Tier-1 symbol graph (definitions-only)

`.c` `.h` `.cpp` `.cc` `.cxx` `.hpp` `.hh` `.hxx` now parse with `tree-sitter-cpp`, under a single `c/c++` label (the cpp grammar parses C, and a `.h` can't be attributed to either language from its name alone).

**Extracted:** free functions; inline methods; out-of-class definitions (`float Physics::step(...)` → `method` named `step`, owner `Physics`, id `physics.cpp#Physics.step`); classes, structs, enums — found through `namespace` and `template` wrappers; destructors and operators keep their spelled names (`~Entity`, `operator==`). Prototypes and forward declarations are **not** definitions and are skipped, so a header's `void update(float);` never shadows the one real definition.

**Deliberately definitions-only, as the issue suggested.** C++ has no import bindings — only `#include`, namespaces, overloads, templates — so the name-only edge resolution the other languages build on would fabricate a `calls` edge between every same-named method in the repo. The extractor emits no call/reference/import edges for C/C++ (structural `contains` edges only), and `callers` on a C/C++ symbol answers honestly:

```
snapEntityToFloor · function · src/game/entity_ground.h:L28-L90
  no edge data — this symbol is in a definitions-only language (C/C++): call edges are
  not extracted, so the graph cannot know its callers. Find its uses with graft grep
  "snapEntityToFloor" or raw grep -rn
```

## 2. Unsupported languages fail loudly

On a repo whose code has no parser, the old messages were confident false negatives — "no hits … All indexed code was searched", "no symbol — check spelling", "no definitions indexed" — and explicitly steered the caller *away* from raw grep, the only tool that would have worked. Now:

- **`graft build`** prints `skipped: N files (no parser: .rs, …) — symbol tools will not cover them` (single-repo and per-workspace-child), and records the gap in the graph as `meta.unindexed` (omitted when empty; old graphs unaffected).
- **Zero-hit `grep`** replaces the "use raw grep -rn only for genuinely unindexed files" tail with the gap: *"…but N source files (.ext) have no parser and are NOT in the symbol graph — if the target lives there, raw grep -rn / reading the file is the right tool"*.
- **Unknown-symbol `callers`** (CLI, MCP, and workspace-federated) appends the same note instead of blaming spelling alone.
- **`skeleton`** on an unsupported-language file says *"this file's language has no parser (.rs)"* instead of "no definitions indexed for this file".
- **MCP `instructions`** carry a coverage caveat scoping the "prefer these tools over grep/read" claim to the languages actually indexed; the static host/skill instruction templates name the skipped-language case too.

The classification of "code the symbol pass should have covered" is `CODE_EXTENSIONS` — the concept pass's own list — so the two passes can no longer silently disagree about what counts as code (`src/graph/coverage.ts`).

## Validation on the codebase from the issue

Same C++ game engine (350 first-party `.cpp`/`.h` + vendored SDL2/ENet, 1,671 files):

| | 0.9.0 | this branch |
|---|---|---|
| indexed files | 33 | **1,623** |
| nodes | 865 | **16,943** (10,647 function, 2,151 method, 2,018 struct, 439 enum, 65 class) |
| build banner | `[javascript, python]` | `[c/c++, javascript, python]` + `skipped: 48 files (no parser: .sh, .java, .swift)` |
| `grep snapEntityToFloor` | "no hits … All indexed code was searched" | **48 hits in 15 symbols across 12 files** |
| `callers snapEntityToFloor` | "no symbol — check spelling" | resolves both definitions + the honest no-edge-data note |
| `skeleton <file>.cpp` | "no definitions indexed" | full signature listing |

Cold build 24.5s, incremental rebuild 1.6s; every query (grep/skeleton/callers/map/ask) sub-second on the 17k-node graph. A 17 MB generated `parser.c` extracts without issue through the existing chunked-parse path.

## Tests

- `test/graph-cpp.test.ts` — extraction shapes: functions, inline/out-of-class/qualified methods with owners, structs/enums through namespace+template wrappers, prototype/forward-decl skipping, destructor/operator names, and the no-edges invariant.
- `test/graph-coverage.test.ts` — build skip-counting + `meta.unindexed` round-trip, the honest grep/callers/skeleton/MCP messages, workspace merging, and the "fully covered repo reports nothing" case.
- `test/graph-languages.test.ts` — the #36 one-table invariant extended over the C-family extensions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
