### PR TITLE
docs: list supported languages in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 - [Benchmark](#benchmark)
 - [SWE-bench Verified](#swe-bench-verified)
 - [How the graph gets built](#how-the-graph-gets-built)
+- [Supported languages](#supported-languages)
 - [What's in a node](#whats-in-a-node)
 - [What runs where](#what-runs-where)
 - [Agent integration](#agent-integration) — [MCP server](#mcp-server) · [Claude Code (deep integration)](#claude-code-deep-integration)
@@ -181,6 +182,32 @@ Every pass is cached by content hash — the LLM ones and the tree-sitter parse 
 That cheapness is what lets **every query refresh the graph before it answers**. A retrieval call stats the tree against the last build's fingerprint (~3ms), and rebuilds only if something moved — so `ask`/`grep`/`callers`/`skeleton`/`map` describe the code as it is right now, including edits that are unsaved to git: uncommitted, unstaged, or staged all look the same to graft, which never reads git at all. The refresh is structural and `$0`; it never calls the LLM. Turn it off per-command with `--no-refresh`, or everywhere with `GRAFT_NO_REFRESH=1`.
 
 Alongside the markdown graph, `graft build` builds `graft/.graph/wiring.json` — a per-symbol code graph — plus a per-file wiring card mirroring your source tree. Tier 1 is pure tree-sitter (every function, class, and call edge; deterministic, no model, no network), which is why plain `graft build` needs no key. The `--deep` pass adds a one-line summary and a crux excerpt per symbol, cached by body hash.
+
+---
+
+## Supported languages
+
+Graft parses with tree-sitter at two levels of fidelity, plus an optional
+compiler-grade layer — all `$0` and deterministic (no model, no key):
+
+- **Full-fidelity** — hand-written extractors with scope-aware, cross-file call
+  and import resolution:
+  **TypeScript / JavaScript** (incl. JSX & TSX), **Python**, **Go**.
+
+- **Broad** — symbols (functions, classes, methods, types, …) plus name-resolved
+  call edges via a generic tree-sitter extractor, one grammar per language:
+  **Rust, Java, C, C++, C#, Ruby, PHP, Kotlin, Scala, Swift, Elixir, Solidity,
+  OCaml, Zig, Dart**.
+
+- **Compiler-grade edges (opt-in)** — `graft build --lsp` adds precise
+  `lsp_resolved` call edges (member calls the static pass can't type) when a
+  language server is on your `PATH`: **rust-analyzer** (Rust), **clangd** (C/C++),
+  **gopls** (Go), **pyright** (Python), **typescript-language-server** (TS/JS).
+  It's best-effort — with no server installed the graph is unchanged.
+
+Twenty languages in total. A file whose language isn't listed is skipped, not
+indexed. Adding a broad-tier language is a small contribution — see
+[CREDITS.md](CREDITS.md) for the folks who added the current set.
 
 ---
 


### PR DESCRIPTION
Full-fidelity (TS/JS/Python/Go), broad tier (15 langs via generic tree-sitter), and the opt-in --lsp compiler-grade layer. Added to the table of contents.