### PR TITLE
fix(graph): resolve Python imports, link JSX components, stop a per-file WASM leak

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,29 @@
 # Graft — configuration
 #
-# Graft calls an LLM for concept nodes + per-symbol summaries, so an API key is
-# required for the deep pass (`build --deep`). The structural build (`build`,
-# `check`, `ask`, `grep`, `map`, traversal) is deterministic tree-sitter and
-# needs no key.
+# Graft calls an LLM for concept nodes + per-symbol summaries, so the deep pass
+# (`build --deep`) needs a model. The structural build (`build`, `check`, `ask`,
+# `grep`, `map`, traversal) is deterministic tree-sitter and needs nothing.
 #
-# Graft is vendor-neutral: GRAFT_PROVIDER picks the WIRE FORMAT, not a company.
-# Bring your own key from whichever provider you use.
+# There are two ways to give it a model:
+#   1. A SUBSCRIPTION — install the Claude Code CLI, sign in, and set nothing at
+#      all. graft detects it and uses it when no API key is configured.
+#   2. An API KEY — any provider. GRAFT_PROVIDER picks the WIRE FORMAT, not a
+#      company; bring your own key.
 
-# --- Provider (required for `build --deep`) -----------------------------------
+# --- Option 1: your Claude subscription (no key) ------------------------------
+# Requires the Claude Code CLI on PATH, signed in (https://claude.com/claude-code).
+# Auto-detected when no API key is set, so this whole block is usually optional.
+# GRAFT_PROVIDER=claude-cli
+# Model alias or full id. Aliases track the current model, so prefer them.
+# GRAFT_MODEL=sonnet
+# Path to the binary, if it is not on PATH.
+# GRAFT_CLAUDE_BIN=
+# Per-call wall clock in ms (default 300000).
+# GRAFT_CLAUDE_TIMEOUT_MS=300000
+# Per-call spend ceiling in USD (notional on a subscription; a safety valve).
+# GRAFT_CLAUDE_MAX_BUDGET_USD=
+
+# --- Option 2: an API key -----------------------------------------------------
 # Wire format / SDK: "openai" (any OpenAI-compatible endpoint) or "anthropic".
 # GRAFT_PROVIDER=openai
 # Your provider API key.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# The two shims under .claude/helpers/ are GENERATED from src/claude/shim-template.ts
+# and checked in because .claude/settings.json points every hook at them — a clone
+# without them fails with "Cannot find module". test/claude-shim-template.test.ts
+# compares them against the template, which only ever emits \n, so their committed
+# bytes have to stay LF no matter what core.autocrlf says on the contributor's box.
+.claude/helpers/*.cjs text eol=lf
+
+# Fixtures whose bytes are the point of the test.
+*.patch -text

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ graft/
 
 # Session transcripts and prompt traces — local analysis, not product.
 transcripts/
+
+# transient agent worktrees
+.claude/worktrees/

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ _Summary, sources, links, and notes ship today in markdown nodes. The crux ships
 ## What runs where
 
 - **On your machine, no key, no network:** the structural code graph. `graft build` (wiring graph + per-file cards), `graft check`, and `graft ask` are deterministic tree-sitter — they never call a model.
+- **On your Claude subscription, no key:** if the [Claude Code](https://claude.com/claude-code) CLI is installed and signed in, `graft build --deep` just works — graft drives it in headless mode and the run bills against your existing subscription instead of metered API credits. This is the default whenever no API key is configured; force it with `GRAFT_PROVIDER=claude-cli` (`GRAFT_MODEL=sonnet|opus|haiku`). The CLI is invoked with every tool disabled and your own settings, hooks, MCP servers and `CLAUDE.md` excluded, so it is a pure summarization call that cannot touch your repo.
 - **Through your provider key:** the LLM-written parts — `graft build --deep` adds the concept nodes (file summaries + node synthesis) and the per-symbol summaries and cruxes. graft is vendor-neutral: set `GRAFT_PROVIDER` (`openai` for any OpenAI-compatible endpoint, or `anthropic` for the native API), your `GRAFT_API_KEY`, `GRAFT_MODEL`, and — for the `openai` wire format — `GRAFT_BASE_URL` to point at OpenRouter, Fireworks, Groq, a LiteLLM proxy, a local server, or OpenAI itself. Or pass `--provider/--model/--api-key/--base-url` on the command line. (`OPENROUTER_API_KEY` still works as a deprecated fallback.)
 - **No telemetry** and no analytics — the only network calls are the LLM requests you configured.
 
@@ -320,7 +321,7 @@ Where a CLI agent supports user-level `hooks.json`, `init` also installs Graft's
   <br/><sub>edit a file → blast radius appears inline → graph auto-resyncs → confirmed in <code>graft viz</code></sub>
 </p>
 
-`graft init` is idempotent and never clobbers your existing `.claude/settings.json` — it merges its blocks and leaves the rest alone. Want the LLM summaries too? Run `graft build --deep` (with a key) whenever you like; auto-sync will never do it for you.
+`graft init` is idempotent and never clobbers your existing `.claude/settings.json` — it merges its blocks and leaves the rest alone. Want the LLM summaries too? Run `graft build --deep` (with a key, or on your Claude subscription) whenever you like; auto-sync will never do it for you.
 
 ---
 
@@ -329,6 +330,7 @@ Where a CLI agent supports user-level `hooks.json`, `init` also installs Graft's
 ```bash
 graft build [dir]                    # build graft/ from the code at [dir]: wiring graph + per-file cards (no LLM, no key)
 graft build --deep                   # add the LLM layer: concept nodes + per-symbol summary/crux (cached)
+                                     # uses your signed-in Claude Code CLI when no API key is set
 graft build --extensions .ts .py     # only include these code extensions
 graft build --no-reuse               # re-parse every file instead of replaying unchanged ones from cache
 

--- a/src/ai/llm/claude-cli.ts
+++ b/src/ai/llm/claude-cli.ts
@@ -1,0 +1,488 @@
+/**
+ * Subscription transport: drives the locally installed `claude` CLI in headless
+ * mode instead of calling an HTTP API with a key.
+ *
+ * `--deep` was gated on GRAFT_API_KEY, so a developer already paying for a Claude
+ * subscription still had to buy separate API credits to get concept nodes and
+ * per-symbol summaries. Claude Code's headless mode (`claude -p`) authenticates
+ * through the same OAuth session as the interactive CLI, so shelling out to it
+ * turns that existing subscription into a usable transport — no key anywhere.
+ *
+ * The CLI is a coding AGENT, not a completions endpoint, so this adapter narrows
+ * it back down to one. Every flag below is load-bearing:
+ *   - `--tools ""` removes every built-in tool, so a turn is prompt → text and the
+ *     model physically cannot touch the filesystem while summarizing.
+ *   - `--setting-sources ""`, `--strict-mcp-config` and `--disable-slash-commands`
+ *     keep the user's own hooks, MCP servers and skills out of the run.
+ *   - `--system-prompt` REPLACES Claude Code's agent system prompt. That is also
+ *     what keeps CLAUDE.md out: a personal "always answer in Portuguese" memory
+ *     would otherwise silently rewrite every summary written into the graph.
+ *   - `--no-session-persistence` stops thousands of one-shot summaries from being
+ *     recorded as resumable sessions on disk.
+ *
+ * Two things the HTTP adapters get for free are unavailable here:
+ *   - Structured output. There is no `tool_choice`, so {@link ChatRequest.responseFormat}
+ *     is emulated: the schema is stated in the prompt and the reply is parsed back
+ *     into a synthetic {@link ToolCall}, with one corrective retry. Callers
+ *     (synthesize, crux) see the same shape they get from Anthropic or OpenAI.
+ *   - `temperature` and `maxTokens`. No flag exposes either; both are dropped.
+ *     graft only ever asks for temperature 0, and the drift that costs is small
+ *     next to not needing a key at all.
+ *
+ * The prompt travels over STDIN, never argv — a 24k-char file summary would blow
+ * the 32767-char Windows command-line limit — which also keeps every argument
+ * short and quote-free, so the cmd.exe shim path below stays safe.
+ */
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import type { ChatModel, ChatRequest, ChatResponse, Message, ToolCall, Usage } from "./types.js";
+
+const PROVIDER = "claude-cli";
+const JSON_TOOL = "emit_json";
+const DEFAULT_TIMEOUT_MS = 300_000;
+
+/**
+ * Replaces Claude Code's agent system prompt. Deliberately short and quote-free:
+ * the caller's real system prompt is far too big (and too quote-heavy) to be safe
+ * as an argv entry, so it rides in the stdin envelope instead.
+ */
+const HARNESS_SYSTEM_PROMPT =
+  "You are a precise documentation and analysis engine, not a conversational assistant. " +
+  "Follow the INSTRUCTIONS block exactly and answer only about the INPUT block. " +
+  "Emit the requested artifact and nothing else: no preamble, no sign-off, no markdown fences.";
+
+export interface ClaudeCliResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+/** Injectable process runner — tests pass a stub so nothing is ever spawned. */
+export type ClaudeCliRunner = (args: string[], stdin: string, timeoutMs: number) => Promise<ClaudeCliResult>;
+
+export interface ClaudeCliChatModelOptions {
+  /** Model alias or full id (`sonnet`, `opus`, `claude-sonnet-5`, …). */
+  model: string;
+  /** Path to the CLI. Default: resolved from PATH (env GRAFT_CLAUDE_BIN wins). */
+  bin?: string;
+  label?: string;
+  /** Per-call wall clock. Default 300s — a crux pass over a big file is slow. */
+  timeoutMs?: number;
+  /** Optional spend ceiling passed through as `--max-budget-usd`. */
+  maxBudgetUsd?: number;
+  /** Inject a runner (tests stub it; production omits it). */
+  run?: ClaudeCliRunner;
+}
+
+/** The `claude -p --output-format json` envelope, narrowed to what we consume. */
+interface CliEnvelope {
+  type?: string;
+  subtype?: string;
+  is_error?: boolean;
+  result?: string;
+  stop_reason?: string | null;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    cache_read_input_tokens?: number;
+    cache_creation_input_tokens?: number;
+  };
+}
+
+export class ClaudeCliChatModel implements ChatModel {
+  readonly label: string;
+  private model: string;
+  private runner: ClaudeCliRunner;
+  private timeoutMs: number;
+  private maxBudgetUsd?: number;
+
+  constructor(opts: ClaudeCliChatModelOptions) {
+    this.model = opts.model;
+    this.label = opts.label ?? `${PROVIDER}:${opts.model}`;
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.maxBudgetUsd = opts.maxBudgetUsd;
+    this.runner = opts.run ?? defaultRunner(opts.bin);
+  }
+
+  async create(req: ChatRequest): Promise<ChatResponse> {
+    const fmt = req.responseFormat ?? { kind: "text" };
+    const schema = schemaFor(req, fmt);
+    const prompt = buildPrompt(req.messages, schema);
+
+    let env = await this.invoke(prompt);
+    let text = (env.result ?? "").trim();
+
+    // Structured output is prompt-enforced, not wire-enforced, so a reply can come
+    // back with prose around the JSON. Retry ONCE, quoting the bad reply back — far
+    // cheaper than failing a 5000-file build on one malformed response.
+    let parsed: unknown;
+    if (fmt.kind !== "text") {
+      parsed = extractJson(text);
+      if (parsed === undefined) {
+        env = await this.invoke(retryPrompt(prompt, text));
+        text = (env.result ?? "").trim();
+        parsed = extractJson(text);
+      }
+      if (parsed === undefined) {
+        throw new Error(
+          `claude CLI did not return parseable JSON for ${fmt.kind === "tool" ? fmt.name : "json"} output. ` +
+            `Got: ${text.slice(0, 200)}${text.length > 200 ? "…" : ""}`,
+        );
+      }
+    }
+
+    const toolCalls: ToolCall[] = [];
+    if (fmt.kind === "tool") {
+      toolCalls.push({ id: `${PROVIDER}_1`, name: fmt.name, args: parsed });
+      text = "";
+    } else if (fmt.kind === "json") {
+      text = JSON.stringify(parsed);
+    }
+
+    return {
+      text,
+      toolCalls,
+      usage: normalizeUsage(env.usage),
+      stopReason: env.stop_reason ?? null,
+      assistant: {
+        role: "assistant",
+        content: text,
+        toolCalls: toolCalls.length ? toolCalls : undefined,
+      },
+    };
+  }
+
+  /**
+   * Transport-level retry. A `--deep` build is thousands of sequential calls over
+   * hours, so a single blip — an overloaded upstream, a dropped connection, one
+   * slow file hitting the wall clock — would otherwise silently cost that file its
+   * summary. Only failures classified transient are retried; a bad login or an
+   * exhausted quota fails immediately, because sleeping on those just turns a
+   * clear error into a slow one.
+   */
+  private async invoke(prompt: string): Promise<CliEnvelope> {
+    let lastErr: unknown;
+    for (let attempt = 0; attempt < TRANSIENT_ATTEMPTS; attempt++) {
+      try {
+        return await this.invokeOnce(prompt);
+      } catch (err) {
+        lastErr = err;
+        const msg = err instanceof Error ? err.message : String(err);
+        if (attempt === TRANSIENT_ATTEMPTS - 1 || !isTransient(msg)) throw err;
+        await sleep(BACKOFF_MS[attempt]);
+      }
+    }
+    throw lastErr;
+  }
+
+  private async invokeOnce(prompt: string): Promise<CliEnvelope> {
+    const args = [
+      "-p",
+      "--output-format",
+      "json",
+      "--model",
+      this.model,
+      "--tools",
+      "", // no filesystem, no network, no shell — this is a completions call
+      "--system-prompt",
+      HARNESS_SYSTEM_PROMPT,
+      "--setting-sources",
+      "", // no user/project settings ⇒ no hooks, no stray permissions
+      "--strict-mcp-config",
+      "--disable-slash-commands",
+      "--no-session-persistence",
+    ];
+    if (this.maxBudgetUsd !== undefined) args.push("--max-budget-usd", String(this.maxBudgetUsd));
+
+    const res = await this.runner(args, prompt, this.timeoutMs);
+    if (res.code !== 0) {
+      throw new Error(
+        `claude CLI exited with code ${res.code ?? "null"}: ${(res.stderr || res.stdout).trim().slice(0, 400)}`,
+      );
+    }
+
+    const env = parseEnvelope(res.stdout);
+    if (!env) {
+      throw new Error(`claude CLI returned no JSON envelope: ${res.stdout.trim().slice(0, 200)}`);
+    }
+    if (env.is_error) {
+      throw new Error(`claude CLI reported an error: ${(env.result ?? env.subtype ?? "unknown").slice(0, 400)}`);
+    }
+    return env;
+  }
+}
+
+// --- transient-failure policy ------------------------------------------------
+
+const TRANSIENT_ATTEMPTS = 3;
+const BACKOFF_MS = [1_000, 5_000];
+
+/**
+ * Retry only what a retry can fix. Quota exhaustion and a missing/expired login
+ * are deliberately absent: both persist for far longer than any backoff here, and
+ * the user needs to see them now rather than after three sleeps per file.
+ */
+const TRANSIENT = /\b(overloaded|rate.?limit|429|50[0234]|timed out|timeout|ETIMEDOUT|ECONNRESET|ECONNREFUSED|EAI_AGAIN|socket hang up|network|temporarily)\b/i;
+const PERMANENT = /\b(usage limit|not found on PATH|invalid api key|\/login|unauthorized|401|403|credit balance)\b/i;
+
+export function isTransient(message: string): boolean {
+  if (PERMANENT.test(message)) return false;
+  return TRANSIENT.test(message);
+}
+
+// Deliberately NOT unref'd: an unref'd backoff lets Node exit while the retry is
+// still pending, which would end a build mid-flight instead of resuming it.
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+// --- prompt assembly ---------------------------------------------------------
+
+/**
+ * The schema the reply must satisfy. `tool` format borrows the named tool's own
+ * parameter schema, so synthesize/crux keep one schema definition rather than
+ * maintaining a second copy for this provider.
+ */
+function schemaFor(req: ChatRequest, fmt: NonNullable<ChatRequest["responseFormat"]>): unknown {
+  if (fmt.kind === "tool") return req.tools?.find((t) => t.name === fmt.name)?.parameters ?? { type: "object" };
+  if (fmt.kind === "json") return { type: "object" };
+  return undefined;
+}
+
+/** Flatten the neutral message list into one stdin document. */
+function buildPrompt(messages: Message[], schema: unknown): string {
+  const system = messages.filter((m) => m.role === "system").map((m) => m.content.trim()).filter(Boolean);
+  const rest = messages.filter((m) => m.role !== "system");
+
+  const body =
+    rest.length === 1 && rest[0].role === "user"
+      ? rest[0].content
+      : rest
+          .map((m) => {
+            const head = m.role === "tool" ? `TOOL RESULT (${m.toolCallId ?? ""})` : m.role.toUpperCase();
+            const calls = m.toolCalls?.length ? `\n${JSON.stringify(m.toolCalls)}` : "";
+            return `### ${head}\n${m.content}${calls}`;
+          })
+          .join("\n\n");
+
+  const parts: string[] = [];
+  if (system.length) parts.push(`<INSTRUCTIONS>\n${system.join("\n\n")}\n</INSTRUCTIONS>`);
+  parts.push(`<INPUT>\n${body}\n</INPUT>`);
+  if (schema !== undefined) {
+    parts.push(
+      "<OUTPUT_FORMAT>\n" +
+        "Reply with a SINGLE JSON object and nothing else. No prose before or after it, " +
+        "no markdown code fences, no explanation. It must validate against this JSON Schema:\n" +
+        JSON.stringify(schema) +
+        "\n</OUTPUT_FORMAT>",
+    );
+  }
+  return parts.join("\n\n");
+}
+
+function retryPrompt(original: string, bad: string): string {
+  return (
+    `${original}\n\n<RETRY>\nYour previous reply could not be parsed as JSON. It began:\n` +
+    `${bad.slice(0, 300)}\n\nReply again with ONLY the JSON object — first character "{", last character "}".\n</RETRY>`
+  );
+}
+
+// --- response parsing --------------------------------------------------------
+
+/**
+ * `--output-format json` prints one object, but a stray warning line on stdout
+ * would break a naive JSON.parse — so fall back to the last JSON-looking line.
+ */
+function parseEnvelope(stdout: string): CliEnvelope | undefined {
+  const trimmed = stdout.trim();
+  if (!trimmed) return undefined;
+  try {
+    return JSON.parse(trimmed) as CliEnvelope;
+  } catch {
+    // fall through
+  }
+  const lines = trimmed.split(/\r?\n/).filter((l) => l.trim().startsWith("{"));
+  for (let i = lines.length - 1; i >= 0; i--) {
+    try {
+      return JSON.parse(lines[i]) as CliEnvelope;
+    } catch {
+      continue;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Pull one JSON value out of a model reply. Handles the two ways a prompt-enforced
+ * schema leaks: a markdown fence around the object, and prose either side of it.
+ * Brace scanning is string- and escape-aware so a `}` inside a summary can't end
+ * the object early. Returns undefined when nothing parses.
+ */
+export function extractJson(text: string): unknown {
+  const stripped = text.replace(/^\s*```(?:json)?\s*/i, "").replace(/\s*```\s*$/, "").trim();
+  for (const candidate of [stripped, text]) {
+    try {
+      return JSON.parse(candidate);
+    } catch {
+      // fall through to brace scanning
+    }
+    const start = candidate.indexOf("{");
+    if (start === -1) continue;
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+    for (let i = start; i < candidate.length; i++) {
+      const ch = candidate[i];
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (ch === "\\") {
+        if (inString) escaped = true;
+        continue;
+      }
+      if (ch === '"') {
+        inString = !inString;
+        continue;
+      }
+      if (inString) continue;
+      if (ch === "{") depth++;
+      else if (ch === "}") {
+        depth--;
+        if (depth === 0) {
+          try {
+            return JSON.parse(candidate.slice(start, i + 1));
+          } catch {
+            break;
+          }
+        }
+      }
+    }
+  }
+  return undefined;
+}
+
+/** The CLI already reports uncached input separately, matching graft's convention. */
+function normalizeUsage(u: CliEnvelope["usage"]): Usage {
+  return {
+    input: u?.input_tokens ?? 0,
+    output: u?.output_tokens ?? 0,
+    cacheRead: u?.cache_read_input_tokens ?? 0,
+    cacheCreate: u?.cache_creation_input_tokens ?? 0,
+  };
+}
+
+// --- process plumbing --------------------------------------------------------
+
+/**
+ * Resolve the CLI without a shell. Node's spawn only appends `.exe` on Windows,
+ * so PATHEXT is walked by hand — the native installer ships `claude.exe` but an
+ * `npm i -g` install leaves only the `claude.cmd` shim, and missing it would make
+ * this provider look uninstalled on a machine where it works fine.
+ */
+export function resolveClaudeBin(explicit?: string): string | undefined {
+  const name = explicit ?? process.env.GRAFT_CLAUDE_BIN ?? "claude";
+  if (name.includes("/") || name.includes("\\")) return existsSync(name) ? name : undefined;
+
+  const exts =
+    process.platform === "win32"
+      ? [".EXE", ".CMD", ".BAT", ".COM", ""] // .exe first: it spawns without a shim
+      : [""];
+  for (const dir of (process.env.PATH ?? "").split(delimiter)) {
+    if (!dir) continue;
+    for (const ext of exts) {
+      const p = join(dir.replace(/^"|"$/g, ""), name + ext);
+      if (existsSync(p)) return p;
+    }
+  }
+  return undefined;
+}
+
+let cachedAvailable: boolean | undefined;
+
+/** True when the `claude` CLI is installed. Cached — this runs per build, not per file. */
+export function claudeCliAvailable(explicit?: string): boolean {
+  if (explicit ?? process.env.GRAFT_CLAUDE_BIN) return !!resolveClaudeBin(explicit);
+  if (cachedAvailable === undefined) cachedAvailable = !!resolveClaudeBin();
+  return cachedAvailable;
+}
+
+/** Test seam: drop the memoized lookup so a test can flip PATH. */
+export function resetClaudeCliCache(): void {
+  cachedAvailable = undefined;
+}
+
+/**
+ * `cmd.exe` cannot be handed a `.cmd` file through CreateProcess, so an npm shim
+ * has to be run as a command line. Every argument we pass is short and quote-free
+ * (the prompt goes over stdin), so quoting each one is enough.
+ */
+function windowsWrap(bin: string, args: string[]): { file: string; argv: string[]; verbatim: boolean } {
+  const isShim = process.platform === "win32" && /\.(cmd|bat)$/i.test(bin);
+  if (!isShim) return { file: bin, argv: args, verbatim: false };
+  const quote = (s: string) => `"${s.replace(/"/g, '""')}"`;
+  const line = [quote(bin), ...args.map(quote)].join(" ");
+  return { file: process.env.ComSpec ?? "cmd.exe", argv: ["/d", "/s", "/c", `"${line}"`], verbatim: true };
+}
+
+function defaultRunner(bin?: string): ClaudeCliRunner {
+  return (args, stdin, timeoutMs) =>
+    new Promise<ClaudeCliResult>((resolve, reject) => {
+      const resolved = resolveClaudeBin(bin);
+      if (!resolved) {
+        reject(
+          new Error(
+            "claude CLI not found on PATH. Install Claude Code (https://claude.com/claude-code) and sign in " +
+              "with your subscription, set GRAFT_CLAUDE_BIN to its path, or use an API-key provider " +
+              "(GRAFT_PROVIDER=anthropic|openai + GRAFT_API_KEY).",
+          ),
+        );
+        return;
+      }
+
+      const { file, argv, verbatim } = windowsWrap(resolved, args);
+      const child = spawn(file, argv, {
+        // Never the user's repo: cwd is what CLAUDE.md discovery keys off, and a
+        // summarization run must not inherit the project's own agent instructions.
+        cwd: tmpdir(),
+        windowsHide: true,
+        windowsVerbatimArguments: verbatim,
+        env: {
+          ...process.env,
+          // Skip the auxiliary Haiku calls (titles, topic detection): pure overhead
+          // when a "session" is one summary that is never resumed.
+          DISABLE_NON_ESSENTIAL_MODEL_CALLS: "1",
+          CLAUDE_CODE_ENTRYPOINT: "graft",
+        },
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+
+      let stdout = "";
+      let stderr = "";
+      let settled = false;
+      const finish = (fn: () => void) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        fn();
+      };
+
+      const timer = setTimeout(() => {
+        child.kill("SIGKILL");
+        finish(() => reject(new Error(`claude CLI timed out after ${timeoutMs}ms`)));
+      }, timeoutMs);
+      timer.unref?.();
+
+      child.stdout.setEncoding("utf8");
+      child.stderr.setEncoding("utf8");
+      child.stdout.on("data", (d: string) => (stdout += d));
+      child.stderr.on("data", (d: string) => (stderr += d));
+      child.on("error", (err) => finish(() => reject(err)));
+      child.on("close", (code) => finish(() => resolve({ code, stdout, stderr })));
+
+      // A CLI that dies before draining stdin gives us EPIPE; the close handler
+      // already carries the real diagnosis, so swallow it here.
+      child.stdin.on("error", () => {});
+      child.stdin.end(stdin, "utf8");
+    });
+}

--- a/src/ai/llm/factory.ts
+++ b/src/ai/llm/factory.ts
@@ -2,31 +2,58 @@
  * One place that turns resolved config into a {@link ChatModel}. `provider` names
  * the WIRE FORMAT, not a vendor: `openai` speaks the OpenAI-compatible API (point
  * `baseUrl` at OpenRouter, Fireworks, a LiteLLM proxy, Groq, a local server, …),
- * `anthropic` speaks the native Messages API. Adding a vendor is a base URL, not
- * a code change; adding a wire format is one new adapter here.
+ * `anthropic` speaks the native Messages API, and `claude-cli` speaks to the
+ * locally installed Claude Code binary over stdio. Adding a vendor is a base URL,
+ * not a code change; adding a wire format is one new adapter here.
+ *
+ * `claude-cli` is the one provider that takes NO api key — it borrows the CLI's
+ * own signed-in session — so key handling is a per-provider question answered by
+ * {@link providerNeedsKey} rather than an invariant of this factory.
  */
 import type { ChatModel } from "./types.js";
 import { OpenAIChatModel } from "./openai.js";
 import { AnthropicChatModel } from "./anthropic.js";
+import { ClaudeCliChatModel } from "./claude-cli.js";
 
-export type ProviderKind = "openai" | "anthropic";
+export type ProviderKind = "openai" | "anthropic" | "claude-cli";
+
+export const PROVIDER_KINDS: readonly ProviderKind[] = ["openai", "anthropic", "claude-cli"];
+
+/** Whether a provider authenticates with an API key at all. */
+export function providerNeedsKey(provider: ProviderKind): boolean {
+  return provider !== "claude-cli";
+}
 
 export interface ChatModelConfig {
   provider: ProviderKind;
-  apiKey: string;
+  /** Required by every provider except `claude-cli`, which uses its own session. */
+  apiKey?: string;
   model: string;
   baseUrl?: string;
   /** Extra default headers for OpenAI-compatible endpoints (e.g. OpenRouter `X-Title`). */
   headers?: Record<string, string>;
+  /** `claude-cli` only: explicit path to the binary (else resolved from PATH). */
+  bin?: string;
+  /** `claude-cli` only: per-call wall clock in milliseconds. */
+  timeoutMs?: number;
+  /** `claude-cli` only: per-call spend ceiling, passed through as `--max-budget-usd`. */
+  maxBudgetUsd?: number;
 }
 
 export function createChatModel(cfg: ChatModelConfig): ChatModel {
   switch (cfg.provider) {
+    case "claude-cli":
+      return new ClaudeCliChatModel({
+        model: cfg.model,
+        bin: cfg.bin,
+        timeoutMs: cfg.timeoutMs,
+        maxBudgetUsd: cfg.maxBudgetUsd,
+      });
     case "anthropic":
-      return new AnthropicChatModel({ apiKey: cfg.apiKey, model: cfg.model, baseUrl: cfg.baseUrl });
+      return new AnthropicChatModel({ apiKey: requireKey(cfg), model: cfg.model, baseUrl: cfg.baseUrl });
     case "openai":
       return new OpenAIChatModel({
-        apiKey: cfg.apiKey,
+        apiKey: requireKey(cfg),
         model: cfg.model,
         baseUrl: cfg.baseUrl,
         headers: cfg.headers,
@@ -36,4 +63,9 @@ export function createChatModel(cfg: ChatModelConfig): ChatModel {
       throw new Error(`unknown provider: ${String(_exhaustive)}`);
     }
   }
+}
+
+function requireKey(cfg: ChatModelConfig): string {
+  if (!cfg.apiKey) throw new Error(`provider "${cfg.provider}" needs an API key — set GRAFT_API_KEY`);
+  return cfg.apiKey;
 }

--- a/src/ai/providers.ts
+++ b/src/ai/providers.ts
@@ -2,7 +2,8 @@ import type { Summarizer } from "./summarize.js";
 import type { Synthesizer } from "./synthesize.js";
 import type { CruxSummarizer } from "./crux.js";
 import type { ChatModel } from "./llm/types.js";
-import type { ProviderKind } from "./llm/factory.js";
+import { providerNeedsKey, type ProviderKind } from "./llm/factory.js";
+import { claudeCliAvailable } from "./llm/claude-cli.js";
 
 /**
  * User-facing configuration. Anything omitted falls back to environment
@@ -11,8 +12,9 @@ import type { ProviderKind } from "./llm/factory.js";
  * graft is vendor-neutral: `provider` names only the WIRE FORMAT, not a company.
  * `openai` speaks the OpenAI-compatible API — point `baseUrl` at OpenRouter,
  * Fireworks, a LiteLLM proxy, Groq, a local server, or OpenAI itself, and pass
- * your own key. `anthropic` speaks the native Messages API. Any LLM-backed
- * operation needs an API key.
+ * your own key. `anthropic` speaks the native Messages API. `claude-cli` drives a
+ * locally installed, already-signed-in Claude Code binary and needs NO key — it
+ * is the one provider that runs on a subscription instead of metered credits.
  */
 export interface EngineConfig {
   /** Where the graph lives. Env: GRAFT_DIR. Default: `<repo>/.context`. */
@@ -26,6 +28,12 @@ export interface EngineConfig {
   model?: string;
   /** Base URL for OpenAI-compatible endpoints. Env: GRAFT_BASE_URL. */
   baseUrl?: string;
+  /** `claude-cli` only: path to the binary. Env: GRAFT_CLAUDE_BIN. Default: PATH lookup. */
+  bin?: string;
+  /** `claude-cli` only: per-call timeout in ms. Env: GRAFT_CLAUDE_TIMEOUT_MS. */
+  timeoutMs?: number;
+  /** `claude-cli` only: per-call spend ceiling. Env: GRAFT_CLAUDE_MAX_BUDGET_USD. */
+  maxBudgetUsd?: number;
 
   // --- advanced: bring your own components ---
   /** Override the whole transport (skips provider/apiKey/baseUrl). */
@@ -46,8 +54,13 @@ export interface ResolvedConfig {
   model: string;
   baseUrl?: string;
   headers?: Record<string, string>;
+  bin?: string;
+  timeoutMs?: number;
+  maxBudgetUsd?: number;
   /** True when the key came from the deprecated OPENROUTER_* fallback. */
   usedLegacyEnv: boolean;
+  /** True when no provider was named and the local Claude CLI was picked for you. */
+  autoDetectedProvider: boolean;
   chatModel?: ChatModel;
   synthesizer?: Synthesizer;
   summarizer?: Summarizer;
@@ -60,6 +73,9 @@ const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
 export const DEFAULT_MODELS: Record<ProviderKind, string> = {
   openai: "openai/gpt-4o-mini",
   anthropic: "claude-sonnet-5",
+  // An alias, not a pinned id: the CLI maps it to the current Sonnet, so a graft
+  // release never has to ship a new version to follow a model refresh.
+  "claude-cli": "sonnet",
 };
 
 export const DEFAULTS = {
@@ -70,12 +86,20 @@ export const DEFAULTS = {
 /** Merge user config with environment variables and defaults. */
 export function resolveConfig(config: EngineConfig = {}): ResolvedConfig {
   const env = process.env;
-  const provider = config.provider ?? (env.GRAFT_PROVIDER as ProviderKind | undefined) ?? DEFAULTS.provider;
 
   const explicitKey = config.apiKey ?? env.GRAFT_API_KEY;
   const legacyKey = env.OPENROUTER_API_KEY;
   const apiKey = explicitKey ?? legacyKey;
   const usedLegacyEnv = !explicitKey && !!legacyKey;
+
+  // Provider choice is explicit-first, then inferred. The inference exists so the
+  // common case — a developer with a Claude subscription and no API credits —
+  // gets a working `--deep` instead of an error telling them to go buy a key. It
+  // only fires when NO key is configured, so an existing key-based setup keeps
+  // resolving to the same provider it always did.
+  const named = config.provider ?? (env.GRAFT_PROVIDER as ProviderKind | undefined);
+  const autoDetectedProvider = !named && !apiKey && claudeCliAvailable(config.bin ?? env.GRAFT_CLAUDE_BIN);
+  const provider = named ?? (autoDetectedProvider ? "claude-cli" : DEFAULTS.provider);
 
   const model =
     config.model ?? env.GRAFT_MODEL ?? env.GRAFT_OPENROUTER_MODEL ?? DEFAULT_MODELS[provider];
@@ -90,6 +114,9 @@ export function resolveConfig(config: EngineConfig = {}): ResolvedConfig {
       ? { "X-Title": "graft" }
       : undefined;
 
+  const timeoutMs = config.timeoutMs ?? numeric(env.GRAFT_CLAUDE_TIMEOUT_MS);
+  const maxBudgetUsd = config.maxBudgetUsd ?? numeric(env.GRAFT_CLAUDE_MAX_BUDGET_USD);
+
   return {
     contextDir: config.contextDir ?? env.GRAFT_DIR,
     provider,
@@ -97,10 +124,45 @@ export function resolveConfig(config: EngineConfig = {}): ResolvedConfig {
     model,
     baseUrl,
     headers,
+    bin: config.bin ?? env.GRAFT_CLAUDE_BIN,
+    timeoutMs,
+    maxBudgetUsd,
+    autoDetectedProvider,
     usedLegacyEnv,
     chatModel: config.chatModel,
     synthesizer: config.synthesizer,
     summarizer: config.summarizer,
     cruxSummarizer: config.cruxSummarizer,
   };
+}
+
+function numeric(v: string | undefined): number | undefined {
+  if (!v) return undefined;
+  const n = Number(v);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
+/**
+ * Can this config actually reach a model? One answer for every caller — the CLI's
+ * pre-flight warning and the engine's hard error used to each spell out "needs a
+ * key", which silently became wrong the moment a keyless provider existed.
+ *
+ * Returns undefined when the config is usable, or the reason it is not.
+ */
+export function credentialProblem(cfg: ResolvedConfig): string | undefined {
+  if (cfg.chatModel || (cfg.synthesizer && cfg.summarizer && cfg.cruxSummarizer)) return undefined;
+  if (!providerNeedsKey(cfg.provider)) {
+    if (claudeCliAvailable(cfg.bin)) return undefined;
+    return (
+      `GRAFT_PROVIDER=${cfg.provider} needs the Claude Code CLI, which is not on PATH.\n` +
+      "  Install it from https://claude.com/claude-code and sign in with your subscription,\n" +
+      "  or point GRAFT_CLAUDE_BIN at the binary."
+    );
+  }
+  if (cfg.apiKey) return undefined;
+  return (
+    "No API key. Set GRAFT_API_KEY (and GRAFT_PROVIDER / GRAFT_BASE_URL / GRAFT_MODEL for your\n" +
+    "  provider), or install the Claude Code CLI and run with GRAFT_PROVIDER=claude-cli to use\n" +
+    "  your Claude subscription instead of a key."
+  );
 }

--- a/src/ask/ask.ts
+++ b/src/ask/ask.ts
@@ -34,6 +34,7 @@ import { rankScopesAndFuse } from "./fuse.js";
 import { personalizedPageRank } from "./graphrank.js";
 import { readSourceFile } from "../util/source.js";
 import { counts, tokenize, type AskIndex, type AskIndexDoc } from "./index-file.js";
+import { formatCount } from "../util/num.js";
 
 export interface AskHit {
   kind: "concept" | "symbol" | "caller" | "callee";
@@ -995,9 +996,9 @@ function askSavingsLine(r: AskResult, body: string): string {
   const saved = base - pack;
   const pct = Math.round((saved / base) * 100);
   return (
-    `[graft] tokens saved ≈ ${saved.toLocaleString()} (${pct}%) — this pack ≈ ` +
-    `${pack.toLocaleString()} tok vs reading the ${r.saved.files} source file(s) whole ≈ ` +
-    `${base.toLocaleString()} tok. Estimate (baseline = those files read in full).` +
+    `[graft] tokens saved ≈ ${formatCount(saved)} (${pct}%) — this pack ≈ ` +
+    `${formatCount(pack)} tok vs reading the ${r.saved.files} source file(s) whole ≈ ` +
+    `${formatCount(base)} tok. Estimate (baseline = those files read in full).` +
     SAVINGS_TURN_NUDGE
   );
 }

--- a/src/claude/format.ts
+++ b/src/claude/format.ts
@@ -5,6 +5,7 @@ import type { GraphV1, EdgeV1 } from '../graph/types.js';
 // "did we hit a real name, or match broadly enough to trust anyway" is the same
 // question in both places, and one set of calibrated numbers beats two.
 import { HIGH_FLOOR, STRONG_FLOOR } from '../ask/fuse.js';
+import { formatCount } from "../util/num.js";
 
 const C = {
   indigo: (s: string) => `\x1b[38;2;84;111;255m${s}\x1b[0m`,
@@ -32,7 +33,7 @@ export function renderStatusline(
   const top = [C.muted('◤ ') + C.indigo('graft'), C.text(`${stats.nodeCount} nodes / ${stats.edgeCount} edges`)];
   top.push(freshnessSegment(stats));
   const saved = session?.savedTokens ?? 0;
-  if (saved > 0) top.push(C.indigo(`~${saved.toLocaleString()} tok saved`));
+  if (saved > 0) top.push(C.indigo(`~${formatCount(saved)} tok saved`));
 
   const bottom: string[] = [];
   if (typeof ctx.ctxPct === 'number') bottom.push(C.text(`ctx ${ctx.ctxPct}%`));
@@ -125,9 +126,9 @@ export function formatRetrieval(ask: AskJson, cap = 5): string | null {
   const base = tokensOf(ask.saved!.baselineChars);
   const pct = Math.round((saved / base) * 100);
   return (
-    `${body}\n[graft] tokens saved ≈ ${saved.toLocaleString()} (${pct}%); this pack ≈ ` +
-    `${tokensOf(body.length).toLocaleString()} tok vs reading the ${ask.saved!.files} file(s) whole ≈ ` +
-    `${base.toLocaleString()} tok (estimate).`
+    `${body}\n[graft] tokens saved ≈ ${formatCount(saved)} (${pct}%); this pack ≈ ` +
+    `${formatCount(tokensOf(body.length))} tok vs reading the ${ask.saved!.files} file(s) whole ≈ ` +
+    `${formatCount(base)} tok (estimate).`
   );
 }
 

--- a/src/cli-epilogue.ts
+++ b/src/cli-epilogue.ts
@@ -4,6 +4,7 @@
  * so the exact text — spacing is hand-aligned, not incidental — can be
  * unit-tested without spawning the CLI.
  */
+import { formatCount } from "./util/num.js";
 
 // The widest line (index 4, tied with index 2 at 26 chars) gets the live
 // node/edge stats appended, when a graph exists.
@@ -47,7 +48,7 @@ export function formatInitEpilogue(opts: InitEpilogueOptions): string {
 
   const wordmark = WORDMARK_LINES.map((l) => (tty ? indigo(l) : l));
   if (graphBuilt && nodes !== undefined && edges !== undefined) {
-    const stats = `  ${nodes.toLocaleString("en-US")} nodes · ${edges.toLocaleString("en-US")} edges`;
+    const stats = `  ${formatCount(nodes)} nodes · ${formatCount(edges)} edges`;
     wordmark[STATS_LINE_INDEX] += tty ? muted(stats) : stats;
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,7 +9,7 @@ import { Command } from "commander";
 import { join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Graft } from "./engine.js";
-import { resolveConfig, type EngineConfig } from "./ai/providers.js";
+import { credentialProblem, resolveConfig, type EngineConfig } from "./ai/providers.js";
 import type { ProviderKind } from "./ai/llm/factory.js";
 import { formatCheckReport } from "./context/check.js";
 import { formatGraphCheckReport } from "./graph/check.js";
@@ -47,9 +47,13 @@ program
   .description("Build a repo's context graph as linked markdown, and keep it in sync with the code.")
   .version(currentVersion, "-v, --version")
   .option("--dir <path>", "context graph directory (default: <repo>/graft)")
-  .option("--provider <name>", "LLM wire format: openai | anthropic (env GRAFT_PROVIDER)")
+  .option(
+    "--provider <name>",
+    "LLM wire format: openai | anthropic | claude-cli (env GRAFT_PROVIDER). " +
+      "claude-cli drives your signed-in Claude Code CLI — a subscription, no API key",
+  )
   .option("--model <id>", "model id for the LLM pass (env GRAFT_MODEL)")
-  .option("--api-key <key>", "provider API key (env GRAFT_API_KEY)")
+  .option("--api-key <key>", "provider API key (env GRAFT_API_KEY); not used by claude-cli")
   .option("--base-url <url>", "OpenAI-compatible endpoint URL (env GRAFT_BASE_URL)");
 
 interface GlobalOpts {
@@ -226,15 +230,20 @@ program
         .map(([k, n]) => `${n} ${k}`)
         .join(", ");
 
-    // --deep needs a key; without one, degrade to the $0 structural build.
+    // --deep needs a reachable model; without one, degrade to the $0 structural build.
     let deep = opts.deep;
     const resolved = resolveConfig(cliConfig());
-    if (deep && !resolved.apiKey) {
+    const problem = deep ? credentialProblem(resolved) : undefined;
+    if (problem) {
       deep = false;
+      console.error(`⚠ falling back to the structural build (no LLM summaries).\n  ${problem}`);
+    }
+    // Say so out loud: the run costs subscription usage, not API credits, and the
+    // user never asked for this provider — they just had the CLI installed.
+    if (deep && resolved.autoDetectedProvider) {
       console.error(
-        "⚠ no API key set — falling back to the structural build (no LLM summaries).\n" +
-          "  Set GRAFT_API_KEY (and GRAFT_PROVIDER / GRAFT_BASE_URL / GRAFT_MODEL for your\n" +
-          "  provider) and re-run `graft build --deep` to add concept nodes and summaries.",
+        `→ no API key found; using your signed-in Claude Code CLI (${resolved.model}).\n` +
+          "  Set GRAFT_API_KEY to use a metered provider instead.",
       );
     }
     if (deep && resolved.usedLegacyEnv) {

--- a/src/context/savings.ts
+++ b/src/context/savings.ts
@@ -13,6 +13,7 @@
  * map — routes through {@link savingsFor} + {@link withSavings} here.
  */
 import type { GraphV1 } from '../graph/types.js';
+import { formatCount } from "../util/num.js";
 
 export interface Savings {
   /** How many source files the baseline covers. */
@@ -74,9 +75,9 @@ export function savingsLine(body: string, saved: Savings | undefined): string {
   const delta = base - pack;
   const pct = Math.round((delta / base) * 100);
   return (
-    `[graft] tokens saved ≈ ${delta.toLocaleString()} (${pct}%) — this output ≈ ` +
-    `${pack.toLocaleString()} tok vs reading the ${saved.files} file(s) it covers whole ≈ ` +
-    `${base.toLocaleString()} tok (estimate).` +
+    `[graft] tokens saved ≈ ${formatCount(delta)} (${pct}%) — this output ≈ ` +
+    `${formatCount(pack)} tok vs reading the ${saved.files} file(s) it covers whole ≈ ` +
+    `${formatCount(base)} tok (estimate).` +
     SAVINGS_TURN_NUDGE
   );
 }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -10,7 +10,7 @@
  * the sync. This class wires the configured LLM provider into the build/check
  * pipelines; an API key is required for any LLM-backed operation.
  */
-import { resolveConfig, type EngineConfig, type ResolvedConfig } from "./ai/providers.js";
+import { credentialProblem, resolveConfig, type EngineConfig, type ResolvedConfig } from "./ai/providers.js";
 import { ChatSynthesizer, type Synthesizer } from "./ai/synthesize.js";
 import { ChatSummarizer, type Summarizer } from "./ai/summarize.js";
 import { ChatCruxSummarizer, type CruxSummarizer } from "./ai/crux.js";
@@ -116,18 +116,17 @@ export class Graft {
   private chatModel(): ChatModel {
     if (this.cfg.chatModel) return this.cfg.chatModel;
     if (this._chatModel) return this._chatModel;
-    if (!this.cfg.apiKey) {
-      throw new Error(
-        "No API key. Set GRAFT_API_KEY (and GRAFT_PROVIDER / GRAFT_BASE_URL / GRAFT_MODEL " +
-          "for your provider) to build or summarize the graph.",
-      );
-    }
+    const problem = credentialProblem(this.cfg);
+    if (problem) throw new Error(problem);
     this._chatModel = createChatModel({
       provider: this.cfg.provider,
       apiKey: this.cfg.apiKey,
       model: this.cfg.model,
       baseUrl: this.cfg.baseUrl,
       headers: this.cfg.headers,
+      bin: this.cfg.bin,
+      timeoutMs: this.cfg.timeoutMs,
+      maxBudgetUsd: this.cfg.maxBudgetUsd,
     });
     return this._chatModel;
   }

--- a/src/graph/build.ts
+++ b/src/graph/build.ts
@@ -18,7 +18,7 @@ import { basename, dirname, resolve } from "node:path";
 import { walkDir } from "../ingest/fs.js";
 import { contextDirFor, ensureGitignored, ensureSearchable } from "../context/node-file.js";
 import { extractFile, languageLabelOf, languageOf, type RawEdge } from "./extract.js";
-import { extractGeneric, genericLangOf, warmGenericGrammars } from "./generic.js";
+import { extractGeneric, genericLangOf, unavailableGrammars, warmGenericGrammars } from "./generic.js";
 import { contentHash } from "../util/id.js";
 import { relPosix } from "../util/paths.js";
 import { readSourceFile } from "../util/source.js";
@@ -74,6 +74,11 @@ export interface GraphBuildOptions {
   /** Replay unchanged files from the extraction cache instead of re-parsing them
    * (default true). False forces a cold parse of the whole repo. */
   reuse?: boolean;
+  /** Narrow the indexed file set to these extensions (`graft build -e`). Absent →
+   * every language graft has a grammar for. Applied in {@link listSourceFiles}, the
+   * single enumeration this build is made of, so the fingerprint and the extraction
+   * cache describe exactly the same set the graph does. */
+  extensions?: string[];
   /** Write only what a query reads — the graph, the `ask` sidecar, the freshness
    * record — and skip the markdown projections and the `.gitignore` touch. Set by
    * the pre-query refresh (`graph/refresh.ts`); an explicit `graft build` never
@@ -153,7 +158,7 @@ export async function buildGraph(
   // resolution must agree on the same Git-ignore-aware working-tree view —
   // including the repo's persisted `--include-dir` override.
   const repoFiles = walkDir(root, readIncludeDirs(root));
-  const files = listSourceStats(root, outDir, repoFiles);
+  const files = listSourceStats(root, outDir, repoFiles, opts.extensions);
   const discoveredScopes = discoverScopes(root, repoFiles);
 
   const nodes: NodeV1[] = [];
@@ -183,9 +188,34 @@ export async function buildGraph(
   // Breadth tier: WASM grammars load asynchronously, so warm the ones this repo
   // needs ONCE here (buildGraph is async) before the synchronous parse loop below
   // can call extractGeneric. Depth-tier (native) grammars need no warmup.
-  await warmGenericGrammars(
-    new Set(files.map((f) => genericLangOf(f.abs)?.name).filter((n): n is string => !!n)),
+  //
+  // The `languageOf(...) === null` filter is what keeps the warmup honest about which
+  // files actually REACH the breadth tier. `.java` is claimed by both registries and the
+  // depth tier always wins in the loop below (`lang ? null : genericLangOf(...)`), so
+  // without it every build of every Java repo instantiated a multi-MB Java wasm and
+  // compiled queries/java.scm for a code path that can never run.
+  const breadthLangs = new Set(
+    files
+      .filter((f) => languageOf(f.abs) === null)
+      .map((f) => genericLangOf(f.abs)?.name)
+      .filter((n): n is string => !!n),
   );
+  await warmGenericGrammars(breadthLangs);
+  // A breadth language whose grammar could not be loaded still "extracts" — as a file
+  // node and nothing else. Reporting it in `meta.languages` anyway made the banner claim
+  // `[dart]` over a repo where not one dart symbol had been indexed, which reads as a
+  // broken query rather than a missing grammar. Name the gap once, and leave the
+  // language out of the roster it did not earn.
+  const noGrammar = new Set(unavailableGrammars(breadthLangs));
+  for (const lang of noGrammar) errors.push(`${lang}: no grammar available — indexed as file-only`);
+
+  // Only the Tier-2 meaning pass reads the source text again (`enrichGraph` returns
+  // before touching `sources` when there is no summarizer), so filling this map on a
+  // Tier-1 build — the default, and every pre-query refresh — retained the whole repo's
+  // text for nothing. JS strings are UTF-16, so a 200 MB monorepo pinned ~400 MB until
+  // the build returned, and the refresh path paid it on every query that saw drift, even
+  // when every single file came from the memo.
+  const keepSources = !!opts.summarizer;
 
   files.forEach((f, i) => {
     const rel = f.rel;
@@ -195,6 +225,9 @@ export async function buildGraph(
     const lang = languageOf(f.abs);
     const generic = lang ? null : genericLangOf(f.abs);
     const label = languageLabelOf(f.abs) ?? generic?.name ?? "unknown";
+    // …unless the breadth grammar it needs isn't there, in which case this file yields a
+    // file node and no symbols, and claiming the language would be a lie (see above).
+    const indexed = !generic || !noGrammar.has(generic.name);
     const cached = priorExtract.files[rel];
 
     // Every file is read and hashed, every build — only the *parse* is memoized.
@@ -227,7 +260,7 @@ export async function buildGraph(
     const hash = contentHash(source);
     if (cached && hash === cached.hash) {
       entries[rel] = { ...cached, size: f.size, mtimeMs: f.mtimeMs };
-      sources.set(rel, source);
+      if (keepSources) sources.set(rel, source);
       reused++;
       if (cached.error) {
         errors.push(cached.error); // this file failed to parse last time too
@@ -235,7 +268,7 @@ export async function buildGraph(
       }
       nodes.push(...cached.nodes);
       rawEdges.push(...cached.rawEdges);
-      langs.add(label);
+      if (indexed) langs.add(label);
       return;
     }
 
@@ -246,8 +279,8 @@ export async function buildGraph(
         : extractGeneric(rel, source, generic!.name);
       nodes.push(...fileNodes);
       rawEdges.push(...fileEdges);
-      sources.set(rel, source);
-      langs.add(label);
+      if (keepSources) sources.set(rel, source);
+      if (indexed) langs.add(label);
       entries[rel] = { size: f.size, mtimeMs: f.mtimeMs, hash, nodes: fileNodes, rawEdges: fileEdges };
     } catch (err) {
       const message = `${rel}: parse failed — ${err instanceof Error ? err.message : String(err)}`;

--- a/src/graph/check.ts
+++ b/src/graph/check.ts
@@ -40,6 +40,12 @@ export interface GraphCheckResult {
 
 export interface GraphCheckOptions {
   contextDir?: string;
+  /** The same `-e` narrowing the build ran under. It has to be passed here too:
+   * a graph built from `-e .ts` holds no Python nodes, so a check that enumerated
+   * every language would re-extract the .py files, find their ids missing from the
+   * committed graph, and report them as `added` — permanent phantom drift that
+   * `graft build` (run without the flag) would then "fix" by widening the graph. */
+  extensions?: string[];
 }
 
 // async: the breadth tier's WASM grammars load asynchronously and must be warmed
@@ -70,9 +76,20 @@ export async function checkGraph(
   }
 
   // Freshly extract Tier-1 nodes from the code on disk (same file set as build).
-  const sourceFiles = listSourceFiles(root, outDir);
+  const sourceFiles = listSourceFiles(root, outDir, undefined, opts.extensions);
+  // Same `languageOf(...) === null` filter buildGraph warms behind, and it has to be
+  // the same one: `.java` is claimed by both registries and the loop below always
+  // gives the file to the depth tier (`lang ? null : genericLangOf(...)`), so warming
+  // its breadth grammar loaded a multi-MB wasm and compiled queries/java.scm on every
+  // `graft check` of every Java repo for a code path that can never run — and `check`
+  // runs in CI, on the hook path, and before every stale-graph query.
   await warmGenericGrammars(
-    new Set(sourceFiles.map((f) => genericLangOf(f)?.name).filter((n): n is string => !!n)),
+    new Set(
+      sourceFiles
+        .filter((f) => languageOf(f) === null)
+        .map((f) => genericLangOf(f)?.name)
+        .filter((n): n is string => !!n),
+    ),
   );
   const current = new Map<string, string>(); // id → body_hash
   for (const file of sourceFiles) {

--- a/src/graph/extract-cache.ts
+++ b/src/graph/extract-cache.ts
@@ -25,6 +25,7 @@
  */
 import { readFileSync, readdirSync, rmSync, statSync } from "node:fs";
 import { createHash } from "node:crypto";
+import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 import { dirname, extname, join } from "node:path";
 import { CACHE_DIR } from "../context/node-file.js";
@@ -147,7 +148,8 @@ function computeStamp(): string | null {
     // `.js` when running from `dist/`, `.ts` under tsx — take the extension from
     // our own filename rather than guessing which layout we're in.
     const dir = dirname(self);
-    const hashed = stampDir(dir, extname(self), packageVersion(dir) ?? "");
+    const version = `${packageVersion(dir) ?? ""}|${grammarVersions()}`;
+    const hashed = stampDir(dir, extname(self), version);
     if (hashed) return hashed;
     // Couldn't read the modules (bundled into one file, say). The version alone is
     // a weaker identity — it can't see a local edit — but it still turns over on
@@ -157,6 +159,64 @@ function computeStamp(): string | null {
   } catch {
     return null;
   }
+}
+
+/** The grammars whose version changes what a parse produces — the depth tier's four
+ * native ones, the wasm bundle the breadth tier loads, and the runtime that loads it. */
+const GRAMMAR_PKGS = [
+  "tree-sitter",
+  "tree-sitter-typescript",
+  "tree-sitter-python",
+  "tree-sitter-go",
+  "tree-sitter-java",
+  "tree-sitter-wasms",
+  "web-tree-sitter",
+] as const;
+
+/**
+ * The RESOLVED versions of the tree-sitter grammars, folded into the extractor identity.
+ *
+ * The docblock above says graft's own package version covers a grammar upgrade. It does
+ * not: every grammar dependency is declared as a `^` range, so a plain `npm i` can pull
+ * `tree-sitter-typescript@0.23.9` under an unchanged graft version — and from that moment
+ * every replayed cache entry is a parse no current build would produce, with nothing to
+ * notice it. Reading each installed package's own `version` is the only thing that tracks
+ * what is actually loaded. Unreadable ones become a stable `absent` marker rather than
+ * churning the stamp on every process.
+ */
+function grammarVersions(): string {
+  const req = createRequire(import.meta.url);
+  return GRAMMAR_PKGS.map((p) => `${p}@${depVersion(req, p)}`).join(",");
+}
+
+function depVersion(req: NodeJS.Require, pkg: string): string {
+  const read = (path: string): string | null => {
+    try {
+      const j = JSON.parse(readFileSync(path, "utf8")) as { name?: string; version?: string };
+      return j.name === pkg ? (j.version ?? null) : null;
+    } catch {
+      return null;
+    }
+  };
+  try {
+    const direct = read(req.resolve(`${pkg}/package.json`));
+    if (direct) return direct;
+  } catch {
+    /* the package's `exports` map may not expose ./package.json — climb from its entry */
+  }
+  try {
+    let dir = dirname(req.resolve(pkg));
+    for (let i = 0; i < 6; i++) {
+      const v = read(join(dir, "package.json"));
+      if (v) return v;
+      const up = dirname(dir);
+      if (up === dir) break;
+      dir = up;
+    }
+  } catch {
+    /* not installed in this environment */
+  }
+  return "absent";
 }
 
 /**
@@ -174,7 +234,26 @@ export function stampDir(dir: string, ext: string, version = ""): string | null 
     h.update(f); // a rename is a change, even at identical content
     h.update(readFileSync(join(dir, f)));
   }
+  // The breadth tier's extraction is DEFINED by `queries/<lang>.scm`, which the module
+  // sweep above cannot see: it's a subdirectory, and .scm is not the module extension.
+  // So fixing queries/c.scm changes every C node in every graph while leaving every file
+  // this function hashed byte-identical — the stamp held, `readExtractCache` accepted the
+  // pre-fix entries, and no build ever re-parsed. Missing (a bundle shipped without the
+  // query dir) folds in nothing and leaves the stamp exactly where it was.
+  for (const q of readQueryDir(join(dir, "queries"))) {
+    h.update(q);
+    h.update(readFileSync(join(dir, "queries", q)));
+  }
   return h.digest("hex").slice(0, 16);
+}
+
+/** The `.scm` files in a queries directory, sorted; empty when there is no such dir. */
+function readQueryDir(dir: string): string[] {
+  try {
+    return readdirSync(dir).filter((f) => f.endsWith(".scm")).sort();
+  } catch {
+    return [];
+  }
 }
 
 /** graft's own version, or null when it can't be read. */

--- a/src/graph/extract.ts
+++ b/src/graph/extract.ts
@@ -192,10 +192,17 @@ const KINDS_BY_LANG: Record<Language, Record<string, Kind>> = {
  * Java is the reason this is a set rather than a string: `method_invocation` and
  * `object_creation_expression` (`new Foo()`) are separate node types, and a Java
  * codebase's constructor calls are a large share of its real edges.
+ *
+ * `new_expression` is here for the same reason Java's `object_creation_expression` is:
+ * `new Foo()` is how a TS/JS module actually depends on a class, and it is NOT a
+ * `call_expression`, so before this no raw edge existed for it at all. The only path
+ * left was `references`, which needs a NAMED import — meaning a class instantiated in
+ * its own file was invisible, and instantiating an imported class produced a weaker
+ * edge than calling a function from the same module did.
  */
 const CALL_TYPES: Record<Language, ReadonlySet<string>> = {
-  typescript: new Set(["call_expression"]),
-  tsx: new Set(["call_expression"]),
+  typescript: new Set(["call_expression", "new_expression"]),
+  tsx: new Set(["call_expression", "new_expression"]),
   python: new Set(["call"]),
   go: new Set(["call_expression"]),
   java: new Set(["method_invocation", "object_creation_expression"]),
@@ -269,7 +276,13 @@ export function extractFile(rel: string, source: string, lang: Language): Extrac
       exported: true,
       origin: "ast",
       body_hash: contentHash(source),
-      chars: source.length,
+      // BYTES, not UTF-16 code units. types.ts documents `chars` as "byte length of the
+      // WHOLE file" and generic.ts writes `Buffer.byteLength`, so `source.length` here
+      // made the same field mean two different things across the two tiers. The `ask`
+      // savings estimate divides it by 4 for a token count and compares tiers directly:
+      // an accented or CJK-heavy .py file under-reported against an equivalent .rs one.
+      // ASCII source is identical either way, which is exactly why it went unnoticed.
+      chars: Buffer.byteLength(source),
       summary_state: "pending",
       summary: null,
       crux: null,
@@ -363,7 +376,14 @@ function walk(node: Parser.SyntaxNode, ctx: WalkCtx, out: NodeV1[], edges: RawEd
     // class heritage — in Java an interface may also `extends`, and a record/enum
     // may `implements`, so every type declaration is a heritage site, not just a class.
     const javaTypeDecl = ctx.lang === "java" && JAVA_TYPE_KINDS.has(desc.kind);
-    if (desc.kind === "class" || javaTypeDecl) edges.push(...heritageEdges(node, id, ctx));
+    // A TS `interface X extends Y` is a heritage site too. Gating on `class` alone left
+    // interface hierarchies — the actual type backbone of a typed TS codebase — with no
+    // `extends` edges at all, while Java's and Python's had them.
+    const tsInterfaceDecl =
+      (ctx.lang === "typescript" || ctx.lang === "tsx") && desc.kind === "interface";
+    if (desc.kind === "class" || javaTypeDecl || tsInterfaceDecl) {
+      edges.push(...heritageEdges(node, id, ctx));
+    }
 
     const enclosingClass =
       desc.kind === "class" || javaTypeDecl
@@ -402,6 +422,18 @@ function walk(node: Parser.SyntaxNode, ctx: WalkCtx, out: NodeV1[], edges: RawEd
       // Java only: the call site's argument count, to pick the right overload.
       const argCount = ctx.lang === "java" ? javaArgCount(node) : undefined;
       if (argCount !== undefined) callEdge.argCount = argCount;
+      // When the callee is a NAMED IMPORT, the source states exactly which module and
+      // which exported name it meant — so hand both to the resolver instead of making it
+      // guess from the bare name. This is what keeps `new Repo()` on an imported class
+      // from being dropped the moment some other `Repo` exists elsewhere in the repo:
+      // bare-name resolution treats a globally ambiguous name as unknowable, and here it
+      // isn't. Member calls are excluded — the name is a property of a receiver, not the
+      // imported binding itself.
+      const importedCallee = callee.viaMember ? undefined : ctx.importedSymbols.get(callee.name);
+      if (importedCallee) {
+        callEdge.name = importedCallee.name;
+        callEdge.specifier = importedCallee.specifier;
+      }
       const recvType = resolveRecvType(callee.receiver, ctx);
       edges.push(recvType ? { ...callEdge, recvType } : callEdge);
     }
@@ -521,12 +553,25 @@ function isFunctionBoundary(node: Parser.SyntaxNode): boolean {
 function isDirectCallee(node: Parser.SyntaxNode, callTypes: ReadonlySet<string>): boolean {
   const parent = node.parent;
   if (!parent || !callTypes.has(parent.type)) return false;
-  return parent.childForFieldName("function") === node || parent.childForFieldName("name") === node;
+  return (
+    parent.childForFieldName("function") === node ||
+    parent.childForFieldName("name") === node ||
+    // TS `new Foo()` spells its callee in a `constructor` field; without this the same
+    // instantiation would emit both a `calls` and a `references` edge for one syntax.
+    parent.childForFieldName("constructor") === node
+  );
 }
 
 /** Definition/declaration identifiers name a new binding; they do not use one. */
 function isDeclarationName(node: Parser.SyntaxNode): boolean {
   const parent = node.parent;
+  // A JSX element's TAG is its parent's `name` field — `<Button />` is a
+  // `jsx_self_closing_element` whose `name` is the identifier `Button` — so the field
+  // test below classified the single most common use of an imported symbol in a .tsx
+  // file as a declaration and silently dropped it. `<Button/>` is not a call_expression
+  // either, so nothing else picked it up: in a React/Next app that meant most real
+  // inter-file dependencies were missing and every component looked like an orphan.
+  if (parent?.type.startsWith("jsx_")) return false;
   return parent?.childForFieldName("name") === node;
 }
 
@@ -706,12 +751,50 @@ function heritageEdges(node: Parser.SyntaxNode, classId: string, ctx: WalkCtx): 
           : null;
     if (!relation) continue;
     for (const t of clause.namedChildren) {
-      if (t.type === "identifier" || t.type === "type_identifier") {
-        edges.push({ source: classId, relation, name: t.text, file: ctx.rel });
-      }
+      const name = heritageNameOf(t);
+      if (name) edges.push({ source: classId, relation, name, file: ctx.rel });
+    }
+  }
+  // An interface's supertypes do NOT live under a `class_heritage`: tree-sitter-typescript
+  // hangs an `extends_type_clause` directly off the `interface_declaration`, so looking
+  // only for `class_heritage` above found nothing for every interface in the repo.
+  for (const clause of node.namedChildren) {
+    if (clause.type !== "extends_type_clause") continue;
+    for (const t of clause.namedChildren) {
+      const name = heritageNameOf(t);
+      if (name) edges.push({ source: classId, relation: "extends", name, file: ctx.rel });
     }
   }
   return edges;
+}
+
+/**
+ * The type a heritage-clause element names, or null when it doesn't name one plainly.
+ *
+ * tree-sitter spells the same supertype differently by clause: an `extends_clause` on a
+ * class holds an EXPRESSION (`identifier`), while `implements_clause` and
+ * `extends_type_clause` hold TYPES (`type_identifier`) — so both spellings count.
+ *
+ * `Foo<T>` arrives as a `generic_type`, which matched neither and so dropped the whole
+ * supertype: `implements Repository<User>` had no edge, and generic base types are the
+ * norm in the TS code that has interfaces at all. Only the base name is taken — the type
+ * ARGUMENTS are not supertypes, and emitting `User` there would be a fabricated edge.
+ *
+ * An expression form (`class A extends mixin(Base)`) stays null on purpose: which of the
+ * names in it is the supertype is a guess, and this extractor does not guess.
+ */
+function heritageNameOf(node: Parser.SyntaxNode): string | null {
+  if (node.type === "identifier" || node.type === "type_identifier") return node.text;
+  if (node.type === "generic_type") {
+    const base = node.childForFieldName("name");
+    return base ? heritageNameOf(base) : null;
+  }
+  if (node.type === "nested_type_identifier") {
+    // `extends ns.Base` — the trailing segment is the type; the namespace is not.
+    const last = node.namedChildren.at(-1);
+    return last?.type === "type_identifier" ? last.text : null;
+  }
+  return null;
 }
 
 /** Every `type_identifier` under a heritage clause, so `implements A, B<C>` yields
@@ -750,6 +833,21 @@ function calleeName(
     // conservative: an unmatched name (e.g. a static import) resolves to nothing.
     if (!obj) return { name: nameNode.text, viaMember: true, receiver: "this" };
     return { name: nameNode.text, viaMember: true, receiver: javaReceiver(obj) };
+  }
+
+  // TS/JS `new Foo()` — the constructed type is the target, and it lives in a
+  // `constructor` field rather than the `function` field the shared lookup below reads.
+  // `new pkg.Foo()` yields the trailing segment; anything more exotic (`new klass()` on
+  // a variable, `new (pick())()`) names no type we can stand behind, so it drops.
+  if (node.type === "new_expression") {
+    const ctor = node.childForFieldName("constructor");
+    if (!ctor) return null;
+    if (ctor.type === "identifier") return { name: ctor.text, viaMember: false };
+    if (ctor.type === "member_expression") {
+      const prop = ctor.childForFieldName("property");
+      return prop ? { name: prop.text, viaMember: false } : null;
+    }
+    return null;
   }
 
   const fn = node.childForFieldName("function");

--- a/src/graph/generic.ts
+++ b/src/graph/generic.ts
@@ -39,17 +39,26 @@ export interface GenericLang {
 }
 
 /** The breadth registry. Add a row + a queries/<name>.scm to support a language.
- * Extensions here must NOT collide with the depth tier's EXTENSIONS (extract.ts). */
+ * Extensions here must NOT collide with the depth tier's EXTENSIONS (extract.ts) —
+ * with ONE deliberate, documented exception, `java` (see its row). */
 export const GENERIC_LANGS: readonly GenericLang[] = [
   { name: "rust", exts: [".rs"], wasm: "rust" },
+  // The exception to the no-collision rule above, and it is a TEST FIXTURE, not a
+  // language graft indexes this way: `.java` belongs to the depth tier (extract.ts),
+  // which always wins in build.ts (`lang ? null : genericLangOf(...)`), so
+  // `extractGeneric` never sees a .java file in a real build. The row exists because
+  // test/generic-extract.test.ts uses Java as its method-heavy example for the
+  // breadth tier's call-kind widening. Callers computing what to WARM must filter out
+  // depth-tier files first, or every Java repo loads a multi-MB wasm for nothing.
   { name: "java", exts: [".java"], wasm: "java" },
   { name: "c", exts: [".c", ".h"], wasm: "c" },
   { name: "cpp", exts: [".cpp", ".cc", ".cxx", ".hpp", ".hh"], wasm: "cpp" },
   { name: "ruby", exts: [".rb"], wasm: "ruby" },
   { name: "php", exts: [".php"], wasm: "php" },
   { name: "c_sharp", exts: [".cs"], wasm: "c_sharp" },
-  // These ship a tags.scm (calls + symbols); ocaml/zig have none and use the
-  // node-kind walker fallback (symbols only) — still one row, zero query.
+  // The rows above and the next four ship a queries/<name>.scm (calls + symbols).
+  // ocaml, zig and dart have none and use the node-kind walker fallback (symbols only,
+  // no call edges) — still one row, zero query.
   { name: "kotlin", exts: [".kt", ".kts"], wasm: "kotlin" },
   { name: "scala", exts: [".scala", ".sc"], wasm: "scala" },
   { name: "swift", exts: [".swift"], wasm: "swift" },
@@ -85,7 +94,15 @@ const KIND: Record<string, Kind> = {
 
 // Loaded grammars + compiled tags queries, keyed by graft lang name. Populated by
 // warmGenericGrammars; read synchronously by extractGeneric.
-interface Loaded { language: unknown; query: unknown | null }
+//
+// The Parser is built ONCE per language and kept here. web-tree-sitter's Parser, Tree
+// and Query all live in the WASM heap, which V8's GC knows nothing about: a Parser
+// constructed per file (and a Tree never `.delete()`d) is leaked for the life of the
+// process. On a repo with thousands of breadth-tier files that grows monotonically
+// through build.ts's whole parse loop and ends in hundreds of MB or an outright
+// `Cannot enlarge memory arrays`. Rebuilding the parser per file was pure waste anyway
+// — the grammar it is set to never changes.
+interface Loaded { language: unknown; query: unknown | null; parser: TsParser }
 const loaded = new Map<string, Loaded>();
 let tsMod: typeof import("web-tree-sitter") | null = null;
 let initPromise: Promise<void> | null = null;
@@ -140,7 +157,9 @@ export async function warmGenericGrammars(langNames: Iterable<string>): Promise<
       if (scm) {
         try { query = new Query(language, scm); } catch { query = null; }
       }
-      loaded.set(name, { language, query });
+      const parser = new tsMod.Parser();
+      parser.setLanguage(language as never);
+      loaded.set(name, { language, query, parser: parser as unknown as TsParser });
     } catch {
       /* grammar failed to instantiate — skip; files extract as file-only */
     }
@@ -150,6 +169,21 @@ export async function warmGenericGrammars(langNames: Iterable<string>): Promise<
 /** True if a grammar has been warmed for this lang (else extractGeneric is file-only). */
 export function isWarm(langName: string): boolean {
   return loaded.has(langName);
+}
+
+/**
+ * Of `langNames`, the breadth languages that have NO usable grammar after a warmup —
+ * their files extract to a file node and nothing else.
+ *
+ * A missing wasm and a grammar that fails to instantiate are both swallowed silently by
+ * {@link warmGenericGrammars} (correctly: neither should fail a build), and the caller
+ * had no way to notice. So a build over a repo whose `dart` wasm isn't in the bundle
+ * announced `[dart]` in its language banner having indexed exactly zero dart symbols —
+ * which reads as "graft is broken at querying dart", not "graft has no dart grammar
+ * here". Call this after warming and report the gap instead of claiming coverage.
+ */
+export function unavailableGrammars(langNames: Iterable<string>): string[] {
+  return [...new Set(langNames)].filter((n) => !loaded.has(n)).sort();
 }
 
 const PARSE_CHUNK = 16384; // <32KB slices — same tree-sitter limit workaround as extract.ts
@@ -163,7 +197,7 @@ function fileNode(rel: string, source: string): NodeV1 {
   };
 }
 
-interface Def { id: string; startIndex: number; endIndex: number }
+export interface Def { id: string; startIndex: number; endIndex: number }
 
 /** Extract a single generic-tier file. Synchronous; needs the grammar pre-warmed.
  * Uses the grammar's compiled tags.scm when present (symbols + call edges);
@@ -172,19 +206,61 @@ interface Def { id: string; startIndex: number; endIndex: number }
 export function extractGeneric(rel: string, source: string, langName: string): ExtractResult {
   const nodes: NodeV1[] = [fileNode(rel, source)];
   const rawEdges: RawEdge[] = [];
-  const entry = loaded.get(langName);
+  const lang = headerGrammarFor(rel, source, langName);
+  const entry = loaded.get(lang);
   if (!entry || !tsMod) return { nodes, rawEdges };
 
-  let tree;
+  let tree: TsTree | null;
   try {
-    const parser = new tsMod.Parser();
-    parser.setLanguage(entry.language as never);
-    tree = parser.parse((i: number) => source.slice(i, i + PARSE_CHUNK));
+    tree = entry.parser.parse((i: number) => source.slice(i, i + PARSE_CHUNK));
   } catch {
     return { nodes, rawEdges };
   }
   if (!tree) return { nodes, rawEdges };
+  try {
+    return extractFromTree(tree.rootNode, rel, source, lang, nodes, rawEdges);
+  } finally {
+    // The one place a Tree can be released: every early return above happens before one
+    // exists, and every path below funnels through here. Without it each parsed file
+    // leaves its whole syntax tree resident in the WASM heap forever (see `Loaded`).
+    tree.delete();
+  }
+}
 
+/**
+ * The grammar a `.h` file should actually be parsed with.
+ *
+ * The registry maps an extension to exactly one grammar and `.h` is claimed by C — but
+ * in a C++ project the headers are precisely where the classes, templates and namespaces
+ * live, and c.scm has no `class_specifier` and no `namespace` pattern at all. Those
+ * symbols simply did not exist in the graph (while resolve.ts happily treated the same
+ * `.h` as a valid `#include` target), and templates additionally produced ERROR nodes.
+ *
+ * The extension cannot decide this — the same `.h` is C in one repo and C++ in the next
+ * — so the content does. The `loaded.has("cpp")` gate is what keeps this safe: the cpp
+ * grammar is warmed only when the repo has real C++ sources, so a pure-C project can
+ * never be routed away from the C parse it had.
+ *
+ * Known seam: adding a repo's FIRST `.cpp` file flips this decision for headers whose
+ * own bytes did not move, and the extraction memo is keyed on bytes — so those headers
+ * keep their C parse until they are edited or the memo turns over. Re-parsing the whole
+ * repo on that transition is not worth the machinery; `graft build --no-reuse` settles it.
+ */
+const CPP_HEADER = /^[ \t]*(?:template\s*<|namespace\s+[\w{]|class\s+\w|public:|private:|protected:|using\s+namespace\b)/m;
+function headerGrammarFor(rel: string, source: string, langName: string): string {
+  if (langName !== "c" || !rel.toLowerCase().endsWith(".h")) return langName;
+  return loaded.has("cpp") && CPP_HEADER.test(source) ? "cpp" : langName;
+}
+
+function extractFromTree(
+  root: TsNode,
+  rel: string,
+  source: string,
+  langName: string,
+  nodes: NodeV1[],
+  rawEdges: RawEdge[],
+): ExtractResult {
+  const entry = loaded.get(langName)!;
   const minted = new Set<string>([rel]);
   const lines = source.split("\n");
   const defs: Def[] = [];
@@ -216,16 +292,16 @@ export function extractGeneric(rel: string, source: string, langName: string): E
   };
 
   if (entry.query) {
-    tagsExtract(entry.query, tree.rootNode as TsNode, rel, mkDef, defs, rawEdges);
+    tagsExtract(entry.query, root, rel, mkDef, defs, rawEdges);
   } else {
-    walkExtract(tree.rootNode as TsNode, mkDef); // no tags.scm → symbols only
+    walkExtract(root, mkDef); // no tags.scm → symbols only
   }
   // The preprocessor is invisible to tags.scm, but in C/C++ a local `#include "x.h"`
   // IS the dependency graph — capture it as a file→file import. Likewise a Rust
   // `use crate::…` is an in-crate module dependency.
-  if (langName === "c" || langName === "cpp") extractIncludes(tree.rootNode as TsNode, rel, rawEdges);
-  else if (langName === "rust") extractUses(tree.rootNode as TsNode, rel, rawEdges);
-  else if (langName === "php") extractPhpUses(tree.rootNode as TsNode, rel, rawEdges);
+  if (langName === "c" || langName === "cpp") extractIncludes(root, rel, rawEdges);
+  else if (langName === "rust") extractUses(root, rel, rawEdges);
+  else if (langName === "php") extractPhpUses(root, rel, rawEdges);
   return { nodes, rawEdges };
 }
 
@@ -357,22 +433,57 @@ function tagsExtract(
          "reference.implementation" in cap || "reference.module" in cap) && cap.name)
       refs.push({ name: cap.name.text, at: cap.name.startIndex });
   }
-  // innermost enclosing definition of a token at byte offset `at`
-  const enclosing = (at: number) =>
-    defs
-      .filter((d) => d.startIndex <= at && at < d.endIndex)
-      .sort((a, b) => (a.endIndex - a.startIndex) - (b.endIndex - b.startIndex))[0];
-  for (const c of calls) {
+  const callEnc = enclosingDefs(defs, calls.map((c) => c.at));
+  for (let i = 0; i < calls.length; i++) {
+    const c = calls[i];
     if (defNameAt.has(c.at)) continue;
-    const enc = enclosing(c.at);
+    const enc = callEnc[i];
     rawEdges.push({ source: enc ? enc.id : rel, relation: "calls", file: rel, name: c.name });
   }
-  for (const r of refs) {
+  const refEnc = enclosingDefs(defs, refs.map((r) => r.at));
+  for (let i = 0; i < refs.length; i++) {
+    const r = refs[i];
     if (defNameAt.has(r.at)) continue;
-    const enc = enclosing(r.at);
+    const enc = refEnc[i];
     if (!enc) continue; // a reference with no enclosing definition has no sound source
     rawEdges.push({ source: enc.id, relation: "references", file: rel, name: r.name });
   }
+}
+
+/**
+ * The innermost definition enclosing each of `offsets`, positionally.
+ *
+ * The obvious per-token `defs.filter(contains).sort(bySize)[0]` is O(D·C) and allocates
+ * two arrays PER TOKEN. On a generated file — a 100k-line C# API client, Rust bindings,
+ * compiled protobuf — that is ~15k definitions against ~50k call sites: 750M comparisons
+ * and 50k throwaway arrays, tens of seconds inside build.ts's synchronous per-file loop,
+ * for bookkeeping nobody would believe costs anything.
+ *
+ * Definition spans come from syntax-tree nodes, so they NEST — no two of them partially
+ * overlap. That is what makes a single ordered sweep sufficient: walk the offsets in
+ * order, push definitions as their start passes, pop them as their end passes, and the
+ * top of the stack is the innermost one still open. O((D+C) log(D+C)) overall.
+ *
+ * Exported so a test can pin the behaviour and the scale directly, without having to
+ * synthesize a 100k-line source file to reach the path.
+ */
+export function enclosingDefs(defs: Def[], offsets: number[]): Array<Def | undefined> {
+  // `.fill` because a bare `new Array(n)` is SPARSE, and a hole is not the same value
+  // as `undefined` to anything that inspects the array (deepEqual, JSON, spread).
+  const out = new Array<Def | undefined>(offsets.length).fill(undefined);
+  if (defs.length === 0) return out;
+  // Ties on startIndex: the wider span is the outer one, so it must be pushed first.
+  const byStart = [...defs].sort((a, b) => a.startIndex - b.startIndex || b.endIndex - a.endIndex);
+  const order = offsets.map((_, i) => i).sort((a, b) => offsets[a] - offsets[b]);
+  const open: Def[] = [];
+  let next = 0;
+  for (const i of order) {
+    const at = offsets[i];
+    while (next < byStart.length && byStart[next].startIndex <= at) open.push(byStart[next++]);
+    while (open.length && open[open.length - 1].endIndex <= at) open.pop();
+    out[i] = open[open.length - 1];
+  }
+  return out;
 }
 
 // Node-type → Kind for the walker fallback. A node is a definition when its type
@@ -427,6 +538,17 @@ function walkExtract(root: TsNode, mkDef: (name: string, kind: Kind, whole: TsNo
     }
   };
   visit(root);
+}
+
+/** The slice of web-tree-sitter's Tree we use. `delete()` is not optional bookkeeping:
+ * it is the only way a tree's WASM-heap memory is ever reclaimed. */
+interface TsTree {
+  rootNode: TsNode;
+  delete(): void;
+}
+
+interface TsParser {
+  parse(input: (index: number) => string): TsTree | null;
 }
 
 interface TsNode {

--- a/src/graph/queries/c.scm
+++ b/src/graph/queries/c.scm
@@ -2,7 +2,23 @@
 
 (declaration type: (union_specifier name: (type_identifier) @name)) @definition.class
 
-(function_declarator declarator: (identifier) @name) @definition.function
+; graft: DEFINITIONS only, never prototypes. The upstream pattern is bare
+; `(function_declarator declarator: (identifier) @name)`, which is right for "go to tag"
+; and wrong for a dependency graph: `int run(void);` in a header parses as
+; (declaration (function_declarator (identifier))) and matches it too. With a header +
+; .c pair — i.e. every C project — every function then had TWO nodes of the same name in
+; two different files, resolve.ts saw an ambiguous global match and dropped it, and the
+; result was that only intra-file calls survived anywhere in the repo.
+; Anchoring on function_definition costs the prototypes' nodes, which is the point: the
+; definition is the thing calls should land on.
+(function_definition
+  declarator: (function_declarator declarator: (identifier) @name)) @definition.function
+
+; …and the same through a pointer return type (`char *dup(const char *)`), whose
+; declarator field is a pointer_declarator wrapping the function_declarator.
+(function_definition
+  declarator: (pointer_declarator
+    declarator: (function_declarator declarator: (identifier) @name))) @definition.function
 
 (type_definition declarator: (type_identifier) @name) @definition.type
 

--- a/src/graph/queries/cpp.scm
+++ b/src/graph/queries/cpp.scm
@@ -2,11 +2,28 @@
 
 (declaration type: (union_specifier name: (type_identifier) @name)) @definition.class
 
-(function_declarator declarator: (identifier) @name) @definition.function
+; graft: DEFINITIONS only, never declarations — see the same note in c.scm. A C++
+; project declares each method in the header and defines it in the .cpp, so the upstream
+; unanchored `function_declarator` patterns minted two nodes per function in two files;
+; resolve.ts drops an ambiguous global match, so every cross-file call edge in the
+; project disappeared. Anchoring on function_definition keeps one node per function, at
+; the place its body actually is.
+(function_definition
+  declarator: (function_declarator declarator: (identifier) @name)) @definition.function
 
-(function_declarator declarator: (field_identifier) @name) @definition.function
+(function_definition
+  declarator: (pointer_declarator
+    declarator: (function_declarator declarator: (identifier) @name))) @definition.function
 
-(function_declarator declarator: (qualified_identifier scope: (namespace_identifier) @local.scope name: (identifier) @name)) @definition.method
+; an inline member definition inside a class body (`void draw() { … }`)
+(function_definition
+  declarator: (function_declarator declarator: (field_identifier) @name)) @definition.method
+
+; the out-of-line definition (`void Widget::draw() { … }`)
+(function_definition
+  declarator: (function_declarator
+    declarator: (qualified_identifier scope: (namespace_identifier) @local.scope
+                                      name: (identifier) @name))) @definition.method
 
 (type_definition declarator: (type_identifier) @name) @definition.type
 

--- a/src/graph/resolve.ts
+++ b/src/graph/resolve.ts
@@ -20,6 +20,15 @@ import type { RawEdge } from "./extract.js";
 const IMPORT_EXTS = [".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs", ".py"];
 /** C/C++ source + header extensions, for resolving `#include` targets. */
 const C_EXT = /\.(c|h|cc|cpp|cxx|hpp|hh|hxx|inl|ipp|c\+\+|h\+\+)$/i;
+/** Python source/stub extensions — a different import spelling entirely (see
+ * {@link resolvePythonImport}), so it gets its own resolver rather than the JS one. */
+const PY_EXT = /\.pyi?$/i;
+/** Languages whose bare call syntax can name a TYPE as well as a function: Python's
+ * `Repo()` IS the constructor call, and TS/JS `new Repo()` reaches here with the type as
+ * the callee name. Resolving those against a function-only index dropped every
+ * object-construction edge — the commonest coupling there is between two modules. The
+ * ambiguity rule in {@link resolveName} still refuses to guess between same-named types. */
+const TYPE_CALL_EXT = /\.(py|pyi|ts|tsx|mts|cts|js|jsx|mjs|cjs)$/i;
 
 /** A Go module discovered in the repo: its `module` path from `go.mod` and the repo
  * directory that `go.mod` lives in (posix, `.` for the repo root). A monorepo may hold
@@ -66,6 +75,11 @@ export function resolveEdges(
   // node ids. A `use App\Models\User` names a PSR-4 class whose file mirrors the namespace
   // tail under some (unknown) source root, so the suffix is the portable key.
   const phpFilesBySuffix = new Map<string, string[]>();
+  // Python module resolution: a file's path-suffix (`app/services/mailer.py`,
+  // `services/mailer.py`, …) → its file node ids. An absolute Python import names a
+  // module relative to a sys.path root graft cannot know, so — as with Java and PHP —
+  // the suffix is the portable key.
+  const pyFilesBySuffix = new Map<string, string[]>();
   const hasGoModules = !!opts.goModules?.length;
   for (const n of nodes) {
     if (n.kind === "file") {
@@ -88,6 +102,10 @@ export function resolveEdges(
         const parts = toPosixPath(n.path).split("/");
         for (let i = 0; i < parts.length; i++) push(phpFilesBySuffix, parts.slice(i).join("/"), n.id);
       }
+      if (PY_EXT.test(n.path)) {
+        const parts = toPosixPath(n.path).split("/");
+        for (let i = 0; i < parts.length; i++) push(pyFilesBySuffix, parts.slice(i).join("/"), n.id);
+      }
       {
         const p = toPosixPath(n.path);
         if (p === "lib.rs" || p === "main.rs") rustCrateRoots.push("");
@@ -104,18 +122,21 @@ export function resolveEdges(
     }
   }
 
-  // classParents: class/interface name → its declared base-class names, from raw
-  // `extends` edges (source id's own name → the base name). Used to walk up an
-  // inheritance chain when a receiver's own type has no matching method.
+  // classParents: class/interface NODE ID → its declared base-class names, from raw
+  // `extends` edges. Used to walk up an inheritance chain when a receiver's own type has
+  // no matching method.
+  //
+  // Keyed by node id, not by bare name. Keyed by name, `a/Base.java` (`class Base extends
+  // Foo`) and `b/Base.java` (`class Base extends Bar`) FUSE into
+  // `Base → [Foo, Bar]`, and a `base.handle()` in package `a` climbs into package b's
+  // `Bar.handle` and emits it as an `inferred` call edge. `Base`, `Client`, `Config`,
+  // `Handler` repeated across modules is ordinary, and silently crossing between them
+  // is exactly the guess the rest of this file exists to refuse.
   const classParents = new Map<string, string[]>();
   for (const e of rawEdges) {
     if (e.relation !== "extends" || !e.name) continue;
-    // The declaring class's own bare name — read from its node (keyed by n.name, set
-    // once at mint time) rather than re-derived by slicing e.source, which breaks once
-    // ids can carry a dedup ordinal (A3's `Cache~2`).
-    const ownName = byId.get(e.source)?.name;
-    if (!ownName) continue;
-    push(classParents, ownName, e.name);
+    if (!byId.has(e.source)) continue;
+    push(classParents, e.source, e.name);
   }
 
   const out: EdgeV1[] = [];
@@ -136,13 +157,15 @@ export function resolveEdges(
           ? resolveGoImport(e.specifier, opts.goModules!, goFilesByDir)
           : e.file.endsWith(".java")
             ? resolveJavaImport(e.specifier, javaFilesBySuffix)
-            : C_EXT.test(e.file)
-              ? resolveCInclude(e.specifier, e.file, byId, cFilesBySuffix)
-              : e.file.endsWith(".rs")
-                ? resolveRustUse(e.specifier, e.file, byId, rustCrateRoots)
-                : e.file.endsWith(".php")
-                  ? resolvePhpUse(e.specifier, phpFilesBySuffix)
-                  : resolveImport(e.specifier, e.file, byId);
+            : PY_EXT.test(e.file)
+              ? resolvePythonImport(e.specifier, e.file, byId, pyFilesBySuffix)
+              : C_EXT.test(e.file)
+                ? resolveCInclude(e.specifier, e.file, byId, cFilesBySuffix)
+                : e.file.endsWith(".rs")
+                  ? resolveRustUse(e.specifier, e.file, byId, rustCrateRoots)
+                  : e.file.endsWith(".php")
+                    ? resolvePhpUse(e.specifier, phpFilesBySuffix)
+                    : resolveImport(e.specifier, e.file, byId);
       add(e.source, target, "imports", "extracted");
     } else if (e.relation === "extends" || e.relation === "implements") {
       const kinds: Kind[] = e.relation === "implements" ? ["interface"] : ["class", "interface"];
@@ -171,7 +194,9 @@ export function resolveEdges(
     } else if (e.relation === "calls") {
       if (e.viaMember) {
         if (!e.recvType) continue;
-        const hit = resolveTypedMember(e.recvType, e.name!, e.file, ownerMethod, classParents, e.argCount);
+        const hit = resolveTypedMember(
+          e.recvType, e.name!, e.file, ownerMethod, classParents, perFileName, globalName, e.argCount,
+        );
         if (hit === "ambiguous") continue; // drop — never guess past an ambiguous owner
         if (hit) add(e.source, hit.id, "calls", hit.confidence);
         // No owner-qualified match means the call is unresolved. A unique bare
@@ -180,7 +205,7 @@ export function resolveEdges(
         // vs a compiler-grade oracle) for a 3x count inflation, i.e. noise. See #35.
         continue;
       }
-      // Three cases, because "a bare call" means something different per tier:
+      // Four cases, because "a bare call" means something different per tier and language:
       //
       //  - generic (breadth tier): tags.scm captures ALL calls as bare names, since it
       //    cannot type a receiver. In method-heavy languages those target methods, so
@@ -189,14 +214,35 @@ export function resolveEdges(
       //  - Java (depth tier): an implicit-`this` call is spelled as a member call in
       //    extract.ts, so the only bare call reaching here is `new Foo()`, whose target
       //    is a TYPE. Against the function index every constructor edge would drop.
-      //  - everything else: functions, exactly as before.
+      //  - Python / TS-JS: a bare call can name a type too — `Repo()` IS Python's
+      //    constructor call, and `new Repo()` arrives here with the type as the callee.
+      //    Function-only kinds dropped every object construction in both languages, i.e.
+      //    the single commonest way two modules couple.
+      //  - everything else (Go): functions, exactly as before.
       const srcOrigin = byId.get(e.source)?.origin;
       const callKinds: Kind[] =
         srcOrigin === "generic"
           ? ["function", "method"]
           : e.file.endsWith(".java")
             ? ["class", "struct", "enum", "interface"]
-            : ["function"];
+            : TYPE_CALL_EXT.test(e.file)
+              ? ["function", "class", "struct", "enum"]
+              : ["function"];
+      if (e.specifier) {
+        // The callee is a named import, so the source already states both halves of the
+        // answer — which module, and which exported name. Resolve inside that file and
+        // stop: a globally ambiguous name is NOT ambiguous here, and bare-name resolution
+        // would have dropped it. Anything the import doesn't settle (an external package,
+        // a barrel re-export) falls through to the bare-name path below, unchanged.
+        const targetFile = resolveImport(e.specifier, e.file, byId);
+        const candidates = byId.has(targetFile)
+          ? (perFileName.get(targetFile)?.get(e.name!) ?? []).filter((n) => callKinds.includes(n.kind))
+          : [];
+        if (candidates.length === 1) {
+          add(e.source, candidates[0].id, "calls", "extracted");
+          continue;
+        }
+      }
       const hit = resolveName(e.name!, e.file, callKinds, perFileName, globalName);
       if (hit) add(e.source, hit.id, "calls", hit.confidence); // drop unresolved calls (too noisy)
     }
@@ -221,12 +267,28 @@ function resolveName(
   perFileName: Map<string, Map<string, NodeV1[]>>,
   globalName: Map<string, NodeV1[]>,
 ): { id: string; confidence: EdgeV1["confidence"] } | null {
+  const hit = resolveNamedNode(name, file, kinds, perFileName, globalName);
+  return hit ? { id: hit.node.id, confidence: hit.confidence } : null;
+}
+
+/** {@link resolveName}, returning the NODE rather than just its id — the inheritance
+ * walk needs the declaring file to keep looking a supertype up in its own scope. */
+function resolveNamedNode(
+  name: string,
+  file: string,
+  kinds: Kind[],
+  perFileName: Map<string, Map<string, NodeV1[]>>,
+  globalName: Map<string, NodeV1[]>,
+): { node: NodeV1; confidence: EdgeV1["confidence"] } | null {
   const local = (perFileName.get(file)?.get(name) ?? []).filter((n) => kinds.includes(n.kind));
-  if (local.length) return { id: local[0].id, confidence: "extracted" };
+  if (local.length) return { node: local[0], confidence: "extracted" };
   const global = (globalName.get(name) ?? []).filter((n) => kinds.includes(n.kind));
-  if (global.length === 1) return { id: global[0].id, confidence: "inferred" };
+  if (global.length === 1) return { node: global[0], confidence: "inferred" };
   return null;
 }
+
+/** The kinds an `extends`/`implements` name can land on, when climbing a hierarchy. */
+const TYPE_KINDS: Kind[] = ["class", "interface", "struct", "enum"];
 
 /**
  * Resolve a typed member call (`recvType.name`) against the owner-qualified method
@@ -270,30 +332,48 @@ function resolveTypedMember(
   file: string,
   ownerMethod: Map<string, NodeV1[]>,
   classParents: Map<string, string[]>,
+  perFileName: Map<string, Map<string, NodeV1[]>>,
+  globalName: Map<string, NodeV1[]>,
   argCount?: number,
 ): { id: string; confidence: EdgeV1["confidence"] } | "ambiguous" | null {
   const MAX_DEPTH = 3;
-  const visited = new Set<string>([recvType]);
-  let frontier = [recvType];
+  // A frontier entry is a type name PLUS the file whose scope named it, because
+  // `classParents` is keyed by node id: to climb from `Base` we first have to know WHICH
+  // `Base`, and the only honest answer is the one visible from the file that named it.
+  const visited = new Set<string>([`${file}\0${recvType}`]);
+  let frontier: Array<{ type: string; file: string }> = [{ type: recvType, file }];
   for (let depth = 0; depth <= MAX_DEPTH && frontier.length; depth++) {
-    for (const type of frontier) {
-      const all = ownerMethod.get(`${type}.${name}`);
+    for (const entry of frontier) {
+      const all = ownerMethod.get(`${entry.type}.${name}`);
       if (!all || all.length === 0) continue; // try next ancestor
       const candidates = narrowByArity(all, argCount);
       if (candidates.length === 1) {
         const c = candidates[0];
         return { id: c.id, confidence: c.path === file ? "extracted" : "inferred" };
       }
-      const sameFile = candidates.find((c) => c.path === file);
-      if (sameFile) return { id: sameFile.id, confidence: "extracted" };
-      return "ambiguous"; // several, none same-file — drop and stop
+      // Several classes share this type NAME. The tiebreak is the scope we reached this
+      // level FROM — at depth 0 that is the call site (as before), but on an ancestor it
+      // is the file that declared the supertype. Falling back to the call site's file up
+      // there would let a homonym next to the CALLER hijack a hierarchy declared
+      // somewhere else entirely.
+      const inScope = candidates.find((c) => c.path === entry.file);
+      if (inScope) return { id: inScope.id, confidence: inScope.path === file ? "extracted" : "inferred" };
+      return "ambiguous"; // several, none in scope — drop and stop
     }
-    const next: string[] = [];
-    for (const type of frontier) {
-      for (const parent of classParents.get(type) ?? []) {
-        if (visited.has(parent)) continue;
-        visited.add(parent);
-        next.push(parent);
+    const next: Array<{ type: string; file: string }> = [];
+    for (const entry of frontier) {
+      // Which declaration of `entry.type` this is decides which hierarchy we climb. When
+      // the name resolves to no single type node (unknown, or several homonyms with no
+      // same-file winner), the chain simply STOPS: drop rather than pick a hierarchy.
+      const decl = resolveNamedNode(entry.type, entry.file, TYPE_KINDS, perFileName, globalName);
+      if (!decl) continue;
+      for (const parent of classParents.get(decl.node.id) ?? []) {
+        // The supertype name is looked up from the DECLARING file, not the call site's:
+        // `a/Base.java`'s `extends Foo` means package a's Foo.
+        const key = `${decl.node.path}\0${parent}`;
+        if (visited.has(key)) continue;
+        visited.add(key);
+        next.push({ type: parent, file: decl.node.path });
       }
     }
     frontier = next;
@@ -319,6 +399,68 @@ function resolveImport(spec: string, file: string, byId: Map<string, NodeV1>): s
   ];
   for (const c of candidates) if (byId.has(c)) return c;
   return spec;
+}
+
+/**
+ * Resolve a Python import to the in-repo module file it names, else the raw specifier.
+ *
+ * Python is spelled nothing like JS and was being run through the JS resolver, which
+ * made every Python import edge in every graph point at an external string. The
+ * extractor hands over the specifier verbatim — `.utils`, `..core.db`, `app.services` —
+ * and `posix.join(dir, ".utils")` is `"src/.utils"`: every candidate path it built was
+ * one that cannot exist, so resolution always fell through to `return spec`. Combined
+ * with `collectImportedSymbols` being TS-only (no `references` edges either), a Python
+ * repo's graph had containment and intra-file calls and NO wiring between files at all.
+ *
+ * Two spellings, both translated before any path exists:
+ *   - Relative: leading dots are the depth (`.` = this package, `..` = its parent), and
+ *     `.` inside the tail is the separator. So `..core.db` from `a/b/c.py` is `a/core/db`.
+ *   - Absolute: `app.services.mailer` names a module relative to a sys.path root graft
+ *     cannot know, so it is matched as a path SUFFIX, longest tail first — the same
+ *     root-agnostic strategy `resolveJavaImport`/`resolvePhpUse` already use.
+ *
+ * A module is `<path>.py` (or `.pyi`), a package is `<path>/__init__.py`. An ambiguous
+ * suffix and a climb past the repo root both stay the raw specifier, never a guess.
+ */
+function resolvePythonImport(
+  spec: string,
+  file: string,
+  byId: Map<string, NodeV1>,
+  bySuffix: Map<string, string[]>,
+): string {
+  const dots = /^\.*/.exec(spec)![0].length;
+  const tail = spec.slice(dots).replace(/\./g, "/");
+  if (dots > 0) {
+    let dir = posix.dirname(toPosixPath(file));
+    if (dir === ".") dir = "";
+    // One dot is the importing file's OWN package, so only the dots beyond the first climb.
+    for (let i = 1; i < dots; i++) {
+      if (dir === "") return spec; // climbed out of the repo — nothing in-repo to name
+      dir = posix.dirname(dir);
+      if (dir === ".") dir = "";
+    }
+    const base = [dir, tail].filter(Boolean).join("/");
+    if (base === "") return spec;
+    for (const c of pyModuleFiles(base)) if (byId.has(c)) return c;
+    return spec;
+  }
+  if (tail === "") return spec;
+  const parts = tail.split("/").filter(Boolean);
+  for (let i = 0; i < parts.length; i++) {
+    const sub = parts.slice(i).join("/");
+    for (const cand of pyModuleFiles(sub)) {
+      const hits = bySuffix.get(cand);
+      if (hits && hits.length === 1) return hits[0];
+      if (hits && hits.length > 1) return spec; // ambiguous at the most specific level
+    }
+  }
+  return spec;
+}
+
+/** The file paths a Python module path can name: a module, a stub, or a package's
+ * `__init__`. Order matters — a real module wins over a same-named package. */
+function pyModuleFiles(base: string): string[] {
+  return [`${base}.py`, `${base}/__init__.py`, `${base}.pyi`, `${base}/__init__.pyi`];
 }
 
 /**

--- a/src/graph/source-files.ts
+++ b/src/graph/source-files.ts
@@ -7,10 +7,10 @@
  * {@link listSourceFiles} so its existing importers are unaffected.
  */
 import { statSync } from "node:fs";
-import { resolve } from "node:path";
+import { resolve, sep } from "node:path";
 import { walkDir } from "../ingest/fs.js";
 import { relPosix } from "../util/paths.js";
-import { readIncludeDirs } from "../util/state.js";
+import { readExtensions, readIncludeDirs } from "../util/state.js";
 import { languageOf, depthExtensions } from "./extract.js";
 import { genericLangOf, genericExtensions } from "./generic.js";
 
@@ -43,17 +43,51 @@ export function unsupportedExtensions(exts: string[]): string[] {
  * so every caller that enumerates through here (the fingerprint probe, the
  * hooks/refresh path, none of which ever see a CLI flag) behaves identically
  * to the `graft build --include-dir` invocation that set it.
+ *
+ * `extensions` is `graft build -e`. It reaches here because this is the ONE
+ * enumeration the wiring graph is built from: applied anywhere else, `-e .ts`
+ * narrowed the concept pass while the wiring graph kept indexing every language
+ * graft has a grammar for — the flag said "only include these code extensions"
+ * and the graph the user actually queries ignored it.
+ *
+ * When the caller passes none, the repo's PERSISTED `-e` is read from state here,
+ * exactly as `--include-dir` is above and for a sharper reason: the freshness probe
+ * (`fingerprint.ts`) and the pre-query refresh never see a CLI flag, so an
+ * unpersisted narrowing meant every excluded file counted as new on the next query
+ * and the refresh rebuilt the graph wide again — `-e` would have lasted until the
+ * first `graft ask`. It also makes `graft check` agree with the build that wrote
+ * the graph without anyone having to repeat the flag.
  */
 export function listSourceFiles(
   root: string,
   outDir: string,
   repoFiles: string[] = walkDir(root, readIncludeDirs(resolve(root))),
+  extensions?: string[],
 ): string[] {
+  // Excluding the output dir needs a SEGMENT boundary, not a string prefix: with the
+  // default outDir `<root>/graft`, a bare `startsWith` also swallows the sibling
+  // `graft-tools/` or `graftlib/`, which then never gets indexed and never says why.
+  // This repo already documents the class of bug in `util/paths.ts#pathUnderPrefix`
+  // ("a plain startsWith would let 'frontend' match 'frontend-utils'"); it just never
+  // reached here. `resolve` too, because a relative `--dir` reaches us verbatim and
+  // would otherwise never match the absolute paths the walk produces — making the
+  // output directory itself part of the source set.
+  const out = resolve(outDir);
+  const outPrefix = out + sep;
+  // Empty is treated as absent, not as "index nothing": commander hands `[]` for a
+  // variadic option that was never given, and a build that silently produced an
+  // empty graph would be the worst possible reading of a missing flag.
+  const asked = extensions?.length ? extensions : readExtensions(resolve(root));
+  const wanted = asked?.length ? asked.map(normExt) : undefined;
   // A file is a source file if a depth-tier grammar (languageOf) OR a breadth-tier
   // grammar (genericLangOf) claims its extension. Both must agree here or `build`
   // and `check` would enumerate different sets.
   return repoFiles.filter(
-    (f) => !f.startsWith(outDir) && (languageOf(f) !== null || genericLangOf(f) !== null),
+    (f) =>
+      !(f === out || f.startsWith(outPrefix)) &&
+      (languageOf(f) !== null || genericLangOf(f) !== null) &&
+      // `endsWith`, not `extname`, to match how both registries claim a file.
+      (wanted === undefined || wanted.some((e) => f.toLowerCase().endsWith(e))),
   );
 }
 
@@ -73,9 +107,14 @@ export interface SourceStat {
  * both the freshness probe and the extraction cache. Files that vanish between
  * the walk and the stat are dropped (same fail-soft posture as `walkDir`).
  */
-export function listSourceStats(root: string, outDir: string, repoFiles?: string[]): SourceStat[] {
+export function listSourceStats(
+  root: string,
+  outDir: string,
+  repoFiles?: string[],
+  extensions?: string[],
+): SourceStat[] {
   const out: SourceStat[] = [];
-  for (const abs of listSourceFiles(root, outDir, repoFiles)) {
+  for (const abs of listSourceFiles(root, outDir, repoFiles, extensions)) {
     let s: { size: number; mtimeMs: number };
     try {
       s = statSync(abs);

--- a/src/graph/traverse.ts
+++ b/src/graph/traverse.ts
@@ -15,7 +15,7 @@
 import type { EdgeV1, GraphV1, NodeV1, Relation } from "./types.js";
 import { WALK_RELATIONS } from "./relations.js";
 import { assertPrefixIndexed, pathUnderPrefix } from "./scopes.js";
-import { normalizePathPrefix } from "../util/paths.js";
+import { normalizePathPrefix, toPosixPath } from "../util/paths.js";
 
 /** Which way to walk the wiring graph: `in` = incoming edges (who points at
  * the symbol — callers / blast radius), `out` = outgoing edges (what the symbol
@@ -68,12 +68,19 @@ export function resolveSymbol(graph: GraphV1, query: string, opts: ResolveSymbol
   }
 
   if (matches.length === 0 && looksLikeFilename) {
+    // Every `node.path` in the graph is posix, and this branch compares against
+    // paths, not names — so a native `src\graph\build.ts` (what a Windows shell's
+    // tab-completion produces, and what `graft_trace_calls` invites when its schema
+    // says "a file path also works") equalled no path at all and fell out as "symbol
+    // not found". Same normalization `--in` and `skeleton` already do; see the
+    // header of src/util/paths.ts for why it is keyed to the platform separator.
+    const lowerPath = toPosixPath(query).toLowerCase();
     matches = graph.nodes.filter(
       (n) =>
         n.kind === "file" &&
         (n.name.toLowerCase() === lowerQuery ||
-          n.path.toLowerCase() === lowerQuery ||
-          n.path.toLowerCase().endsWith("/" + lowerQuery)),
+          n.path.toLowerCase() === lowerPath ||
+          n.path.toLowerCase().endsWith("/" + lowerPath)),
     );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,13 +27,21 @@ export type { GraphCheckResult, GraphCheckOptions } from "./graph/check.js";
 export type { ContextNode, NodeLink, SourceRef, Manifest } from "./context/node-file.js";
 
 export type { EngineConfig, ResolvedConfig } from "./ai/providers.js";
-export { resolveConfig, DEFAULTS, DEFAULT_MODELS } from "./ai/providers.js";
+export { resolveConfig, credentialProblem, DEFAULTS, DEFAULT_MODELS } from "./ai/providers.js";
 
 // Provider transport, for advanced/custom setups.
 export type { ChatModel, ChatRequest, ChatResponse, Message, ToolSpec, ToolCall, Usage } from "./ai/llm/types.js";
-export { createChatModel, type ProviderKind, type ChatModelConfig } from "./ai/llm/factory.js";
+export {
+  createChatModel,
+  providerNeedsKey,
+  PROVIDER_KINDS,
+  type ProviderKind,
+  type ChatModelConfig,
+} from "./ai/llm/factory.js";
 export { OpenAIChatModel } from "./ai/llm/openai.js";
 export { AnthropicChatModel } from "./ai/llm/anthropic.js";
+export { ClaudeCliChatModel, claudeCliAvailable, resolveClaudeBin } from "./ai/llm/claude-cli.js";
+export type { ClaudeCliChatModelOptions, ClaudeCliRunner, ClaudeCliResult } from "./ai/llm/claude-cli.js";
 
 // Engine ops, for advanced/custom setups.
 export { ChatSynthesizer } from "./ai/synthesize.js";

--- a/src/ingest/fs.ts
+++ b/src/ingest/fs.ts
@@ -59,7 +59,38 @@ export function shouldSkipDir(name: string, includes?: ReadonlySet<string>): boo
  * index it, the same contract as tracked-but-ignored files).
  */
 export function walkDir(dir: string, includes?: ReadonlySet<string>): string[] {
+  assertRepoDir(dir);
   return gitVisibleFiles(dir, includes) ?? walkFilesystem(dir, includes);
+}
+
+/**
+ * Fail on a bad `[dir]` here, where the argument is still named, rather than four
+ * frames down in `readdirSync`.
+ *
+ * `graft build ./typo` used to reach the user as `ENOENT: no such file or directory,
+ * scandir 'C:\...'` — cli.ts's top-level handler prints `err.message` and nothing else,
+ * so the message never mentioned `graft build` or which argument was wrong. Every
+ * command that takes a repo root funnels through this walk, so validating once here
+ * covers `build`, `init` and `check` without each of them remembering to.
+ *
+ * Note the git path can't do this check for us: `gitVisibleFiles` spawns with
+ * `cwd: root`, and a spawn into a nonexistent cwd merely returns an error, which the
+ * walker fail-softs into the filesystem fallback.
+ *
+ * Exported because the walk is not always the FIRST thing a command does with the
+ * argument: `graft build ./typo --include-dir x` persisted a config file first, and
+ * `writeJsonAtomic` mkdir's recursively — so a typo silently created the directory
+ * it was complaining about. cli.ts calls this up front for exactly that reason; the
+ * check stays here so both callers can never disagree on the wording.
+ */
+export function assertRepoDir(dir: string): void {
+  let stat;
+  try {
+    stat = statSync(dir);
+  } catch {
+    throw new Error(`✗ ${dir}: no such directory — pass a repository root`);
+  }
+  if (!stat.isDirectory()) throw new Error(`✗ ${dir}: not a directory — pass a repository root`);
 }
 
 /** Git's canonical working-tree file set, relative to `dir`. Tracked files are
@@ -80,8 +111,19 @@ function gitVisibleFiles(dir: string, includes?: ReadonlySet<string>): string[] 
   if (result.status !== 0 || result.error || typeof result.stdout !== "string") return null;
 
   const out: string[] = [];
+  // `ls-files` prints one line PER INDEX STAGE, so during a merge conflict every
+  // unmerged path arrives three times (stages 1/2/3). Nothing downstream deduplicates:
+  // `listSourceStats` yields three SourceStats with the same `rel`, and build.ts's loop
+  // re-parses and re-pushes the same nodes three times, minting three nodes per id.
+  // `checkGraphInvariants` then reports `duplicate node id`, meta.nodeCount is inflated,
+  // and `ask` scores the same body 3×. The Claude Code `Stop` hook runs a build at the
+  // end of every turn, so this fires on its own in the middle of a conflicted merge.
+  // A Set rather than git's `--deduplicate` flag: that flag needs git >= 2.31 and this
+  // has to hold on whatever git the user has.
+  const seen = new Set<string>();
   for (const rel of result.stdout.split("\0")) {
-    if (!rel || skippedPath(rel, includes)) continue;
+    if (!rel || seen.has(rel) || skippedPath(rel, includes)) continue;
+    seen.add(rel);
     const abs = resolve(root, rel);
     try {
       const stat = lstatSync(abs);

--- a/src/util/num.ts
+++ b/src/util/num.ts
@@ -1,0 +1,20 @@
+/**
+ * Number formatting for text graft emits.
+ *
+ * `toLocaleString()` with no locale follows the MACHINE's locale, which is the
+ * wrong authority for two of graft's outputs. The savings lines are read by an
+ * LLM and explicitly ask it to sum them across calls; on a pt-BR/de-DE box the
+ * bare call renders 1990 as "1.990", which an agent reads as 1.99 — so the
+ * headline "tokens saved this turn" total comes out ~1000× low. The graph's own
+ * stats are compared across machines and CI, where a separator that moves with
+ * the host makes two identical runs look different.
+ *
+ * One pinned locale for both: the output is a data interchange format that
+ * happens to be human-readable, not localized UI.
+ */
+const FORMATTER = new Intl.NumberFormat("en-US");
+
+/** Thousands-separated integer, identical on every machine. */
+export function formatCount(n: number): string {
+  return FORMATTER.format(Math.round(n));
+}

--- a/src/util/source.ts
+++ b/src/util/source.ts
@@ -6,5 +6,16 @@ export function readSourceFile(path: string): string | null {
   const bytes = readFileSync(path);
   if (bytes[0] === 0xfe && bytes[1] === 0xff) return null;
   if (bytes[0] === 0xff && bytes[1] === 0xfe) return bytes.subarray(2).toString("utf16le");
+  // A UTF-8 BOM has to come off here, not be left for the grammar: U+FEFF is category
+  // Cf, not whitespace, and only the TS/JS and Python grammars list it in `extras`.
+  // Every breadth grammar whose extras are just `/\s/` (Go, Java, C, C#, Rust…) starts
+  // the parse with an ERROR node at offset 0 and recovers unpredictably from there.
+  // This is not exotic on Windows: Visual Studio writes .cs with a BOM by default and
+  // PowerShell 5.1's `Out-File -Encoding utf8` writes one for any file at all. Stripping
+  // it in the single reader also keeps `contentHash` over exactly the bytes we parse,
+  // which is what build/check/fingerprint agreement rests on.
+  if (bytes[0] === 0xef && bytes[1] === 0xbb && bytes[2] === 0xbf) {
+    return bytes.subarray(3).toString("utf8");
+  }
   return bytes.toString("utf8");
 }

--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -74,6 +74,12 @@ export interface BuildConfig {
    * no-flag build — and the fingerprint/refresh path, which never sees CLI
    * flags at all — behave identically to the invocation that set it. */
   includeDirs?: string[];
+  /** `graft build -e` extensions, persisted for the same reason and it matters
+   * more here: `-e` NARROWS the indexed set, and the freshness probe enumerates
+   * the tree with no flags at all. Unpersisted, every excluded file read as new
+   * on the next query, which rebuilt the graph wide again — so the narrowing
+   * lasted exactly until someone ran `graft ask`. Empty means "no override". */
+  extensions?: string[];
 }
 
 /** Local, Git-ignored repository configuration. Kept outside generated
@@ -100,9 +106,15 @@ function ensureBuildConfigIgnored(d: string): void {
 }
 
 export function readBuildConfig(d: string): BuildConfig | null { return readJson<BuildConfig>(buildConfigPath(d)); }
+
+/** Merged over what is already on disk, never replacing it: the fields are set by
+ * different flags of the same command (`--include-dir`, `-e`), so a plain write
+ * would let `graft build --include-dir build` silently drop a persisted `-e`. An
+ * explicit empty array still clears its own field — that is how `--no-include-dir`
+ * and `--no-extensions` undo themselves. */
 export function writeBuildConfig(d: string, c: BuildConfig): void {
   ensureBuildConfigIgnored(d);
-  writeJsonAtomic(buildConfigPath(d), c);
+  writeJsonAtomic(buildConfigPath(d), { ...(readBuildConfig(d) ?? {}), ...c });
 }
 
 /** The persisted `--include-dir` override for repo `d`, as a Set — `undefined`
@@ -113,6 +125,15 @@ export function writeBuildConfig(d: string, c: BuildConfig): void {
 export function readIncludeDirs(d: string): Set<string> | undefined {
   const dirs = readBuildConfig(d)?.includeDirs;
   return dirs && dirs.length ? new Set(dirs) : undefined;
+}
+
+/** The persisted `-e/--extensions` narrowing for repo `d`, or undefined when there
+ * is none. Same contract as {@link readIncludeDirs}: read inside `listSourceFiles`
+ * rather than threaded from the CLI, so the build, the freshness probe, `check`
+ * and the hooks/refresh path enumerate one identical file set. */
+export function readExtensions(d: string): string[] | undefined {
+  const exts = readBuildConfig(d)?.extensions;
+  return exts && exts.length ? exts : undefined;
 }
 // Best-effort read-modify-write; not atomic across concurrent processes, but acceptable
 // for episodic hook writes (worst case is a lost update, not corruption).

--- a/test/ask-index.test.ts
+++ b/test/ask-index.test.ts
@@ -20,6 +20,7 @@ import { readGraph, wiringPath } from "../src/graph/write.js";
 import { askIndexPath, readAskIndex, tokenize, counts, writeAskIndex } from "../src/ask/index-file.js";
 import { extractFile, languageOf } from "../src/graph/extract.js";
 import type { GraphV1, NodeV1 } from "../src/graph/types.js";
+import { rmDir } from "./helpers.js";
 
 /** A small multi-file fixture with enough overlapping vocabulary that IDF and
  * BM25 actually differentiate hits, so a parity test on scores is meaningful. */
@@ -124,7 +125,7 @@ test("writeAskIndex + readAskIndex round-trip matches live tokenization exactly"
     const reread = readAskIndex(outDir);
     assert.deepEqual(reread, index, "re-writing an unchanged graph reproduces the same sidecar");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -155,7 +156,7 @@ test("ask results are IDENTICAL with and without the sidecar (same hits, same sc
       writeFileSync(idxPath, backup);
     }
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -177,7 +178,7 @@ test("unknown sidecar version falls back to live tokenization without crashing",
     const withBadVersion = ask(dir, QUERY, { source: false });
     assert.deepEqual(withBadVersion, live, "unknown-version sidecar must not change results");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -198,7 +199,7 @@ test("a stale sidecar (docCount mismatch) falls back to live tokenization", asyn
     const stale = ask(dir, QUERY, { source: false });
     assert.deepEqual(stale, live, "a docCount-mismatched sidecar must not change results");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -217,7 +218,7 @@ test("an unparseable sidecar file falls back to live tokenization", async () => 
     const withGarbage = ask(dir, QUERY, { source: false });
     assert.deepEqual(withGarbage, live);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -247,7 +248,7 @@ test("A3: a duplicate-named definition still gets its own ask-index doc (unique 
     const docIds = new Set(index!.docs.map((d) => d.id));
     for (const id of ids) assert.ok(docIds.has(id), `sidecar missing doc for ${id}`);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -256,7 +257,7 @@ test("readAskIndex returns null when the sidecar is simply missing", () => {
   try {
     assert.equal(readAskIndex(contextDirFor(dir)), null);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -276,7 +277,7 @@ test("readAskIndex returns null when docCount doesn't match docs.length", () => 
     writeFileSync(idxPath, JSON.stringify(corrupted));
     assert.equal(readAskIndex(outDir), null, "docCount !== docs.length must read as null");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -302,7 +303,7 @@ test("a failed sidecar write is recorded in build errors, not fatal", async () =
     assert.ok(graph, "wiring graph should still be written despite the sidecar failure");
     assert.ok(result.cards > 0, "cards should still be written despite the sidecar failure");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -333,7 +334,7 @@ test("ask WITH sidecar: identical hits/scores whether the underlying wiring.json
       "sidecar-driven ask must be identical whether wiring.json is slim or carries body_text",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -368,7 +369,7 @@ test("ask WITHOUT sidecar on a SLIM graph: no crash, body contributions absent, 
     const hit = byName.hits.find((h) => h.title.startsWith("checkout"));
     assert.ok(hit, "name-field matching still works with no sidecar and a slim graph");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -402,6 +403,6 @@ test("ask on an OLD fat graph (body_text present, no sidecar): unchanged behavio
     const hit = r.hits.find((h) => h.title.startsWith("checkout"));
     assert.ok(hit, "an old fat graph with no sidecar must still find a body-only term via node.body_text");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });

--- a/test/ask.test.ts
+++ b/test/ask.test.ts
@@ -13,6 +13,7 @@ import { readFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { buildGraph } from "../src/graph/build.js";
 import { ask, formatAsk, skeleton, formatSkeleton, isTestPath } from "../src/ask/ask.js";
+import { rmDir } from "./helpers.js";
 
 test("isTestPath: de-ranks test files, not real source", () => {
   for (const p of ["server/download_test.go", "packages/x/tests/foo.test.tsx", "a/__tests__/b.ts", "src/api.spec.ts", "pkg/foo/bar_test.go"])
@@ -65,7 +66,7 @@ test("test files rank below the source they exercise for a non-test query, but n
     const rt = ask(dir, "tests for downloadChunk stall");
     assert.ok(rt.hits.some((h) => /download\.test\.ts/.test(h.pointer)), "test file surfaces for a test-seeking query");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -94,7 +95,7 @@ test("test de-ranking survives normalization when a test is the strongest lexica
     assert.ok(source >= 0, "implementation hit present");
     assert.ok(testHit === -1 || source < testHit, "implementation ranks above the stronger lexical test match");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -119,7 +120,7 @@ test("ask without source returns pointers but no inlined code", async () => {
     assert.match(hit.pointer, /^math\.ts:L\d+-L\d+$/);
     assert.equal(hit.code, undefined, "no source inlined without the option");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -147,7 +148,7 @@ test("ask --source inlines the crux by default, the whole span with full", async
     assert.match(fullHit.code!, /export function addNumbers/, "full definition span inlined");
     assert.doesNotMatch(fullHit.code!, /rerun with --full/);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -159,7 +160,7 @@ test("ask --source falls back to the span when a node has no crux", async () => 
     const hit = r.hits.find((h) => h.title.startsWith("addNumbers"))!;
     assert.match(hit.code!, /export function addNumbers/);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -182,7 +183,7 @@ test("skeleton lists a file's definitions in span order, matches by basename", a
     assert.match(txt, /L\d+-L\d+ {2}function first/);
     assert.match(skeleton(dir, "nope.ts").note ?? "", /no definitions/);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -199,7 +200,7 @@ test("ask reports coverage: 1.0 when every query term hits, low on mostly-off-co
     assert.ok(chatty.hits.length > 0, "still returns lexical hits");
     assert.ok((chatty.coverage ?? 1) < 0.15, `coverage should be under the floor, got ${chatty.coverage}`);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -220,7 +221,7 @@ test("ask finds a symbol by a term that appears only in its body (body-indexing)
     assert.ok(hit, "checkout is findable via a term that only appears in its body");
     assert.match(hit.pointer, /^pay\.ts:L\d+-L\d+$/);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -240,7 +241,7 @@ test("ask surfaces a file by a term only in its module-level code (file-body ind
     assert.ok(hit, "the file surfaces via a term that lives only in module-level code");
     assert.ok(hit.title.endsWith("· file"), "it is the file node, pointed at the whole file (no span)");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -261,7 +262,7 @@ test("ask indexes a symbol past the 32KB tree-sitter boundary (chunked parse)", 
       "a symbol defined past the 32KB boundary is indexed and findable",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -303,7 +304,7 @@ test("ask: 'who calls Cache.get' resolves via qualified id-suffix (the previousl
       "loadItem calls Cache.get, and must show up as a caller",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -318,7 +319,7 @@ test("ask: structural subject resolves but has zero edges — falls through to l
     assert.match(r.note!, /graft callers 'unusedHelper'/);
     assert.ok(r.hits.length > 0, "lexical fallback still finds the function by name");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -331,7 +332,7 @@ test("ask: structural intent for an unresolvable subject also falls through with
     assert.ok(r.note, "a fallthrough note must be set even when nothing resolved");
     assert.match(r.note!, /structural index: no entries for 'NoSuchSymbolXyz'/);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -347,7 +348,7 @@ test("formatAsk: the structural fallthrough note prints prominently, before any 
     const firstHitIdx = out.search(/\n1\.\s/); // lexical hit numbering starts at "1. "
     assert.ok(firstHitIdx === -1 || noteIdx < firstHitIdx, "the note prints before any hit");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -408,7 +409,7 @@ test("ask on a multi-scope repo: top hits federate both scopes, labeled, with a 
     assert.match(out, /matched in: .*frontend\/ \(\d+\)/, "footer reports frontend's hit count");
     assert.match(out, /matched in: .*backend\/ \(\d+\)/, "footer reports backend's hit count");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -489,7 +490,7 @@ test("cross-seam fix: a monorepo scope with only a body-comment collision is gat
     assert.match(out, /also matched: junk\/ — narrow with --in junk\//, `expected an alsoMatched footer, got:\n${out}`);
     assert.doesNotMatch(out, /\[junk\/\]/, "no junk/-labeled hit anywhere in the rendered output");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -522,7 +523,7 @@ test("ask --in: filters to nodes under the prefix, segment-aware ('widgets' must
       "widgets-extra/ must NOT be pulled in by a naive substring/prefix match",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -567,7 +568,7 @@ test("ask --in: per-scope idf differs from global — a term's rank flips relati
       "filtered to proj/, zzzcommonword_b (now the locally-rare term) overtakes zzzraretoken (now locally-common)",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -580,7 +581,7 @@ test("ask --in: unknown/no-match prefix throws a scope-enumerating error", async
       /nothing indexed under "wrong\/" — scopes here: .*frontend\/.*backend\/.* \(or any path prefix\)/,
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -596,7 +597,7 @@ test("ask --in: unknown prefix on a single-scope repo throws without a scopes-he
       return true;
     });
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -619,7 +620,7 @@ test("CLI: `graft ask --in <unknown>` exits 1 with the scope-enumerating error o
     assert.match(threw!.stderr ?? "", /✗ nothing indexed under "wrong\/"/);
     assert.match(threw!.stderr ?? "", /scopes here:.*frontend\/.*backend\//);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -632,7 +633,7 @@ test("ask: a zero-hit query on a multi-scope graph appends scope enumeration to 
     assert.match(r.note ?? "", /no matching nodes — try different words/);
     assert.match(r.note ?? "", /scopes here: .*frontend\/.*backend\//);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -650,7 +651,7 @@ test("ask --in on the multi-scope fixture: filtering to one scope carries no sco
     const out = formatAsk(r);
     assert.doesNotMatch(out, /\[frontend\/\] |\[backend\/\] |matched in:|also matched:/);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -686,7 +687,7 @@ test("ask --in: a body-only term is still found when filtered to its own directo
     const hit = r.hits.find((h) => h.title.startsWith("checkout"));
     assert.ok(hit, "checkout must still be findable via its body-only term when --in filters to its OWN directory");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -705,7 +706,7 @@ test("ask --in: a trailing slash is accepted — `--in frontend/` behaves exactl
       "trailing slash must not change which hits are returned",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -752,7 +753,7 @@ test("ask --in: structural queries narrow the resolved subject by prefix, not ju
       "backend's handle/caller must not leak in when --in=frontend",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -770,7 +771,7 @@ test("ask --in: a structural subject that exists ONLY outside the prefix falls t
     assert.ok(r.note, "a fallthrough note must be set");
     assert.match(r.note!, /structural index: no entries for 'handle'/);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -794,7 +795,7 @@ test("regression pin: single-scope ask output is byte-equal with canonical meta.
     assert.equal(canonical, absent, "single-scope output must not drift by a byte");
     assert.doesNotMatch(absent, /matched in:|also matched:|\[\w+\/\] /, "zero new output on single-scope");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -810,6 +811,6 @@ test("ask with source inlines the actual span from disk", async () => {
     // formatAsk renders it as a fenced block so it drops into agent context.
     assert.match(formatAsk(r), /```[\s\S]*return a \+ b;[\s\S]*```/);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -12,7 +12,7 @@ import { buildContext } from "../src/context/build.js";
 import { checkContext, indexFreshness, staleBanner } from "../src/context/check.js";
 import { contextDirFor, ensureGitignored, ensureSearchable } from "../src/context/node-file.js";
 import { writeBuildConfig } from "../src/util/state.js";
-import { fakeProviders } from "./helpers.js";
+import { fakeProviders, rmDir } from "./helpers.js";
 
 // CLI-spawn helper (same pattern as test/graph-traverse-cli.test.ts) — these tests
 // exercise the real process boundary (exit codes), which a unit-level call into
@@ -74,7 +74,7 @@ test("init builds one markdown node per entity, with links and a manifest", asyn
     assert.equal(manifest.files.length, 2);
     assert.equal(manifest.nodes.length, 3);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -86,7 +86,7 @@ test("check passes immediately after init", async () => {
     assert.equal(r.ok, true);
     assert.equal(r.missing, false);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -97,7 +97,7 @@ test("check reports NO GRAPH when init never ran", () => {
     assert.equal(r.missing, true);
     assert.equal(r.ok, false);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -111,7 +111,7 @@ test("check detects content drift when a source file changes", async () => {
     assert.equal(r.contentDrift.length, 1);
     assert.equal(r.contentDrift[0].path, "auth.ts");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -131,7 +131,7 @@ test("indexFreshness/staleBanner: recorded files gone from disk (the branch-swit
     assert.match(banner ?? "", /ahead of your working tree/, "banner fires when stale");
     assert.match(banner ?? "", /graft grep/, "banner steers to graft grep, not raw grep");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -141,7 +141,7 @@ test("indexFreshness returns null when there is no graph", () => {
     assert.equal(indexFreshness(dir), null);
     assert.equal(staleBanner(null), null);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -154,7 +154,7 @@ test("check detects a new file not yet in the graph (coverage drift)", async () 
     assert.equal(r.ok, false);
     assert.deepEqual(r.coverage, ["new.ts"]);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -190,7 +190,7 @@ test("A5: a persisted --include-dir override reaches context/build.ts's file lis
     assert.deepEqual(check.removed, [], "build/ must not be reported removed — check.ts must see it too");
     assert.deepEqual(check.coverage, [], "build/ must not be reported as new/uncovered — it's already in the manifest");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -208,7 +208,7 @@ test("re-running init clears drift", async () => {
     await buildContext(dir, buildOpts());
     assert.equal(checkContext(dir).ok, true);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -222,7 +222,7 @@ test("human notes below the generated block survive regeneration", async () => {
     await buildContext(dir, buildOpts());
     assert.match(readFileSync(path, "utf8"), /Hand-written note: watch out for retries\./);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -243,7 +243,7 @@ test("graft check: keyless build (no --deep) exits 0 — wiring graph present, m
     assert.match(r.stdout, /wiring graph is the source of truth/);
     assert.match(r.stdout, /graph check: OK/);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -255,7 +255,7 @@ test("graft check: neither layer ever built exits 1", () => {
     assert.match(r.stdout, /NO GRAPH/);
     assert.match(r.stdout, /graft build/);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -280,7 +280,7 @@ test("graft check: keyless build then code changes (wiring stale) exits 1", () =
     assert.equal(r.status, 1, `expected exit 1, got ${r.status}\nstdout: ${r.stdout}\nstderr: ${r.stderr}`);
     assert.match(r.stdout, /graph check: STALE/);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -293,7 +293,7 @@ test("ensureGitignored: creates .gitignore with the graft/ entry when none exist
     assert.match(gi, /^graft\/$/m);
     assert.match(gi, /regenerable, not committed/);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -307,7 +307,7 @@ test("ensureGitignored: appends to an existing .gitignore without clobbering it"
     assert.match(gi, /dist\//);
     assert.match(gi, /^graft\/$/m);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -321,7 +321,7 @@ test("ensureGitignored: idempotent — a second build adds nothing", () => {
     assert.equal(once, twice);
     assert.equal((twice.match(/^graft\/$/gm) ?? []).length, 1);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -332,7 +332,7 @@ test("ensureGitignored: recognizes a pre-existing bare `graft` entry (no slash) 
     ensureGitignored(dir, contextDirFor(dir));
     assert.equal(readFileSync(join(dir, ".gitignore"), "utf8"), "graft\n");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -342,7 +342,7 @@ test("ensureGitignored: no-op when the graph dir is outside the repo root", () =
     ensureGitignored(dir, join(tmpdir(), "somewhere-else-graft"));
     assert.equal(existsSync(join(dir, ".gitignore")), false);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -359,7 +359,7 @@ test("ensureSearchable: re-admits the card tree while excluding the caches", () 
     assert.match(ig, /^graft\/\.graph\/$/m, "and not wiring.json");
     assert.match(ig, /ripgrep reads/, "carries the why, for whoever finds this file");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -375,7 +375,7 @@ test("ensureSearchable: appends to an existing .ignore, and is idempotent", () =
     assert.equal(once, twice);
     assert.equal((twice.match(/^!graft\/$/gm) ?? []).length, 1);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -387,7 +387,7 @@ test("ensureSearchable: leaves a hand-written negation alone", () => {
     ensureSearchable(dir, contextDirFor(dir));
     assert.equal(readFileSync(join(dir, ".ignore"), "utf8"), "# mine\n!graft/\n");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -397,6 +397,6 @@ test("ensureSearchable: no-op when the graph dir is outside the repo root", () =
     ensureSearchable(dir, join(tmpdir(), "somewhere-else-graft"));
     assert.equal(existsSync(join(dir, ".ignore")), false);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });

--- a/test/covers.test.ts
+++ b/test/covers.test.ts
@@ -11,7 +11,7 @@ import { tmpdir } from "node:os";
 import matter from "gray-matter";
 import { buildContext } from "../src/context/build.js";
 import { buildGraph } from "../src/graph/build.js";
-import { fakeProviders } from "./helpers.js";
+import { fakeProviders, rmDir } from "./helpers.js";
 
 function makeFixture(): string {
   const dir = mkdtempSync(join(tmpdir(), "graft-covers-"));
@@ -36,7 +36,7 @@ test("wiring build backfills covers: onto concept nodes", async () => {
     assert.equal(login.kind, "function");
     assert.match(login.at, /^auth\.ts:L\d+-L\d+$/);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -57,7 +57,7 @@ test("patching covers preserves the node's body and other frontmatter", async ()
     assert.deepEqual(after.data.links, before.data.links);
     assert.ok("covers" in after.data && !("covers" in before.data));
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -71,6 +71,6 @@ test("re-running the wiring build leaves covers byte-stable", async () => {
     const second = readFileSync(join(dir, "graft", "auth-service.md"), "utf8");
     assert.equal(second, first);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });

--- a/test/graph-breadth-tier.test.ts
+++ b/test/graph-breadth-tier.test.ts
@@ -1,0 +1,214 @@
+/**
+ * The breadth (generic) tier's machinery, as distinct from "does language X extract"
+ * (test/generic-extract.test.ts): which grammar a file is routed to, which grammars a
+ * build actually loads, how call sites are attributed to their enclosing definition,
+ * and what a build says when a grammar simply isn't there.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  enclosingDefs,
+  extractGeneric,
+  isWarm,
+  unavailableGrammars,
+  warmGenericGrammars,
+  type Def,
+} from "../src/graph/generic.js";
+import { resolveEdges } from "../src/graph/resolve.js";
+import { buildGraph } from "../src/graph/build.js";
+import { checkGraph } from "../src/graph/check.js";
+import { readGraph, wiringPath } from "../src/graph/write.js";
+import type { NodeV1 } from "../src/graph/types.js";
+import type { RawEdge } from "../src/graph/extract.js";
+import { tmpRepo } from "./helpers.js";
+
+function extractAll(files: Record<string, string>, lang: string) {
+  const nodes: NodeV1[] = [];
+  const raw: RawEdge[] = [];
+  for (const [rel, src] of Object.entries(files)) {
+    const r = extractGeneric(rel, src, lang);
+    nodes.push(...r.nodes);
+    raw.push(...r.rawEdges);
+  }
+  return { nodes, raw };
+}
+
+/**
+ * The header/implementation split is universal in C, and the upstream tags.scm pattern
+ * matches a prototype as readily as a definition — so every function had two nodes of
+ * the same name in two files, `resolveName` saw an ambiguous global match, and dropped
+ * it. The visible symptom is that no C project with headers had ANY cross-file call.
+ */
+test("C prototypes in a header are not definitions, so cross-file calls resolve", async () => {
+  await warmGenericGrammars(["c"]);
+  const { nodes, raw } = extractAll(
+    {
+      "src/app.h": "int run(void);\nchar *dup_it(const char *);\n",
+      "src/app.c": "int run(void){ return 0; }\nchar *dup_it(const char *s){ return 0; }\n",
+      "src/other.c": '#include "app.h"\nint go(void){ return run(); }\n',
+    },
+    "c",
+  );
+
+  const named = nodes.filter((n) => n.kind !== "file").map((n) => `${n.path}:${n.name}`).sort();
+  assert.deepEqual(
+    named,
+    ["src/app.c:dup_it", "src/app.c:run", "src/other.c:go"],
+    "one node per function, at its definition — the header's two prototypes mint nothing",
+  );
+
+  const call = resolveEdges(nodes, raw).find((e) => e.relation === "calls" && e.source === "src/other.c#go");
+  assert.ok(call, "the cross-file call must survive resolution");
+  assert.equal(call!.target, "src/app.c#run");
+});
+
+/**
+ * `.h` can only be claimed by one registry row and C claims it — but a C++ project's
+ * headers are exactly where the classes, templates and namespaces live, and c.scm has
+ * no pattern for any of them. Those symbols were simply absent from the graph.
+ */
+test("a C++-looking .h is parsed with the cpp grammar once cpp is warm", async () => {
+  await warmGenericGrammars(["c", "cpp"]);
+  const header = [
+    "#pragma once",
+    "namespace app {",
+    "class Widget {",
+    "public:",
+    "  void draw();",
+    "  int size() const { return 1; }",
+    "};",
+    "}",
+    "",
+  ].join("\n");
+  const names = extractGeneric("src/widget.h", header, "c")
+    .nodes.filter((n) => n.kind !== "file")
+    .map((n) => `${n.kind}:${n.name}`)
+    .sort();
+  assert.deepEqual(names, ["class:Widget", "method:size"], "the C grammar knows no class_specifier at all");
+
+  // …and a plain C header must NOT be dragged along with it, even with cpp warm.
+  const plain = extractGeneric("src/plain.h", "struct Point { int x; };\nint run(void);\n", "c")
+    .nodes.filter((n) => n.kind !== "file")
+    .map((n) => `${n.kind}:${n.name}`);
+  assert.deepEqual(plain, ["class:Point"], "no C++ markers → still the C grammar");
+});
+
+/**
+ * Attribution used to be `defs.filter(contains).sort(bySize)[0]` per token — O(D·C)
+ * with two array allocations per token, which on a generated file (15k defs, 50k call
+ * sites) is 750M comparisons inside build's synchronous loop.
+ */
+test("enclosingDefs picks the innermost definition, including nested ones", () => {
+  const defs: Def[] = [
+    { id: "outer", startIndex: 0, endIndex: 100 },
+    { id: "inner", startIndex: 10, endIndex: 40 },
+    { id: "deepest", startIndex: 20, endIndex: 30 },
+    { id: "sibling", startIndex: 50, endIndex: 70 },
+  ];
+  const offsets = [5, 15, 25, 35, 60, 80, 120];
+  assert.deepEqual(
+    enclosingDefs(defs, offsets).map((d) => d?.id),
+    ["outer", "inner", "deepest", "inner", "sibling", "outer", undefined],
+  );
+  // Order of the offsets must not matter — the sweep sorts internally and writes back
+  // positionally, so a caller can hand them over in document order or any other.
+  assert.deepEqual(
+    enclosingDefs(defs, [...offsets].reverse()).map((d) => d?.id),
+    ["outer", "inner", "deepest", "inner", "sibling", "outer", undefined].reverse(),
+  );
+  assert.deepEqual(enclosingDefs([], [1, 2]), [undefined, undefined]);
+});
+
+test("enclosingDefs stays fast at generated-file scale", () => {
+  // 15k nested-ish definitions and 60k tokens: the quadratic version is ~10^9
+  // comparisons plus 60k array allocations, which took tens of seconds for one file.
+  const defs: Def[] = [];
+  for (let i = 0; i < 15_000; i++) {
+    defs.push({ id: `f${i}`, startIndex: i * 100, endIndex: i * 100 + 90 });
+  }
+  const offsets: number[] = [];
+  for (let i = 0; i < 60_000; i++) offsets.push((i % 15_000) * 100 + 10);
+
+  const started = Date.now();
+  const got = enclosingDefs(defs, offsets);
+  const elapsed = Date.now() - started;
+
+  assert.equal(got[0]?.id, "f0");
+  assert.equal(got[14_999]?.id, "f14999");
+  assert.ok(elapsed < 3_000, `attribution took ${elapsed}ms — the quadratic shape is back`);
+});
+
+/**
+ * `warmGenericGrammars` swallows a missing wasm and a failed grammar on purpose
+ * (neither should fail a build), which left the caller with no way to tell "indexed"
+ * from "indexed as an empty file node".
+ */
+test("unavailableGrammars names the breadth languages with no loaded grammar", async () => {
+  assert.deepEqual(
+    unavailableGrammars(["zig", "solidity"]).sort(),
+    ["solidity", "zig"],
+    "nothing is warm yet in this process",
+  );
+  await warmGenericGrammars(["zig"]);
+  assert.equal(isWarm("zig"), true);
+  assert.deepEqual(unavailableGrammars(["zig", "solidity"]), ["solidity"]);
+  assert.deepEqual(unavailableGrammars([]), []);
+});
+
+/**
+ * `.java` is claimed by BOTH registries and the depth tier always wins the actual
+ * extraction, so warming its breadth grammar loaded a multi-MB wasm and compiled
+ * queries/java.scm on every build of every Java repo, for a path that can never run.
+ */
+test("a build never warms a breadth grammar the depth tier owns", async () => {
+  const d = tmpRepo("breadth-warm-");
+  mkdirSync(join(d, "src"), { recursive: true });
+  writeFileSync(join(d, "src", "App.java"), "public class App {\n  int run() { return 1; }\n}\n");
+  writeFileSync(join(d, "src", "main.py"), "def go():\n    return 1\n");
+
+  await buildGraph(d, { reuse: false });
+  assert.equal(isWarm("java"), false, "the java wasm must never be loaded for a .java file");
+
+  // …and the file is still fully indexed, by the depth tier.
+  const graph = readGraph(wiringPath(join(d, "graft")))!;
+  assert.ok(graph.nodes.some((n) => n.id === "src/App.java#App"), "the depth tier still indexes it");
+  assert.ok(graph.meta.languages.includes("java"), "and it is still reported as a language");
+});
+
+/**
+ * The same filter, on the OTHER caller. `checkGraph` re-runs Tier-1 extraction and so
+ * warms grammars too, but warmed the unfiltered set — and `check` runs in CI, from the
+ * hooks, and before every query that finds the graph stale, so a Java repo paid the
+ * multi-MB wasm load far more often here than on the build path that was fixed first.
+ */
+test("a check never warms a breadth grammar the depth tier owns", async () => {
+  const d = tmpRepo("breadth-warm-check-");
+  mkdirSync(join(d, "src"), { recursive: true });
+  writeFileSync(join(d, "src", "App.java"), "public class App {\n  int run() { return 1; }\n}\n");
+
+  await buildGraph(d, { reuse: false });
+  const r = await checkGraph(d);
+  assert.equal(r.missing, false, "the graph built above is what check reads");
+  assert.equal(isWarm("java"), false, "the java wasm must never be loaded for a .java file");
+  assert.equal(r.ok, true, "and the depth tier still re-extracts it, so nothing reads as drift");
+});
+
+/**
+ * Reusing one parser per language and deleting each tree is invisible in the output by
+ * design — this pins that it stays invisible, since a parser wrongly shared or a tree
+ * deleted too early would corrupt the very next file's extraction.
+ */
+test("repeated extraction through the shared per-language parser is stable", async () => {
+  await warmGenericGrammars(["rust"]);
+  const src = "pub struct Config { name: String }\n\npub fn load() -> Config {\n    parse()\n}\n\nfn parse() -> Config {\n    load()\n}\n";
+  const first = JSON.stringify(extractGeneric("lib.rs", src, "rust"));
+  for (let i = 0; i < 200; i++) {
+    assert.equal(JSON.stringify(extractGeneric("lib.rs", src, "rust")), first, `run ${i} diverged`);
+  }
+  // Interleaving a second language must not disturb the first's parser either.
+  await warmGenericGrammars(["c"]);
+  extractGeneric("a.c", "int f(void){return 1;}\n", "c");
+  assert.equal(JSON.stringify(extractGeneric("lib.rs", src, "rust")), first);
+});

--- a/test/graph-extract-ts.test.ts
+++ b/test/graph-extract-ts.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Depth-tier extraction gaps that made whole classes of TypeScript dependency
+ * invisible: a JSX component use, a `new Foo()`, an `interface X extends Y`. Each
+ * of these is the MOST common way its language feature couples two modules, and each
+ * produced no edge at all — so the symbol on the receiving end read as an orphan.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { extractFile } from "../src/graph/extract.js";
+import { resolveEdges } from "../src/graph/resolve.js";
+import { buildGraph } from "../src/graph/build.js";
+import { readGraph, wiringPath } from "../src/graph/write.js";
+import { tmpRepo } from "./helpers.js";
+
+/** Every raw edge but containment, which is noise for these assertions. */
+function wiring(rel: string, src: string, lang: "typescript" | "tsx") {
+  return extractFile(rel, src, lang).rawEdges.filter((e) => e.relation !== "contains");
+}
+
+test("a JSX component use is a reference, not a declaration name", () => {
+  const edges = wiring(
+    "page.tsx",
+    'import { Button } from "./button.js";\nexport function Page() {\n  return <Button label="go" />;\n}\n',
+    "tsx",
+  );
+  const ref = edges.find((e) => e.relation === "references");
+  assert.ok(ref, `<Button/> must produce a reference edge (got ${JSON.stringify(edges)})`);
+  assert.equal(ref!.source, "page.tsx#Page");
+  assert.equal(ref!.name, "Button");
+  assert.equal(ref!.specifier, "./button.js");
+});
+
+test("a JSX component use wires the two files end to end", async () => {
+  const root = tmpRepo("extract-jsx-");
+  mkdirSync(join(root, "src"), { recursive: true });
+  writeFileSync(join(root, "src", "button.tsx"), "export function Button(): null {\n  return null;\n}\n");
+  writeFileSync(
+    join(root, "src", "page.tsx"),
+    'import { Button } from "./button.js";\nexport function Page(): null {\n  return <Button />;\n}\n',
+  );
+  await buildGraph(root, { reuse: false });
+  const graph = readGraph(wiringPath(join(root, "graft")))!;
+  assert.ok(
+    graph.edges.some(
+      (e) =>
+        e.source === "src/page.tsx#Page" &&
+        e.target === "src/button.tsx#Button" &&
+        e.relation === "references",
+    ),
+    // Without this a React/Next app's component graph is entirely empty: `<Button/>`
+    // is not a call_expression, so the reference path was the only one available.
+    `Page must reference Button (got ${JSON.stringify(graph.edges)})`,
+  );
+});
+
+test("`new Foo()` in the same file is a call edge to the class", () => {
+  const src = "class Repo {\n  find(): number { return 1; }\n}\nexport function make(): Repo {\n  return new Repo();\n}\n";
+  const { nodes, rawEdges } = extractFile("b.ts", src, "typescript");
+  const edges = resolveEdges(nodes, rawEdges);
+  const call = edges.find((e) => e.relation === "calls" && e.source === "b.ts#make");
+  assert.ok(call, "`new Repo()` must produce a call edge — it is not a call_expression");
+  assert.equal(call!.target, "b.ts#Repo");
+  assert.equal(call!.confidence, "extracted");
+});
+
+test("`Foo()` in Python is a call edge to the class it constructs", () => {
+  const src = "class Repo:\n    def find(self):\n        return 1\n\n\ndef make():\n    return Repo()\n";
+  const { nodes, rawEdges } = extractFile("d.py", src, "python");
+  const edges = resolveEdges(nodes, rawEdges);
+  const call = edges.find((e) => e.relation === "calls" && e.source === "d.py#make");
+  assert.ok(call, "Python's `Repo()` IS the constructor call, so it must resolve to the class");
+  assert.equal(call!.target, "d.py#Repo");
+});
+
+test("a `new Foo()` on an imported class resolves through the import, not by bare name", () => {
+  // The import states which module, so a homonym elsewhere in the repo must not make
+  // this ambiguous — bare-name resolution would drop the edge outright.
+  const files: Record<string, string> = {
+    "src/repo.ts": "export class Repo {\n  find(): number { return 1; }\n}\n",
+    "other/repo.ts": "export class Repo {\n  find(): number { return 2; }\n}\n",
+    "src/use.ts": 'import { Repo } from "./repo.js";\nexport function make(): Repo {\n  return new Repo();\n}\n',
+  };
+  const nodes = [], raw = [];
+  for (const [rel, src] of Object.entries(files)) {
+    const r = extractFile(rel, src, "typescript");
+    nodes.push(...r.nodes);
+    raw.push(...r.rawEdges);
+  }
+  const edges = resolveEdges(nodes, raw);
+  const calls = edges.filter((e) => e.relation === "calls" && e.source === "src/use.ts#make");
+  assert.deepEqual(calls.map((e) => e.target), ["src/repo.ts#Repo"]);
+  assert.equal(calls[0].confidence, "extracted", "the import names the file — this is certain, not a guess");
+});
+
+test("`interface X extends Y` produces an extends edge, generics and all", () => {
+  const src = [
+    "interface User { id: number }",
+    "interface Repo<T> { get(): T }",
+    "export interface AdminUser extends User {}",
+    "export interface Both extends User, Repo<User> {}",
+    "export class Impl implements Repo<User> {}",
+    "",
+  ].join("\n");
+  const { nodes, rawEdges } = extractFile("a.ts", src, "typescript");
+  const heritage = rawEdges
+    .filter((e) => e.relation === "extends" || e.relation === "implements")
+    .map((e) => `${e.source.split("#")[1]} ${e.relation} ${e.name}`)
+    .sort();
+  assert.deepEqual(heritage, [
+    "AdminUser extends User",
+    "Both extends Repo",
+    "Both extends User",
+    "Impl implements Repo",
+  ]);
+
+  // …and they resolve to the interface nodes, so the hierarchy is navigable.
+  const edges = resolveEdges(nodes, rawEdges);
+  assert.ok(
+    edges.some((e) => e.source === "a.ts#AdminUser" && e.target === "a.ts#User" && e.relation === "extends"),
+  );
+  // `implements Repo<User>` used to drop entirely: `generic_type` matched neither
+  // `identifier` nor `type_identifier`, so the whole supertype went missing.
+  assert.ok(
+    edges.some((e) => e.source === "a.ts#Impl" && e.target === "a.ts#Repo" && e.relation === "implements"),
+  );
+  // The type ARGUMENT is not a supertype and must never become one.
+  assert.ok(!edges.some((e) => e.source === "a.ts#Impl" && e.target === "a.ts#User"));
+});
+
+test("`chars` on a file node is BYTES, matching types.ts and the breadth tier", () => {
+  // The savings estimate divides this by 4 for a token count and compares nodes from
+  // both tiers; generic.ts writes Buffer.byteLength, so UTF-16 code units here made an
+  // accented .ts file look smaller than an identical .rs one. ASCII hides it entirely.
+  const src = "export const gréé = 'ação';\n";
+  const file = extractFile("acc.ts", src, "typescript").nodes.find((n) => n.kind === "file")!;
+  assert.equal(file.chars, Buffer.byteLength(src));
+  assert.notEqual(file.chars, src.length, "the fixture must actually contain multi-byte characters");
+});

--- a/test/graph-go.test.ts
+++ b/test/graph-go.test.ts
@@ -12,6 +12,7 @@ import { buildGraph } from "../src/graph/build.js";
 import { readGraph, wiringPath } from "../src/graph/write.js";
 import { writeBuildConfig } from "../src/util/state.js";
 import type { GraphV1, NodeV1 } from "../src/graph/types.js";
+import { rmDir } from "./helpers.js";
 
 const MAIN_GO = `package main
 
@@ -92,7 +93,7 @@ test("Go extraction: funcs, methods, structs, interfaces, type aliases", async (
     assert.equal(nodeById(graph!, "main.go#Reader")?.kind, "interface");
     assert.equal(nodeById(graph!, "main.go#ID")?.kind, "type");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -127,7 +128,7 @@ test("Go extraction: call and import edges", async () => {
     );
     assert.ok(external, "fmt should remain an external package string");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -163,7 +164,7 @@ test("Go extraction: go.mod in a subdirectory resolves intra-module imports", as
       "fmt should remain an external package string",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -200,6 +201,6 @@ test("A5: a go.mod under a persisted --include-dir override is found, so imports
     );
     assert.ok(!external, "must not be left as an unresolved external package string once the module is found");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });

--- a/test/graph-include-dir.test.ts
+++ b/test/graph-include-dir.test.ts
@@ -16,6 +16,7 @@ import { execFileSync } from "node:child_process";
 import { readGraph, wiringPath } from "../src/graph/write.js";
 import { probeDrift, isClean } from "../src/graph/fingerprint.js";
 import type { GraphV1 } from "../src/graph/types.js";
+import { rmDir } from "./helpers.js";
 
 function repoWithBuildDir(): string {
   const d = mkdtempSync(join(tmpdir(), "graft-include-dir-"));
@@ -87,14 +88,14 @@ test("A5: deleting the generated graft cache does not delete the persisted inclu
   const d = repoWithBuildDir();
   try {
     runCli(["build", d, "--include-dir", "build"]);
-    rmSync(join(d, "graft"), { recursive: true, force: true });
+    rmDir(join(d, "graft"));
 
     runCli(["build", d]);
     const rebuilt = graphOf(d);
     assert.ok(rebuilt?.nodes.some((n) => n.id === "build/util.ts#fromBuild"));
     assert.equal(existsSync(join(d, ".graft", "config.json")), true);
   } finally {
-    rmSync(d, { recursive: true, force: true });
+    rmDir(d);
   }
 });
 
@@ -111,8 +112,8 @@ test("A5: custom --dir builds keep repository config outside both output directo
     assert.equal(existsSync(join(d, "graft", ".cache", "config.json")), false);
     assert.equal(existsSync(join(out, ".cache", "config.json")), false);
   } finally {
-    rmSync(d, { recursive: true, force: true });
-    rmSync(out, { recursive: true, force: true });
+    rmDir(d);
+    rmDir(out);
   }
 });
 
@@ -132,7 +133,7 @@ test("A5: --include-dir rejects a dot-prefixed name", () => {
     assert.match(r.stderr, /\.github/);
     assert.equal(existsSync(join(d, ".graft", "config.json")), false, "must not persist an invalid value");
   } finally {
-    rmSync(d, { recursive: true, force: true });
+    rmDir(d);
   }
 });
 
@@ -145,7 +146,7 @@ test("A5: --include-dir rejects a value containing a path separator", () => {
     assert.match(r.stderr, /foo\/bar/);
     assert.equal(existsSync(join(d, ".graft", "config.json")), false, "must not persist an invalid value");
   } finally {
-    rmSync(d, { recursive: true, force: true });
+    rmDir(d);
   }
 });
 
@@ -156,7 +157,7 @@ test("A5: --include-dir rejects a value containing a backslash", () => {
     assert.equal(r.status, 1, `expected exit 1, got ${r.status}\nstdout: ${r.stdout}\nstderr: ${r.stderr}`);
     assert.match(r.stderr, /--include-dir/);
   } finally {
-    rmSync(d, { recursive: true, force: true });
+    rmDir(d);
   }
 });
 
@@ -167,6 +168,6 @@ test("A5: a later valid --include-dir still works (validation isn't over-eager)"
     const g = graphOf(d);
     assert.ok(g && g.nodes.some((n) => n.id === "build/util.ts#fromBuild"));
   } finally {
-    rmSync(d, { recursive: true, force: true });
+    rmDir(d);
   }
 });

--- a/test/graph-incremental.test.ts
+++ b/test/graph-incremental.test.ts
@@ -7,6 +7,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
+import { createRequire } from "node:module";
 import { chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
@@ -240,7 +241,11 @@ test("an unreadable file is still recorded, so it can't look new on every probe"
  */
 test("extractorStamp: a real identity for the loaded extraction code", () => {
   const s = extractorStamp();
-  assert.notEqual(s, "unknown", "path resolution must work under both tsx and dist/, or invalidation silently stops");
+  // null is the live failure mode (no identity could be established at all) and it
+  // disables memoization entirely, so it has to be asserted, not assumed; "unknown"
+  // is the superseded sentinel that used to be written into sidecars as a real id.
+  assert.ok(s, "path resolution must work under both tsx and dist/, or invalidation silently stops");
+  assert.notEqual(s, "unknown", "the failure sentinel must never come back as a usable stamp");
   assert.match(s, /^[0-9a-f]{16}$/);
   assert.equal(s, extractorStamp(), "memoized — the cost is paid once per process");
 });
@@ -273,10 +278,67 @@ test("the stamp moves for any module in the extractor directory, not just one", 
   assert.notEqual(stampDir(dir, ".js", "0.8.0"), beforeRename, "a rename at identical content is still a change");
 });
 
+/**
+ * The breadth tier's whole extraction is the `.scm` query — `queries/c.scm` decides
+ * which C nodes exist at all — and it lives in a SUBDIRECTORY with a non-module
+ * extension, so the module sweep above cannot see it. That meant fixing a query left
+ * the stamp identical, `readExtractCache` accepted every pre-fix entry, and the fix
+ * reached nobody until something else in graph/ happened to change.
+ */
+test("the stamp moves when a queries/*.scm changes, not just a module", () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-stamp-scm-"));
+  writeFileSync(join(dir, "extract.js"), "export const a = 1;\n");
+  const noQueries = stampDir(dir, ".js", "0.8.0");
+  assert.ok(noQueries, "a directory with modules has an identity");
+
+  mkdirSync(join(dir, "queries"), { recursive: true });
+  writeFileSync(join(dir, "queries", "c.scm"), "(function_definition) @definition.function\n");
+  const withQuery = stampDir(dir, ".js", "0.8.0");
+  assert.notEqual(withQuery, noQueries, "a query file is part of the extractor's identity");
+  assert.equal(stampDir(dir, ".js", "0.8.0"), withQuery, "stable for identical input");
+
+  writeFileSync(join(dir, "queries", "c.scm"), "(function_declarator) @definition.function\n");
+  const edited = stampDir(dir, ".js", "0.8.0");
+  assert.notEqual(edited, withQuery, "editing a query must invalidate every replayed parse");
+
+  writeFileSync(join(dir, "queries", "notes.txt"), "not a query\n");
+  assert.equal(stampDir(dir, ".js", "0.8.0"), edited, "a non-query file in queries/ must not churn the memo");
+
+  writeFileSync(join(dir, "queries", "cpp.scm"), "(class_specifier) @definition.class\n");
+  assert.notEqual(stampDir(dir, ".js", "0.8.0"), edited, "adding a query for another language counts too");
+});
+
+/**
+ * Every grammar is a `^` dependency, so `npm i` can swap the parser under an unchanged
+ * graft version. The stamp has to move with the grammar it actually loaded, or the memo
+ * replays parses the current parser would no longer produce.
+ */
+test("extractorStamp folds in the resolved grammar versions, not just graft's own", () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-stamp-grammar-"));
+  writeFileSync(join(dir, "extract.js"), "export const a = 1;\n");
+  const req = createRequire(import.meta.url);
+  const tsVersion = JSON.parse(
+    readFileSync(req.resolve("tree-sitter-typescript/package.json"), "utf8"),
+  ).version as string;
+
+  // computeStamp's `version` argument is `<graft version>|<grammar versions>`, so the
+  // grammar half moving must move the stamp exactly as graft's own version does.
+  const before = stampDir(dir, ".js", `0.8.0|tree-sitter-typescript@${tsVersion}`);
+  const after = stampDir(dir, ".js", `0.8.0|tree-sitter-typescript@${tsVersion}-bump`);
+  assert.notEqual(after, before, "a grammar upgrade under an unchanged graft version must invalidate");
+
+  // …and the real stamp really does carry them: the same modules + graft version alone
+  // would collide with the stamp computed from graft's own directory otherwise.
+  assert.match(extractorStamp()!, /^[0-9a-f]{16}$/);
+});
+
 test("a memo written by a different extractor is dropped, not replayed", async () => {
   const d = repo();
   await buildGraph(d);
   const path = extractCachePath(outOf(d));
+  // null here means the stamp failed and no memo was written at all — the test
+  // would then trivially "pass" on an empty cache it never planted anything in.
+  assert.ok(path, "a memo path is required for this test to have a memo to corrupt");
   const cache = JSON.parse(readFileSync(path, "utf8"));
   assert.ok(Object.keys(cache.files).length > 0);
 

--- a/test/graph-incremental.test.ts
+++ b/test/graph-incremental.test.ts
@@ -16,7 +16,7 @@ import { fingerprintPath, isClean, probeDrift, readFingerprint } from "../src/gr
 import { readAskIndex } from "../src/ask/index-file.js";
 import { readGraph, wiringPath } from "../src/graph/write.js";
 import type { GraphV1 } from "../src/graph/types.js";
-import { chmodDenialUnavailable } from "./helpers.js";
+import { chmodDenialUnavailable, rmDir } from "./helpers.js";
 
 const MATH = [
   "export function add(a: number, b: number): number {",
@@ -196,7 +196,7 @@ test("gitignored generated files stay out of the graph, fingerprint, and drift p
     writeFileSync(bundle, "export function generatedBundle(): number { return 2; }\n");
     assert.ok(isClean(probeDrift(d, outOf(d))!), "ignored output changes must not trigger a refresh");
   } finally {
-    rmSync(d, { recursive: true, force: true });
+    rmDir(d);
   }
 });
 

--- a/test/graph-invariants.test.ts
+++ b/test/graph-invariants.test.ts
@@ -18,6 +18,7 @@ import { readGraph, wiringPath } from "../src/graph/write.js";
 import { contextDirFor } from "../src/context/node-file.js";
 import { checkGraphInvariants } from "../src/graph/invariants.js";
 import type { GraphV1 } from "../src/graph/types.js";
+import { rmDir } from "./helpers.js";
 
 // A recursion-free fixture spanning both tiers: main→helper (TS, depth),
 // load→parse (Rust, breadth), Circle implements Shape (PHP, breadth → a
@@ -73,7 +74,7 @@ test("Tier-0: a built multi-tier graph satisfies every structural invariant", as
     assert.deepEqual(problems, [], `no invariant violations (got: ${problems.slice(0, 5).join("; ")})`);
     assert.equal(selfLoopCalls, 0, "a recursion-free fixture has no self-loop calls");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -122,7 +123,7 @@ test("Tier-0: the build is deterministic — two cold builds produce the identic
       assert.ok(g, "graph built");
       return g!;
     } finally {
-      rmSync(dir, { recursive: true, force: true });
+      rmDir(dir);
     }
   };
   // Two separate cold builds of byte-identical source (relative ids, so paths match).

--- a/test/graph-java.test.ts
+++ b/test/graph-java.test.ts
@@ -23,6 +23,7 @@ import { tmpdir } from "node:os";
 import { buildGraph } from "../src/graph/build.js";
 import { readGraph, wiringPath } from "../src/graph/write.js";
 import type { GraphV1, NodeV1 } from "../src/graph/types.js";
+import { rmDir } from "./helpers.js";
 
 const PKG = "src/main/java/com/acme";
 
@@ -135,7 +136,7 @@ test("Java extraction: classes, interfaces, enums, records, methods, constructor
     assert.equal(nodeById(graph!, `${APP_JAVA}#App.greet`)?.kind, "method");
     assert.equal(nodeById(graph!, `${APP_JAVA}#App.App`)?.kind, "method");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -163,7 +164,7 @@ test("Java extraction: visibility comes from the modifier list, not the name", a
       "package-private (no modifier) is not API surface",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -199,7 +200,7 @@ test("Java extraction: call edges — implicit `this`, typed field receiver, con
       "persist should have a constructor edge to Point",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -227,7 +228,7 @@ test("Java extraction: a `var` local states no type, so its member call stays un
       "the constructor edge still resolves, so the dependency is still visible",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -256,7 +257,7 @@ test("Java extraction: extends and implements", async () => {
       "App implements Greeter",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -280,7 +281,7 @@ test("Java extraction: imports resolve by package path; external types stay stri
       "java.util.List should remain an external type string",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -311,7 +312,7 @@ test("Java extraction: a static-member import resolves to its enclosing type", a
       "a static-member import should fall back to its enclosing type's file",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -344,7 +345,7 @@ test("Java extraction: an ambiguous package suffix stays unresolved rather than 
       "an ambiguous suffix must stay an unresolved specifier",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -407,7 +408,7 @@ test("Java overloads: a delegating call resolves to the other overload, not itse
       "and must not call itself",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -431,7 +432,7 @@ test("Java overloads: a variadic candidate is never filtered out by argument cou
       "a 3-argument call should still reach the variadic overload",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -451,6 +452,6 @@ test("Java overloads: same-arity overloads stay unresolved rather than guessing"
     assert.equal(a?.arity, 1);
     assert.equal(b?.arity, 1, "both render overloads have arity 1, so count cannot separate them");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });

--- a/test/graph-load.test.ts
+++ b/test/graph-load.test.ts
@@ -37,6 +37,19 @@ function node(id: string): NodeV1 {
   };
 }
 
+/** A wiring graph the loader would actually meet on disk. The fixtures here used
+ * to be `{ version: 1, nodes, edges } as GraphV1` — a top-level `version` field
+ * GraphV1 does not have, and no `meta` at all, which the cast hid: `writeGraph`
+ * spreads what it is given, so those tests were exercising the loader against a
+ * file no build can produce. */
+function graphOf(nodes: NodeV1[]): GraphV1 {
+  return {
+    meta: { version: 1, nodeCount: nodes.length, edgeCount: 0, languages: ["typescript"] },
+    nodes,
+    edges: [],
+  };
+}
+
 function fixtureDir(): string {
   return mkdtempSync(join(tmpdir(), "graft-load-"));
 }
@@ -51,7 +64,7 @@ function bump(path: string): void {
 
 test("loadGraphCached: two loads of an unchanged file return the same parsed object", () => {
   const dir = fixtureDir();
-  writeGraph({ version: 1, nodes: [node("a")], edges: [] } as GraphV1, dir);
+  writeGraph(graphOf([node("a")]), dir);
   __resetParseCounts();
 
   const g1 = loadGraphCached(dir);
@@ -63,7 +76,7 @@ test("loadGraphCached: two loads of an unchanged file return the same parsed obj
 
 test("loadGraphCached: rewriting the wiring file invalidates the cache", () => {
   const dir = fixtureDir();
-  writeGraph({ version: 1, nodes: [node("a")], edges: [] } as GraphV1, dir);
+  writeGraph(graphOf([node("a")]), dir);
   __resetParseCounts();
 
   const g1 = loadGraphCached(dir);
@@ -72,7 +85,7 @@ test("loadGraphCached: rewriting the wiring file invalidates the cache", () => {
 
   // Rewrite with a changed node, then force a distinct mtime so the cache
   // can't coast on a filesystem with coarse mtime granularity.
-  writeGraph({ version: 1, nodes: [node("b")], edges: [] } as GraphV1, dir);
+  writeGraph(graphOf([node("b")]), dir);
   bump(wiringPath(dir));
 
   const g2 = loadGraphCached(dir);
@@ -92,7 +105,7 @@ test("loadGraphCached: missing file returns null and a later-created file is pic
   const missAgain = loadGraphCached(dir);
   assert.equal(missAgain, null, "missing file must not be negatively cached forever");
 
-  writeGraph({ version: 1, nodes: [node("late")], edges: [] } as GraphV1, dir);
+  writeGraph(graphOf([node("late")]), dir);
   const found = loadGraphCached(dir);
   assert.equal(found?.nodes[0]?.id, "late");
   assert.equal(__parseCount.graph, 1);
@@ -100,7 +113,7 @@ test("loadGraphCached: missing file returns null and a later-created file is pic
 
 test("loadAskIndexCached: caches and invalidates the same way as the graph loader", () => {
   const dir = fixtureDir();
-  const graph = { version: 1, nodes: [node("a"), node("b")], edges: [] } as GraphV1;
+  const graph = graphOf([node("a"), node("b")]);
   writeAskIndex(dir, graph);
   __resetParseCounts();
 
@@ -110,7 +123,7 @@ test("loadAskIndexCached: caches and invalidates the same way as the graph loade
   assert.strictEqual(i1, i2);
   assert.equal(__parseCount.askIndex, 1);
 
-  writeAskIndex(dir, { version: 1, nodes: [node("a")], edges: [] } as GraphV1);
+  writeAskIndex(dir, graphOf([node("a")]));
   bump(askIndexPath(dir));
 
   const i3 = loadAskIndexCached(dir);
@@ -127,18 +140,14 @@ test("callTool: graft_trace_calls on the same dir twice doesn't reparse the grap
   const dir = fixtureDir();
   mkdirSync(join(dir, "src"), { recursive: true });
   writeFileSync(join(dir, "src", "math.ts"), "export function add() { return 1; }\n");
-  const graph: GraphV1 = {
-    version: 1,
-    // A real `buildGraph` always emits a `kind: "file"` node per source file;
-    // include one here too so `graft_trace_calls` with depth (a `resolveSymbol` +
-    // `edgeWalk` walk, the old `graft impact`) can resolve the filename-shaped
-    // query the way it would against a real build.
-    nodes: [
-      { ...node("src/math.ts#add"), path: "src/math.ts" },
-      { ...node("src/math.ts"), kind: "file", path: "src/math.ts", name: "math.ts", signature: null },
-    ],
-    edges: [],
-  } as GraphV1;
+  // A real `buildGraph` always emits a `kind: "file"` node per source file;
+  // include one here too so `graft_trace_calls` with depth (a `resolveSymbol` +
+  // `edgeWalk` walk, the old `graft impact`) can resolve the filename-shaped
+  // query the way it would against a real build.
+  const graph = graphOf([
+    { ...node("src/math.ts#add"), path: "src/math.ts" },
+    { ...node("src/math.ts"), kind: "file", path: "src/math.ts", name: "math.ts", signature: null },
+  ]);
   // graft_trace_calls reads through `contextDirFor(root)`, i.e. `<root>/graft`
   // by default — write the graph there directly rather than round-tripping
   // through a real `graft build`.

--- a/test/graph-python-imports.test.ts
+++ b/test/graph-python-imports.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Python imports resolving to in-repo modules.
+ *
+ * They were being run through the JS resolver, which is nonsense for every Python
+ * spelling there is: `posix.join("app", ".utils")` is `"app/.utils"`, so every
+ * candidate path it built was one that cannot exist and the resolver always fell
+ * through to "external string". Since `collectImportedSymbols` is TS-only there were
+ * no `references` edges either — meaning a Python repo's graph had containment and
+ * intra-file calls and NOT ONE edge between two files.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { extractFile } from "../src/graph/extract.js";
+import { resolveEdges } from "../src/graph/resolve.js";
+import { buildGraph } from "../src/graph/build.js";
+import { readGraph, wiringPath } from "../src/graph/write.js";
+import type { NodeV1 } from "../src/graph/types.js";
+import type { RawEdge } from "../src/graph/extract.js";
+import { tmpRepo } from "./helpers.js";
+
+/** Extract a whole fixture repo of .py files and resolve its edges. */
+function graphOf(files: Record<string, string>) {
+  const nodes: NodeV1[] = [];
+  const raw: RawEdge[] = [];
+  for (const [rel, src] of Object.entries(files)) {
+    const r = extractFile(rel, src, "python");
+    nodes.push(...r.nodes);
+    raw.push(...r.rawEdges);
+  }
+  return resolveEdges(nodes, raw);
+}
+
+const PKG: Record<string, string> = {
+  "app/__init__.py": "",
+  "app/core/__init__.py": "",
+  "app/core/db.py": "def connect():\n    return 1\n",
+  "app/utils.py": "def helper():\n    return 2\n",
+  "app/services/__init__.py": "",
+  "app/services/mailer.py": "def send():\n    return 3\n",
+  "app/services/orders.py": [
+    "from .mailer import send",        // sibling module in this package
+    "from ..utils import helper",      // one package up
+    "from ..core.db import connect",   // one package up, then down a package
+    "from . import mailer",            // the package itself
+    "from app.core import db",         // absolute, by dotted path
+    "import app.utils",                // absolute `import a.b`
+    "import os",                       // stdlib — nothing in-repo to point at
+    "from third_party.thing import x", // external
+    "",
+  ].join("\n"),
+};
+
+test("relative Python imports resolve to the module files they name", () => {
+  const targets = graphOf(PKG)
+    .filter((e) => e.relation === "imports" && e.source === "app/services/orders.py")
+    .map((e) => e.target)
+    .sort();
+
+  assert.ok(targets.includes("app/services/mailer.py"), "`from .mailer import send` → the sibling module");
+  assert.ok(targets.includes("app/utils.py"), "`from ..utils import helper` → one package up");
+  assert.ok(targets.includes("app/core/db.py"), "`from ..core.db import connect` → up then down");
+  assert.ok(
+    targets.includes("app/services/__init__.py"),
+    "`from . import mailer` names this package, whose file is its __init__.py",
+  );
+});
+
+test("absolute Python imports resolve by path suffix, since the sys.path root is unknown", () => {
+  const targets = graphOf(PKG)
+    .filter((e) => e.relation === "imports" && e.source === "app/services/orders.py")
+    .map((e) => e.target);
+
+  assert.ok(targets.includes("app/core/__init__.py"), "`from app.core import db` names the package");
+  assert.ok(targets.includes("app/utils.py"), "`import app.utils` names the module");
+  // Nothing in-repo is called `os` or `third_party`, so both stay raw strings — the
+  // resolver must never invent a file for an out-of-repo module.
+  assert.ok(targets.includes("os"), "stdlib stays an external string");
+  assert.ok(targets.includes("third_party.thing"), "a third-party module stays an external string");
+});
+
+test("a relative import that climbs past the repo root stays a string, never a guess", () => {
+  const edges = graphOf({
+    "a.py": "def f():\n    return 1\n",
+    "b.py": "from ...way.up import thing\n",
+  });
+  const targets = edges.filter((e) => e.relation === "imports" && e.source === "b.py").map((e) => e.target);
+  assert.deepEqual(targets, ["...way.up"]);
+});
+
+test("an ambiguous absolute module suffix is dropped rather than guessed", () => {
+  // Two in-repo files can end in `shared/conf.py`; nothing in `import shared.conf`
+  // says which, so — exactly like the Java and PHP resolvers — it stays a string.
+  const edges = graphOf({
+    "svc_a/shared/conf.py": "X = 1\n",
+    "svc_b/shared/conf.py": "X = 2\n",
+    "main.py": "import shared.conf\n",
+  });
+  const targets = edges.filter((e) => e.relation === "imports" && e.source === "main.py").map((e) => e.target);
+  assert.deepEqual(targets, ["shared.conf"]);
+});
+
+test("a built Python repo has real file→file import edges", async () => {
+  const d = tmpRepo("py-imports-");
+  mkdirSync(join(d, "app", "core"), { recursive: true });
+  writeFileSync(join(d, "app", "__init__.py"), "");
+  writeFileSync(join(d, "app", "core", "__init__.py"), "");
+  writeFileSync(join(d, "app", "core", "db.py"), "def connect():\n    return 1\n");
+  writeFileSync(join(d, "app", "main.py"), "from .core.db import connect\n\n\ndef run():\n    return connect()\n");
+
+  await buildGraph(d, { reuse: false });
+  const graph = readGraph(wiringPath(join(d, "graft")))!;
+  assert.ok(
+    graph.edges.some(
+      (e) => e.source === "app/main.py" && e.target === "app/core/db.py" && e.relation === "imports",
+    ),
+    `main.py must import core/db.py (got ${JSON.stringify(graph.edges.filter((e) => e.relation === "imports"))})`,
+  );
+});

--- a/test/graph-refresh.test.ts
+++ b/test/graph-refresh.test.ts
@@ -220,9 +220,13 @@ test("GRAFT_REFRESH=hash: drift the probe reports is drift the rebuild repairs",
   const staleHash = fp.files["src/math.ts"][2];
   fp.files["src/math.ts"] = [now.size, now.mtimeMs, staleHash];
   writeFileSync(fingerprintPath(outOf(d)), JSON.stringify(fp));
-  const memo = JSON.parse(readFileSync(extractCachePath(outOf(d)), "utf8"));
+  // null when no extractor stamp could be computed, i.e. no memo exists — the
+  // stat-trusting rebuild this test provokes could then never happen.
+  const memoPath = extractCachePath(outOf(d));
+  assert.ok(memoPath, "the memo the rebuild must not trust has to exist for the test to mean anything");
+  const memo = JSON.parse(readFileSync(memoPath, "utf8"));
   Object.assign(memo.files["src/math.ts"], { size: now.size, mtimeMs: now.mtimeMs });
-  writeFileSync(extractCachePath(outOf(d)), JSON.stringify(memo));
+  writeFileSync(memoPath, JSON.stringify(memo));
 
   // Nobody notices without the flag — that's the documented trade-off, and the
   // whole reason the flag exists.

--- a/test/graph-resolve-typed.test.ts
+++ b/test/graph-resolve-typed.test.ts
@@ -133,6 +133,68 @@ test("unresolved member calls cannot inflate map hubs and hotspots (#35)", () =>
   assert.equal(set?.inDegree, 1, "only the owner-qualified FileBindings.set call contributes");
 });
 
+/**
+ * `classParents` used to be keyed by the declaring class's BARE NAME, which fuses the
+ * hierarchies of two same-named classes in different packages: `a/Base` extending `Foo`
+ * and `b/Base` extending `Bar` became `Base → [Foo, Bar]`. A `base.handle()` in package
+ * a then climbed into package b's `Bar.handle` and shipped it as an `inferred` call
+ * edge. `Base`, `Client`, `Config`, `Handler` repeated across modules is ordinary, and
+ * crossing between them silently is exactly the guess the rest of resolve.ts refuses.
+ */
+test("homonymous classes in different packages do not share an inheritance chain", () => {
+  const nodes = [
+    n("a/Base.java", "file"), n("a/Base.java#Base", "class"),
+    n("a/Foo.java", "file"), n("a/Foo.java#Foo", "class"), n("a/Foo.java#Foo.handle", "method"),
+    n("b/Base.java", "file"), n("b/Base.java#Base", "class"),
+    n("b/Bar.java", "file"), n("b/Bar.java#Bar", "class"), n("b/Bar.java#Bar.handle", "method"),
+    n("a/Use.java", "file"), n("a/Use.java#use", "method"),
+  ];
+  const raw: RawEdge[] = [
+    { source: "a/Base.java#Base", relation: "extends", name: "Foo", file: "a/Base.java" },
+    { source: "b/Base.java#Base", relation: "extends", name: "Bar", file: "b/Base.java" },
+    // The call site is in package a, but `Base` is ambiguous across the repo, so there
+    // is no honest answer about whose hierarchy to climb.
+    { source: "a/Use.java#use", relation: "calls", name: "handle", viaMember: true, recvType: "Base", file: "a/Use.java" },
+  ];
+  const calls = resolveEdges(nodes, raw).filter((e) => e.relation === "calls");
+  assert.deepEqual(calls, [], "an ambiguous receiver type must stop the climb, not pick a package");
+});
+
+test("an unambiguous inherited method still resolves through a same-file superclass", () => {
+  // The guard above must not cost recall: when the receiver type resolves to exactly
+  // one class, its own `extends` chain is walked exactly as before.
+  const nodes = [
+    n("a/Base.java", "file"), n("a/Base.java#Base", "class"),
+    n("a/Foo.java", "file"), n("a/Foo.java#Foo", "class"), n("a/Foo.java#Foo.handle", "method"),
+    n("a/Use.java", "file"), n("a/Use.java#use", "method"),
+  ];
+  const raw: RawEdge[] = [
+    { source: "a/Base.java#Base", relation: "extends", name: "Foo", file: "a/Base.java" },
+    { source: "a/Use.java#use", relation: "calls", name: "handle", viaMember: true, recvType: "Base", file: "a/Use.java" },
+  ];
+  const call = resolveEdges(nodes, raw).find((e) => e.relation === "calls");
+  assert.equal(call?.target, "a/Foo.java#Foo.handle");
+});
+
+test("a homonym beside the CALLER cannot hijack an inherited method", () => {
+  // `pkg/Widget` extends `Base`; the call site lives in another package that declares
+  // its own unrelated `Base`. Climbing to the "same file as the caller" candidate would
+  // hand back `other`'s `draw` for a receiver that has nothing to do with it. Two
+  // `Base`s and no way to tell which one `Widget` meant is a drop, not a coin toss.
+  const nodes = [
+    n("pkg/Widget.java", "file"), n("pkg/Widget.java#Widget", "class"),
+    n("pkg/Base.java", "file"), n("pkg/Base.java#Base", "class"), n("pkg/Base.java#Base.draw", "method"),
+    n("other/Use.java", "file"), n("other/Use.java#Base", "class"), n("other/Use.java#Base.draw", "method"),
+    n("other/Use.java#use", "method"),
+  ];
+  const raw: RawEdge[] = [
+    { source: "pkg/Widget.java#Widget", relation: "extends", name: "Base", file: "pkg/Widget.java" },
+    { source: "other/Use.java#use", relation: "calls", name: "draw", viaMember: true, recvType: "Widget", file: "other/Use.java" },
+  ];
+  const calls = resolveEdges(nodes, raw).filter((e) => e.relation === "calls");
+  assert.deepEqual(calls.map((e) => e.target), [], "the caller's own Base is not evidence about Widget's");
+});
+
 // A2: resolve.ts used to derive ownerMethod/classParents keys by slicing `n.id`,
 // which breaks once ids can carry a dedup ordinal (A3). extract.ts now stamps a
 // `owner` field at mint time instead; these tests pin the field's contract and

--- a/test/graph-scopes.test.ts
+++ b/test/graph-scopes.test.ts
@@ -15,6 +15,7 @@ import { readGraph, wiringPath, writeGraph } from "../src/graph/write.js";
 import { loadGraphCached } from "../src/graph/load.js";
 import { writeBuildConfig } from "../src/util/state.js";
 import type { GraphV1 } from "../src/graph/types.js";
+import { rmDir } from "./helpers.js";
 
 function fx(layout: Record<string, string>): string {
   const dir = mkdtempSync(join(tmpdir(), "scopes-"));
@@ -34,7 +35,7 @@ test("frontend/backend markers under one git root -> two scopes", () => {
   assert.deepEqual(scopes.map((s) => s.prefix).sort(), ["backend", "frontend"]);
   assert.equal(scopeOf("frontend/src/app.ts", scopes).label, "frontend");
   assert.equal(scopeOf("README.md", scopes).prefix, "");  // root scope always exists as fallback
-  rmSync(d, { recursive: true, force: true });
+  rmDir(d);
 });
 
 test("workspace globs are intent: packages/* honored, deeper ignored", () => {
@@ -46,7 +47,7 @@ test("workspace globs are intent: packages/* honored, deeper ignored", () => {
   });
   const prefixes = discoverScopes(d).map((s) => s.prefix).sort();
   assert.deepEqual(prefixes, ["packages/cli", "packages/core"]);
-  rmSync(d, { recursive: true, force: true });
+  rmDir(d);
 });
 
 test("gitignored generated workspace directories cannot become scopes (#39)", () => {
@@ -62,7 +63,7 @@ test("gitignored generated workspace directories cannot become scopes (#39)", ()
     execFileSync("git", ["init", "-q"], { cwd: d });
     assert.deepEqual(discoverScopes(d).map((s) => s.prefix), ["packages/app"]);
   } finally {
-    rmSync(d, { recursive: true, force: true });
+    rmDir(d);
   }
 });
 
@@ -70,19 +71,19 @@ test("root-only marker -> canonical single scope", () => {
   const d = fx({ "package.json": "{}", "src/a.ts": "1" });
   const scopes = discoverScopes(d);
   assert.deepEqual(scopes, [{ prefix: "", label: "", markers: ["package.json"] }]);
-  rmSync(d, { recursive: true, force: true });
+  rmDir(d);
 });
 
 test("depth guard: markers 3 levels down ignored without workspace glob", () => {
   const d = fx({ "a/b/c/package.json": "{}", "src/x.ts": "1" });
   assert.equal(discoverScopes(d).length, 1); // root only
-  rmSync(d, { recursive: true, force: true });
+  rmDir(d);
 });
 
 test("nesting collapse keeps shallower candidate", () => {
   const d = fx({ "svc/package.json": "{}", "svc/sub/package.json": "{}", "svc/i.ts": "1" });
   assert.deepEqual(discoverScopes(d).filter((s) => s.prefix).map((s) => s.prefix), ["svc"]);
-  rmSync(d, { recursive: true, force: true });
+  rmDir(d);
 });
 
 test("nesting collapse is layout-deterministic regardless of sibling readdir order (P10)", () => {
@@ -103,7 +104,7 @@ test("nesting collapse is layout-deterministic regardless of sibling readdir ord
         .map((s) => s.prefix)
         .sort();
     } finally {
-      rmSync(d, { recursive: true, force: true });
+      rmDir(d);
     }
   };
   // Normalize the sibling's own name away so the two runs compare structurally:
@@ -126,7 +127,7 @@ test("literal (non-glob) workspace entry resolves as a workspace match", () => {
   });
   const prefixes = discoverScopes(d).map((s) => s.prefix).sort();
   assert.deepEqual(prefixes, ["apps/web", "docs"]);
-  rmSync(d, { recursive: true, force: true });
+  rmDir(d);
 });
 
 test("workspace-under-workspace collapses to the shallower scope (packages/**)", () => {
@@ -137,7 +138,7 @@ test("workspace-under-workspace collapses to the shallower scope (packages/**)",
   });
   const prefixes = discoverScopes(d).map((s) => s.prefix).sort();
   assert.deepEqual(prefixes, ["packages/a"]);
-  rmSync(d, { recursive: true, force: true });
+  rmDir(d);
 });
 
 test("workspace-under-workspace collapse also sweeps markerless dirs under a **-glob", () => {
@@ -148,7 +149,7 @@ test("workspace-under-workspace collapse also sweeps markerless dirs under a **-
   });
   const prefixes = discoverScopes(d).map((s) => s.prefix).sort();
   assert.deepEqual(prefixes, ["packages/a"]); // no markerless packages/a/src* survives
-  rmSync(d, { recursive: true, force: true });
+  rmDir(d);
 });
 
 test("literal + glob workspace overlap collapses to the shallower literal entry", () => {
@@ -159,7 +160,7 @@ test("literal + glob workspace overlap collapses to the shallower literal entry"
   });
   const prefixes = discoverScopes(d).map((s) => s.prefix).sort();
   assert.deepEqual(prefixes, ["apps"]);
-  rmSync(d, { recursive: true, force: true });
+  rmDir(d);
 });
 
 test("discoverWorkspaceChildren finds immediate git children only", () => {
@@ -168,7 +169,7 @@ test("discoverWorkspaceChildren finds immediate git children only", () => {
   mkdirSync(join(d, "repoB/.git"), { recursive: true });
   mkdirSync(join(d, "repoB/vendored/.git"), { recursive: true }); // nested: not a child of d
   assert.deepEqual(discoverWorkspaceChildren(d).sort(), ["repoA", "repoB"]);
-  rmSync(d, { recursive: true, force: true });
+  rmDir(d);
 });
 
 test("A5: discoverScopes finds a marker under a SKIP_DIRS name once persisted via --include-dir state, absent otherwise", () => {
@@ -178,7 +179,7 @@ test("A5: discoverScopes finds a marker under a SKIP_DIRS name once persisted vi
   writeBuildConfig(d, { includeDirs: ["build"] });
   const prefixes = discoverScopes(d).map((s) => s.prefix);
   assert.deepEqual(prefixes, ["build"], "once persisted, build/'s own marker is discovered as a scope");
-  rmSync(d, { recursive: true, force: true });
+  rmDir(d);
 });
 
 function tsFns(n: number): string {
@@ -205,7 +206,7 @@ test("buildGraph wires meta.scopes: substantial scopes survive, tiny scopes merg
     const prefixes = (graph!.meta.scopes ?? []).map((s) => s.prefix).sort();
     assert.deepEqual(prefixes, ["backend", "frontend"]); // tiny (1 symbol) merged into root
   } finally {
-    rmSync(d, { recursive: true, force: true });
+    rmDir(d);
   }
 });
 
@@ -226,6 +227,6 @@ test("old graphs without meta.scopes fall back to the canonical root scope via s
     assert.deepEqual(scopes, [{ prefix: "", label: "", markers: [] }]);
     assert.equal(scopeOf("anything/at/all.ts", scopes).prefix, "");
   } finally {
-    rmSync(d, { recursive: true, force: true });
+    rmDir(d);
   }
 });

--- a/test/graph-seed.test.ts
+++ b/test/graph-seed.test.ts
@@ -22,7 +22,7 @@ import { ensureFreshGraph, refreshNote } from "../src/graph/refresh.js";
 import { mainWorktreeRoot, seedGraph } from "../src/graph/seed.js";
 import { readGraph, wiringPath } from "../src/graph/write.js";
 import { callTool } from "../src/mcp/tools.js";
-import { tmpRepo } from "./helpers.js";
+import { tmpRepo, rmDir } from "./helpers.js";
 
 const MATH = "export function add(a: number, b: number): number {\n  return a + b;\n}\n";
 const MUL = "export function mul(a: number, b: number): number {\n  return a * b;\n}\n";
@@ -212,8 +212,8 @@ test("a git worktree starts with no graph, and one query gives it a correct one"
   // Seeding reads the parent; it must never write to it.
   assert.equal(readFileSync(wiringPath(outOf(main)), "utf8"), parentGraph, "parent graph untouched");
 
-  rmSync(main, { recursive: true, force: true });
-  rmSync(wt, { recursive: true, force: true });
+  rmDir(main);
+  rmDir(wt);
 });
 
 test("a worktree nested inside the repo is seeded too, and isn't double-indexed", async () => {
@@ -238,7 +238,7 @@ test("a worktree nested inside the repo is seeded too, and isn't double-indexed"
     "the parent must not index the worktree's copy of its own files",
   );
 
-  rmSync(main, { recursive: true, force: true });
+  rmDir(main);
 });
 
 test("the MCP tool answers from a seeded worktree instead of refusing", async () => {
@@ -251,8 +251,8 @@ test("the MCP tool answers from a seeded worktree instead of refusing", async ()
   assert.doesNotMatch(res.text, /no graph found/);
   assert.match(res.text, /math\.ts/);
 
-  rmSync(main, { recursive: true, force: true });
-  rmSync(wt, { recursive: true, force: true });
+  rmDir(main);
+  rmDir(wt);
 });
 
 test("GRAFT_NO_SEED leaves the worktree exactly as it was", async () => {
@@ -275,8 +275,8 @@ test("GRAFT_NO_SEED leaves the worktree exactly as it was", async () => {
     delete process.env.GRAFT_NO_SEED;
   }
 
-  rmSync(main, { recursive: true, force: true });
-  rmSync(wt, { recursive: true, force: true });
+  rmDir(main);
+  rmDir(wt);
 });
 
 test("seedGraph declines a --dir override and a checkout that already has a graph", async () => {
@@ -311,8 +311,8 @@ test("seedGraph declines a --dir override and a checkout that already has a grap
   assert.ok(!landed.includes("stats.json"), `borrowed savings do not — ${why}`);
   assert.ok(!landed.includes("session"), `another session's transcripts do not — ${why}`);
 
-  rmSync(main, { recursive: true, force: true });
-  rmSync(wt, { recursive: true, force: true });
+  rmDir(main);
+  rmDir(wt);
 });
 
 test("a plain repo with no parent checkout is left to `graft build`", async () => {
@@ -320,7 +320,7 @@ test("a plain repo with no parent checkout is left to `graft build`", async () =
   const r = await ensureFreshGraph(solo);
   assert.equal(existsSync(wiringPath(outOf(solo))), false, "no surprise full build under a query");
   assert.equal(refreshNote(r), null);
-  rmSync(solo, { recursive: true, force: true });
+  rmDir(solo);
 });
 
 test("`graft build` in a worktree starts from the parent's graph, not from scratch", async () => {
@@ -336,6 +336,6 @@ test("`graft build` in a worktree starts from the parent's graph, not from scrat
   assert.equal(g.parsed, 1, "only the file this checkout changed was re-parsed");
   assert.ok(g.cards > 0, "and the passive surface is rebuilt for this checkout");
 
-  rmSync(main, { recursive: true, force: true });
-  rmSync(wt, { recursive: true, force: true });
+  rmDir(main);
+  rmDir(wt);
 });

--- a/test/graph-source-files.test.ts
+++ b/test/graph-source-files.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Which files a build parses — specifically, that excluding the output directory does
+ * not also exclude its neighbours.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { listSourceFiles } from "../src/graph/source-files.js";
+import { buildGraph } from "../src/graph/build.js";
+import { checkGraph } from "../src/graph/check.js";
+import { readGraph, wiringPath } from "../src/graph/write.js";
+import { tmpRepo } from "./helpers.js";
+
+/**
+ * `!f.startsWith(outDir)` has no segment boundary, so with the default outDir
+ * `<root>/graft` it also swallowed `graft-tools/`, `graftlib/`, `graft.config.ts` —
+ * silently, with no error and no warning. `util/paths.ts#pathUnderPrefix` documents
+ * exactly this class of bug ("'frontend' would match 'frontend-utils'") and fixes it
+ * there; it had simply never reached here.
+ */
+test("the output dir is excluded, but not a sibling whose name merely starts with it", () => {
+  const root = resolve("/repo");
+  const outDir = join(root, "graft");
+  const files = [
+    join(outDir, "wiring.ts"),
+    join(root, "graft-tools", "a.ts"),
+    join(root, "graftlib", "b.ts"),
+    join(root, "src", "c.ts"),
+  ];
+  assert.deepEqual(listSourceFiles(root, outDir, files), [
+    join(root, "graft-tools", "a.ts"),
+    join(root, "graftlib", "b.ts"),
+    join(root, "src", "c.ts"),
+  ]);
+});
+
+test("a relative outDir still excludes the output dir, and only it", () => {
+  // `contextDirFor` resolves its override now, but this stays the defence in depth
+  // for the value arriving relative anyway (a direct library caller, a future path
+  // that skips contextDirFor): compared unresolved against the walker's absolute
+  // paths it never matches, and the output directory becomes part of the source set.
+  const root = process.cwd();
+  const files = [join(root, "graft", "wiring.ts"), join(root, "graft-tools", "a.ts")];
+  assert.deepEqual(listSourceFiles(root, "graft", files), [join(root, "graft-tools", "a.ts")]);
+});
+
+/**
+ * `-e/--extensions` says "only include these code extensions". It reached the concept
+ * pass only, so the wiring graph — the thing every query actually answers from — kept
+ * indexing every language graft has a grammar for, and a user who narrowed a build to
+ * `.ts` still got Python nodes back from `ask`/`grep`/`callers`.
+ */
+test("-e narrows the file set, normalizing a bare/upper-case extension", () => {
+  const root = resolve("/repo");
+  const outDir = join(root, "graft");
+  const files = [join(root, "a.ts"), join(root, "b.py"), join(root, "c.rs")];
+  assert.deepEqual(listSourceFiles(root, outDir, files, [".ts"]), [join(root, "a.ts")]);
+  assert.deepEqual(listSourceFiles(root, outDir, files, ["py", ".RS"]).sort(), [
+    join(root, "b.py"),
+    join(root, "c.rs"),
+  ].sort());
+  // Absent and empty both mean "everything": commander hands `[]` for a variadic
+  // option nobody passed, and reading that as "index nothing" would turn a missing
+  // flag into an empty graph.
+  assert.equal(listSourceFiles(root, outDir, files, []).length, 3);
+  assert.equal(listSourceFiles(root, outDir, files).length, 3);
+});
+
+test("a build under -e indexes only those extensions, and a check under the same -e sees no drift", async () => {
+  const d = tmpRepo("sourcefiles-ext-");
+  mkdirSync(join(d, "src"), { recursive: true });
+  writeFileSync(join(d, "src", "app.ts"), "export function fromTs(): number {\n  return 1;\n}\n");
+  writeFileSync(join(d, "src", "app.py"), "def from_py():\n    return 2\n");
+
+  await buildGraph(d, { reuse: false, extensions: [".ts"] });
+  const graph = readGraph(wiringPath(join(d, "graft")))!;
+  assert.ok(graph.nodes.some((n) => n.id === "src/app.ts#fromTs"), "the named extension is indexed");
+  assert.ok(!graph.nodes.some((n) => n.path.endsWith(".py")), "and nothing else is");
+
+  // The two halves have to agree: a check that enumerated every language would find
+  // the .py definitions missing from the committed graph and report them as `added`
+  // — permanent phantom drift on a build the user narrowed deliberately.
+  const narrowed = await checkGraph(d, { extensions: [".ts"] });
+  assert.equal(narrowed.ok, true, JSON.stringify(narrowed));
+  const wide = await checkGraph(d);
+  assert.ok(wide.added.some((id) => id.startsWith("src/app.py")), "…and without the flag the drift is real");
+});
+
+test("a directory next to the output dir is really indexed by a build", async () => {
+  const d = tmpRepo("sourcefiles-sibling-");
+  mkdirSync(join(d, "graft-tools"), { recursive: true });
+  mkdirSync(join(d, "src"), { recursive: true });
+  writeFileSync(join(d, "graft-tools", "gen.ts"), "export function fromSibling(): number {\n  return 1;\n}\n");
+  writeFileSync(join(d, "src", "app.ts"), "export function fromSrc(): number {\n  return 2;\n}\n");
+
+  await buildGraph(d, { reuse: false });
+  const graph = readGraph(wiringPath(join(d, "graft")))!;
+  assert.ok(
+    graph.nodes.some((n) => n.id === "graft-tools/gen.ts#fromSibling"),
+    "a sibling of the output dir must be indexed like any other directory",
+  );
+  assert.ok(!graph.nodes.some((n) => n.path.startsWith("graft/")), "the output dir itself is still excluded");
+});

--- a/test/graph-sources-retention.test.ts
+++ b/test/graph-sources-retention.test.ts
@@ -1,0 +1,75 @@
+/**
+ * `buildGraph`'s `sources` map exists for one consumer: the Tier-2 meaning pass. It was
+ * filled unconditionally, so a Tier-1 build — the default, and every pre-query refresh —
+ * held the whole repo's text in memory for the length of the build and handed it to a
+ * function that returns before reading it. JS strings are UTF-16, so a 200 MB monorepo
+ * pinned roughly 400 MB for nothing, on every query that saw drift.
+ *
+ * The saving itself is invisible from outside, which is exactly why the guarded path
+ * needs pinning: the map must still be complete whenever a summarizer IS present, and
+ * a Tier-1 build's output must be unchanged.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { buildGraph } from "../src/graph/build.js";
+import { readGraph, wiringPath } from "../src/graph/write.js";
+import type { CruxSummarizer, FileCruxInput, NodeCrux } from "../src/ai/crux.js";
+import { tmpRepo } from "./helpers.js";
+
+/** Records exactly what source text the meaning pass was handed, per file. */
+class RecordingSummarizer implements CruxSummarizer {
+  readonly seen = new Map<string, string>();
+  async describeFile(input: FileCruxInput): Promise<NodeCrux[]> {
+    this.seen.set(input.path, input.source);
+    return input.nodes.map((n) => ({ id: n.id, summary: `about ${n.id}`, crux_start: 0, crux_end: 0 }));
+  }
+}
+
+function fixture(tag: string): string {
+  const d = tmpRepo(tag);
+  mkdirSync(join(d, "src"), { recursive: true });
+  writeFileSync(join(d, "src", "a.ts"), "export function alpha(): number {\n  return 1;\n}\n");
+  writeFileSync(join(d, "src", "b.py"), "def beta():\n    return 2\n");
+  return d;
+}
+
+test("with a summarizer, every parsed file's source still reaches the meaning pass", async () => {
+  const d = fixture("sources-tier2-");
+  const summarizer = new RecordingSummarizer();
+  await buildGraph(d, { reuse: false, summarizer });
+
+  assert.deepEqual([...summarizer.seen.keys()].sort(), ["src/a.ts", "src/b.py"]);
+  assert.match(summarizer.seen.get("src/a.ts")!, /export function alpha/);
+  assert.match(summarizer.seen.get("src/b.py")!, /def beta/);
+
+  const graph = readGraph(wiringPath(join(d, "graft")))!;
+  assert.ok(
+    graph.nodes.some((n) => n.summary_state === "ready" && n.summary?.startsWith("about ")),
+    "the summaries really were written",
+  );
+});
+
+test("a file replayed from the extraction cache still reaches the meaning pass", async () => {
+  // The reuse branch has its own `sources.set` — the memo skips the PARSE, never the
+  // read — so a Tier-2 build on an already-built repo must summarize just the same.
+  const d = fixture("sources-tier2-reuse-");
+  await buildGraph(d);
+  const summarizer = new RecordingSummarizer();
+  const r = await buildGraph(d, { summarizer });
+  assert.ok(r.reused > 0, "the second build must actually be replaying from the memo");
+  assert.deepEqual([...summarizer.seen.keys()].sort(), ["src/a.ts", "src/b.py"]);
+});
+
+test("a Tier-1 build produces the same graph as a Tier-2 one, minus the meaning layer", async () => {
+  const plain = fixture("sources-tier1-");
+  const enriched = fixture("sources-tier1-ref-");
+  const a = await buildGraph(plain, { reuse: false });
+  const b = await buildGraph(enriched, { reuse: false, summarizer: new RecordingSummarizer() });
+
+  assert.equal(a.nodes, b.nodes);
+  assert.equal(a.edges, b.edges);
+  assert.deepEqual(a.byKind, b.byKind);
+  assert.deepEqual(a.errors, []);
+});

--- a/test/graph-traverse-cli.test.ts
+++ b/test/graph-traverse-cli.test.ts
@@ -116,7 +116,12 @@ function ambiguousRepo(): string {
   writeFileSync(join(d, 'src', 'b.ts'), 'export function shared(): number {\n  return 2;\n}\n');
   // A cross-file call to the ambiguous name — resolve.ts drops it rather than
   // guessing which `shared` it means, so NEITHER definition gets a caller edge.
-  writeFileSync(join(d, 'src', 'user.ts'), 'import { shared } from "./a.js";\nexport function use(): number {\n  return shared();\n}\n');
+  //
+  // Deliberately NO import statement. A named import states which module the callee
+  // came from, and resolve.ts now resolves inside that file alone — which makes the
+  // call unambiguous and defeats the very fixture this test needs. An unimported bare
+  // call is the case that genuinely has nothing to go on but the name.
+  writeFileSync(join(d, 'src', 'user.ts'), 'declare function shared(): number;\nexport function use(): number {\n  return shared();\n}\n');
   execFileSync(process.execPath, ['--import', 'tsx', 'src/cli.ts', 'build', d], { stdio: 'pipe' });
   return d;
 }

--- a/test/graph-traverse.test.ts
+++ b/test/graph-traverse.test.ts
@@ -151,6 +151,19 @@ test("resolveSymbol: file nodes are matched as a last resort for filename-shaped
   assert.deepEqual(matches.map((n) => n.id), ["src/file.ts"]);
 });
 
+test("resolveSymbol: a filename query is matched with native separators too", () => {
+  const g = baseGraph();
+  // `graft_trace_calls`'s schema says "a file path also works", and on Windows the
+  // path an agent has in hand (from a tool result, or from tab-completion) is
+  // `src\file.ts` — which matched no `node.path` at all and read as "symbol not
+  // found". `join` rather than a literal `\`, for the same reason the `--in` test
+  // above uses it: normalization is keyed to the platform separator.
+  assert.deepEqual(
+    resolveSymbol(g, join("src", "file.ts")).map((n) => n.id),
+    ["src/file.ts"],
+  );
+});
+
 test("resolveSymbol: unknown symbol returns empty array", () => {
   const g = baseGraph();
   assert.deepEqual(resolveSymbol(g, "NoSuchSymbol"), []);
@@ -226,7 +239,10 @@ test("callersOf / calleesOf: no edges → empty array", () => {
 
 // ── impactOf ─────────────────────────────────────────────────────────────
 
-function diamondGraph(): GraphV1 {
+/** The graph plus the seed node every caller walks from — declared as the pair it
+ * returns. It used to claim `GraphV1` and then double-cast the pair back, so the
+ * annotation and the value disagreed and neither side was checked. */
+function diamondGraph(): { node: NodeV1; graph: GraphV1 } {
   const X = nodeStub({ id: "X", name: "X" });
   const A = nodeStub({ id: "A", name: "A" });
   const B = nodeStub({ id: "B", name: "B" });
@@ -237,7 +253,7 @@ function diamondGraph(): GraphV1 {
       [X, A, B, C],
       [edge("A", "X", "calls"), edge("B", "X", "calls"), edge("C", "A", "calls"), edge("C", "B", "calls")],
     ),
-  } as unknown as { node: NodeV1; graph: GraphV1 };
+  };
 }
 
 test("impactOf: BFS over incoming edges, diamond converges to one hit, deduped at min depth", () => {

--- a/test/graph-workspace-include-dir.test.ts
+++ b/test/graph-workspace-include-dir.test.ts
@@ -19,6 +19,7 @@ import { buildGraph } from "../src/graph/build.js";
 import { readGraph, wiringPath } from "../src/graph/write.js";
 import { writeBuildConfig } from "../src/util/state.js";
 import type { GraphV1 } from "../src/graph/types.js";
+import { rmDir } from "./helpers.js";
 
 function workspaceWithBuildDirs(): string {
   const parent = mkdtempSync(join(tmpdir(), "ws-include-dir-"));
@@ -60,7 +61,7 @@ test("A5: --include-dir on a workspace build reaches every child, which persists
       "child's own persisted include-dir state must survive a no-flag rebuild",
     );
   } finally {
-    rmSync(parent, { recursive: true, force: true });
+    rmDir(parent);
   }
 });
 
@@ -80,6 +81,6 @@ test("A5: a skipped-name workspace child remains discoverable on a later no-flag
     assert.deepEqual(workspace.children, ["app", "build"]);
     assert.equal(readFileSync(join(parent, ".graft", "config.json"), "utf8").includes("build"), true);
   } finally {
-    rmSync(parent, { recursive: true, force: true });
+    rmDir(parent);
   }
 });

--- a/test/graph-write.test.ts
+++ b/test/graph-write.test.ts
@@ -15,6 +15,7 @@ import { buildGraph } from "../src/graph/build.js";
 import { writeGraph, readGraph, wiringPath } from "../src/graph/write.js";
 import { contextDirFor } from "../src/context/node-file.js";
 import type { GraphV1, NodeV1 } from "../src/graph/types.js";
+import { rmDir } from "./helpers.js";
 
 function makeNode(overrides: Partial<NodeV1> = {}): NodeV1 {
   return {
@@ -71,7 +72,7 @@ test("writeGraph strips body_text from the serialized node but keeps every other
     assert.equal(reread!.nodes[0].body_text, undefined);
     assertUniqueIds(graph.nodes);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -89,7 +90,7 @@ test("writeGraph does not mutate the in-memory node — build.ts's sidecar pass 
     assert.equal(graph.nodes[0].body_text, "untouched body text", "graph.nodes must still reference the live object");
     assertUniqueIds(graph.nodes);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -108,7 +109,7 @@ test("a node with no body_text (e.g. a file node) round-trips unchanged", () => 
     assert.equal(raw.nodes[0].kind, "file");
     assertUniqueIds(graph.nodes);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -139,7 +140,7 @@ test("buildGraph: the serialized wiring.json has no body_text key on ANY node", 
     }
     assertUniqueIds(parsed.nodes);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -158,6 +159,6 @@ test("A3 PERMANENT gate: duplicate-named definitions still produce unique node i
     const ids = graph!.nodes.map((n) => n.id);
     assert.ok(ids.includes("dup.ts#helper") && ids.includes("dup.ts#helper~2"), "sanity: the dup actually minted an ordinal id");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });

--- a/test/graphrank.test.ts
+++ b/test/graphrank.test.ts
@@ -17,6 +17,7 @@ import { buildGraph } from "../src/graph/build.js";
 import { ask } from "../src/ask/ask.js";
 import { personalizedPageRank } from "../src/ask/graphrank.js";
 import type { GraphV1, NodeV1, EdgeV1, Relation } from "../src/graph/types.js";
+import { rmDir } from "./helpers.js";
 
 // ── Unit: personalizedPageRank ───────────────────────────────────────────────
 
@@ -209,7 +210,7 @@ test("ask (graphRank off): pure lexical does not favour the connected hit", asyn
       "without graph-rank the connected hit gets no ranking advantage",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -223,7 +224,7 @@ test("ask (graphRank on): connected hit outranks the isolated collision", async 
     assert.ok(iHandler >= 0 && iWidget >= 0, "both same-word hits still present");
     assert.ok(iHandler < iWidget, "the graph-connected fooHandler ranks above isolated fooWidget");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -239,7 +240,7 @@ test("ask (graphRank on): a strongly-connected neighbour is rescued in", async (
       "a helper the query never named is rescued via connectivity",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -251,6 +252,6 @@ test("ask: graph-rank is on by default (same as graphRank:true)", async () => {
     const on = ask(dir, "foo", { graphRank: true }).hits.map((h) => h.title);
     assert.deepEqual(def, on, "default ordering equals explicit graphRank:true");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -7,7 +7,7 @@
  * than being hand-rolled per file because both carry a platform trap that is
  * invisible until CI runs on Windows: see {@link tmpRepo} and {@link homeEnv}.
  */
-import { mkdtempSync, realpathSync } from "node:fs";
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
 import { spawnSync, type SpawnSyncReturns } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -29,6 +29,25 @@ import type { Summarizer, Synthesizer, SynthNode, SynthLink, FileSummary } from 
  */
 export function tmpRepo(tag: string): string {
   return realpathSync.native(mkdtempSync(join(tmpdir(), `graft-${tag}-`)));
+}
+
+/**
+ * Delete a scratch directory — the `finally` half of {@link tmpRepo}.
+ *
+ * The retries are the point, and they are a Windows trap of the same family as
+ * the one above. POSIX unlinks a path immediately even while a handle is open;
+ * Windows only *marks* the file for deletion and keeps it in its directory until
+ * the last handle closes, so an rmdir racing a just-closed tree-sitter parse, a
+ * child process still exiting, or a virus scanner that opened the file behind
+ * your back fails with ENOTEMPTY/EBUSY/EPERM. Nothing is wrong with the test —
+ * a few milliseconds later the same call succeeds.
+ *
+ * Left bare, this shows up as a *different* test failing on each CI run, which
+ * reads as a real intermittent bug and costs an afternoon to chase. `maxRetries`
+ * is node's own remedy for exactly this.
+ */
+export function rmDir(dir: string): void {
+  rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
 }
 
 /**
@@ -92,9 +111,12 @@ export function runCli(args: string[], opts: { home?: string; timeoutMs?: number
   return res;
 }
 
-/** Summarizer that passes the source through unchanged, so tests control the text. */
+/** Summarizer that passes the source through unchanged, so tests control the text.
+ * Declares `opts` even though it ignores it: dropping the parameter still satisfies
+ * `Summarizer`, but then a test wrapping this one cannot forward the call it
+ * received, and the delegation stops type-checking. */
 export class PassthroughSummarizer implements Summarizer {
-  async summarize(code: string): Promise<string> {
+  async summarize(code: string, _opts?: { path: string }): Promise<string> {
     return code;
   }
 }

--- a/test/ingest-fs.test.ts
+++ b/test/ingest-fs.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import { join, relative } from "node:path";
 import { shouldSkipDir, walkDir, SKIP_DIRS } from "../src/ingest/fs.js";
 import { discoverScopes, discoverWorkspaceChildren } from "../src/graph/scopes.js";
+import { rmDir } from "./helpers.js";
 
 function fixture(tag: string): string {
   const dir = mkdtempSync(join(tmpdir(), `graft-walk-${tag}-`));
@@ -42,7 +43,7 @@ test("walkDir respects root and nested .gitignore rules, including negation", ()
       "src/app.ts",
     ]);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -57,7 +58,7 @@ test("walkDir keeps tracked files that match an ignore rule and untracked visibl
 
     assert.deepEqual(walked(dir), ["tracked.generated.ts", "visible.ts"]);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -70,7 +71,7 @@ test("walkDir retains fixed skips and filesystem fallback outside Git", () => {
 
     assert.deepEqual(walked(dir), ["src/app.ts"]);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -124,7 +125,7 @@ test("A5: walkDir(dir, includes) descends into an included SKIP_DIRS-named direc
     assert.ok(withIncludes.some((f) => f.startsWith("build")), "build/ is walked once included");
     assert.ok(!withIncludes.some((f) => f.startsWith("vendor")), "vendor/ stays skipped — only the named dir is included");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -137,7 +138,7 @@ test("A5: in a Git repo, --include-dir lifts the built-in skip for git-visible f
     assert.ok(!walked(dir).includes("vendor/lib.ts"), "default: vendor/ is skipped by the built-in list");
     assert.deepEqual(walked(dir, new Set(["vendor"])), ["src/app.ts", "vendor/lib.ts"]);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -150,7 +151,7 @@ test("A5: --include-dir does not override gitignore — an ignored directory sta
 
     assert.deepEqual(walked(dir, new Set(["build"])), ["src/app.ts"]);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -201,7 +202,7 @@ test("walkDir and every scopes.ts consumer agree on the skip set: SKIP_DIRS + a 
     for (const name of SKIP_DIRS) assert.ok(!children.includes(name), `discoverWorkspaceChildren must skip ${name}`);
     assert.ok(!children.includes(".hidden"), "discoverWorkspaceChildren must skip the dot-dir");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -220,6 +221,6 @@ test("workspace-glob resolution (scopes.ts's resolveGlob over visible-file dirs)
     for (const name of SKIP_DIRS) assert.ok(!prefixes.includes(name), `the glob must not resolve into ${name}`);
     assert.ok(!prefixes.includes(".hidden"), "the glob must not resolve into the dot-dir");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });

--- a/test/ingest-fs.test.ts
+++ b/test/ingest-fs.test.ts
@@ -62,6 +62,77 @@ test("walkDir keeps tracked files that match an ignore rule and untracked visibl
   }
 });
 
+/**
+ * `git ls-files` prints one line PER INDEX STAGE, so an unmerged path arrives three
+ * times (stages 1/2/3). Nothing downstream deduplicated: the build looped over the
+ * same file three times and pushed three nodes per id, which trips
+ * `checkGraphInvariants`, inflates `meta.nodeCount`, and makes `ask` score one body
+ * 3×. The Claude Code `Stop` hook builds at the end of every turn, so this fired on
+ * its own in the middle of a conflicted merge.
+ */
+test("walkDir returns each file once during a merge conflict, not once per index stage", () => {
+  const dir = fixture("conflict");
+  try {
+    execFileSync("git", ["config", "user.email", "t@example.com"], { cwd: dir });
+    execFileSync("git", ["config", "user.name", "t"], { cwd: dir });
+    write(dir, "a.ts", "export const value = 1;\n");
+    execFileSync("git", ["add", "-A"], { cwd: dir });
+    execFileSync("git", ["commit", "-qm", "base"], { cwd: dir });
+    const base = execFileSync("git", ["rev-parse", "HEAD"], { cwd: dir, encoding: "utf8" }).trim();
+
+    execFileSync("git", ["checkout", "-qb", "other"], { cwd: dir });
+    write(dir, "a.ts", "export const value = 2;\n");
+    execFileSync("git", ["commit", "-qam", "other"], { cwd: dir });
+
+    execFileSync("git", ["checkout", "-q", base], { cwd: dir });
+    execFileSync("git", ["checkout", "-qb", "mine"], { cwd: dir });
+    write(dir, "a.ts", "export const value = 3;\n");
+    execFileSync("git", ["commit", "-qam", "mine"], { cwd: dir });
+
+    try {
+      execFileSync("git", ["merge", "other"], { cwd: dir, stdio: "pipe" });
+      assert.fail("the fixture must actually conflict");
+    } catch {
+      /* the conflict is the point */
+    }
+    const staged = execFileSync("git", ["ls-files", "--cached", "--", "a.ts"], { cwd: dir, encoding: "utf8" })
+      .split("\n")
+      .filter(Boolean);
+    assert.ok(staged.length > 1, `the path must really be unmerged (git printed ${staged.length} line(s))`);
+
+    assert.deepEqual(walked(dir), ["a.ts"]);
+  } finally {
+    rmDir(dir);
+  }
+});
+
+/**
+ * A bad `[dir]` used to surface as `ENOENT: no such file or directory, scandir 'C:\…'`
+ * from four frames down in `readdirSync` — cli.ts prints `err.message` and nothing more,
+ * so the message named neither the command nor the argument that was wrong.
+ */
+test("walkDir rejects a missing or non-directory path with a message that names it", () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-walk-baddir-"));
+  try {
+    const missing = join(dir, "definitely-not-here");
+    assert.throws(() => walkDir(missing), (err: Error) => {
+      assert.match(err.message, /no such directory — pass a repository root/);
+      assert.ok(err.message.includes(missing), "the message must name the argument that was wrong");
+      return true;
+    });
+
+    const file = join(dir, "notes.txt");
+    writeFileSync(file, "not a repo\n");
+    assert.throws(() => walkDir(file), (err: Error) => {
+      assert.match(err.message, /not a directory — pass a repository root/);
+      assert.ok(err.message.includes(file));
+      return true;
+    });
+  } finally {
+    rmDir(dir);
+  }
+});
+
 test("walkDir retains fixed skips and filesystem fallback outside Git", () => {
   const dir = mkdtempSync(join(tmpdir(), "graft-walk-nongit-"));
   try {

--- a/test/llm-claude-cli.test.ts
+++ b/test/llm-claude-cli.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Process-free tests for the subscription transport. The adapter takes an
+ * injectable runner, so every case here asserts both directions of the
+ * translation (neutral → argv/stdin, CLI envelope → neutral) without ever
+ * spawning `claude`, hitting the network, or needing a key.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+import { ClaudeCliChatModel, extractJson, isTransient, resolveClaudeBin } from "../src/ai/llm/claude-cli.js";
+import { createChatModel, providerNeedsKey } from "../src/ai/llm/factory.js";
+import { credentialProblem, resolveConfig } from "../src/ai/providers.js";
+import type { ClaudeCliResult } from "../src/ai/llm/claude-cli.js";
+
+/** A path that certainly exists (this file) — stands in for an installed CLI. */
+const REAL_PATH = fileURLToPath(import.meta.url);
+const MISSING_PATH = `${REAL_PATH}.does-not-exist`;
+
+function envelope(over: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    type: "result",
+    subtype: "success",
+    is_error: false,
+    result: "hello",
+    stop_reason: "end_turn",
+    usage: {
+      input_tokens: 70,
+      output_tokens: 20,
+      cache_read_input_tokens: 30,
+      cache_creation_input_tokens: 5,
+    },
+    ...over,
+  });
+}
+
+/** Records every invocation and replays canned stdout, one response per call. */
+function fakeRunner(responses: Array<Partial<ClaudeCliResult> | string>) {
+  const calls: Array<{ args: string[]; stdin: string; timeoutMs: number }> = [];
+  const run = async (args: string[], stdin: string, timeoutMs: number): Promise<ClaudeCliResult> => {
+    calls.push({ args, stdin, timeoutMs });
+    const r = responses[Math.min(calls.length - 1, responses.length - 1)];
+    const base = typeof r === "string" ? { stdout: r } : r;
+    return { code: 0, stdout: "", stderr: "", ...base };
+  };
+  return { run, calls };
+}
+
+/** Read the value that follows a flag in the recorded argv. */
+const flagValue = (args: string[], flag: string) => args[args.indexOf(flag) + 1];
+
+// --- plain text --------------------------------------------------------------
+
+test("claude-cli: text — argv isolates the CLI and usage is normalized", async () => {
+  const { run, calls } = fakeRunner([envelope()]);
+  const m = new ClaudeCliChatModel({ model: "sonnet", run });
+  const res = await m.create({
+    messages: [
+      { role: "system", content: "sys" },
+      { role: "user", content: "hi" },
+    ],
+    temperature: 0,
+  });
+
+  const { args, stdin } = calls[0];
+  assert.equal(flagValue(args, "--model"), "sonnet");
+  assert.equal(flagValue(args, "--output-format"), "json");
+  assert.ok(args.includes("-p"));
+  // The isolation flags are the whole reason this is safe to run over a repo.
+  assert.equal(flagValue(args, "--tools"), "", "every built-in tool must be off");
+  assert.equal(flagValue(args, "--setting-sources"), "", "user hooks/settings must not load");
+  assert.ok(args.includes("--strict-mcp-config"));
+  assert.ok(args.includes("--disable-slash-commands"));
+  assert.ok(args.includes("--no-session-persistence"));
+  // graft's own system prompt rides in stdin; argv carries only the short harness one.
+  assert.ok(!flagValue(args, "--system-prompt").includes("sys"));
+  assert.match(stdin, /<INSTRUCTIONS>\nsys\n<\/INSTRUCTIONS>/);
+  assert.match(stdin, /<INPUT>\nhi\n<\/INPUT>/);
+  assert.ok(!stdin.includes("<OUTPUT_FORMAT>"), "no schema block for a text call");
+
+  assert.equal(res.text, "hello");
+  assert.deepEqual(res.toolCalls, []);
+  assert.equal(res.stopReason, "end_turn");
+  assert.deepEqual(res.usage, { input: 70, output: 20, cacheRead: 30, cacheCreate: 5 });
+  assert.equal(res.assistant.role, "assistant");
+});
+
+test("claude-cli: a single user message is sent verbatim, multi-turn gets role headers", async () => {
+  const { run, calls } = fakeRunner([envelope(), envelope()]);
+  const m = new ClaudeCliChatModel({ model: "sonnet", run });
+
+  await m.create({ messages: [{ role: "user", content: "just this" }] });
+  assert.match(calls[0].stdin, /<INPUT>\njust this\n<\/INPUT>/);
+
+  await m.create({
+    messages: [
+      { role: "user", content: "q" },
+      { role: "assistant", content: "a" },
+      { role: "user", content: "q2" },
+    ],
+  });
+  assert.match(calls[1].stdin, /### USER\nq/);
+  assert.match(calls[1].stdin, /### ASSISTANT\na/);
+});
+
+// --- structured output -------------------------------------------------------
+
+const RECORD_TOOL = {
+  name: "record_graph",
+  description: "Record nodes.",
+  parameters: { type: "object", properties: { nodes: { type: "array" } }, required: ["nodes"] },
+};
+
+const toolReq = {
+  tools: [RECORD_TOOL],
+  responseFormat: { kind: "tool", name: "record_graph" } as const,
+  messages: [{ role: "user" as const, content: "summaries" }],
+};
+
+test("claude-cli: tool format — schema is prompted and the reply becomes a tool call", async () => {
+  const { run, calls } = fakeRunner([envelope({ result: '{"nodes":[{"name":"Auth"}]}' })]);
+  const m = new ClaudeCliChatModel({ model: "sonnet", run });
+  const res = await m.create(toolReq);
+
+  // No tool_choice on this wire, so the schema has to travel in the prompt.
+  assert.match(calls[0].stdin, /<OUTPUT_FORMAT>/);
+  assert.ok(calls[0].stdin.includes('"required":["nodes"]'), "the tool's own schema is inlined");
+
+  assert.equal(res.toolCalls.length, 1);
+  assert.equal(res.toolCalls[0].name, "record_graph");
+  assert.deepEqual(res.toolCalls[0].args, { nodes: [{ name: "Auth" }] });
+  assert.equal(res.text, "", "text is empty when the turn is a forced tool call");
+});
+
+test("claude-cli: json format returns the object re-serialized as text", async () => {
+  const { run } = fakeRunner([envelope({ result: '{"a":1}' })]);
+  const m = new ClaudeCliChatModel({ model: "sonnet", run });
+  const res = await m.create({
+    responseFormat: { kind: "json" },
+    messages: [{ role: "user", content: "x" }],
+  });
+  assert.equal(res.text, '{"a":1}');
+  assert.deepEqual(res.toolCalls, []);
+});
+
+test("claude-cli: a fenced or prose-wrapped object still parses", async () => {
+  for (const raw of [
+    '```json\n{"nodes":[]}\n```',
+    'Here you go:\n{"nodes":[]}\nHope that helps!',
+    '{"nodes":[{"summary":"uses } and { in prose"}]}',
+  ]) {
+    const { run } = fakeRunner([envelope({ result: raw })]);
+    const m = new ClaudeCliChatModel({ model: "sonnet", run });
+    const res = await m.create(toolReq);
+    assert.ok(res.toolCalls[0], `failed to recover JSON from: ${raw}`);
+  }
+});
+
+test("claude-cli: unparseable output retries once, quoting the bad reply back", async () => {
+  const { run, calls } = fakeRunner([
+    envelope({ result: "I'm sorry, I can't do that." }),
+    envelope({ result: '{"nodes":[]}' }),
+  ]);
+  const m = new ClaudeCliChatModel({ model: "sonnet", run });
+  const res = await m.create(toolReq);
+
+  assert.equal(calls.length, 2, "exactly one corrective retry");
+  assert.match(calls[1].stdin, /<RETRY>/);
+  assert.match(calls[1].stdin, /I'm sorry/);
+  assert.deepEqual(res.toolCalls[0].args, { nodes: [] });
+});
+
+test("claude-cli: still unparseable after the retry fails loudly", async () => {
+  const { run, calls } = fakeRunner([envelope({ result: "nope" })]);
+  const m = new ClaudeCliChatModel({ model: "sonnet", run });
+  await assert.rejects(() => m.create(toolReq), /did not return parseable JSON/);
+  assert.equal(calls.length, 2);
+});
+
+// --- failure surfaces --------------------------------------------------------
+
+test("claude-cli: a non-zero exit surfaces stderr, not a JSON parse error", async () => {
+  const { run } = fakeRunner([{ code: 1, stderr: "Invalid API key · Please run /login" }]);
+  const m = new ClaudeCliChatModel({ model: "sonnet", run });
+  await assert.rejects(() => m.create({ messages: [{ role: "user", content: "x" }] }), /Please run \/login/);
+});
+
+test("claude-cli: is_error in the envelope is an error, not an empty summary", async () => {
+  const { run } = fakeRunner([envelope({ is_error: true, result: "usage limit reached" })]);
+  const m = new ClaudeCliChatModel({ model: "sonnet", run });
+  await assert.rejects(() => m.create({ messages: [{ role: "user", content: "x" }] }), /usage limit reached/);
+});
+
+test("isTransient: retries blips, never a login or quota problem", () => {
+  for (const m of ["Overloaded", "rate limit exceeded", "HTTP 503", "claude CLI timed out after 300000ms", "ECONNRESET"]) {
+    assert.equal(isTransient(m), true, m);
+  }
+  // A backoff cannot fix these, and sleeping on them hides the real diagnosis.
+  for (const m of [
+    "usage limit reached",
+    "Invalid API key · Please run /login",
+    "claude CLI not found on PATH",
+    "your credit balance is too low",
+    "rate limit exceeded — usage limit reached", // permanent wins over transient
+  ]) {
+    assert.equal(isTransient(m), false, m);
+  }
+});
+
+test("claude-cli: a transient failure is retried, and the result is kept", async () => {
+  const { run, calls } = fakeRunner([{ code: 1, stderr: "Overloaded" }, envelope()]);
+  const m = new ClaudeCliChatModel({ model: "sonnet", run });
+  const res = await m.create({ messages: [{ role: "user", content: "x" }] });
+  assert.equal(calls.length, 2);
+  assert.equal(res.text, "hello");
+});
+
+test("claude-cli: a permanent failure fails on the first attempt, not after backoff", async () => {
+  const { run, calls } = fakeRunner([{ code: 1, stderr: "Invalid API key · Please run /login" }]);
+  const m = new ClaudeCliChatModel({ model: "sonnet", run });
+  await assert.rejects(() => m.create({ messages: [{ role: "user", content: "x" }] }), /login/);
+  assert.equal(calls.length, 1, "a login problem must surface immediately");
+});
+
+test("claude-cli: a warning line before the envelope does not break parsing", async () => {
+  const { run } = fakeRunner([`warning: something\n${envelope()}`]);
+  const m = new ClaudeCliChatModel({ model: "sonnet", run });
+  const res = await m.create({ messages: [{ role: "user", content: "x" }] });
+  assert.equal(res.text, "hello");
+});
+
+// --- JSON recovery -----------------------------------------------------------
+
+test("extractJson: brace scanning is string- and escape-aware", () => {
+  assert.deepEqual(extractJson('{"s":"a } b"}'), { s: "a } b" });
+  assert.deepEqual(extractJson('{"s":"esc \\" then }"}'), { s: 'esc " then }' });
+  assert.deepEqual(extractJson('pre {"a":{"b":1}} post'), { a: { b: 1 } });
+  assert.equal(extractJson("no json here"), undefined);
+  assert.equal(extractJson('{"unterminated": '), undefined);
+});
+
+// --- wiring ------------------------------------------------------------------
+
+test("factory: claude-cli builds with no key; key providers still demand one", () => {
+  assert.equal(providerNeedsKey("claude-cli"), false);
+  assert.equal(providerNeedsKey("anthropic"), true);
+  const m = createChatModel({ provider: "claude-cli", model: "sonnet", bin: MISSING_PATH });
+  assert.equal(m.label, "claude-cli:sonnet");
+  assert.throws(() => createChatModel({ provider: "anthropic", model: "x" }), /needs an API key/);
+});
+
+test("resolveClaudeBin: an explicit path is trusted only when it exists", () => {
+  assert.equal(resolveClaudeBin(REAL_PATH), REAL_PATH);
+  assert.equal(resolveClaudeBin(MISSING_PATH), undefined);
+});
+
+/** Run `fn` with a scrubbed provider environment, restoring it afterwards. */
+function withEnv(over: Record<string, string | undefined>, fn: () => void): void {
+  const keys = ["GRAFT_PROVIDER", "GRAFT_API_KEY", "OPENROUTER_API_KEY", "GRAFT_MODEL", "GRAFT_CLAUDE_BIN"];
+  const saved = Object.fromEntries(keys.map((k) => [k, process.env[k]]));
+  for (const k of keys) delete process.env[k];
+  for (const [k, v] of Object.entries(over)) if (v !== undefined) process.env[k] = v;
+  try {
+    fn();
+  } finally {
+    for (const k of keys) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k]!;
+    }
+  }
+}
+
+test("resolveConfig: no key + a local CLI picks claude-cli, and says it inferred it", () => {
+  withEnv({ GRAFT_CLAUDE_BIN: REAL_PATH }, () => {
+    const c = resolveConfig();
+    assert.equal(c.provider, "claude-cli");
+    assert.equal(c.model, "sonnet");
+    assert.equal(c.autoDetectedProvider, true);
+    assert.equal(credentialProblem(c), undefined);
+  });
+});
+
+test("resolveConfig: an existing key-based setup is untouched by the new provider", () => {
+  withEnv({ GRAFT_API_KEY: "sk-test", GRAFT_CLAUDE_BIN: REAL_PATH }, () => {
+    const c = resolveConfig();
+    assert.equal(c.provider, "openai", "a configured key must never be silently bypassed");
+    assert.equal(c.autoDetectedProvider, false);
+  });
+});
+
+test("resolveConfig: an explicit provider always wins over inference", () => {
+  withEnv({ GRAFT_PROVIDER: "anthropic", GRAFT_CLAUDE_BIN: REAL_PATH }, () => {
+    const c = resolveConfig();
+    assert.equal(c.provider, "anthropic");
+    assert.equal(c.autoDetectedProvider, false);
+    assert.match(credentialProblem(c)!, /No API key/);
+  });
+});
+
+test("resolveConfig: no key and no CLI keeps the old default and the old complaint", () => {
+  withEnv({ GRAFT_CLAUDE_BIN: MISSING_PATH }, () => {
+    const c = resolveConfig();
+    assert.equal(c.provider, "openai");
+    assert.match(credentialProblem(c)!, /No API key/);
+  });
+});
+
+test("credentialProblem: claude-cli without the binary explains how to fix it", () => {
+  withEnv({ GRAFT_PROVIDER: "claude-cli", GRAFT_CLAUDE_BIN: MISSING_PATH }, () => {
+    const c = resolveConfig();
+    assert.match(credentialProblem(c)!, /not on PATH/);
+  });
+});
+
+test("credentialProblem: an injected chatModel needs no credentials at all", () => {
+  withEnv({ GRAFT_CLAUDE_BIN: MISSING_PATH }, () => {
+    const c = resolveConfig({ chatModel: { label: "stub", create: async () => ({}) as never } });
+    assert.equal(credentialProblem(c), undefined);
+  });
+});

--- a/test/regression-single-repo.test.ts
+++ b/test/regression-single-repo.test.ts
@@ -22,6 +22,7 @@ import { buildRepoMap, formatRepoMap } from "../src/graph/map.js";
 import { grepGraph } from "../src/search/grep.js";
 import { resolveSymbol, callersOf } from "../src/graph/traverse.js";
 import type { GraphV1 } from "../src/graph/types.js";
+import { rmDir } from "./helpers.js";
 
 /** Materialize a fixture repo from a path→content map. */
 function fx(layout: Record<string, string>): string {
@@ -128,7 +129,7 @@ for (const [name, layout] of Object.entries(FIXTURES)) {
       const callers = callersOf(graph, targets[0]);
       assert.ok(callers.length > 0, `${name}/callers: "${calleeName}" should have >=1 caller`);
     } finally {
-      rmSync(dir, { recursive: true, force: true });
+      rmDir(dir);
     }
   });
 }

--- a/test/savings.test.ts
+++ b/test/savings.test.ts
@@ -5,6 +5,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { savingsFor, savingsLine, withSavings, toTokens } from '../src/context/savings.js';
+import { formatCount } from '../src/util/num.js';
 import type { GraphV1, NodeV1 } from '../src/graph/types.js';
 
 function fileNode(path: string, chars?: number): NodeV1 {
@@ -48,7 +49,10 @@ test('savingsLine: reports saved tokens and percent when the output is smaller',
   assert.match(footer, /tokens saved ≈ [\d,]+ \(\d+%\)/);
   assert.match(footer, /2 file\(s\)/);
   const base = toTokens(8000);
-  assert.ok(footer.includes((base - toTokens(body.length)).toLocaleString()));
+  // Pinned en-US, not the machine locale: this line is parsed by an agent that is
+  // asked to sum it, and a pt-BR "1.990" would read as 1.99.
+  assert.ok(footer.includes(formatCount(base - toTokens(body.length))));
+  assert.equal(savingsLine('x'.repeat(4000), { files: 2, baselineChars: 8_000_000 }).includes('1,999,000'), true);
   // The nudge rides along so the agent reports the turn total without SKILL.md.
   assert.match(footer, /end of your reply/i);
   assert.match(footer, /graft saved ~N tokens this turn/);

--- a/test/utf16-source.test.ts
+++ b/test/utf16-source.test.ts
@@ -57,6 +57,44 @@ test("readSourceFile: decodes a UTF-16LE BOM, returns null for UTF-16BE, and rea
   }
 });
 
+/** BOM + UTF-8 bytes — what Visual Studio writes for .cs by default and what
+ * PowerShell 5.1's `Out-File -Encoding utf8` writes for anything at all. */
+function utf8bom(text: string): Buffer {
+  return Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from(text, "utf8")]);
+}
+
+test("readSourceFile: strips a UTF-8 BOM instead of handing U+FEFF to the grammar", () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-utf8bom-unit-"));
+  try {
+    writeFileSync(join(dir, "bom.ts"), utf8bom("export const x = 1;\n"));
+    const got = readSourceFile(join(dir, "bom.ts"));
+    assert.equal(got, "export const x = 1;\n");
+    assert.ok(!got!.startsWith("﻿"), "U+FEFF is category Cf, not whitespace — it becomes an ERROR node at offset 0");
+  } finally {
+    rmDir(dir);
+  }
+});
+
+test("a BOM-prefixed source file is indexed like any other", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-utf8bom-build-"));
+  try {
+    // Go's grammar lists only /\s/ in its `extras`, so a leading U+FEFF is what
+    // actually breaks — it starts the parse in error recovery.
+    writeFileSync(join(dir, "main.go"), utf8bom("package main\n\nfunc FromBom() int {\n\treturn 1\n}\n"));
+    writeFileSync(join(dir, "app.ts"), utf8bom("export function fromBomTs(): void {}\n"));
+    const r = await buildGraph(dir, { reuse: false });
+    assert.deepEqual(r.errors, []);
+    const graph = readGraph(wiringPath(join(dir, "graft")))!;
+    assert.ok(graph.nodes.some((n) => n.id === "main.go#FromBom"), "the BOM'd Go function must be extracted");
+    assert.ok(graph.nodes.some((n) => n.id === "app.ts#fromBomTs"), "…and the BOM'd TS one");
+    // hash-what-you-parse: the stripped text is what is hashed, so check must agree.
+    const check = await checkGraph(dir);
+    assert.equal(check.ok, true, "build and check must decode the BOM the same way");
+  } finally {
+    rmDir(dir);
+  }
+});
+
 test("A1 graph/build.ts: a UTF-16LE .ts file is decoded at graph ingest, not mojibake-parsed", async () => {
   const dir = mkdtempSync(join(tmpdir(), "graft-utf16-build-"));
   try {

--- a/test/utf16-source.test.ts
+++ b/test/utf16-source.test.ts
@@ -29,7 +29,7 @@ import { grepGraph } from "../src/search/grep.js";
 import { ask } from "../src/ask/ask.js";
 import { readGraph, wiringPath } from "../src/graph/write.js";
 import { contextDirFor } from "../src/context/node-file.js";
-import { fakeProviders } from "./helpers.js";
+import { fakeProviders, rmDir } from "./helpers.js";
 
 /** BOM + UTF-16LE bytes — the shape Windows tooling in general actually writes. */
 function utf16le(text: string): Buffer {
@@ -53,7 +53,7 @@ test("readSourceFile: decodes a UTF-16LE BOM, returns null for UTF-16BE, and rea
     assert.equal(readSourceFile(join(dir, "be.ts")), null);
     assert.equal(readSourceFile(join(dir, "plain.ts")), "export const x = 1;\n");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -66,7 +66,7 @@ test("A1 graph/build.ts: a UTF-16LE .ts file is decoded at graph ingest, not moj
     const graph = readGraph(wiringPath(join(dir, "graft")))!;
     assert.ok(graph.nodes.some((n) => n.id === "legacy.ts#fromLegacy"), "the UTF-16LE file's function must be extracted");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -79,7 +79,7 @@ test("A1 graph/build.ts: a UTF-16BE file is an empty entry, not a build error (n
     const graph = readGraph(wiringPath(join(dir, "graft")))!;
     assert.ok(!graph.nodes.some((n) => n.path === "legacy.ts"), "no nodes minted for the undecodable file");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -98,7 +98,7 @@ test("A1 hash-what-you-parse consistency: build/check/fingerprint agree on a UTF
     const drift = probeDrift(join(dir), join(dir, "graft"));
     assert.deepEqual(drift, { changed: [], added: [], removed: [] }, "fingerprint's probe must agree too — no drift");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -128,7 +128,7 @@ test("A1 fingerprint reports drift when indexed UTF-16LE becomes unsupported UTF
   } finally {
     if (previousRefresh === undefined) delete process.env.GRAFT_REFRESH;
     else process.env.GRAFT_REFRESH = previousRefresh;
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -150,7 +150,7 @@ test("A1 context/build.ts + check.ts: a UTF-16LE file's summarizer input decodes
     assert.equal(check.ok, true, "content hash must agree between build and check for the same UTF-16LE file");
     assert.deepEqual(check.contentDrift, []);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -169,7 +169,7 @@ test("A1 search/grep.ts: finds a pattern inside a UTF-16LE file", async () => {
     assert.equal(r.totalHits, 1, "grep must find the pattern in the UTF-16LE file's decoded text");
     assert.match(r.groups[0]!.hits[0]!.text, /NEEDLE hit/);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -189,6 +189,6 @@ test("A1 ask.ts --source: inlines clean (non-garbled) source sliced from a UTF-1
     assert.match(hit!.code!, /return 42/, "the sliced span must decode cleanly, not as mojibake");
     assert.ok(!hit!.code!.includes("\u0000"), "no stray NUL bytes from a mis-decoded UTF-16LE read");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });

--- a/test/viz-assemble.test.ts
+++ b/test/viz-assemble.test.ts
@@ -8,6 +8,7 @@ import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { assembleContextGraph, normalizeRelation } from "../src/viz/assemble.js";
+import { rmDir } from "./helpers.js";
 
 function makeContextDir(): string {
   const dir = mkdtempSync(join(tmpdir(), "graftviz-"));
@@ -87,7 +88,7 @@ test("assembleContextGraph builds nodes and edges from frontmatter", () => {
     assert.equal(g.meta.droppedEdges, 1);
     assert.equal(g.meta.skippedFiles, 1);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 

--- a/test/viz-serve.test.ts
+++ b/test/viz-serve.test.ts
@@ -9,6 +9,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createServer } from "node:http";
 import { startVizServer } from "../src/viz/serve.js";
+import { rmDir } from "./helpers.js";
 
 function makeDirs(): { contextDir: string; viewerDir: string; root: string } {
   const root = mkdtempSync(join(tmpdir(), "graftviz-srv-"));
@@ -54,7 +55,7 @@ test("viz server serves viewer, context graph, and gates code graph", async () =
     assert.equal(code.meta.version, 1);
   } finally {
     await srv.close();
-    rmSync(root, { recursive: true, force: true });
+    rmDir(root);
   }
 });
 
@@ -68,7 +69,7 @@ test("viz server falls back to the next free port", async () => {
   } finally {
     await srv.close();
     await new Promise((res) => blocker.close(res));
-    rmSync(root, { recursive: true, force: true });
+    rmDir(root);
   }
 });
 
@@ -95,6 +96,6 @@ test("viz server emits an SSE event when the context dir changes", async () => {
     assert.match(seen, /data: change/);
   } finally {
     await srv.close();
-    rmSync(root, { recursive: true, force: true });
+    rmDir(root);
   }
 });

--- a/test/workspace.test.ts
+++ b/test/workspace.test.ts
@@ -21,6 +21,7 @@ import {
 } from "../src/graph/workspace.js";
 import { formatAsk } from "../src/ask/ask.js";
 import type { GraphV1 } from "../src/graph/types.js";
+import { rmDir } from "./helpers.js";
 
 /** A parent dir with git children (each a `.git` dir + one source file). */
 function workspaceFx(children: Record<string, Record<string, string>>): string {
@@ -59,14 +60,14 @@ function pad(n: number): string {
 test("isWorkspaceBuildRoot: ≥2 git children, no own .git → workspace", () => {
   const p = workspaceFx(REPOS);
   assert.equal(isWorkspaceBuildRoot(p), true);
-  rmSync(p, { recursive: true, force: true });
+  rmDir(p);
 });
 
 test("isWorkspaceBuildRoot: own .git (submodules) → NOT a workspace", () => {
   const p = workspaceFx(REPOS);
   mkdirSync(join(p, ".git"), { recursive: true });
   assert.equal(isWorkspaceBuildRoot(p), false);
-  rmSync(p, { recursive: true, force: true });
+  rmDir(p);
 });
 
 test("child built via parent is byte-identical to building it standalone", async () => {
@@ -76,12 +77,12 @@ test("child built via parent is byte-identical to building it standalone", async
   const viaParent = readFileSync(wiringPath(childGraft), "utf8");
 
   // Rebuild the same child standalone — deterministic writer, same source.
-  rmSync(childGraft, { recursive: true, force: true });
+  rmDir(childGraft);
   await buildGraph(join(p, "repoA"));
   const standalone = readFileSync(wiringPath(childGraft), "utf8");
 
   assert.equal(viaParent, standalone);
-  rmSync(p, { recursive: true, force: true });
+  rmDir(p);
 });
 
 test("workspace.json lists both children; parent holds no mega-graph", async () => {
@@ -92,7 +93,7 @@ test("workspace.json lists both children; parent holds no mega-graph", async () 
   // Parent graft holds ONLY workspace.json — no .graph/wiring.json.
   assert.equal(existsSync(wiringPath(contextDirFor(p))), false);
   assert.equal(existsSync(join(contextDirFor(p), "workspace.json")), true);
-  rmSync(p, { recursive: true, force: true });
+  rmDir(p);
 });
 
 test("ask at the parent federates hits from both children, labeled <child>/", async () => {
@@ -105,7 +106,7 @@ test("ask at the parent federates hits from both children, labeled <child>/", as
   // Pointers are child-prefixed so they open from the parent.
   assert.ok(r.hits.some((h) => h.pointer.startsWith("repoA/")));
   assert.ok(r.hits.some((h) => h.pointer.startsWith("repoB/")));
-  rmSync(p, { recursive: true, force: true });
+  rmDir(p);
 });
 
 test("ask inside a single child = standalone (no federation scopes)", async () => {
@@ -116,7 +117,7 @@ test("ask inside a single child = standalone (no federation scopes)", async () =
   assert.equal(r.scopes, undefined); // single-scope repo → no scope labels
   assert.ok(r.hits.length > 0);
   assert.ok(!r.hits.some((h) => h.pointer.startsWith("repoA/"))); // paths are child-relative
-  rmSync(p, { recursive: true, force: true });
+  rmDir(p);
 });
 
 test("migration: mega-graph parent split → .graph removed, workspace.json written, exact note", async () => {
@@ -139,7 +140,7 @@ test("migration: mega-graph parent split → .graph removed, workspace.json writ
     migrationNote(["repoA", "repoB"]),
     "⚠ this folder contains 2 separate git repos — splitting: each repo now gets its own committable graft/ (repoA/graft/, repoB/graft/); the combined graph here is replaced by a workspace index. Queries from here now search all repos, fairly.",
   );
-  rmSync(p, { recursive: true, force: true });
+  rmDir(p);
 });
 
 test("check federation: OK when all in sync, STALE + not-ok when a child drifts", async () => {
@@ -156,7 +157,7 @@ test("check federation: OK when all in sync, STALE + not-ok when a child drifts"
   const drifted = await federateCheck(p);
   assert.equal(drifted.ok, false);
   assert.ok(drifted.text.includes("repoA/: STALE"));
-  rmSync(p, { recursive: true, force: true });
+  rmDir(p);
 });
 
 test("callers federation resolves a symbol per child, grouped", async () => {
@@ -165,7 +166,7 @@ test("callers federation resolves a symbol per child, grouped", async () => {
   const { text, found } = federateCallers(p, undefined, "helperThing", {});
   assert.equal(found, true);
   assert.ok(text.includes("## repoA/"));
-  rmSync(p, { recursive: true, force: true });
+  rmDir(p);
 });
 
 test("grep federation merges groups across children with child-prefixed paths", async () => {
@@ -176,7 +177,7 @@ test("grep federation merges groups across children with child-prefixed paths", 
   const paths = result.groups.map((g) => g.path);
   assert.ok(paths.some((p) => p.startsWith("repoA/")));
   assert.ok(paths.some((p) => p.startsWith("repoB/")));
-  rmSync(p, { recursive: true, force: true });
+  rmDir(p);
 });
 
 test("one unbuilt child is surfaced, not silently skipped", async () => {
@@ -186,7 +187,7 @@ test("one unbuilt child is surfaced, not silently skipped", async () => {
   });
   await buildWorkspace(p);
   // Simulate repoC never having been built.
-  rmSync(contextDirFor(join(p, "repoC")), { recursive: true, force: true });
+  rmDir(contextDirFor(join(p, "repoC")));
 
   const wg = loadWorkspaceGraphs(p);
   assert.deepEqual(wg.loaded.map((l) => l.child), ["repoA", "repoB"]);
@@ -195,7 +196,7 @@ test("one unbuilt child is surfaced, not silently skipped", async () => {
     coverageNote(wg),
     "2 of 3 workspace repos have graphs; run graft build to cover repoC",
   );
-  rmSync(p, { recursive: true, force: true });
+  rmDir(p);
 });
 
 const JUNK = {
@@ -214,7 +215,7 @@ test("federated ask: a junk-body-token child is gated out of the ranking, into a
   assert.ok(!titles.some((t) => t.startsWith("renderPanel")), `junk hit must NOT federate:\n${titles.join("\n")}`);
   assert.ok(r.hits.every((h) => h.scope!.startsWith("repoA")), "only repoA federates");
   assert.deepEqual(r.scopes?.alsoMatched.map((m) => m.scope), ["repoB"], "junk child reported in alsoMatched");
-  rmSync(p, { recursive: true, force: true });
+  rmDir(p);
 });
 
 test("federated ask: a genuinely-shared query still federates both children", async () => {
@@ -223,7 +224,7 @@ test("federated ask: a genuinely-shared query still federates both children", as
   const r = federateAsk(p, undefined, "handler", { limit: 8 });
   const scopeSet = new Set(r.hits.map((h) => h.scope!.split("/")[0]));
   assert.ok(scopeSet.has("repoA") && scopeSet.has("repoB"), "both children federate a shared term");
-  rmSync(p, { recursive: true, force: true });
+  rmDir(p);
 });
 
 test("federated ask: --in <child> narrows to that child; --in <unknown> errors listing repos", async () => {
@@ -238,7 +239,7 @@ test("federated ask: --in <child> narrows to that child; --in <unknown> errors l
     () => federateAsk(p, undefined, "handler", { in: "nope" }),
     /no workspace repo "nope".*repoA.*repoB/s,
   );
-  rmSync(p, { recursive: true, force: true });
+  rmDir(p);
 });
 
 test("federated ask: explicit --in <weak child> bypasses the cross-child gate (footer hint is reachable)", async () => {
@@ -258,7 +259,7 @@ test("federated ask: explicit --in <weak child> bypasses the cross-child gate (f
   const scoped = federateAsk(p, undefined, "scrollbar overlay position", { limit: 8, in: "repoJunk" });
   assert.ok(scoped.hits.length > 0, "explicit --in on a gate-weak child must not return empty");
   assert.ok(scoped.hits.every((h) => h.scope!.startsWith("repoJunk")), "--in repoJunk stays in repoJunk");
-  rmSync(p, { recursive: true, force: true });
+  rmDir(p);
 });
 
 for (const padN of [0, 200]) {
@@ -275,7 +276,7 @@ for (const padN of [0, 200]) {
     assert.ok(!titles.some((t) => t.startsWith("drawFrame")), `body-only junk must NOT federate:\n${titles.join("\n")}`);
     assert.ok(r.hits.every((h) => h.scope!.startsWith("repoStrong")), "only the strong child federates");
     assert.deepEqual(r.scopes?.alsoMatched.map((m) => m.scope), ["repoJunk"], "junk reported in alsoMatched");
-    rmSync(p, { recursive: true, force: true });
+    rmDir(p);
   });
 }
 
@@ -291,7 +292,7 @@ test("strength gate: 3-child payment/gateway/refund — strong + mid federate, i
   assert.ok(scopes.has("repoStrong") && scopes.has("repoMid"), "genuine name matches federate");
   assert.ok(!scopes.has("repoJunk"), "incidental-var junk excluded from the ranking");
   assert.ok(r.scopes?.alsoMatched.some((m) => m.scope === "repoJunk"), "junk reported in alsoMatched");
-  rmSync(p, { recursive: true, force: true });
+  rmDir(p);
 });
 
 test("strength gate: a legit COMMON-term (low-idf) name match is NOT overcorrected out", async () => {
@@ -304,7 +305,7 @@ test("strength gate: a legit COMMON-term (low-idf) name match is NOT overcorrect
   await buildWorkspace(p);
   const r = federateAsk(p, undefined, "config loader", { limit: 8 });
   assert.ok(r.hits.some((h) => h.scope!.startsWith("repoConfig")), "real partial-relevance (low-idf name hit) must still federate");
-  rmSync(p, { recursive: true, force: true });
+  rmDir(p);
 });
 
 for (const [kind, junkFiles] of [
@@ -321,7 +322,7 @@ for (const [kind, junkFiles] of [
     assert.ok(r.hits[0]?.title.startsWith("paymentGatewayRefund"), `strong repo's real hit must be #1, got: ${r.hits[0]?.title}`);
     assert.ok(!r.hits.some((h) => h.scope!.startsWith("repoJunk")), "coincidental path-name junk must NOT federate");
     assert.ok(r.scopes?.alsoMatched.some((m) => m.scope === "repoJunk"), "junk reported in alsoMatched");
-    rmSync(p, { recursive: true, force: true });
+    rmDir(p);
   });
 }
 
@@ -332,5 +333,5 @@ test("readWorkspace: rejects foreign/invalid json as not-a-workspace", () => {
   assert.equal(readWorkspace(p), null);
   writeWorkspace(p, { version: 1, children: ["x", "a"] });
   assert.deepEqual(readWorkspace(p), { version: 1, children: ["a", "x"] });
-  rmSync(p, { recursive: true, force: true });
+  rmDir(p);
 });


### PR DESCRIPTION
**A Python repo graph had no cross-file edges at all.** `resolveImport` treated the specifier `.utils` as a JS-relative path: `posix.join("src", ".utils")` produces `src/.utils`, which never exists, so every import fell through to an external string target. Relative dots now walk directories and `__init__.py` is a candidate.

**JSX component usage produced no edge either.** `<Button/>` is the field `name` of a `jsx_self_closing_element`, and `isDeclarationName` counted any identifier in a parent `name` field as a declaration — so the most common use of an imported symbol in a TSX file was dropped. In a React app that is most of the real dependencies between files.

Also in here:

- The breadth tier allocated a `Parser` and a `Tree` per file and freed neither. Both live in the WASM heap, where V8 GC cannot reach them.
- `git ls-files` prints one line per index stage, so `graft build` during a merge conflict processed each conflicted file three times and emitted three nodes per symbol — and the Claude Code `Stop` hook runs build automatically, so it fires on its own mid-merge.
- C/C++ header prototypes were recorded as definitions, shadowing the real ones and dropping cross-file calls.
- The extraction cache stamp ignored `queries/*.scm`, so editing a grammar query invalidated nothing.
- UTF-8 BOM was not stripped, `interface X extends Y` produced no inheritance edge, and `classParents` was keyed by simple name, mixing the hierarchies of same-named classes.

---

**Part of a stack.** This work started as an audit of `main` and is split by area so each piece is reviewable on its own. Order, each based on the one before it:

1. `feat/subscription-provider` — `--deep` without an API key, + the locale bug
2. `fix/graph-extraction` — Python imports, JSX edges, WASM leak
3. `fix/query-and-viz-security` — ReDoS, DNS rebinding, XSS, `--in`
4. `fix/hosts-settings-safety` — the `settings.json` wipe
5. `fix/llm-build-robustness` — the concept-layer wipe, usage accounting
6. `fix/windows-and-cli-ux` — the dead npm path on Windows
7. `chore/ci-and-packaging` — type-check the tests, run the packaged artifact
8. `docs/config-reference` — the config surface the above introduced

Cross-fork PRs can only target `main`, so GitHub shows the cumulative diff here. **This PR own diff:** https://github.com/NanoNets/Graft/compare/feat/subscription-provider...christian-jorge:Graft:fix/graph-extraction

Every link in the stack is green on its own: `tsc` clean and the full suite at 0 failures on Windows. Happy to reorder, rebase, drop any piece, or squash the lot back into one — just say which.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
