### PR TITLE
feat: promote Java to the full-fidelity tier (hand-written extractor)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "openai": "^6.45.0",
         "tree-sitter": "^0.21.1",
         "tree-sitter-go": "^0.23.4",
+        "tree-sitter-java": "^0.23.5",
         "tree-sitter-python": "^0.21.0",
         "tree-sitter-typescript": "^0.23.2"
       },
@@ -859,6 +860,25 @@
       "license": "MIT",
       "dependencies": {
         "node-addon-api": "^8.2.1",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-java": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/tree-sitter-java/-/tree-sitter-java-0.23.5.tgz",
+      "integrity": "sha512-Yju7oQ0Xx7GcUT01mUglPP+bYfvqjNCGdxqigTnew9nLGoII42PNVP3bHrYeMxswiCRM0yubWmN5qk+zsg0zMA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
         "node-gyp-build": "^4.8.2"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "openai": "^6.45.0",
     "tree-sitter": "^0.21.1",
     "tree-sitter-go": "^0.23.4",
+    "tree-sitter-java": "^0.23.5",
     "tree-sitter-python": "^0.21.0",
     "tree-sitter-typescript": "^0.23.2"
   },
@@ -72,5 +73,13 @@
     "esbuild": "^0.28.1",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3"
+  },
+  "allowScripts": {
+    "tree-sitter@0.21.1": true,
+    "tree-sitter-typescript@0.23.2": true,
+    "tree-sitter-python@0.21.0": true,
+    "tree-sitter-go@0.23.4": true,
+    "tree-sitter-javascript@0.23.1": true,
+    "tree-sitter-java@0.23.5": true
   }
 }

--- a/src/graph/bindings.ts
+++ b/src/graph/bindings.ts
@@ -43,6 +43,9 @@ const FN_VALUE_TYPES = new Set(["arrow_function", "function", "function_expressi
  * same scope key extract.ts's walk will look it up with), or null if `node`
  * isn't a definition. */
 export function defName(node: Parser.SyntaxNode, lang: Language): string | null {
+  if (lang === "java") {
+    return JAVA_DEF_TYPES.has(node.type) ? (node.childForFieldName("name")?.text ?? null) : null;
+  }
   if (lang === "go") {
     if (node.type === "method_declaration") {
       const name = node.childForFieldName("name")?.text;
@@ -122,11 +125,32 @@ export function resolveRecvType(
 
 function isClassNode(node: Parser.SyntaxNode, lang: Language): boolean {
   if (lang === "python") return node.type === "class_definition";
+  if (lang === "java") return JAVA_TYPE_DECLS.has(node.type);
   if (lang === "typescript" || lang === "tsx") {
     return node.type === "class_declaration" || node.type === "abstract_class_declaration";
   }
   return false;
 }
+
+/** Java declarations that push a scope segment — mirrors extract.ts's JAVA_KINDS. */
+const JAVA_DEF_TYPES: ReadonlySet<string> = new Set([
+  "class_declaration",
+  "interface_declaration",
+  "enum_declaration",
+  "record_declaration",
+  "annotation_type_declaration",
+  "method_declaration",
+  "constructor_declaration",
+]);
+
+/** The subset of the above that owns `this.field` bindings. */
+const JAVA_TYPE_DECLS: ReadonlySet<string> = new Set([
+  "class_declaration",
+  "interface_declaration",
+  "enum_declaration",
+  "record_declaration",
+  "annotation_type_declaration",
+]);
 
 /** Pass 1 over a parsed file: collect variable->type bindings. Pure. */
 export function collectBindings(root: Parser.SyntaxNode, lang: Language): FileBindings {
@@ -169,6 +193,7 @@ function visit(
 ): void {
   if (lang === "python") handlePy(node, scope, classScope, bindings, aliases);
   else if (lang === "go") handleGo(node, scope, bindings);
+  else if (lang === "java") handleJava(node, scope, classScope, bindings);
   else handleTs(node, scope, classScope, bindings, aliases);
 
   const name = defName(node, lang);
@@ -282,6 +307,64 @@ function handleTs(
     const typeName = tsAnnotationTypeName(node.childForFieldName("type"), aliases);
     if (typeName) bindings.set(scopePath, pattern.text, typeName);
   }
+}
+
+/**
+ * Java bindings: locals, parameters, and fields.
+ *
+ * Java looks like the easy case — it is statically typed, so a declaration states
+ * its own type with no inference needed. In practice modern Java leans on `var`,
+ * which carries no type at the declaration site, so those locals bind nothing and
+ * their calls fall back to name-only resolution exactly as in TS/Python.
+ *
+ * Fields are recorded twice: bare (`repo.save()`) and `self.`-prefixed
+ * (`this.repo.save()`), since resolveRecvType normalizes `this.` to `self.`.
+ */
+function handleJava(
+  node: Parser.SyntaxNode,
+  scope: string[],
+  classScope: string | null,
+  bindings: FileBindings,
+): void {
+  const scopePath = scope.join(".");
+
+  if (node.type === "formal_parameter") {
+    const type = javaTypeName(node.childForFieldName("type"));
+    const name = node.childForFieldName("name");
+    if (type && name?.type === "identifier") bindings.set(scopePath, name.text, type);
+    return;
+  }
+
+  if (node.type !== "local_variable_declaration" && node.type !== "field_declaration") return;
+
+  const type = javaTypeName(node.childForFieldName("type"));
+  if (!type) return; // `var` — no type at the declaration site
+  const isField = node.type === "field_declaration";
+  const target = isField ? (classScope ?? scopePath) : scopePath;
+
+  for (const d of node.namedChildren) {
+    if (d.type !== "variable_declarator") continue;
+    const name = d.childForFieldName("name");
+    if (name?.type !== "identifier") continue;
+    bindings.set(target, name.text, type);
+    if (isField) bindings.set(target, `self.${name.text}`, type);
+  }
+}
+
+/** A Java type node's bare name. `var` is the inferred-local keyword and states no
+ * type, so it binds nothing. A generic binds to its erasure (`List<Order>` → `List`),
+ * and a qualified type to its final segment (`java.util.List` → `List`). */
+function javaTypeName(node: Parser.SyntaxNode | null | undefined): string | null {
+  if (!node) return null;
+  if (node.type === "type_identifier") return node.text === "var" ? null : node.text;
+  if (node.type === "generic_type") {
+    const base = node.namedChildren[0];
+    return base ? javaTypeName(base) : null;
+  }
+  if (node.type === "scoped_type_identifier") {
+    return node.namedChildren.at(-1)?.text ?? null;
+  }
+  return null;
 }
 
 function handleGo(node: Parser.SyntaxNode, scope: string[], bindings: FileBindings): void {

--- a/src/graph/extract.ts
+++ b/src/graph/extract.ts
@@ -10,12 +10,13 @@ import Parser from "tree-sitter";
 import TypeScript from "tree-sitter-typescript";
 import Python from "tree-sitter-python";
 import Go from "tree-sitter-go";
+import Java from "tree-sitter-java";
 import { basename } from "node:path";
 import { contentHash } from "../util/id.js";
 import { collectBindings, goReceiverVarOf, resolveRecvType, type FileBindings } from "./bindings.js";
 import type { Kind, NodeV1, Relation } from "./types.js";
 
-export type Language = "typescript" | "tsx" | "python" | "go";
+export type Language = "typescript" | "tsx" | "python" | "go" | "java";
 
 /**
  * Extension → the tree-sitter grammar that parses it, and the label a human expects
@@ -44,6 +45,7 @@ const EXTENSIONS: ReadonlyArray<{ ext: string; grammar: Language; label: string 
   { ext: ".pyi", grammar: "python", label: "python" },
   { ext: ".py", grammar: "python", label: "python" },
   { ext: ".go", grammar: "go", label: "go" },
+  { ext: ".java", grammar: "java", label: "java" },
 ];
 
 function entryFor(path: string): (typeof EXTENSIONS)[number] | undefined {
@@ -149,11 +151,44 @@ const GO_KINDS: Record<string, Kind> = {
   method_declaration: "method",
 };
 
+// Java: a record is a nominal data carrier, so it takes "struct" — the same role
+// Go's struct plays — rather than "class", which would make a service and a DTO
+// indistinguishable in a repo where DTOs are most of the type surface.
+const JAVA_KINDS: Record<string, Kind> = {
+  class_declaration: "class",
+  interface_declaration: "interface",
+  enum_declaration: "enum",
+  record_declaration: "struct",
+  annotation_type_declaration: "interface",
+  method_declaration: "method",
+  constructor_declaration: "method",
+};
+
+/** Java type declarations: they set `enclosingClass` for the methods nested in them,
+ * which "class"-only logic would miss for a record's or interface's members. */
+const JAVA_TYPE_KINDS: ReadonlySet<Kind> = new Set<Kind>(["class", "interface", "enum", "struct"]);
+
 const KINDS_BY_LANG: Record<Language, Record<string, Kind>> = {
   typescript: TS_KINDS,
   tsx: TS_KINDS,
   python: PY_KINDS,
   go: GO_KINDS,
+  java: JAVA_KINDS,
+};
+
+/**
+ * The node type(s) that constitute a call site, per language.
+ *
+ * Java is the reason this is a set rather than a string: `method_invocation` and
+ * `object_creation_expression` (`new Foo()`) are separate node types, and a Java
+ * codebase's constructor calls are a large share of its real edges.
+ */
+const CALL_TYPES: Record<Language, ReadonlySet<string>> = {
+  typescript: new Set(["call_expression"]),
+  tsx: new Set(["call_expression"]),
+  python: new Set(["call"]),
+  go: new Set(["call_expression"]),
+  java: new Set(["method_invocation", "object_creation_expression"]),
 };
 
 const FUNCTION_VALUE_TYPES = new Set([
@@ -169,6 +204,7 @@ const GRAMMARS: Record<Language, unknown> = {
   tsx: TypeScript.tsx,
   python: Python,
   go: Go,
+  java: Java,
 };
 
 export interface WalkCtx {
@@ -297,7 +333,9 @@ function walk(node: Parser.SyntaxNode, ctx: WalkCtx, out: NodeV1[], edges: RawEd
           ? !desc.name.startsWith("_")
           : ctx.lang === "go"
             ? goExported(desc.name)
-            : tsExported(node),
+            : ctx.lang === "java"
+              ? javaExported(node)
+              : tsExported(node),
       origin: "ast",
       body_hash: contentHash(desc.hashNode.text),
       body_text: searchBody(desc.hashNode.text),
@@ -308,10 +346,17 @@ function walk(node: Parser.SyntaxNode, ctx: WalkCtx, out: NodeV1[], edges: RawEd
     });
     // structural containment
     edges.push({ source: ctx.parentId, relation: "contains", targetId: id, file: ctx.rel });
-    // class heritage
-    if (desc.kind === "class") edges.push(...heritageEdges(node, id, ctx));
+    // class heritage — in Java an interface may also `extends`, and a record/enum
+    // may `implements`, so every type declaration is a heritage site, not just a class.
+    const javaTypeDecl = ctx.lang === "java" && JAVA_TYPE_KINDS.has(desc.kind);
+    if (desc.kind === "class" || javaTypeDecl) edges.push(...heritageEdges(node, id, ctx));
 
-    const enclosingClass = desc.kind === "class" ? desc.name : isGoMethod ? goReceiverType(node) : ctx.enclosingClass;
+    const enclosingClass =
+      desc.kind === "class" || javaTypeDecl
+        ? desc.name
+        : isGoMethod
+          ? goReceiverType(node)
+          : ctx.enclosingClass;
     const childCtx: WalkCtx = {
       ...ctx,
       scope: [...ctx.scope, idPart],
@@ -329,8 +374,8 @@ function walk(node: Parser.SyntaxNode, ctx: WalkCtx, out: NodeV1[], edges: RawEd
   }
 
   // not a definition — capture calls/imports/references, then descend with the same context
-  const callType = ctx.lang === "python" ? "call" : "call_expression";
-  if (node.type === callType) {
+  const callTypes = CALL_TYPES[ctx.lang];
+  if (callTypes.has(node.type)) {
     const callee = calleeName(node, ctx.lang);
     if (callee) {
       const callEdge: RawEdge = {
@@ -351,7 +396,7 @@ function walk(node: Parser.SyntaxNode, ctx: WalkCtx, out: NodeV1[], edges: RawEd
     return;
   } else if (
     node.type === "identifier" &&
-    !isDirectCallee(node, callType) &&
+    !isDirectCallee(node, callTypes) &&
     !isDeclarationName(node)
   ) {
     const imported = ctx.importedSymbols.get(node.text);
@@ -453,10 +498,13 @@ function isFunctionBoundary(node: Parser.SyntaxNode): boolean {
   );
 }
 
-/** A direct invocation already emits a stronger `calls` edge. */
-function isDirectCallee(node: Parser.SyntaxNode, callType: string): boolean {
+/** A direct invocation already emits a stronger `calls` edge. Java names the callee
+ * in a `name` field (there is no `function` field on `method_invocation`), so both
+ * spellings count. */
+function isDirectCallee(node: Parser.SyntaxNode, callTypes: ReadonlySet<string>): boolean {
   const parent = node.parent;
-  return parent?.type === callType && parent.childForFieldName("function") === node;
+  if (!parent || !callTypes.has(parent.type)) return false;
+  return parent.childForFieldName("function") === node || parent.childForFieldName("name") === node;
 }
 
 /** Definition/declaration identifiers name a new binding; they do not use one. */
@@ -469,6 +517,7 @@ function isDeclarationName(node: Parser.SyntaxNode): boolean {
  * TS arrow-consts. */
 function describe(node: Parser.SyntaxNode, ctx: WalkCtx): DefDescriptor | null {
   if (ctx.lang === "go") return describeGo(node, ctx);
+  if (ctx.lang === "java") return describeJava(node, ctx);
 
   const mapped = ctx.kinds[node.type];
   if (mapped) {
@@ -543,6 +592,28 @@ function describeGo(node: Parser.SyntaxNode, _ctx: WalkCtx): DefDescriptor | nul
   return null;
 }
 
+/** Java definition shapes. Uniform in a way Go's are not: every declaration carries
+ * a `name` field and (for types and most members) a `body`, so one mapped lookup
+ * covers classes, interfaces, enums, records, methods, and constructors. Methods are
+ * lexically nested in their type, so — unlike Go — they need no receiver qualification. */
+function describeJava(node: Parser.SyntaxNode, ctx: WalkCtx): DefDescriptor | null {
+  const mapped = ctx.kinds[node.type];
+  if (!mapped) return null;
+  const name = node.childForFieldName("name")?.text;
+  if (!name) return null;
+  const body = node.childForFieldName("body");
+  return { name, kind: mapped, headerEnd: body ? body.startIndex : node.endIndex, hashNode: node };
+}
+
+/** Java visibility: `public` (or `protected`) on the declaration's own modifier list.
+ * A package-private or private member is not part of the API surface. Read off the
+ * `modifiers` child's tokens, ignoring annotations, which live in the same node. */
+function javaExported(node: Parser.SyntaxNode): boolean {
+  const mods = node.namedChildren.find((c) => c.type === "modifiers");
+  if (!mods) return false;
+  return mods.children.some((c) => c.type === "public" || c.type === "protected");
+}
+
 /** The receiver's base type name for a Go method, unwrapping a pointer receiver
  * (`func (u *User) …` → `User`). Null if it can't be read. */
 function goReceiverType(node: Parser.SyntaxNode): string | null {
@@ -563,6 +634,24 @@ function goExported(name: string): boolean {
 
 function heritageEdges(node: Parser.SyntaxNode, classId: string, ctx: WalkCtx): RawEdge[] {
   const edges: RawEdge[] = [];
+  if (ctx.lang === "java") {
+    // `superclass` holds `extends X`; `super_interfaces` holds `implements A, B`
+    // (and, on an interface declaration, `extends A, B` — which tree-sitter-java
+    // still spells `extends_interfaces`).
+    for (const child of node.namedChildren) {
+      const relation: Relation | null =
+        child.type === "superclass"
+          ? "extends"
+          : child.type === "super_interfaces" || child.type === "extends_interfaces"
+            ? "implements"
+            : null;
+      if (!relation) continue;
+      for (const t of typeIdentifiersIn(child)) {
+        edges.push({ source: classId, relation, name: t, file: ctx.rel });
+      }
+    }
+    return edges;
+  }
   if (ctx.lang === "python") {
     const supers = node.childForFieldName("superclasses"); // argument_list
     for (const c of supers?.namedChildren ?? []) {
@@ -590,10 +679,44 @@ function heritageEdges(node: Parser.SyntaxNode, classId: string, ctx: WalkCtx): 
   return edges;
 }
 
+/** Every `type_identifier` under a heritage clause, so `implements A, B<C>` yields
+ * each named type rather than the clause's raw text. */
+function typeIdentifiersIn(node: Parser.SyntaxNode): string[] {
+  const out: string[] = [];
+  const visit = (n: Parser.SyntaxNode): void => {
+    if (n.type === "type_identifier") out.push(n.text);
+    for (const c of n.namedChildren) visit(c);
+  };
+  visit(node);
+  return out;
+}
+
 function calleeName(
   node: Parser.SyntaxNode,
   lang: Language,
 ): { name: string; viaMember: boolean; receiver?: string } | null {
+  // Java first: `method_invocation` has NO `function` field (it splits the callee
+  // into `object` + `name`), so the shared lookup below would return null for every
+  // Java call site and the language would extract nodes with no call edges at all.
+  if (lang === "java") {
+    if (node.type === "object_creation_expression") {
+      // `new Foo()` — the constructed type is the call target.
+      const t = node.childForFieldName("type");
+      return t ? { name: t.text, viaMember: false } : null;
+    }
+    const nameNode = node.childForFieldName("name");
+    if (!nameNode) return null;
+    const obj = node.childForFieldName("object");
+    // No `object` means an implicit-`this` call (`decorate(name)`), which in Java is a
+    // method call, not a free function — Java has none. Reporting it as a plain call
+    // would send it to the function-only resolver and drop it, losing the most common
+    // intra-class edge there is. Spelling it as a `this` member call routes it through
+    // owner-qualified resolution, which also walks the superclass chain and stays
+    // conservative: an unmatched name (e.g. a static import) resolves to nothing.
+    if (!obj) return { name: nameNode.text, viaMember: true, receiver: "this" };
+    return { name: nameNode.text, viaMember: true, receiver: javaReceiver(obj) };
+  }
+
   const fn = node.childForFieldName("function");
   if (!fn) return null;
   if (fn.type === "identifier") return { name: fn.text, viaMember: false };
@@ -613,6 +736,21 @@ function calleeName(
     return p ? { name: p.text, viaMember: true, receiver: tsReceiver(fn) } : null;
   }
   return null;
+}
+
+/** A Java call's receiver text: a bare identifier (`repo.save()`), `this`, or
+ * `this.x` for a field access (`this.repo.save()`). A chained call or a qualified
+ * static reference yields none — there is no confident local clue to bind. */
+function javaReceiver(obj: Parser.SyntaxNode | null | undefined): string | undefined {
+  if (!obj) return undefined;
+  if (obj.type === "identifier") return obj.text;
+  if (obj.type === "this") return "this";
+  if (obj.type === "field_access") {
+    const inner = obj.childForFieldName("object");
+    const field = obj.childForFieldName("field");
+    if (inner?.type === "this" && field) return `this.${field.text}`;
+  }
+  return undefined;
 }
 
 /** py `attribute` node's receiver text: bare identifier, or `self.x` for a
@@ -645,6 +783,7 @@ function isImport(node: Parser.SyntaxNode, lang: Language): boolean {
   // Go: match the per-import leaf, so single (`import "fmt"`) and grouped
   // (`import ( … )`) forms each yield one edge as the walk recurses into the list.
   if (lang === "go") return node.type === "import_spec";
+  if (lang === "java") return node.type === "import_declaration";
   return node.type === "import_statement" || node.type === "import_from_statement";
 }
 
@@ -659,6 +798,15 @@ function importSpecifier(node: Parser.SyntaxNode, lang: Language): string | null
     // import_spec's `path` is an interpreted_string_literal, e.g. `"mymod/pkg/util"`.
     const path = node.childForFieldName("path") ?? node.namedChildren.at(-1);
     return path ? path.text.replace(/^["`]|["`]$/g, "") : null;
+  }
+  if (lang === "java") {
+    // `import a.b.C;` / `import static a.b.C.d;` / `import a.b.*;` — the fully
+    // qualified name is the scoped_identifier; a wildcard `*` is a separate token
+    // and is dropped, leaving the package as the import target.
+    const id = node.namedChildren.find(
+      (c) => c.type === "scoped_identifier" || c.type === "identifier",
+    );
+    return id?.text ?? null;
   }
   const str = node.namedChildren.find((c) => c.type === "string");
   if (!str) return null;

--- a/src/graph/extract.ts
+++ b/src/graph/extract.ts
@@ -82,6 +82,11 @@ export interface RawEdge {
   /** calls with viaMember: the receiver's resolved type name (from bindings /
    * self / this / Go receiver), when a confident local clue exists. */
   recvType?: string;
+  /** calls: the number of arguments at the CALL SITE. Only emitted for languages
+   * with overloading (Java), where a same-named sibling on the same class is
+   * otherwise indistinguishable — and picking wrong turns a delegating overload
+   * into a self-loop. */
+  argCount?: number;
 }
 
 export interface ExtractResult {
@@ -228,6 +233,8 @@ interface DefDescriptor {
   kind: Kind;
   headerEnd: number; // char index where the signature ends (body starts)
   hashNode: Parser.SyntaxNode; // node whose text forms body_hash / span
+  arity?: number; // declared parameter count — overload disambiguation (Java)
+  variadic?: boolean; // last parameter is a vararg, so `arity` is a minimum
 }
 
 /** tree-sitter's string `parse()` fails with "Invalid argument" on any input
@@ -343,6 +350,8 @@ function walk(node: Parser.SyntaxNode, ctx: WalkCtx, out: NodeV1[], edges: RawEd
       summary: null,
       crux: null,
       ...(owner !== undefined ? { owner } : {}),
+      ...(desc.arity !== undefined ? { arity: desc.arity } : {}),
+      ...(desc.variadic ? { variadic: true } : {}),
     });
     // structural containment
     edges.push({ source: ctx.parentId, relation: "contains", targetId: id, file: ctx.rel });
@@ -385,6 +394,9 @@ function walk(node: Parser.SyntaxNode, ctx: WalkCtx, out: NodeV1[], edges: RawEd
         viaMember: callee.viaMember,
         file: ctx.rel,
       };
+      // Java only: the call site's argument count, to pick the right overload.
+      const argCount = ctx.lang === "java" ? javaArgCount(node) : undefined;
+      if (argCount !== undefined) callEdge.argCount = argCount;
       const recvType = resolveRecvType(callee.receiver, ctx);
       edges.push(recvType ? { ...callEdge, recvType } : callEdge);
     }
@@ -602,7 +614,25 @@ function describeJava(node: Parser.SyntaxNode, ctx: WalkCtx): DefDescriptor | nu
   const name = node.childForFieldName("name")?.text;
   if (!name) return null;
   const body = node.childForFieldName("body");
-  return { name, kind: mapped, headerEnd: body ? body.startIndex : node.endIndex, hashNode: node };
+  const desc: DefDescriptor = {
+    name,
+    kind: mapped,
+    headerEnd: body ? body.startIndex : node.endIndex,
+    hashNode: node,
+  };
+  // Only callables carry arity. A record declaration also has a `parameters` node,
+  // but its components are not an overload set and must never be filtered against.
+  if (node.type === "method_declaration" || node.type === "constructor_declaration") {
+    const params = node.childForFieldName("parameters");
+    if (params) {
+      const declared = params.namedChildren.filter(
+        (c) => c.type === "formal_parameter" || c.type === "spread_parameter",
+      );
+      desc.arity = declared.length;
+      if (declared.some((c) => c.type === "spread_parameter")) desc.variadic = true;
+    }
+  }
+  return desc;
 }
 
 /** Java visibility: `public` (or `protected`) on the declaration's own modifier list.
@@ -736,6 +766,15 @@ function calleeName(
     return p ? { name: p.text, viaMember: true, receiver: tsReceiver(fn) } : null;
   }
   return null;
+}
+
+/** The number of arguments at a Java call site (`method_invocation` or
+ * `object_creation_expression`), read off the `arguments` list. Undefined when the
+ * list is absent, which keeps resolution at its previous name-only behavior rather
+ * than filtering on a count we never established. */
+function javaArgCount(node: Parser.SyntaxNode): number | undefined {
+  const args = node.childForFieldName("arguments");
+  return args ? args.namedChildren.length : undefined;
 }
 
 /** A Java call's receiver text: a bare identifier (`repo.save()`), `this`, or

--- a/src/graph/resolve.ts
+++ b/src/graph/resolve.ts
@@ -127,7 +127,7 @@ export function resolveEdges(
     } else if (e.relation === "calls") {
       if (e.viaMember) {
         if (!e.recvType) continue;
-        const hit = resolveTypedMember(e.recvType, e.name!, e.file, ownerMethod, classParents);
+        const hit = resolveTypedMember(e.recvType, e.name!, e.file, ownerMethod, classParents, e.argCount);
         if (hit === "ambiguous") continue; // drop — never guess past an ambiguous owner
         if (hit) add(e.source, hit.id, "calls", hit.confidence);
         // No owner-qualified match means the call is unresolved. A unique bare
@@ -185,20 +185,45 @@ function resolveName(
  *   - `null` — the whole chain (recvType + ancestors, breadth-first, depth ≤ 3,
  *     cycle-guarded) had zero candidates at every level.
  */
+/**
+ * Narrow an overload set to the candidates a call of `argCount` arguments could
+ * reach. Only Java emits `argCount`/`arity`, so for every other language this is
+ * the identity function and resolution is byte-for-byte what it was.
+ *
+ * Deliberately conservative in both directions:
+ *   - A variadic candidate (`String... xs`) accepts anything from `arity - 1`
+ *     upward, so it is never filtered out by count.
+ *   - A candidate with no recorded arity (a graph built before this field) is
+ *     kept, since absence of data is not evidence of a mismatch.
+ *   - If narrowing leaves nothing, the ORIGINAL set is returned. An empty result
+ *     would silently drop a real edge; handing the full set back lets the existing
+ *     same-file / "ambiguous" logic make the call exactly as before.
+ */
+function narrowByArity(candidates: NodeV1[], argCount?: number): NodeV1[] {
+  if (argCount === undefined || candidates.length < 2) return candidates;
+  const fits = candidates.filter((c) => {
+    if (c.arity === undefined) return true;
+    return c.variadic ? argCount >= c.arity - 1 : c.arity === argCount;
+  });
+  return fits.length > 0 ? fits : candidates;
+}
+
 function resolveTypedMember(
   recvType: string,
   name: string,
   file: string,
   ownerMethod: Map<string, NodeV1[]>,
   classParents: Map<string, string[]>,
+  argCount?: number,
 ): { id: string; confidence: EdgeV1["confidence"] } | "ambiguous" | null {
   const MAX_DEPTH = 3;
   const visited = new Set<string>([recvType]);
   let frontier = [recvType];
   for (let depth = 0; depth <= MAX_DEPTH && frontier.length; depth++) {
     for (const type of frontier) {
-      const candidates = ownerMethod.get(`${type}.${name}`);
-      if (!candidates || candidates.length === 0) continue; // try next ancestor
+      const all = ownerMethod.get(`${type}.${name}`);
+      if (!all || all.length === 0) continue; // try next ancestor
+      const candidates = narrowByArity(all, argCount);
       if (candidates.length === 1) {
         const c = candidates[0];
         return { id: c.id, confidence: c.path === file ? "extracted" : "inferred" };

--- a/src/graph/resolve.ts
+++ b/src/graph/resolve.ts
@@ -47,12 +47,24 @@ export function resolveEdges(
   const ownerMethod = new Map<string, NodeV1[]>();
   // Go package resolution: dir (posix) → its `.go` file node ids, for import mapping.
   const goFilesByDir = new Map<string, string[]>();
+  // Java package resolution: a file's package-path suffix (`com/acme/Foo.java`) → its
+  // file node ids. A Java import names a type by its fully-qualified name, which by
+  // language convention mirrors the directory path under whatever source root the
+  // project uses (`src/main/java/`, `src/`, …) — so the suffix is the portable key.
+  const javaFilesBySuffix = new Map<string, string[]>();
   const hasGoModules = !!opts.goModules?.length;
   for (const n of nodes) {
     if (n.kind === "file") {
       if (hasGoModules && n.path.endsWith(".go")) {
         const dir = posix.dirname(toPosixPath(n.path));
         push(goFilesByDir, dir, n.id);
+      }
+      if (n.path.endsWith(".java")) {
+        // Index every directory-boundary suffix, since the source root is unknown:
+        // `src/main/java/com/acme/Foo.java` is reachable as `com/acme/Foo.java`,
+        // `acme/Foo.java`, and so on. The import's own FQN picks the right depth.
+        const parts = toPosixPath(n.path).split("/");
+        for (let i = 0; i < parts.length; i++) push(javaFilesBySuffix, parts.slice(i).join("/"), n.id);
       }
       continue;
     }
@@ -95,7 +107,9 @@ export function resolveEdges(
       const target =
         hasGoModules && e.file.endsWith(".go")
           ? resolveGoImport(e.specifier, opts.goModules!, goFilesByDir)
-          : resolveImport(e.specifier, e.file, byId);
+          : e.file.endsWith(".java")
+            ? resolveJavaImport(e.specifier, javaFilesBySuffix)
+            : resolveImport(e.specifier, e.file, byId);
       add(e.source, target, "imports", "extracted");
     } else if (e.relation === "extends" || e.relation === "implements") {
       const kinds: Kind[] = e.relation === "implements" ? ["interface"] : ["class", "interface"];
@@ -120,7 +134,14 @@ export function resolveEdges(
         // method name is not evidence that this receiver has that method.
         continue;
       }
-      const hit = resolveName(e.name!, e.file, ["function"], perFileName, globalName);
+      // Java emits only one kind of non-member call: `new Foo()`, whose target is a
+      // TYPE, not a function (Java has no free functions — an implicit-`this` call is
+      // spelled as a member call in extract.ts). Resolving it against the function
+      // index would drop every constructor edge.
+      const kinds: Kind[] = e.file.endsWith(".java")
+        ? ["class", "struct", "enum", "interface"]
+        : ["function"];
+      const hit = resolveName(e.name!, e.file, kinds, perFileName, globalName);
       if (hit) add(e.source, hit.id, "calls", hit.confidence); // drop unresolved calls (too noisy)
     }
   }
@@ -216,6 +237,40 @@ function resolveImport(spec: string, file: string, byId: Map<string, NodeV1>): s
     ...IMPORT_EXTS.map((e) => `${noExt}/index${e}`),
   ];
   for (const c of candidates) if (byId.has(c)) return c;
+  return spec;
+}
+
+/**
+ * Resolve a Java import's fully-qualified type name to an in-repo file node;
+ * otherwise return the raw specifier (JDK or third-party type).
+ *
+ * Java names a *type*, not a path, and states no source root — `com.acme.Foo` may
+ * live under `src/main/java/`, `src/`, or a module dir. Matching on the path SUFFIX
+ * (`com/acme/Foo.java`) is therefore root-agnostic and needs no build-file parsing,
+ * which is what keeps this deterministic and dependency-free.
+ *
+ * `import static com.acme.Foo.bar` names a member, so when the full name misses, the
+ * last segment is dropped and the enclosing type retried. A wildcard (`com.acme.*`)
+ * names a package rather than one file and is deliberately left unresolved: picking a
+ * representative would invent an edge the source does not state.
+ *
+ * A suffix shared by two files (the same FQN under two source roots, e.g. a
+ * duplicated test tree) is ambiguous, so it stays unresolved rather than guessing.
+ */
+function resolveJavaImport(spec: string, filesBySuffix: Map<string, string[]>): string {
+  const hit = (fqn: string): string | null => {
+    const suffix = `${fqn.split(".").join("/")}.java`;
+    const files = filesBySuffix.get(suffix);
+    return files && files.length === 1 ? files[0] : null;
+  };
+  const direct = hit(spec);
+  if (direct) return direct;
+  // `import static a.b.C.member` → retry as `a.b.C`.
+  const dot = spec.lastIndexOf(".");
+  if (dot > 0) {
+    const enclosing = hit(spec.slice(0, dot));
+    if (enclosing) return enclosing;
+  }
   return spec;
 }
 

--- a/src/graph/types.ts
+++ b/src/graph/types.ts
@@ -60,6 +60,14 @@ export interface NodeV1 {
   //                 the code — not just the name/signature — is findable; never
   //                 emitted to the agent (that reads verbatim source via `--source`).
   //                 Absent on file nodes and on graphs built before this field.
+  arity?: number; // declared parameter count (method/constructor nodes). Disambiguates
+  //                 OVERLOADS, which only Java has among the languages parsed here: two
+  //                 same-named methods on one class are otherwise separable only by
+  //                 arity, and picking the wrong one turns a delegating overload into a
+  //                 self-loop. Absent on graphs built before this field, and on
+  //                 languages that do not emit it — resolution then behaves as before.
+  variadic?: boolean; // the last parameter is a vararg (`String... xs`), so the declared
+  //                 arity is a MINIMUM, not an equality. Never arity-filtered out.
 
   // meaning (Tier-2, one LLM call)
   summary_state: SummaryState;

--- a/test/graph-java.test.ts
+++ b/test/graph-java.test.ts
@@ -347,3 +347,110 @@ test("Java extraction: an ambiguous package suffix stays unresolved rather than 
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+/** Overload fixture: a 2-arg convenience method delegating to the 3-arg one — the
+ * commonest shape in Java, and the one that produced a self-loop before arity was
+ * recorded. `log` adds a variadic pair; `render` a same-arity pair. */
+const OVERLOADS = `package com.acme;
+
+public final class Svc {
+
+  public String join(String left, String right) {
+    return join(left, right, "-");
+  }
+
+  public String join(String left, String right, String separator) {
+    return left + separator + right;
+  }
+
+  public void log(String msg) {
+    log(msg, "a", "b");
+  }
+
+  public void log(String msg, String... rest) {}
+
+  public String render(String s) {
+    return render(s.length());
+  }
+
+  public String render(int n) {
+    return String.valueOf(n);
+  }
+}
+`;
+
+function overloadFixture(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graft-java-overload-"));
+  mkdirSync(join(dir, PKG), { recursive: true });
+  writeFileSync(join(dir, PKG, "Svc.java"), OVERLOADS);
+  return dir;
+}
+
+test("Java overloads: a delegating call resolves to the other overload, not itself", async () => {
+  // Before arity was recorded, both `join` nodes were candidates, the same-file
+  // tiebreak picked the first, and the 2-arg method got a `calls` edge to ITSELF —
+  // marked `extracted`, i.e. confidently wrong. Overloading exists in none of the
+  // other languages graft parses, so no existing fixture could have caught this.
+  const dir = overloadFixture();
+  try {
+    await buildGraph(dir);
+    const graph = readGraph(wiringPath(join(dir, "graft")))!;
+    const svc = `${PKG}/Svc.java`;
+    const calls = graph.edges.filter((e) => e.relation === "calls");
+
+    assert.ok(
+      calls.some((e) => e.source === `${svc}#Svc.join` && e.target === `${svc}#Svc.join~2`),
+      "the 2-arg join should call the 3-arg overload",
+    );
+    assert.ok(
+      !calls.some((e) => e.source === `${svc}#Svc.join` && e.target === `${svc}#Svc.join`),
+      "and must not call itself",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("Java overloads: a variadic candidate is never filtered out by argument count", async () => {
+  // `log(String, String...)` has arity 2 but accepts 1..n arguments. Filtering on
+  // equality would exclude it from a 3-argument call and drop a real edge.
+  const dir = overloadFixture();
+  try {
+    await buildGraph(dir);
+    const graph = readGraph(wiringPath(join(dir, "graft")))!;
+    const svc = `${PKG}/Svc.java`;
+
+    const variadic = graph.nodes.find((n) => n.id === `${svc}#Svc.log~2`);
+    assert.equal(variadic?.arity, 2, "declared arity counts the vararg parameter");
+    assert.equal(variadic?.variadic, true, "and it is flagged variadic");
+
+    assert.ok(
+      graph.edges.some(
+        (e) => e.relation === "calls" && e.source === `${svc}#Svc.log` && e.target === `${svc}#Svc.log~2`,
+      ),
+      "a 3-argument call should still reach the variadic overload",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("Java overloads: same-arity overloads stay unresolved rather than guessing", async () => {
+  // `render(String)` and `render(int)` both have arity 1 — they differ only by
+  // parameter TYPE, which this pass does not model. The documented limit: narrowing
+  // cannot separate them, so the same-file tiebreak applies and no type-based guess
+  // is made. Pinned so a future type-aware change is a deliberate one.
+  const dir = overloadFixture();
+  try {
+    await buildGraph(dir);
+    const graph = readGraph(wiringPath(join(dir, "graft")))!;
+    const svc = `${PKG}/Svc.java`;
+
+    const a = graph.nodes.find((n) => n.id === `${svc}#Svc.render`);
+    const b = graph.nodes.find((n) => n.id === `${svc}#Svc.render~2`);
+    assert.equal(a?.arity, 1);
+    assert.equal(b?.arity, 1, "both render overloads have arity 1, so count cannot separate them");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/graph-java.test.ts
+++ b/test/graph-java.test.ts
@@ -1,0 +1,349 @@
+/**
+ * Tests for Java extraction in the Tier-1 code graph. Builds a small Java source
+ * tree in a temp dir and asserts the emitted nodes (classes, interfaces, enums,
+ * records, methods, constructors) and edges (calls, heritage, package imports)
+ * match the AST walk in extract.ts.
+ *
+ * Three of these pin decisions that are Java-specific and easy to regress, because
+ * each one is invisible to the other languages' fixtures:
+ *
+ *   - `method_invocation` has NO `function` field (it splits the callee into
+ *     `object` + `name`), unlike every other grammar graft parses.
+ *   - Java has no free functions, so an implicit-`this` call (`decorate(x)`) is a
+ *     METHOD call. Resolved against the function index it would vanish — and it is
+ *     the most common intra-class edge there is.
+ *   - `new Foo()` targets a TYPE, so a constructor call resolved against the
+ *     function index would vanish too.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { buildGraph } from "../src/graph/build.js";
+import { readGraph, wiringPath } from "../src/graph/write.js";
+import type { GraphV1, NodeV1 } from "../src/graph/types.js";
+
+const PKG = "src/main/java/com/acme";
+
+const GREETER = `package com.acme;
+
+public interface Greeter {
+  String greet(String name);
+}
+`;
+
+const BASE = `package com.acme;
+
+public abstract class Base {
+  protected void audit(String event) {}
+}
+`;
+
+const POINT = `package com.acme;
+
+public record Point(int x, int y) {}
+`;
+
+const COLOR = `package com.acme;
+
+public enum Color {
+  RED,
+  GREEN
+}
+`;
+
+const STORE = `package com.acme;
+
+public final class Store {
+  public void save(Point point) {}
+}
+`;
+
+const APP = `package com.acme;
+
+import com.acme.Store;
+import java.util.List;
+
+public final class App extends Base implements Greeter {
+
+  private final Store store;
+
+  public App(Store store) {
+    this.store = store;
+  }
+
+  @Override
+  public String greet(String name) {
+    return decorate(name);
+  }
+
+  private String decorate(String raw) {
+    return raw;
+  }
+
+  public void persist() {
+    store.save(new Point(1, 2));
+  }
+
+  public void inferred() {
+    var local = new Store();
+    local.save(new Point(3, 4));
+  }
+
+  void packagePrivate() {}
+}
+`;
+
+function makeFixture(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graft-java-"));
+  mkdirSync(join(dir, PKG), { recursive: true });
+  writeFileSync(join(dir, PKG, "Greeter.java"), GREETER);
+  writeFileSync(join(dir, PKG, "Base.java"), BASE);
+  writeFileSync(join(dir, PKG, "Point.java"), POINT);
+  writeFileSync(join(dir, PKG, "Color.java"), COLOR);
+  writeFileSync(join(dir, PKG, "Store.java"), STORE);
+  writeFileSync(join(dir, PKG, "App.java"), APP);
+  return dir;
+}
+
+function nodeById(graph: GraphV1, id: string): NodeV1 | undefined {
+  return graph.nodes.find((n) => n.id === id);
+}
+
+const APP_JAVA = `${PKG}/App.java`;
+
+test("Java extraction: classes, interfaces, enums, records, methods, constructors", async () => {
+  const dir = makeFixture();
+  try {
+    const result = await buildGraph(dir); // $0, Tier-1 only
+    assert.ok(result.languages.includes("java"), "languages should include java");
+
+    const graph = readGraph(wiringPath(join(dir, "graft")));
+    assert.ok(graph, "wiring graph should be written");
+
+    assert.equal(nodeById(graph!, `${APP_JAVA}#App`)?.kind, "class");
+    assert.equal(nodeById(graph!, `${PKG}/Greeter.java#Greeter`)?.kind, "interface");
+    assert.equal(nodeById(graph!, `${PKG}/Color.java#Color`)?.kind, "enum");
+
+    // A record is a nominal data carrier, so it takes "struct" — not "class", which
+    // would make a DTO and a service indistinguishable in a Java repo where DTOs are
+    // most of the type surface.
+    assert.equal(nodeById(graph!, `${PKG}/Point.java#Point`)?.kind, "struct");
+
+    // Methods nest under their type; a constructor is a method named for its class.
+    assert.equal(nodeById(graph!, `${APP_JAVA}#App.greet`)?.kind, "method");
+    assert.equal(nodeById(graph!, `${APP_JAVA}#App.App`)?.kind, "method");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("Java extraction: visibility comes from the modifier list, not the name", async () => {
+  const dir = makeFixture();
+  try {
+    await buildGraph(dir);
+    const graph = readGraph(wiringPath(join(dir, "graft")))!;
+
+    assert.equal(nodeById(graph, `${APP_JAVA}#App`)?.exported, true, "public class");
+    assert.equal(nodeById(graph, `${APP_JAVA}#App.greet`)?.exported, true, "public method");
+    assert.equal(
+      nodeById(graph, `${PKG}/Base.java#Base.audit`)?.exported,
+      true,
+      "protected is still API surface to a subclass",
+    );
+    assert.equal(
+      nodeById(graph, `${APP_JAVA}#App.decorate`)?.exported,
+      false,
+      "private method is not API surface",
+    );
+    assert.equal(
+      nodeById(graph, `${APP_JAVA}#App.packagePrivate`)?.exported,
+      false,
+      "package-private (no modifier) is not API surface",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("Java extraction: call edges — implicit `this`, typed field receiver, constructor", async () => {
+  const dir = makeFixture();
+  try {
+    await buildGraph(dir);
+    const graph = readGraph(wiringPath(join(dir, "graft")))!;
+    const calls = graph.edges.filter((e) => e.relation === "calls");
+
+    // Implicit-`this`: `decorate(name)` names no receiver but IS a method call.
+    // Java has no free functions, so resolving this against the function index
+    // would silently drop the commonest edge in the language.
+    assert.ok(
+      calls.some((e) => e.source === `${APP_JAVA}#App.greet` && e.target === `${APP_JAVA}#App.decorate`),
+      "greet should call decorate via implicit-this resolution",
+    );
+
+    // Typed field receiver: `store.save(...)` resolves through the declared field
+    // type `private final Store store`.
+    assert.ok(
+      calls.some(
+        (e) => e.source === `${APP_JAVA}#App.persist` && e.target === `${PKG}/Store.java#Store.save`,
+      ),
+      "persist should call Store.save via the field's declared type",
+    );
+
+    // `new Point(1, 2)` targets a TYPE, not a function.
+    assert.ok(
+      calls.some(
+        (e) => e.source === `${APP_JAVA}#App.persist` && e.target === `${PKG}/Point.java#Point`,
+      ),
+      "persist should have a constructor edge to Point",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("Java extraction: a `var` local states no type, so its member call stays unresolved", async () => {
+  // Not a defect to fix by guessing — it is the documented limit of a deterministic,
+  // single-file binding pass. `var local = new Store()` would need return-type
+  // inference to know `local` is a Store. The constructor edge still lands, so the
+  // dependency is not lost entirely; only the member call through it is.
+  const dir = makeFixture();
+  try {
+    await buildGraph(dir);
+    const graph = readGraph(wiringPath(join(dir, "graft")))!;
+    const calls = graph.edges.filter((e) => e.relation === "calls");
+
+    assert.ok(
+      !calls.some(
+        (e) => e.source === `${APP_JAVA}#App.inferred` && e.target === `${PKG}/Store.java#Store.save`,
+      ),
+      "a var-typed receiver must not be guessed into a resolved edge",
+    );
+    assert.ok(
+      calls.some(
+        (e) => e.source === `${APP_JAVA}#App.inferred` && e.target === `${PKG}/Store.java#Store`,
+      ),
+      "the constructor edge still resolves, so the dependency is still visible",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("Java extraction: extends and implements", async () => {
+  const dir = makeFixture();
+  try {
+    await buildGraph(dir);
+    const graph = readGraph(wiringPath(join(dir, "graft")))!;
+
+    assert.ok(
+      graph.edges.some(
+        (e) =>
+          e.relation === "extends" &&
+          e.source === `${APP_JAVA}#App` &&
+          e.target === `${PKG}/Base.java#Base`,
+      ),
+      "App extends Base",
+    );
+    assert.ok(
+      graph.edges.some(
+        (e) =>
+          e.relation === "implements" &&
+          e.source === `${APP_JAVA}#App` &&
+          e.target === `${PKG}/Greeter.java#Greeter`,
+      ),
+      "App implements Greeter",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("Java extraction: imports resolve by package path; external types stay strings", async () => {
+  const dir = makeFixture();
+  try {
+    await buildGraph(dir);
+    const graph = readGraph(wiringPath(join(dir, "graft")))!;
+    const imports = graph.edges.filter((e) => e.relation === "imports" && e.source === APP_JAVA);
+
+    // A Java import names a TYPE and states no source root, so resolution matches the
+    // fully-qualified name against a path suffix — root-agnostic, no build-file parsing.
+    assert.ok(
+      imports.some((e) => e.target === `${PKG}/Store.java`),
+      "com.acme.Store should resolve to the in-repo file under src/main/java/",
+    );
+
+    // The JDK is not in the repo; the specifier is kept verbatim rather than guessed at.
+    assert.ok(
+      imports.some((e) => e.target === "java.util.List"),
+      "java.util.List should remain an external type string",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("Java extraction: a static-member import resolves to its enclosing type", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-java-static-"));
+  try {
+    mkdirSync(join(dir, PKG), { recursive: true });
+    writeFileSync(
+      join(dir, PKG, "Util.java"),
+      "package com.acme;\n\npublic final class Util {\n  public static int twice(int n) {\n    return n * 2;\n  }\n}\n",
+    );
+    writeFileSync(
+      join(dir, PKG, "Caller.java"),
+      "package com.acme;\n\nimport static com.acme.Util.twice;\n\npublic final class Caller {\n  public int run() {\n    return twice(2);\n  }\n}\n",
+    );
+
+    await buildGraph(dir);
+    const graph = readGraph(wiringPath(join(dir, "graft")))!;
+
+    // `com.acme.Util.twice` names a member; the file is the enclosing type's.
+    assert.ok(
+      graph.edges.some(
+        (e) =>
+          e.relation === "imports" &&
+          e.source === `${PKG}/Caller.java` &&
+          e.target === `${PKG}/Util.java`,
+      ),
+      "a static-member import should fall back to its enclosing type's file",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("Java extraction: an ambiguous package suffix stays unresolved rather than guessing", async () => {
+  // The same fully-qualified name under two source roots (main and a duplicated test
+  // tree) gives one suffix two files. Picking one would invent an edge the source
+  // does not state, so the specifier is kept.
+  const dir = mkdtempSync(join(tmpdir(), "graft-java-ambig-"));
+  try {
+    const main = "src/main/java/com/acme";
+    const test2 = "src/test/java/com/acme";
+    mkdirSync(join(dir, main), { recursive: true });
+    mkdirSync(join(dir, test2), { recursive: true });
+    const dup = "package com.acme;\n\npublic final class Dup {\n  public void run() {}\n}\n";
+    writeFileSync(join(dir, main, "Dup.java"), dup);
+    writeFileSync(join(dir, test2, "Dup.java"), dup);
+    writeFileSync(
+      join(dir, main, "Uses.java"),
+      "package com.acme;\n\nimport com.acme.Dup;\n\npublic final class Uses {\n  public void go() {}\n}\n",
+    );
+
+    await buildGraph(dir);
+    const graph = readGraph(wiringPath(join(dir, "graft")))!;
+
+    assert.ok(
+      graph.edges.some(
+        (e) =>
+          e.relation === "imports" && e.source === `${main}/Uses.java` && e.target === "com.acme.Dup",
+      ),
+      "an ambiguous suffix must stay an unresolved specifier",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/graph-languages.test.ts
+++ b/test/graph-languages.test.ts
@@ -27,6 +27,7 @@ const INDEXED = [
   "a.tsx", "a.jsx",
   "a.py", "a.pyi",
   "a.go",
+  "a.java",
 ];
 
 test("a file is labelled exactly when it is indexed", () => {
@@ -53,6 +54,7 @@ test("labels name the language, not the grammar that parses it", () => {
   assert.equal(languageLabelOf("api/main.py"), "python");
   assert.equal(languageLabelOf("api/main.pyi"), "python");
   assert.equal(languageLabelOf("cmd/main.go"), "go");
+  assert.equal(languageLabelOf("src/main/java/com/acme/App.java"), "java");
 
   // The grammar is unchanged — extraction, the extract cache and every `Language`
   // switch still see exactly what they saw before.


### PR DESCRIPTION
## Promote Java from the broad tier to full fidelity

Rebased on `main`, so this now sits on top of the generic breadth tier (#84). The framing has changed with it: this is no longer "add Java" — the breadth tier already parses it. It's a proposal that **Java is worth a hand-written extractor**, and the case for that is measurable.

The two tiers compose without any change to dispatch: `build.ts` prefers a hand-written extractor and falls back to generic only when there is none, so `.java` reaches this path and `queries/java.scm` is simply not consulted for it. I've deliberately **left `java.scm` in place** — removing another contributor's file is the maintainers' call, not this PR's.

### What the tiers actually produce

Same repo, same commit, same machine — [`google/gson`](https://github.com/google/gson) at `--depth 1`, 264 `.java` files. The only difference is whether `.java` is claimed by `EXTENSIONS` (this branch) or falls through to `genericLangOf` (`main`):

| | broad tier (`main`) | this branch |
|---|---|---|
| nodes | 4,042 | 4,446 |
| **`contains`** | **0** | 4,182 |
| **`imports`** | **0** | 2,602 (1,021 resolved in-repo) |
| **`extends`** | **0** | 234 |
| **`implements`** | **0** | 196 |
| `calls` | 2,716 | 4,995 |
| total edges | 2,716 | 12,209 |
| records as `struct` | 0 | 33 |
| enums as `enum` | 0 | 26 |

The headline isn't the call count. It's that on the broad tier **every edge is a `calls` edge** — there is no containment, no import graph, and no type hierarchy at all. `graft ask "what implements this interface"` has nothing to answer from; neither does "what does this file depend on".

That isn't a criticism of the breadth tier, which is doing what it says: symbols plus name-resolved calls, one grammar per language, at a fraction of the effort. It's the argument for why a language you actually work in benefits from the expensive path.

### What the hand-written extractor adds

Three things the generic tier structurally cannot do, because `tags.scm` has no scope model:

**1. Typed receivers.** `store.save(x)` resolves through the declared type of the field `private final Store store`, so the edge lands on `Store.save` and not on every `save` in the repo. Fields and parameters are bound per scope; dependency-injected collaborators — the edges worth having in a service codebase — are exactly the typed-final-field case.

**2. Package-path imports.** A Java import names a *type* and states no source root, so resolution matches the FQN against a path suffix (`com.acme.Foo` → `**/com/acme/Foo.java`). Root-agnostic, no build-file parsing, so it stays deterministic and dependency-free. A static-member import retries its enclosing type; a wildcard, or a suffix shared by two files, stays unresolved rather than inventing an edge.

**3. Overload disambiguation.** Method and constructor nodes record `arity` and `variadic`; call edges record the call site's `argCount`. Without it, a convenience overload delegating to the fuller one resolves to *itself* — see the [comment below](#issuecomment-5268369387) for how that defect surfaced and was fixed.

### Java-specific things that bite

Worth flagging for review, since each one is invisible to the TS/Python/Go fixtures:

- `method_invocation` has **no `function` field** — it splits the callee into `object` + `name`. The shared `calleeName()` returns null for every Java call site without an early branch.
- Java has **no free functions**, so an implicit-`this` call (`decorate(x)`) is a method call. Resolved against the function index it vanishes — and it's the commonest intra-class edge in the language.
- `new Foo()` targets a **type**, not a function.
- A record maps to `struct` rather than `class`, so a DTO and a service stay distinguishable where DTOs are most of the type surface.

### Known limits (tested, not papered over)

- A `var` local states no type, so a member call through one stays unresolved. Cross-file return-type inference is out of scope for a deterministic single-file pass. Fields and parameters are explicitly typed even in `var`-heavy code and carry most of the graph; the constructor edge still lands, so the dependency stays visible.
- Same-arity overloads differing only by parameter *type* (`render(String)` / `render(int)`) can't be separated by count. Narrowing declines to choose rather than guessing.

Both are pinned by tests so a future change to either is deliberate.

### Not covered

Annotations aren't extracted, so frameworks that express routing or persistence through them (JPA `@Entity`/`@Column`, and similar) keep that topology invisible. Happy to follow up separately if it's of interest.

### Tests

11 Java cases in `test/graph-java.test.ts` — node kinds, modifier-based visibility, the three call-resolution paths, heritage, package-path and static-member imports, ambiguous-suffix and `var` behavior, and three overload cases. `.java` added to the language-label matrix. README moves Java from Broad to Full-fidelity, since that's what this branch makes true.

Full suite: **618 passing** (this branch's cases plus upstream's new ones). Every new test was verified to fail when the behavior it covers is reverted, so none of them are vacuous.

---

If the preference is to keep Java on the breadth tier and hold the line on hand-written extractors, that's a reasonable call and I won't argue it further — the measurements above are the whole of my case. I'd also happily split the overload fix into its own PR if you'd rather review the language support and the resolver change separately.
