### PR TITLE
fix: Java constructor calls lose their target when the type is generic

### DIFF
--- a/src/graph/extract.ts
+++ b/src/graph/extract.ts
@@ -730,9 +730,10 @@ function calleeName(
   // Java call site and the language would extract nodes with no call edges at all.
   if (lang === "java") {
     if (node.type === "object_creation_expression") {
-      // `new Foo()` — the constructed type is the call target.
-      const t = node.childForFieldName("type");
-      return t ? { name: t.text, viaMember: false } : null;
+      // `new Foo()` — the constructed type is the call target, named as the graph
+      // names it.
+      const name = javaConstructedTypeName(node.childForFieldName("type"));
+      return name ? { name, viaMember: false } : null;
     }
     const nameNode = node.childForFieldName("name");
     if (!nameNode) return null;
@@ -775,6 +776,40 @@ function calleeName(
 function javaArgCount(node: Parser.SyntaxNode): number | undefined {
   const args = node.childForFieldName("arguments");
   return args ? args.namedChildren.length : undefined;
+}
+
+/**
+ * The name a `new` CONSTRUCTS, as the graph names it — or null when this pass cannot
+ * say, in which case the construction resolves to nothing.
+ *
+ * Erasing type arguments is the only transformation here, because it is the only one
+ * that provably does not change which type is being named:
+ *
+ *     Box            -> Box
+ *     Box<String>    -> Box     (the node is `Box`; the arguments are not part of it)
+ *     Box<>          -> Box
+ *
+ * A QUALIFIED name is deliberately dropped rather than reduced to its final segment:
+ *
+ *     java.io.File   -> null    (not the repo's own `File`)
+ *     Beta.Builder   -> null    (not `Alpha.Builder` in the same file)
+ *
+ * Collapsing those was the first attempt at this fix, and it traded lost edges for
+ * WRONG ones — `new java.io.File(…)` resolved to an unrelated in-repo `File`, and a
+ * nested `Beta.Builder` bound to a sibling `Alpha.Builder` at `extracted` confidence,
+ * because the same-file tiebreak takes the first candidate. Dropping keeps this pass
+ * on the resolver's own rule: resolve precisely, or not at all.
+ *
+ * Deliberately NOT shared with bindings.ts's `javaTypeName`. That one answers "what
+ * type does this variable HOLD", where reducing `java.util.List` to `List` is a local
+ * heuristic with different stakes; this one answers "what type is being constructed",
+ * and the two questions do not have the same safe answer. Supporting qualified
+ * construction properly needs an import-aware type index, not a longer helper.
+ */
+function javaConstructedTypeName(node: Parser.SyntaxNode | null | undefined): string | null {
+  if (!node) return null;
+  if (node.type === "generic_type") return javaConstructedTypeName(node.namedChildren[0]);
+  return node.type === "type_identifier" ? node.text : null;
 }
 
 /** A Java call's receiver text: a bare identifier (`repo.save()`), `this`, or

--- a/test/graph-java.test.ts
+++ b/test/graph-java.test.ts
@@ -454,3 +454,177 @@ test("Java overloads: same-arity overloads stay unresolved rather than guessing"
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+/** Construction fixture. `Box` is built raw, with explicit type arguments, and with the
+ * diamond — three spellings of one node. `File` and the nested `Alpha`/`Beta` builders
+ * exist so the negative half can be pinned: a qualified `new` must resolve to NOTHING
+ * rather than to the same-named type that happens to be in the repo. */
+const GENERIC_BOX = `package com.acme;
+
+public final class Box<T> {
+  private final T value;
+
+  public Box(T value) {
+    this.value = value;
+  }
+
+  public T get() {
+    return value;
+  }
+}
+`;
+
+/** A repo-local type whose simple name collides with a JDK one. */
+const LOCAL_FILE = `package com.acme;
+
+public final class File {
+  public void touch() {}
+}
+`;
+
+/**
+ * Two nested builders under one outer type, and a method that constructs one of them —
+ * all in ONE file, deliberately. A last-segment collapse yields the bare name `Builder`,
+ * which matches both; the resolver's same-file tiebreak then takes the FIRST candidate.
+ * Split across files the ambiguity would simply drop, so a cross-file fixture would pass
+ * whether or not the collapse happens and would pin nothing.
+ */
+const NESTED = `package com.acme;
+
+public final class Api {
+
+  public static class Alpha {
+    public static class Builder {
+      public Api build() {
+        return null;
+      }
+    }
+  }
+
+  public static class Beta {
+    public static class Builder {
+      public Api build() {
+        return null;
+      }
+    }
+  }
+
+  public Api make() {
+    return new Beta.Builder().build();
+  }
+}
+`;
+
+const GENERIC_USES = `package com.acme;
+
+import com.acme.Box;
+
+public final class Uses {
+
+  public Box<String> explicitArguments() {
+    return new Box<String>("a");
+  }
+
+  public Box<String> diamond() {
+    return new Box<>("b");
+  }
+
+  @SuppressWarnings("rawtypes")
+  public Box raw() {
+    return new Box("c");
+  }
+
+  public Object qualified() {
+    return new java.io.File("x");
+  }
+
+}
+`;
+
+function genericFixture(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graft-java-generic-"));
+  mkdirSync(join(dir, PKG), { recursive: true });
+  writeFileSync(join(dir, PKG, "Box.java"), GENERIC_BOX);
+  writeFileSync(join(dir, PKG, "File.java"), LOCAL_FILE);
+  writeFileSync(join(dir, PKG, "Api.java"), NESTED);
+  writeFileSync(join(dir, PKG, "Uses.java"), GENERIC_USES);
+  return dir;
+}
+
+test("Java construction: a generic `new` reaches the same type node as a raw one", async () => {
+  // `object_creation_expression` used to hand the constructed type's RAW TEXT to the
+  // resolver, so `new Box<String>()` searched for a node named "Box<String>" and the
+  // diamond form for "Box<>". Neither exists — the node is "Box" — so every generic
+  // construction lost its edge while the raw form worked, which is why it went
+  // unnoticed.
+  //
+  // The constructed type is now erased by `javaConstructedTypeName`, which is
+  // deliberately NOT bindings.ts's `javaTypeName`: that one collapses a qualified name
+  // to its last segment, which is safe for deciding what a variable holds and NOT safe
+  // for naming a constructor target. Wiring the two together is what the sibling test
+  // below ("a QUALIFIED `new` resolves to nothing") exists to forbid.
+  const dir = genericFixture();
+  try {
+    await buildGraph(dir);
+    const graph = readGraph(wiringPath(join(dir, "graft")))!;
+    const box = `${PKG}/Box.java#Box`;
+    const uses = `${PKG}/Uses.java`;
+    const calls = graph.edges.filter((e) => e.relation === "calls" && e.target === box);
+    const sources = new Set(calls.map((e) => e.source));
+
+    assert.ok(sources.has(`${uses}#Uses.explicitArguments`), "new Box<String>() should reach Box");
+    assert.ok(sources.has(`${uses}#Uses.diamond`), "new Box<>() should reach Box");
+    assert.ok(sources.has(`${uses}#Uses.raw`), "new Box() should still reach Box");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("Java construction: a QUALIFIED `new` resolves to nothing, not to a same-named local type", async () => {
+  // The negative half of the same change, and the reason erasure is done by a helper of
+  // its own rather than by the binding pass's `javaTypeName`. Reducing `java.io.File` to
+  // its final segment would find the repo's unrelated `com.acme.File` and assert an edge
+  // the source never expressed — trading a missing edge for a wrong one, which is the
+  // trade the resolver exists to refuse.
+  const dir = genericFixture();
+  try {
+    await buildGraph(dir);
+    const graph = readGraph(wiringPath(join(dir, "graft")))!;
+    const calls = graph.edges.filter((e) => e.relation === "calls");
+
+    assert.ok(
+      !calls.some(
+        (e) =>
+          e.source === `${PKG}/Uses.java#Uses.qualified` && e.target === `${PKG}/File.java#File`,
+      ),
+      "new java.io.File(...) must not resolve to the repo's own File",
+    );
+    assert.ok(
+      !calls.some((e) => e.source === `${PKG}/Uses.java#Uses.qualified`),
+      "and must not resolve to anything else either",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("Java construction: a nested `new` does not bind to a sibling of the same simple name", async () => {
+  // `new Beta.Builder()` collapsed to `Builder` matches two nodes in the SAME file, and
+  // the resolver's same-file tiebreak returns the FIRST — `Alpha.Builder` — at
+  // `extracted` confidence, i.e. confidently wrong. Resolving nested construction
+  // properly needs a qualified-name index; until then it resolves to nothing.
+  const dir = genericFixture();
+  try {
+    await buildGraph(dir);
+    const graph = readGraph(wiringPath(join(dir, "graft")))!;
+    const api = `${PKG}/Api.java`;
+    const ctor = graph.edges.filter(
+      (e) =>
+        e.relation === "calls" && e.source === `${api}#Api.make` && e.target.includes("Builder"),
+    );
+
+    assert.deepEqual(ctor, [], "a qualified nested construction must not pick a Builder at all");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
A regression from #83, found while measuring what to propose next. Reporting it as a fix rather than a feature because the defect is mine.

## The defect

`calleeName` handed an `object_creation_expression`'s constructed type to the resolver as raw text:

```java
new Box()          ->  "Box"           resolves
new Box<String>()  ->  "Box<String>"   no such node
new Box<>()        ->  "Box<>"         no such node
```

The node is named `Box`, so **every generic construction lost its edge** while the raw form kept working. That asymmetry is why it survived review: the fixtures added in #83 all construct non-generic types, so the tests agreed with the bug.

## The fix, and the half that says no

`javaConstructedTypeName` erases type arguments — and does only that. Erasure is the one transformation that provably does not change *which* type is named:

```
Box  |  Box<String>  |  Box<>   ->  Box
```

A qualified name is deliberately **dropped** rather than reduced to its final segment:

```
java.io.File  ->  unresolved   (not the repo's own `File`)
Beta.Builder  ->  unresolved   (not `Alpha.Builder` beside it)
```

Collapsing those was my first attempt, and it traded missing edges for wrong ones. Verified on purpose-built fixtures: `new java.io.File(…)` produced an edge to an unrelated in-repo `com.acme.File`, and a nested `new Beta.Builder()` bound to its sibling `Alpha.Builder` at **`extracted`** confidence, because `resolveName`'s same-file branch returns the first candidate. Both are edges the source never expresses.

Dropping keeps this pass on the resolver's own rule — resolve precisely, or not at all — and costs 5 edges on gson against the collapsing version.

This helper is deliberately **not** shared with `bindings.ts`'s `javaTypeName`. That one answers "what type does this variable hold", where reducing `java.util.List` to `List` is a local heuristic with different stakes. The two questions do not have the same safe answer, so they get separate helpers rather than one that is right for one caller and wrong for the other.

## Measurement

[`google/gson`](https://github.com/google/gson), 264 files, `origin/main` vs this commit (baseline built from a clean worktree, not a stash):

| | before | after |
|---|---:|---:|
| `calls` edges | 4,995 | **5,329** |
| of those, targeting a type node | 1,673 | **2,007** |
| self-loop calls | 26 | 27 |

`+334`, and the two deltas are identical — every recovered edge is a constructor edge, and no other call kind moves.

The one added self-loop is a field initializer constructing its own enclosing class (`Box next = new Box()`), which is attributed to the class node. That relation is real, so it is left alone; the other 26 pre-date this change and are direct recursion. Worth flagging since `selfLoopCalls` is a reported quality signal: the counter now mixes recursion with class-level self-construction, and distinguishing them would need the call-site kind preserved, which is not this change.

Spot-check on the case that made me look: the three `RuntimeTypeAdapterFactory.of` overloads construct `new RuntimeTypeAdapterFactory<>()`, and the class node went from **0 incoming edges to 3**. `TypeToken` now shows 167, `TypeAdapter` 51, `LinkedTreeMap` 20 — all silently absent before.

## Tests

Three cases, all in `test/graph-java.test.ts`:

- explicit-argument, diamond and raw construction all reach the same node;
- a qualified `new` resolves to **nothing**, not to a same-named local type;
- a nested `new` does not bind to a sibling of the same simple name.

Verified red both when erasure is removed and when qualified collapsing is reintroduced.

The nested fixture keeps the construction in the **same file** as both candidates on purpose. My first version of it put them in separate files, where the cross-file ambiguity check drops the edge anyway — so it passed with or without the bug and pinned nothing.

Suite: **625 passing**.

## Scope

No new node field, relation, resolver pass, dependency, or configuration. Two files.

Known and deliberately left for separate issues, since none is caused by this change:

- `typeIdentifiersIn` walks into `type_arguments`, so `implements Function<Greeter, String>` emits `implements Greeter` and `implements String`. Worse than the constructor case, because `extends` edges feed `classParents` and a wrong parent produces wrong *call* edges through the ancestor walk.
- `resolveName`'s same-file branch returns `local[0]` with no ambiguity check at `extracted` confidence. That is the root cause the two negative tests here route around per-spelling; a `local.length === 1` guard fixes the class once for every relation. I have measured it as a no-op on gson and spring-petclinic with the suite green, and would rather propose it on its own than fold a change to shared resolution semantics into a regression fix.
- Anonymous-class methods take `owner` from the enclosing class.
- `argCount` is persisted on constructor edges and never read, since a constructor edge targets the class node rather than a specific constructor.

Also not addressed: `outer.new Inner()` puts the qualifier in a sibling node, leaving `type` a bare `type_identifier` — so that spelling still reaches the same first-candidate tiebreak. The `local.length === 1` guard above is what closes it; naming more spellings here would not.
