### PR TITLE
Warn when -e names an unsupported extension (#98)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,6 +21,7 @@ import { loadGraphCached } from "./graph/load.js";
 import { ensureFreshChildren, ensureFreshGraph, refreshNote } from "./graph/refresh.js";
 import { isWorkspaceBuildRoot, readWorkspace } from "./graph/workspace.js";
 import { nearestGraftRoot } from "./graph/root.js";
+import { unsupportedExtensions, supportedExtensions } from "./graph/source-files.js";
 import { discoverWorkspaceChildren } from "./graph/scopes.js";
 import {
   runWorkspaceAsk,
@@ -71,6 +72,22 @@ function cliConfig(): EngineConfig {
 }
 
 const engineFrom = (): Graft => new Graft(cliConfig());
+
+/**
+ * Warn (never fail) when a user's `-e` extension has no parser, so it is never a silent
+ * no-op — `graft build -e ".vue"` used to accept it, index nothing, and exit 0. The
+ * supported set is listed so `-e` also answers "what is actually supported".
+ */
+function warnUnsupportedExtensions(exts?: string[]): void {
+  if (!exts?.length) return;
+  const bad = unsupportedExtensions(exts);
+  if (bad.length === 0) return;
+  for (const e of bad) {
+    const shown = e.trim().startsWith(".") ? e.trim() : `.${e.trim()}`;
+    console.error(`⚠ -e "${shown}": no parser registered for this extension — ignoring it.`);
+  }
+  console.error(`  supported: ${supportedExtensions().join(" ")}`);
+}
 
 /** Text for the omitted-`[dir]` case, shared by every query command's help. */
 const DIR_ARG = ["[dir]", "repository root (default: nearest ancestor with a graft/ index)"] as const;
@@ -135,7 +152,7 @@ program
   )
   .argument("[dir]", "repository root", ".")
   .option("--deep", "run the LLM pass: concept nodes (graft/*.md) + per-symbol summary/crux")
-  .option("-e, --extensions <exts...>", 'code extensions to include (e.g. ".ts" ".py")')
+  .option("-e, --extensions <exts...>", 'code extensions to include (e.g. ".ts" ".py"); an extension with no parser is ignored with a warning that lists the supported set')
   .option("-j, --concurrency <n>", "files summarized in parallel during --deep (default 5)")
   .option("--no-reuse", "re-parse every file instead of replaying unchanged ones from the extraction cache")
   .option("--lsp", "add compiler-grade call edges via a language server if one is installed (opt-in, slower; e.g. rust-analyzer, clangd)")
@@ -152,6 +169,7 @@ program
       console.error(`✗ --concurrency must be a number, got "${opts.concurrency}"`);
       process.exit(1);
     }
+    warnUnsupportedExtensions(opts.extensions);
     // Persisted BEFORE the build itself runs, so this invocation's walks (and
     // every later no-flag build / hooks refresh) see it identically — the
     // walkDir call sites read it from state, not from a threaded option.
@@ -318,6 +336,7 @@ program
   .option("-e, --extensions <exts...>", "code extensions to include")
   .option("--json", "output the drift as JSON")
   .action(async (dirArg: string | undefined, opts: { extensions?: string[]; json?: boolean }) => {
+    warnUnsupportedExtensions(opts.extensions);
     const dir = queryRoot(dirArg);
     const checkGlobalDir = program.opts<GlobalOpts>().dir;
     if (readWorkspace(dir, checkGlobalDir)) {

--- a/src/graph/extract.ts
+++ b/src/graph/extract.ts
@@ -53,6 +53,11 @@ function entryFor(path: string): (typeof EXTENSIONS)[number] | undefined {
   return EXTENSIONS.find((e) => p.endsWith(e.ext));
 }
 
+/** Every file extension a depth-tier (hand-written) extractor claims. */
+export function depthExtensions(): string[] {
+  return EXTENSIONS.map((e) => e.ext);
+}
+
 /** Map a file path to a supported language, or null if unsupported. */
 export function languageOf(path: string): Language | null {
   return entryFor(path)?.grammar ?? null;

--- a/src/graph/generic.ts
+++ b/src/graph/generic.ts
@@ -70,6 +70,11 @@ export function genericLangOf(path: string): GenericLang | null {
   return null;
 }
 
+/** Every file extension a breadth-tier (generic tree-sitter) grammar claims. */
+export function genericExtensions(): string[] {
+  return GENERIC_LANGS.flatMap((l) => l.exts);
+}
+
 // tags.scm @definition.<X>  →  graft Kind (types.ts). Unmapped → "function".
 const KIND: Record<string, Kind> = {
   function: "function", method: "method", class: "class", interface: "interface",

--- a/src/graph/source-files.ts
+++ b/src/graph/source-files.ts
@@ -11,8 +11,30 @@ import { resolve } from "node:path";
 import { walkDir } from "../ingest/fs.js";
 import { relPosix } from "../util/paths.js";
 import { readIncludeDirs } from "../util/state.js";
-import { languageOf } from "./extract.js";
-import { genericLangOf } from "./generic.js";
+import { languageOf, depthExtensions } from "./extract.js";
+import { genericLangOf, genericExtensions } from "./generic.js";
+
+/** Every extension graft has a parser for (depth + breadth), sorted and de-duped —
+ * the authoritative answer to "what does `-e` actually support". */
+export function supportedExtensions(): string[] {
+  return [...new Set([...depthExtensions(), ...genericExtensions()])].sort();
+}
+
+/** Normalize a user-supplied extension: ensure a leading dot, lower-case. */
+function normExt(e: string): string {
+  const t = e.trim().toLowerCase();
+  return t.startsWith(".") ? t : `.${t}`;
+}
+
+/**
+ * The subset of user-supplied `-e` extensions that no parser claims (depth or breadth).
+ * `graft build -e ".vue"` used to accept these silently and index nothing; the CLI warns
+ * on whatever this returns so an unsupported extension is never a quiet no-op.
+ */
+export function unsupportedExtensions(exts: string[]): string[] {
+  const supported = new Set(supportedExtensions());
+  return exts.filter((e) => !supported.has(normExt(e)));
+}
 
 /**
  * The source files a graph build parses: supported languages, minus the

--- a/test/supported-extensions.test.ts
+++ b/test/supported-extensions.test.ts
@@ -1,0 +1,36 @@
+/**
+ * `-e` extension validation (#98): a `graft build -e ".vue"` must not silently index
+ * nothing — the CLI warns on any extension no parser claims. These test the pure helper
+ * the warning is built on: the supported set (depth + breadth) and which inputs fall
+ * outside it, including normalization (leading dot optional, case-insensitive).
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { supportedExtensions, unsupportedExtensions } from "../src/graph/source-files.js";
+
+test("supportedExtensions covers both tiers, sorted and de-duped", () => {
+  const exts = supportedExtensions();
+  // depth tier
+  for (const e of [".ts", ".tsx", ".py", ".go", ".java", ".js"]) assert.ok(exts.includes(e), `depth ${e}`);
+  // breadth tier
+  for (const e of [".rs", ".rb", ".php", ".c", ".cpp", ".kt", ".swift"]) assert.ok(exts.includes(e), `breadth ${e}`);
+  // de-duped (.java is in BOTH tiers but must appear once) and sorted
+  assert.equal(exts.filter((e) => e === ".java").length, 1, ".java de-duped across tiers");
+  assert.deepEqual(exts, [...exts].sort(), "sorted");
+});
+
+test("unsupportedExtensions flags only what has no parser (the #98 repro)", () => {
+  // .vue is the reported case — no parser → flagged
+  assert.deepEqual(unsupportedExtensions([".vue"]), [".vue"]);
+  // mixed: supported ones drop out, unsupported stay
+  assert.deepEqual(unsupportedExtensions([".ts", ".vue", ".rs", ".svelte"]), [".vue", ".svelte"]);
+  // fully-supported input → nothing flagged
+  assert.deepEqual(unsupportedExtensions([".ts", ".php", ".c"]), []);
+});
+
+test("extension normalization: missing dot and mixed case still match a parser", () => {
+  // a user typing `-e vue` or `-e .TS` should be judged on the normalized form
+  assert.deepEqual(unsupportedExtensions(["ts"]), [], "no leading dot still recognized");
+  assert.deepEqual(unsupportedExtensions([".TS", ".Php"]), [], "case-insensitive");
+  assert.deepEqual(unsupportedExtensions(["vue"]), ["vue"], "unsupported without dot still flagged (echoed as given)");
+});


### PR DESCRIPTION
Fixes #98.

## Problem
`graft build -e ".vue"` accepts any extension, indexes zero `.vue`, and exits 0 with no warning — so `-e` (the natural way a user probes what's supported) silently answers wrong.

## Fix
Validate each `-e` value against the actual parser set — depth `EXTENSIONS` (extract.ts) ∪ breadth `GENERIC_LANGS` exts (generic.ts) — and **warn** (never fail) on any with no parser, listing the supported set so `-e` now also answers *"what is supported"*:

```
⚠ -e ".vue": no parser registered for this extension — ignoring it.
  supported: .c .cc .cjs .cpp .cs .cts .cxx .dart .ex .exs .go .h .hh .hpp .java .js .jsx .kt .kts .mjs .ml .mli .mts .php .py .pyi .rb .rs .sc .scala .sol .swift .ts .tsx .zig
```

- `depthExtensions()` / `genericExtensions()` expose each tier's set; `supportedExtensions()` + `unsupportedExtensions()` (leading-dot-optional, case-insensitive) in source-files.ts.
- Warns on both `build` and `check`; `-e` help text now points to the supported set.
- Build still proceeds on the remaining supported files — it's a warning, not an error.

**629 tests** (+3 covering the set, the `.vue` repro, and normalization). Verified the exact reported command now emits the warning.

This is the standalone half of the report. `.vue` *support* is the separate feature in #97.