### PR TITLE
Breadth tier: file-level import edges for C/C++ (#include), Rust (use), and PHP (use)

### DIFF
--- a/src/graph/generic.ts
+++ b/src/graph/generic.ts
@@ -216,9 +216,45 @@ export function extractGeneric(rel: string, source: string, langName: string): E
     walkExtract(tree.rootNode as TsNode, mkDef); // no tags.scm → symbols only
   }
   // The preprocessor is invisible to tags.scm, but in C/C++ a local `#include "x.h"`
-  // IS the dependency graph — capture it as a file→file import.
+  // IS the dependency graph — capture it as a file→file import. Likewise a Rust
+  // `use crate::…` is an in-crate module dependency.
   if (langName === "c" || langName === "cpp") extractIncludes(tree.rootNode as TsNode, rel, rawEdges);
+  else if (langName === "rust") extractUses(tree.rootNode as TsNode, rel, rawEdges);
   return { nodes, rawEdges };
+}
+
+/** Rust `use crate::a::b::Item` → a file→module `imports` raw edge whose specifier is the
+ * crate-relative module path (`a/b`). Only in-crate imports are captured; `std::`,
+ * `super::`, `self::`, external crates, and globs are skipped — resolve.ts settles the
+ * path against the file's crate root, and drops it when it can't. */
+function extractUses(root: TsNode, rel: string, rawEdges: RawEdge[]): void {
+  const visit = (n: TsNode): void => {
+    if (n.type === "use_declaration") {
+      const spec = rustUseModule(n.text);
+      if (spec !== null) rawEdges.push({ source: rel, relation: "imports", specifier: spec ? `crate/${spec}` : "crate", file: rel });
+    }
+    for (let i = 0; i < (n.namedChildCount ?? 0); i++) {
+      const c = n.namedChild?.(i);
+      if (c) visit(c);
+    }
+  };
+  visit(root);
+}
+
+/** The crate-relative path a Rust `use crate::…` names (`::`→`/`), or null when it is not
+ * an in-crate import. The FULL path is returned — including any trailing item segment —
+ * because a single `crate::lexical` can be either a module OR a crate-root item; the
+ * resolver settles that by finding the longest prefix that is a real module file. A
+ * `{ … }` group has no single item, so its prefix (before `{`) is the path. */
+function rustUseModule(text: string): string | null {
+  let s = text.replace(/^\s*use\s+/, "").replace(/;\s*$/, "").trim();
+  const brace = s.indexOf("{");
+  if (brace >= 0) s = s.slice(0, brace).replace(/::\s*$/, "");
+  else s = s.replace(/\s+as\s+\w+$/, "");
+  s = s.trim();
+  if (s !== "crate" && !s.startsWith("crate::")) return null; // only in-crate absolute imports
+  if (s.includes("*")) return null; // glob — no single module target
+  return s.replace(/^crate::?/, "").replace(/\s+/g, "").replace(/::/g, "/"); // "" = crate root
 }
 
 /** C/C++ `#include "header.h"` → a file→file `imports` raw edge. Only LOCAL includes

--- a/src/graph/generic.ts
+++ b/src/graph/generic.ts
@@ -220,7 +220,41 @@ export function extractGeneric(rel: string, source: string, langName: string): E
   // `use crate::…` is an in-crate module dependency.
   if (langName === "c" || langName === "cpp") extractIncludes(tree.rootNode as TsNode, rel, rawEdges);
   else if (langName === "rust") extractUses(tree.rootNode as TsNode, rel, rawEdges);
+  else if (langName === "php") extractPhpUses(tree.rootNode as TsNode, rel, rawEdges);
   return { nodes, rawEdges };
+}
+
+/** PHP `use App\Models\User;` → a file→class-file `imports` raw edge, one per imported
+ * name (a `{ … }` group expands to several). `use function`/`use const` are skipped —
+ * those name a symbol, not a PSR-4 class file. resolve.ts settles the fully-qualified
+ * name to the in-repo file by namespace suffix, and drops it when it can't. */
+function extractPhpUses(root: TsNode, rel: string, rawEdges: RawEdge[]): void {
+  const visit = (n: TsNode): void => {
+    if (n.type === "namespace_use_declaration") {
+      for (const fqn of phpUseNames(n.text)) rawEdges.push({ source: rel, relation: "imports", specifier: fqn, file: rel });
+    }
+    for (let i = 0; i < (n.namedChildCount ?? 0); i++) {
+      const c = n.namedChild?.(i);
+      if (c) visit(c);
+    }
+  };
+  visit(root);
+}
+
+/** The fully-qualified class names a PHP `use` declaration imports. Handles a plain
+ * `use A\B\C;`, a comma list `use A\B, C\D;`, a group `use A\B\{C, D};`, and `as` aliases;
+ * returns [] for `use function`/`use const` (symbol imports, not class files). */
+function phpUseNames(text: string): string[] {
+  let s = text.replace(/^\s*use\s+/, "").replace(/;\s*$/, "").trim();
+  if (/^(function|const)\b/.test(s)) return [];
+  const brace = s.indexOf("{");
+  if (brace >= 0) {
+    const prefix = s.slice(0, brace).replace(/\\\s*$/, "");
+    const inner = s.slice(brace + 1, s.lastIndexOf("}"));
+    return inner.split(",").map((m) => m.trim().replace(/\s+as\s+\w+$/i, "").trim()).filter(Boolean)
+      .map((m) => `${prefix}\\${m}`);
+  }
+  return s.split(",").map((c) => c.trim().replace(/\s+as\s+\w+$/i, "").trim()).filter(Boolean);
 }
 
 /** Rust `use crate::a::b::Item` → a file→module `imports` raw edge whose specifier is the

--- a/src/graph/generic.ts
+++ b/src/graph/generic.ts
@@ -215,7 +215,32 @@ export function extractGeneric(rel: string, source: string, langName: string): E
   } else {
     walkExtract(tree.rootNode as TsNode, mkDef); // no tags.scm → symbols only
   }
+  // The preprocessor is invisible to tags.scm, but in C/C++ a local `#include "x.h"`
+  // IS the dependency graph — capture it as a file→file import.
+  if (langName === "c" || langName === "cpp") extractIncludes(tree.rootNode as TsNode, rel, rawEdges);
   return { nodes, rawEdges };
+}
+
+/** C/C++ `#include "header.h"` → a file→file `imports` raw edge. Only LOCAL includes
+ * (quoted) are captured; system includes (`<stdio.h>`) are skipped — high volume, and
+ * there is no in-repo target to navigate to. resolve.ts settles the quoted path to an
+ * in-repo header (relative to the including file, else a unique path-suffix match), and
+ * keeps it as an external string when it cannot — never a guessed edge. */
+function extractIncludes(root: TsNode, rel: string, rawEdges: RawEdge[]): void {
+  const visit = (n: TsNode): void => {
+    if (n.type === "preproc_include") {
+      const raw = n.childForFieldName?.("path")?.text ?? "";
+      if (raw.startsWith('"')) {
+        const spec = raw.replace(/^"|"$/g, "").trim();
+        if (spec) rawEdges.push({ source: rel, relation: "imports", specifier: spec, file: rel });
+      }
+    }
+    for (let i = 0; i < (n.namedChildCount ?? 0); i++) {
+      const c = n.namedChild?.(i);
+      if (c) visit(c);
+    }
+  };
+  visit(root);
 }
 
 /** tags.scm path: @definition.<kind> → nodes, @reference.call/@reference.send →

--- a/src/graph/resolve.ts
+++ b/src/graph/resolve.ts
@@ -18,6 +18,8 @@ import type { EdgeV1, Kind, NodeV1, Relation } from "./types.js";
 import type { RawEdge } from "./extract.js";
 
 const IMPORT_EXTS = [".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs", ".py"];
+/** C/C++ source + header extensions, for resolving `#include` targets. */
+const C_EXT = /\.(c|h|cc|cpp|cxx|hpp|hh|hxx|inl|ipp|c\+\+|h\+\+)$/i;
 
 /** A Go module discovered in the repo: its `module` path from `go.mod` and the repo
  * directory that `go.mod` lives in (posix, `.` for the repo root). A monorepo may hold
@@ -52,6 +54,10 @@ export function resolveEdges(
   // language convention mirrors the directory path under whatever source root the
   // project uses (`src/main/java/`, `src/`, …) — so the suffix is the portable key.
   const javaFilesBySuffix = new Map<string, string[]>();
+  // C/C++ header resolution: a file's path-suffix (`net/socket.h`, `socket.h`) → its
+  // file node ids, so an `#include` reached through an `-I` dir (not relative to the
+  // including file) still resolves to the in-repo header when the suffix is unique.
+  const cFilesBySuffix = new Map<string, string[]>();
   const hasGoModules = !!opts.goModules?.length;
   for (const n of nodes) {
     if (n.kind === "file") {
@@ -65,6 +71,10 @@ export function resolveEdges(
         // `acme/Foo.java`, and so on. The import's own FQN picks the right depth.
         const parts = toPosixPath(n.path).split("/");
         for (let i = 0; i < parts.length; i++) push(javaFilesBySuffix, parts.slice(i).join("/"), n.id);
+      }
+      if (C_EXT.test(n.path)) {
+        const parts = toPosixPath(n.path).split("/");
+        for (let i = 0; i < parts.length; i++) push(cFilesBySuffix, parts.slice(i).join("/"), n.id);
       }
       continue;
     }
@@ -109,7 +119,9 @@ export function resolveEdges(
           ? resolveGoImport(e.specifier, opts.goModules!, goFilesByDir)
           : e.file.endsWith(".java")
             ? resolveJavaImport(e.specifier, javaFilesBySuffix)
-            : resolveImport(e.specifier, e.file, byId);
+            : C_EXT.test(e.file)
+              ? resolveCInclude(e.specifier, e.file, byId, cFilesBySuffix)
+              : resolveImport(e.specifier, e.file, byId);
       add(e.source, target, "imports", "extracted");
     } else if (e.relation === "extends" || e.relation === "implements") {
       const kinds: Kind[] = e.relation === "implements" ? ["interface"] : ["class", "interface"];
@@ -320,6 +332,27 @@ function resolveJavaImport(spec: string, filesBySuffix: Map<string, string[]>): 
     if (enclosing) return enclosing;
   }
   return spec;
+}
+
+/**
+ * Resolve a C/C++ `#include "path"` to an in-repo file node: relative to the including
+ * file first (the common case, and certain), else a UNIQUE path-suffix match — which
+ * covers a header reached through an `-I` include directory rather than a relative path.
+ * Anything ambiguous or not found stays the raw path (a system or out-of-repo header),
+ * never a guessed edge.
+ */
+function resolveCInclude(
+  spec: string,
+  file: string,
+  byId: Map<string, NodeV1>,
+  bySuffix: Map<string, string[]>,
+): string {
+  const dir = posix.dirname(toPosixPath(file));
+  const relJoin = posix.normalize(posix.join(dir, spec));
+  if (byId.has(relJoin)) return relJoin; // relative to the including file — certain
+  const hits = bySuffix.get(spec.replace(/^\.?\//, ""));
+  if (hits && hits.length === 1) return hits[0]; // unique suffix — an -I-reached header
+  return spec; // system/out-of-repo/ambiguous — keep the string, do not guess
 }
 
 /**

--- a/src/graph/resolve.ts
+++ b/src/graph/resolve.ts
@@ -58,6 +58,10 @@ export function resolveEdges(
   // file node ids, so an `#include` reached through an `-I` dir (not relative to the
   // including file) still resolves to the in-repo header when the suffix is unique.
   const cFilesBySuffix = new Map<string, string[]>();
+  // Rust crate roots: the directory holding a `lib.rs` or `main.rs`. A `use crate::a::b`
+  // resolves to `<crate root>/a/b.rs` (or `.../a/b/mod.rs`), relative to the crate the
+  // importing file belongs to — so a workspace with several crates stays unambiguous.
+  const rustCrateRoots: string[] = [];
   const hasGoModules = !!opts.goModules?.length;
   for (const n of nodes) {
     if (n.kind === "file") {
@@ -75,6 +79,11 @@ export function resolveEdges(
       if (C_EXT.test(n.path)) {
         const parts = toPosixPath(n.path).split("/");
         for (let i = 0; i < parts.length; i++) push(cFilesBySuffix, parts.slice(i).join("/"), n.id);
+      }
+      {
+        const p = toPosixPath(n.path);
+        if (p === "lib.rs" || p === "main.rs") rustCrateRoots.push("");
+        else if (p.endsWith("/lib.rs") || p.endsWith("/main.rs")) rustCrateRoots.push(posix.dirname(p));
       }
       continue;
     }
@@ -121,7 +130,9 @@ export function resolveEdges(
             ? resolveJavaImport(e.specifier, javaFilesBySuffix)
             : C_EXT.test(e.file)
               ? resolveCInclude(e.specifier, e.file, byId, cFilesBySuffix)
-              : resolveImport(e.specifier, e.file, byId);
+              : e.file.endsWith(".rs")
+                ? resolveRustUse(e.specifier, e.file, byId, rustCrateRoots)
+                : resolveImport(e.specifier, e.file, byId);
       add(e.source, target, "imports", "extracted");
     } else if (e.relation === "extends" || e.relation === "implements") {
       const kinds: Kind[] = e.relation === "implements" ? ["interface"] : ["class", "interface"];
@@ -353,6 +364,54 @@ function resolveCInclude(
   const hits = bySuffix.get(spec.replace(/^\.?\//, ""));
   if (hits && hits.length === 1) return hits[0]; // unique suffix — an -I-reached header
   return spec; // system/out-of-repo/ambiguous — keep the string, do not guess
+}
+
+/**
+ * Resolve a Rust `crate`-relative module path (`crate/a/b`, from `use crate::a::b::Item`)
+ * to the in-repo module file — `<crate root>/a/b.rs` or `<crate root>/a/b/mod.rs`, where
+ * the crate root is the `lib.rs`/`main.rs` directory the importing file lives under. The
+ * per-file crate root keeps a multi-crate workspace unambiguous. Not found or ambiguous
+ * (two roots, both `a/b.rs` and `a/b/mod.rs`) stays a `crate::…` string — never a guess.
+ */
+function resolveRustUse(spec: string, file: string, byId: Map<string, NodeV1>, crateRoots: string[]): string {
+  const full = spec.replace(/^crate\/?/, ""); // "crate/a/b/Item" → "a/b/Item"; "crate" → ""
+  const fpath = toPosixPath(file);
+  // the crate this file belongs to: the longest root that contains it (workspace-safe)
+  const owning = crateRoots
+    .filter((r) => r === "" ? true : fpath === r || fpath.startsWith(`${r}/`))
+    .sort((a, b) => b.length - a.length);
+  // No owning crate root (e.g. an integration test under `tests/`, whose `crate::` is the
+  // TEST binary's own root, not a lib) → do NOT search every crate in a workspace: that
+  // resolves `crate::util` to some unrelated crate's util.rs. Keep it a string instead.
+  if (owning.length === 0) return full === "" ? "crate" : `crate::${full.replace(/\//g, "::")}`;
+  const roots = [owning[0]];
+  const segs = full === "" ? [] : full.split("/");
+  const hitsFor = (rels: string[]): Set<string> => {
+    const hits = new Set<string>();
+    for (const r of roots) for (const rel of rels) {
+      const cand = r === "" ? rel : `${r}/${rel}`;
+      if (byId.has(cand)) hits.add(cand);
+    }
+    return hits;
+  };
+  // Try the longest module prefix first, shrinking toward — but NOT past — the first
+  // segment. `crate::a::b::C` resolves as module `a/b` (C is the item); `crate::net` as
+  // module `net`. The first prefix naming exactly one in-repo file wins; two matches at a
+  // level are ambiguous → drop rather than guess.
+  for (let k = segs.length; k >= 1; k--) {
+    const modPath = segs.slice(0, k).join("/");
+    const hits = hitsFor([`${modPath}.rs`, `${modPath}/mod.rs`]);
+    if (hits.size === 1) return [...hits][0];
+    if (hits.size > 1) break;
+  }
+  // The crate root (`lib.rs`/`main.rs`) is a target ONLY for `use crate::Item` or
+  // `use crate::{…}` — a deeper path whose module chain didn't resolve is genuinely
+  // unknown (a re-export, an inline `mod`, or out-of-tree), so keep it as a string.
+  if (segs.length <= 1) {
+    const hits = hitsFor(["lib.rs", "main.rs"]);
+    if (hits.size === 1) return [...hits][0];
+  }
+  return full === "" ? "crate" : `crate::${full.replace(/\//g, "::")}`;
 }
 
 /**

--- a/src/graph/resolve.ts
+++ b/src/graph/resolve.ts
@@ -62,6 +62,10 @@ export function resolveEdges(
   // resolves to `<crate root>/a/b.rs` (or `.../a/b/mod.rs`), relative to the crate the
   // importing file belongs to — so a workspace with several crates stays unambiguous.
   const rustCrateRoots: string[] = [];
+  // PHP class resolution: a file's path-suffix (`Models/User.php`, `User.php`) → its file
+  // node ids. A `use App\Models\User` names a PSR-4 class whose file mirrors the namespace
+  // tail under some (unknown) source root, so the suffix is the portable key.
+  const phpFilesBySuffix = new Map<string, string[]>();
   const hasGoModules = !!opts.goModules?.length;
   for (const n of nodes) {
     if (n.kind === "file") {
@@ -79,6 +83,10 @@ export function resolveEdges(
       if (C_EXT.test(n.path)) {
         const parts = toPosixPath(n.path).split("/");
         for (let i = 0; i < parts.length; i++) push(cFilesBySuffix, parts.slice(i).join("/"), n.id);
+      }
+      if (n.path.endsWith(".php")) {
+        const parts = toPosixPath(n.path).split("/");
+        for (let i = 0; i < parts.length; i++) push(phpFilesBySuffix, parts.slice(i).join("/"), n.id);
       }
       {
         const p = toPosixPath(n.path);
@@ -132,7 +140,9 @@ export function resolveEdges(
               ? resolveCInclude(e.specifier, e.file, byId, cFilesBySuffix)
               : e.file.endsWith(".rs")
                 ? resolveRustUse(e.specifier, e.file, byId, rustCrateRoots)
-                : resolveImport(e.specifier, e.file, byId);
+                : e.file.endsWith(".php")
+                  ? resolvePhpUse(e.specifier, phpFilesBySuffix)
+                  : resolveImport(e.specifier, e.file, byId);
       add(e.source, target, "imports", "extracted");
     } else if (e.relation === "extends" || e.relation === "implements") {
       const kinds: Kind[] = e.relation === "implements" ? ["interface"] : ["class", "interface"];
@@ -364,6 +374,25 @@ function resolveCInclude(
   const hits = bySuffix.get(spec.replace(/^\.?\//, ""));
   if (hits && hits.length === 1) return hits[0]; // unique suffix — an -I-reached header
   return spec; // system/out-of-repo/ambiguous — keep the string, do not guess
+}
+
+/**
+ * Resolve a PHP `use` fully-qualified name (`App\Models\User`) to the in-repo class file.
+ * PSR-4 maps the namespace to a directory under some (unknown) source root and the class
+ * to a `<Class>.php` file, so we match the longest namespace-tail suffix that names exactly
+ * one file: `App/Models/User.php`, then `Models/User.php`, then `User.php`. The longest
+ * unique match wins; an ambiguous tail or a vendor/out-of-repo class stays the raw name.
+ */
+function resolvePhpUse(fqn: string, bySuffix: Map<string, string[]>): string {
+  const parts = fqn.split("\\").filter(Boolean);
+  if (parts.length === 0) return fqn;
+  for (let i = 0; i < parts.length; i++) {
+    const suffix = `${parts.slice(i).join("/")}.php`;
+    const hits = bySuffix.get(suffix);
+    if (hits && hits.length === 1) return hits[0];
+    if (hits && hits.length > 1) break; // ambiguous at the most specific level — do not guess
+  }
+  return fqn;
 }
 
 /**

--- a/test/generic-extract.test.ts
+++ b/test/generic-extract.test.ts
@@ -145,6 +145,41 @@ test("breadth tier: Java extends/implements/new become resolved references edges
   assert.ok(!refs.some((e) => e.source === e.target), "no self-loop references");
 });
 
+// C/C++ #include is the dependency graph the tags.scm can't see (it's the
+// preprocessor). A local `#include "x.h"` becomes a file→file import the resolver
+// settles to an in-repo header — relative first, then a unique path-suffix (an
+// -I-reached header), and never a guess. System `<...>` includes are skipped.
+test("breadth tier: C #include becomes a resolved file→file import (local only, drop-rather-than-guess)", async () => {
+  await warmGenericGrammars(["c"]);
+  const files: Record<string, string> = {
+    "src/app.c": '#include "app.h"\n#include "net/sock.h"\n#include <stdio.h>\nint run(void){return 0;}\n',
+    "src/app.h": "int run(void);\n",
+    "src/net/sock.h": "int connect_sock(void);\n",
+    "include/uniq.h": "int uq(void);\n", // reachable only via -I, unique basename
+    "src/uses.c": '#include "uniq.h"\n',
+    "a/util.h": "int a_u(void);\n", // two util.h → an ambiguous basename
+    "b/util.h": "int b_u(void);\n",
+    "src/amb.c": '#include "util.h"\n',
+  };
+  const nodes = [], raw = [];
+  for (const [rel, src] of Object.entries(files)) {
+    const r = extractGeneric(rel, src, "c");
+    nodes.push(...r.nodes); raw.push(...r.rawEdges);
+  }
+  const imports = resolveEdges(nodes, raw).filter((e) => e.relation === "imports");
+  const targetsOf = (src: string) => imports.filter((e) => e.source === src).map((e) => e.target);
+
+  // relative include → the in-repo header (exact; same dir and a subdir)
+  assert.ok(targetsOf("src/app.c").includes("src/app.h"), "app.c → app.h (same dir)");
+  assert.ok(targetsOf("src/app.c").includes("src/net/sock.h"), "app.c → net/sock.h (subdir)");
+  // system <stdio.h> is skipped entirely — no import edge minted
+  assert.ok(!imports.some((e) => String(e.target).includes("stdio")), "system include is not captured");
+  // a unique basename reached via -I resolves by suffix
+  assert.ok(targetsOf("src/uses.c").includes("include/uniq.h"), "unique -I header resolves by suffix");
+  // an ambiguous basename is NOT guessed — kept as the raw string, resolving to neither file
+  assert.deepEqual(targetsOf("src/amb.c"), ["util.h"], "ambiguous include kept external, never guessed");
+});
+
 test("buildGraph + checkGraph handle a breadth-tier (.rs) repo end-to-end", async () => {
   const dir = mkdtempSync(join(tmpdir(), "graft-rust-"));
   mkdirSync(join(dir, "src"), { recursive: true });

--- a/test/generic-extract.test.ts
+++ b/test/generic-extract.test.ts
@@ -180,6 +180,54 @@ test("breadth tier: C #include becomes a resolved file→file import (local only
   assert.deepEqual(targetsOf("src/amb.c"), ["util.h"], "ambiguous include kept external, never guessed");
 });
 
+// Rust `use crate::…` → a file→module import, resolved against the file's crate root
+// (the lib.rs/main.rs dir). The longest-prefix rule disambiguates a module from an item
+// and a `foo.rs` from a `foo/mod.rs`; std/super/external/glob are skipped, and an
+// unresolvable in-crate path is kept as a `crate::…` string, never guessed.
+test("breadth tier: Rust use crate::… resolves to the in-repo module (longest-prefix, drop-rather-than-guess)", async () => {
+  await warmGenericGrammars(["rust"]);
+  const files: Record<string, string> = {
+    "src/lib.rs": "pub mod error;\npub mod net;\n",
+    "src/error.rs": "pub struct Error;\n",
+    "src/net/mod.rs": "pub mod tcp;\n",
+    "src/net/tcp.rs": "pub struct Stream;\n",
+    "src/app.rs":
+      "use crate::error::Error;\n" +          // item under a module → src/error.rs
+      "use crate::net::tcp::Stream;\n" +       // nested module → src/net/tcp.rs
+      "use crate::net;\n" +                    // single-segment module → src/net/mod.rs
+      "use crate::missing::Thing;\n" +         // in-crate but no such file → kept as string
+      "use std::io::Read;\n" +                 // external — skipped
+      "use super::sibling::Thing;\n" +         // relative — skipped
+      "use serde::Serialize;\n" +              // external crate — skipped
+      "fn go() {}\n",
+    // an integration test lives OUTSIDE the crate root (src/); its `crate::` is the test
+    // binary's own root, not the lib — so it must NOT resolve across to src/error.rs.
+    "tests/it.rs": "use crate::error::Error;\nfn t() {}\n",
+  };
+  const nodes = [], raw = [];
+  for (const [rel, src] of Object.entries(files)) {
+    const r = extractGeneric(rel, src, "rust");
+    nodes.push(...r.nodes); raw.push(...r.rawEdges);
+  }
+  const imports = resolveEdges(nodes, raw).filter((e) => e.relation === "imports" && e.source === "src/app.rs");
+  const targets = imports.map((e) => e.target).sort();
+
+  assert.ok(targets.includes("src/error.rs"), "crate::error::Error → error.rs");
+  assert.ok(targets.includes("src/net/tcp.rs"), "crate::net::tcp::Stream → net/tcp.rs");
+  assert.ok(targets.includes("src/net/mod.rs"), "crate::net (single-segment module) → net/mod.rs");
+  // in-crate but unresolvable → the full path kept as a string, never a guessed file edge
+  // (crucially NOT silently resolved to the crate-root lib.rs)
+  assert.ok(targets.includes("crate::missing::Thing"), "unresolved in-crate path kept as a string");
+  // std / super / external crate are not in-crate imports — no edge at all
+  assert.ok(!targets.some((t) => /io|sibling|serde|Read|Serialize/.test(t)), "external/relative use skipped");
+  assert.equal(imports.length, 4, "exactly the 4 crate:: uses became edges");
+
+  // an integration test's `crate::error::Error` must NOT cross into src/error.rs — its
+  // crate root is unknown (it's the test binary), so it stays a string, never a false edge
+  const fromTest = resolveEdges(nodes, raw).filter((e) => e.relation === "imports" && e.source === "tests/it.rs");
+  assert.deepEqual(fromTest.map((e) => e.target), ["crate::error::Error"], "test-binary crate:: never resolves into the lib");
+});
+
 test("buildGraph + checkGraph handle a breadth-tier (.rs) repo end-to-end", async () => {
   const dir = mkdtempSync(join(tmpdir(), "graft-rust-"));
   mkdirSync(join(dir, "src"), { recursive: true });

--- a/test/generic-extract.test.ts
+++ b/test/generic-extract.test.ts
@@ -228,6 +228,43 @@ test("breadth tier: Rust use crate::… resolves to the in-repo module (longest-
   assert.deepEqual(fromTest.map((e) => e.target), ["crate::error::Error"], "test-binary crate:: never resolves into the lib");
 });
 
+// PHP `use App\Models\User` → a file→class-file import, resolved to the in-repo class by
+// the longest namespace-tail suffix (PSR-4 root is unknown). Groups expand; `use function`
+// is skipped; a vendor/unknown class or an ambiguous tail stays a string, never guessed.
+test("breadth tier: PHP use resolves to the class file (namespace-suffix, groups, drop-rather-than-guess)", async () => {
+  await warmGenericGrammars(["php"]);
+  const files: Record<string, string> = {
+    "src/Models/User.php": "<?php\nnamespace App\\Models;\nclass User {}\n",
+    "src/Http/Request.php": "<?php\nnamespace App\\Http;\nclass Request {}\n",
+    "src/Http/Response.php": "<?php\nnamespace App\\Http;\nclass Response {}\n",
+    "a/Dup.php": "<?php\nclass Dup {}\n",
+    "b/Dup.php": "<?php\nclass Dup {}\n",
+    "src/App.php":
+      "<?php\nnamespace App;\n" +
+      "use App\\Models\\User;\n" +              // → src/Models/User.php
+      "use App\\Http\\{Request, Response};\n" +  // group → both Http files
+      "use App\\Support\\Str as S;\n" +          // in-namespace but no file → string
+      "use function App\\helpers\\tap;\n" +      // function import → skipped, no edge
+      "use Psr\\Log\\LoggerInterface;\n" +       // external vendor → string
+      "use Whatever\\Dup;\n" +                   // ambiguous basename → drop
+      "class App {}\n",
+  };
+  const nodes = [], raw = [];
+  for (const [rel, src] of Object.entries(files)) {
+    const r = extractGeneric(rel, src, "php");
+    nodes.push(...r.nodes); raw.push(...r.rawEdges);
+  }
+  const imports = resolveEdges(nodes, raw).filter((e) => e.relation === "imports" && e.source === "src/App.php");
+  const targets = imports.map((e) => e.target).sort();
+
+  assert.ok(targets.includes("src/Models/User.php"), "use App\\Models\\User → Models/User.php");
+  assert.ok(targets.includes("src/Http/Request.php") && targets.includes("src/Http/Response.php"), "group expands to both");
+  assert.ok(targets.includes("App\\Support\\Str"), "in-namespace but fileless → kept as string");
+  assert.ok(targets.includes("Psr\\Log\\LoggerInterface"), "external vendor class → kept as string");
+  assert.ok(targets.includes("Whatever\\Dup"), "ambiguous basename → kept as string, never guessed");
+  assert.ok(!targets.some((t) => /tap|helpers/.test(t)), "use function … is skipped (symbol import, not a class file)");
+});
+
 test("buildGraph + checkGraph handle a breadth-tier (.rs) repo end-to-end", async () => {
   const dir = mkdtempSync(join(tmpdir(), "graft-rust-"));
   mkdirSync(join(dir, "src"), { recursive: true });


### PR DESCRIPTION
## What

The breadth tier captured definitions, calls, and references — but not the preprocessor / module imports. A codebase's dependency graph (its `#include` / `use` graph) was invisible. This adds it for the two languages where it resolves to a *file* cleanly and precision-first:

### C/C++ `#include "x.h"`
- **generic.ts** walks `preproc_include`; **local** includes become `imports` raw edges, **system** `<stdio.h>` includes are skipped (high volume, no in-repo target).
- **resolve.ts** `resolveCInclude`: relative-to-includer first (certain), else a **unique path-suffix** match (an `-I`-reached header). Ambiguous/not-found stays a string — never guessed.

### Rust `use crate::…`
- **generic.ts** walks `use_declaration`; in-crate `crate::` paths become `imports` raw edges (std/super/self/external crates and globs skipped).
- **resolve.ts** `resolveRustUse` settles the path against the file's **own crate root** (the `lib.rs`/`main.rs` dir — workspace-safe) by **longest module prefix**: `crate::a::b::C` → module `a/b`; `crate::lexical` → `lexical.rs` or `lexical/mod.rs`. Two guardrails found via a real multi-crate run: the crate-root (`lib.rs`) is a target only for a single-segment `use crate::Item`; and a file with **no owning crate root** (an integration test under `tests/`, whose `crate::` is the *test binary*, not the lib) is never resolved across the workspace.

## Validation (safe, static — no code executed)

Crater-style breadth, done safely: graft only *parses* source, so cloning + `graft build` over real ecosystem crates is inert (unlike `cargo build`/`test`).

**Rust, 5 crates** (anyhow, clap, regex, ripgrep, serde_json): **every library `src/` `use crate::` edge resolves, 0 cross-crate false edges**, invariants pass. The only unresolved are integration-test `crate::` paths — correct Rust semantics (a test binary's own root).

**Cross-language matrix, 11 repos / 8 languages** — all pass `--strict` invariants, all builds byte-identical on rebuild:

| repo | lang | tier | invariants |
|---|---|---|---|
| gson, JSON-java | Java | depth | ✓ |
| hiredis | C | breadth + include | ✓ |
| fmt | C++ | breadth + include | ✓ |
| serde_json, clap, ripgrep | Rust | breadth + use | ✓ |
| FastRoute | PHP | breadth + references | ✓ |
| cobra | Go | depth | ✓ |
| flask | Python | depth | ✓ |
| sinatra | Ruby | breadth | ✓ |

hiredis: 82 include edges, 79 resolved (96%). serde_json: 38 use edges, 100% resolved.

## Scope / honesty

Symbol-orphan is unchanged by design — imports are *file*-level. The win is dependency navigation ("what includes/uses this"). Deliberately C/C++ + Rust only: those resolve to a file. PHP/other `use` name namespaces (PSR-4) — lower precision, separate work.

**625 tests** (+2: C include resolve/skip/ambiguous-drop; Rust longest-prefix/single-segment/skip/unresolved/test-binary-drop).