### PR TITLE
First-class Google Antigravity host (#62)

### DIFF
--- a/src/hosts/antigravity.ts
+++ b/src/hosts/antigravity.ts
@@ -1,0 +1,46 @@
+/**
+ * Antigravity-specific global writes that don't fit the per-repo host model.
+ *
+ * Antigravity loads "shared" skills — available to every workspace — from
+ * `~/.gemini/skills/`. graft's skill card is the same one Claude Code and AdaL get;
+ * placing it here is the skill half of first-class Antigravity support (#62). The
+ * instruction file (AGENTS.md) and MCP registration are handled by the `antigravity`
+ * host in the registry and `mcp-config.ts` respectively.
+ *
+ * `antigravitySkillTargets()` is the pure "which files would this touch" half (for
+ * `graft init --dry-run` / the picker); `installAntigravitySkill()` does the write.
+ */
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { skillTemplate } from '../claude/skill-template.js';
+import type { PlannedWrite } from './plan.js';
+import type { HookWrite } from './codex-hooks.js';
+
+/** The skill file path, under the user's global Antigravity skills dir. */
+function skillPath(home: string): string {
+  return join(home, '.gemini', 'skills', 'graft', 'SKILL.md');
+}
+
+/** The files installing Antigravity's global skill would touch — pure, no writes. */
+export function antigravitySkillTargets(home: string): PlannedWrite[] {
+  return [
+    {
+      hostId: 'antigravity', id: 'antigravity-skill',
+      path: skillPath(home),
+      scope: 'global', kind: 'skill', what: 'graft skill (shared)',
+    },
+  ];
+}
+
+/** Write graft's skill into `~/.gemini/skills/graft/SKILL.md`, idempotently. */
+export function installAntigravitySkill(home: string): HookWrite[] {
+  const path = skillPath(home);
+  const content = skillTemplate();
+  const existed = existsSync(path);
+  if (existed && readFileSync(path, 'utf8') === content) {
+    return [{ id: 'antigravity-skill', path, action: 'unchanged' }];
+  }
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+  return [{ id: 'antigravity-skill', path, action: existed ? 'updated' : 'created' }];
+}

--- a/src/hosts/init.ts
+++ b/src/hosts/init.ts
@@ -10,6 +10,7 @@ import { HOSTS, detectHosts, type DetectProbe, type HostTarget } from './registr
 import { upsertSection } from './sections.js';
 import { registerMcpConfigs, type McpWrite } from './mcp-config.js';
 import { installCodexHooks, type HookWrite } from './codex-hooks.js';
+import { installAntigravitySkill } from './antigravity.js';
 
 export interface HostsInitResult {
   written: { id: string; path: string; action: string }[];
@@ -80,5 +81,10 @@ export function runHostsInit(
     opts.hooks === false || opts.global === false || !selected.some((h) => h.id === 'agents')
       ? []
       : installCodexHooks(home);
-  return { written, skipped, unknown, mcp, hooks };
+  // Antigravity's skill is a global write too, so --no-global suppresses it as well.
+  const antigravitySkill =
+    opts.global === false || !selected.some((h) => h.id === 'antigravity')
+      ? []
+      : installAntigravitySkill(home);
+  return { written, skipped, unknown, mcp, hooks: [...hooks, ...antigravitySkill] };
 }

--- a/src/hosts/mcp-config.ts
+++ b/src/hosts/mcp-config.ts
@@ -144,6 +144,15 @@ export function mcpTargets(
       case 'gemini':
         out.push(jsonTarget(id, id, join(repo, '.gemini', 'settings.json'), 'mcpServers', entry));
         break;
+      case 'antigravity':
+        // Antigravity reads MCP from its OWN registry, separate from Gemini CLI's
+        // `.gemini/settings.json` — a global `~/.gemini/config/mcp_config.json` (the
+        // gap #62 reported). Standard `{command,args}` under `mcpServers`. Global
+        // scope: it applies to every workspace opened in Antigravity.
+        out.push(
+          jsonTarget(id, 'antigravity', join(home, '.gemini', 'config', 'mcp_config.json'), 'mcpServers', entry, 'global'),
+        );
+        break;
       case 'kiro':
         out.push(jsonTarget(id, id, join(repo, '.kiro', 'settings', 'mcp.json'), 'mcpServers', entry));
         break;

--- a/src/hosts/plan.ts
+++ b/src/hosts/plan.ts
@@ -13,6 +13,7 @@ import { statSync } from 'node:fs';
 import { HOSTS, detectHosts, type DetectProbe, type HostTarget } from './registry.js';
 import { mcpTargets } from './mcp-config.js';
 import { hookTargets } from './codex-hooks.js';
+import { antigravitySkillTargets } from './antigravity.js';
 import { claudeTargets } from '../claude/init.js';
 
 /** Where a write lands. 'global' = outside the repo, affects every project. */
@@ -26,7 +27,7 @@ export interface PlannedWrite {
   id: string;
   path: string;
   scope: WriteScope;
-  kind: 'instruction' | 'mcp' | 'hook' | 'claude';
+  kind: 'instruction' | 'mcp' | 'hook' | 'claude' | 'skill';
   /** Short human label for what changes in that file. */
   what: string;
 }
@@ -77,6 +78,7 @@ export function planInit(repo: string, opts: { home?: string; ids?: string[] } =
         instructionTarget(repo, host),
         ...mcpTargets(repo, [host.id], { home }),
         ...(host.id === 'agents' ? hookTargets(home) : []),
+        ...(host.id === 'antigravity' ? antigravitySkillTargets(home) : []),
       ],
     })),
   ];

--- a/src/hosts/registry.ts
+++ b/src/hosts/registry.ts
@@ -63,6 +63,20 @@ export const HOSTS: HostTarget[] = [
     detect: (p) => p.dirExists(join(p.home, '.gemini')),
   },
   {
+    id: 'antigravity',
+    name: 'Google Antigravity',
+    kind: 'section',
+    relPath: 'AGENTS.md',
+    content: instructionBody,
+    // Antigravity-specific markers, NOT the bare `~/.gemini` (which is also Gemini CLI's):
+    // its global config dir (`~/.gemini/config/`, where mcp_config.json + hooks.json live)
+    // or a workspace `.agents/` dir. Keeps a plain Gemini-CLI user from auto-selecting it.
+    detect: (p) =>
+      p.dirExists(join(p.home, '.gemini', 'config')) ||
+      p.dirExists(join(p.home, '.gemini', 'antigravity-cli')) ||
+      p.dirExists(join(p.repo, '.agents')),
+  },
+  {
     id: 'copilot',
     name: 'GitHub Copilot',
     kind: 'section',

--- a/test/hosts-antigravity.test.ts
+++ b/test/hosts-antigravity.test.ts
@@ -1,0 +1,67 @@
+/**
+ * First-class Google Antigravity host (#62): AGENTS.md instructions, MCP registration
+ * in Antigravity's OWN config path (not Gemini CLI's), and the shared skill. Detection
+ * keys off Antigravity-specific markers so a plain Gemini-CLI user isn't dragged in.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { detectHosts } from '../src/hosts/registry.js';
+import { mcpTargets } from '../src/hosts/mcp-config.js';
+import { installAntigravitySkill, antigravitySkillTargets } from '../src/hosts/antigravity.js';
+import { runHostsInit } from '../src/hosts/init.js';
+
+function fresh(): string { return mkdtempSync(join(tmpdir(), 'graft-agy-')); }
+const probe = (home: string, repo: string, dirs: string[]) => ({
+  home, repo, dirExists: (p: string) => dirs.some((d) => p === join(home, d) || p === join(repo, d)),
+});
+
+test("Antigravity detects on its own markers, not bare ~/.gemini", () => {
+  const home = fresh(), repo = fresh();
+  const ids = (dirs: string[]) => detectHosts(probe(home, repo, dirs)).map((h) => h.id);
+  // Antigravity's global config dir → antigravity (Gemini CLI needs bare ~/.gemini)
+  assert.ok(ids([join('.gemini', 'config')]).includes('antigravity'), 'config dir → antigravity');
+  // a workspace .agents dir → antigravity
+  assert.ok(ids(['.agents']).includes('antigravity'), '.agents → antigravity');
+  // bare ~/.gemini alone is Gemini CLI, NOT Antigravity
+  const bare = ids(['.gemini']);
+  assert.ok(bare.includes('gemini') && !bare.includes('antigravity'), 'bare ~/.gemini is gemini only');
+});
+
+test("Antigravity MCP registers in ~/.gemini/config/mcp_config.json (global, mcpServers)", () => {
+  const home = fresh();
+  const [t] = mcpTargets('/repo', ['antigravity'], { home });
+  assert.ok(t, 'a target exists');
+  assert.equal(t.path, join(home, '.gemini', 'config', 'mcp_config.json'));
+  assert.equal(t.scope, 'global', 'applies to every workspace');
+  assert.equal(t.format, 'json');
+  assert.equal(t.topKey, 'mcpServers');
+});
+
+test("Antigravity skill lands in ~/.gemini/skills/graft/SKILL.md, idempotently", () => {
+  const home = fresh();
+  const [target] = antigravitySkillTargets(home);
+  assert.equal(target.path, join(home, '.gemini', 'skills', 'graft', 'SKILL.md'));
+
+  const first = installAntigravitySkill(home);
+  assert.equal(first[0].action, 'created');
+  assert.ok(existsSync(target.path) && readFileSync(target.path, 'utf8').includes('graft ask'));
+  const second = installAntigravitySkill(home);
+  assert.equal(second[0].action, 'unchanged', 're-run is a no-op');
+});
+
+test("runHostsInit --agents antigravity writes AGENTS.md + MCP + skill", () => {
+  const home = fresh(), repo = fresh();
+  mkdirSync(join(home, '.gemini', 'config'), { recursive: true });
+  const r = runHostsInit(repo, { agents: ['antigravity'], home });
+  assert.deepEqual(r.written.map((w) => w.id), ['antigravity']);
+  assert.ok(readFileSync(join(repo, 'AGENTS.md'), 'utf8').includes('graft ask'), 'AGENTS.md written');
+  assert.ok(r.mcp.some((w) => w.path.endsWith(join('.gemini', 'config', 'mcp_config.json'))), 'MCP registered');
+  assert.ok(r.hooks.some((w) => w.path.endsWith(join('skills', 'graft', 'SKILL.md'))), 'skill placed');
+  // --no-global suppresses the two global writes (MCP + skill), keeps AGENTS.md
+  const noGlobal = runHostsInit(fresh(), { agents: ['antigravity'], home: fresh(), global: false });
+  assert.equal(noGlobal.mcp.length, 0, 'no MCP write under --no-global');
+  assert.equal(noGlobal.hooks.length, 0, 'no skill write under --no-global');
+});

--- a/test/hosts-init.test.ts
+++ b/test/hosts-init.test.ts
@@ -34,9 +34,10 @@ test('explicit agents list overrides detection and flags unknown ids', () => {
 test('all writes every host and re-run converges (idempotent)', () => {
   const home = fresh(); const repo = fresh();
   const first = runHostsInit(repo, { home, all: true });
-  assert.equal(first.written.length, 7);
+  assert.equal(first.written.length, 8);
   const second = runHostsInit(repo, { home, all: true });
   assert.ok(second.written.every((w) => w.action === 'unchanged'));
+  // `agents` and `antigravity` share AGENTS.md, but the fenced section is written once
   const agents = readFileSync(join(repo, 'AGENTS.md'), 'utf8');
   assert.equal(agents.match(/graft:start/g)!.length, 1);
 });

--- a/test/hosts-registry.test.ts
+++ b/test/hosts-registry.test.ts
@@ -15,7 +15,7 @@ function probeFor(home: string, repo: string): DetectProbe {
 function fresh(): string { return mkdtempSync(join(tmpdir(), 'graft-registry-')); }
 
 test('registry exposes the known hosts', () => {
-  assert.deepEqual(hostIds().sort(), ['adal', 'agents', 'copilot', 'cursor', 'gemini', 'kiro', 'windsurf']);
+  assert.deepEqual(hostIds().sort(), ['adal', 'agents', 'antigravity', 'copilot', 'cursor', 'gemini', 'kiro', 'windsurf']);
   for (const h of HOSTS) {
     assert.ok(h.relPath.length > 0);
     assert.ok(h.content().length > 0);


### PR DESCRIPTION
Closes #62.

## What

Antigravity already reads `AGENTS.md`, so graft partially worked, but its MCP registry and skills live in dedicated paths graft never wrote to. This adds a first-class `antigravity` host so `graft init --agents antigravity` lands every piece in the right spot.

- **registry.ts**: the `antigravity` host writes the `AGENTS.md` instruction section. It detects on Antigravity-specific markers (`~/.gemini/config`, `~/.gemini/antigravity-cli`, or a workspace `.agents/`), NOT bare `~/.gemini` (which is Gemini CLI), so a plain Gemini-CLI user is not auto-selected.
- **mcp-config.ts**: registers the graft MCP server in Antigravity's own global registry, `~/.gemini/config/mcp_config.json` (standard `{command, args}` under `mcpServers`), separate from Gemini CLI's `.gemini/settings.json`. This is the gap #62 reported.
- **antigravity.ts**: places the shared skill in `~/.gemini/skills/graft/SKILL.md`.
- **init.ts / plan.ts**: wire the skill into the install and the `--dry-run` plan. `--no-global` suppresses the two global writes (MCP + skill) while keeping `AGENTS.md`.

## Verified

`graft init --agents antigravity` end to end: AGENTS.md written, MCP at the correct global path, skill placed, all idempotent. Detection keys off Antigravity markers only. **633 tests** (+4 Antigravity; host-list and all-hosts convergence updated for the shared AGENTS.md).

## Deliberately deferred: hooks

Antigravity exposes a Codex-style hook model (`PreToolUse`, `PostToolUse`, `PreInvocation`, `PostInvocation`, `Stop` via `~/.gemini/config/hooks.json`), which could carry graft's retrieval / sync hooks. I am NOT shipping those yet, for two reasons:

1. The `injectSteps` output format for `PreInvocation` context injection is not authoritatively documented.
2. A malformed `PreToolUse` hook can deny every tool call and make Antigravity unusable (manaflow-ai/cmux#5358).

Writing an unverified `hooks.json` to a user's global config is worse than not writing it, so hooks are a fast-follow pending a check against a real Antigravity install.