### PR TITLE
docs: describe the config surface the preceding fixes introduce

### DIFF
--- a/.claude/helpers/graft-hooks.cjs
+++ b/.claude/helpers/graft-hooks.cjs
@@ -1,10 +1,13 @@
 #!/usr/bin/env node
 const path = require('path');
 const fs = require('fs');
+const os = require('os');
 const { pathToFileURL } = require('url');
 const { execFileSync } = require('child_process');
 const dir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
-const BAKED = "/Users/shrishdwivedi/Documents/Context graphs/context-graph-engine/dist/claude";
+// Relative when graft's dist lives inside this repo; path.resolve leaves an absolute one be.
+const BAKED = "dist/claude";
+const bakedDir = BAKED ? path.resolve(dir, BAKED) : null;
 
 // The dist/claude dir of @nanonets/graft resolved from a base whose node_modules is searched.
 function fromPkg(base) {
@@ -14,28 +17,70 @@ function fromPkg(base) {
   } catch { return null; }
 }
 
-// The global node_modules dir per npm (handles Homebrew/Windows/volta). Queried on demand.
+// The global node_modules dir per npm (handles Homebrew/Windows/volta).
+//
+// Asking npm costs a subprocess (~0.5s), and this file runs on every hook and every
+// statusline render, so the answer is cached for a day. Under the user's own ~/.graft,
+// beside graft's update check — NOT a world-writable path like /tmp, where a co-tenant
+// on a shared machine could point the cache at their own code for us to import.
+const ROOT_TTL_MS = 24 * 60 * 60 * 1000;
 function globalRoot() {
+  const cache = path.join(os.homedir(), '.graft', 'npm-root.json');
   try {
-    const root = execFileSync('npm', ['root', '-g'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], shell: process.platform === 'win32' }).trim();
-    return root || null;
-  } catch { return null; /* npm unavailable */ }
+    const c = JSON.parse(fs.readFileSync(cache, 'utf8'));
+    if (typeof c.at === 'number' && Date.now() - c.at < ROOT_TTL_MS) return c.root || null;
+  } catch { /* no cache yet, or unreadable — ask npm */ }
+  let root = null;
+  try {
+    root = execFileSync('npm', ['root', '-g'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], shell: process.platform === 'win32' }).trim() || null;
+  } catch { /* npm unavailable */ }
+  try {
+    fs.mkdirSync(path.dirname(cache), { recursive: true });
+    fs.writeFileSync(cache, JSON.stringify({ root: root, at: Date.now() }));
+  } catch { /* unwritable home — just pay the spawn again next time */ }
+  return root;
 }
 
-function candidates() {
-  const out = [];
-  if (BAKED) out.push(BAKED);
-  const local = fromPkg(dir); if (local) out.push(local);
-  const legacy = fromPkg(path.join(path.dirname(process.execPath), '..', 'lib')); if (legacy) out.push(legacy);
-  const gr = globalRoot(); if (gr) out.push(path.join(gr, '@nanonets', 'graft', 'dist', 'claude'));
-  return out;
+// The version of the package a dist/claude dir belongs to, or null if unreadable.
+function versionOf(distClaude) {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(distClaude, '..', '..', 'package.json'), 'utf8')).version || null;
+  } catch { return null; }
+}
+
+// Numeric-dotted compare of the release part; an unreadable version loses to any known one.
+function newer(a, b) {
+  if (!a) return false;
+  if (!b) return true;
+  const p = (v) => String(v).split('-')[0].split('.').map((n) => Number(n) || 0);
+  const pa = p(a), pb = p(b);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const d = (pa[i] || 0) - (pb[i] || 0);
+    if (d !== 0) return d > 0;
+  }
+  return false;
+}
+
+// The highest-versioned dir in `dirs` that actually contains `name`, or null.
+function best(dirs, name) {
+  let bestDir = null, bestVer = null;
+  for (const d of dirs) {
+    if (!d || !fs.existsSync(path.join(d, name))) continue;
+    const v = versionOf(d);
+    if (bestDir === null || newer(v, bestVer)) { bestDir = d; bestVer = v; }
+  }
+  return bestDir;
 }
 
 function entry(name) {
-  for (const d of candidates()) {
-    const f = path.join(d, name);
-    if (fs.existsSync(f)) return f;
-  }
+  const gr = globalRoot();
+  const hit = best([
+    bakedDir,
+    fromPkg(dir),
+    fromPkg(path.join(path.dirname(process.execPath), '..', 'lib')),
+    gr && path.join(gr, '@nanonets', 'graft', 'dist', 'claude'),
+  ], name);
+  if (hit) return path.join(hit, name);
   return path.join(dir, 'dist', 'claude', name); // last-ditch; import will no-op if absent
 }
 

--- a/.claude/helpers/graft-statusline.cjs
+++ b/.claude/helpers/graft-statusline.cjs
@@ -1,10 +1,13 @@
 #!/usr/bin/env node
 const path = require('path');
 const fs = require('fs');
+const os = require('os');
 const { pathToFileURL } = require('url');
 const { execFileSync } = require('child_process');
 const dir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
-const BAKED = "/Users/shrishdwivedi/Documents/Context graphs/context-graph-engine/dist/claude";
+// Relative when graft's dist lives inside this repo; path.resolve leaves an absolute one be.
+const BAKED = "dist/claude";
+const bakedDir = BAKED ? path.resolve(dir, BAKED) : null;
 
 // The dist/claude dir of @nanonets/graft resolved from a base whose node_modules is searched.
 function fromPkg(base) {
@@ -14,28 +17,70 @@ function fromPkg(base) {
   } catch { return null; }
 }
 
-// The global node_modules dir per npm (handles Homebrew/Windows/volta). Queried on demand.
+// The global node_modules dir per npm (handles Homebrew/Windows/volta).
+//
+// Asking npm costs a subprocess (~0.5s), and this file runs on every hook and every
+// statusline render, so the answer is cached for a day. Under the user's own ~/.graft,
+// beside graft's update check — NOT a world-writable path like /tmp, where a co-tenant
+// on a shared machine could point the cache at their own code for us to import.
+const ROOT_TTL_MS = 24 * 60 * 60 * 1000;
 function globalRoot() {
+  const cache = path.join(os.homedir(), '.graft', 'npm-root.json');
   try {
-    const root = execFileSync('npm', ['root', '-g'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], shell: process.platform === 'win32' }).trim();
-    return root || null;
-  } catch { return null; /* npm unavailable */ }
+    const c = JSON.parse(fs.readFileSync(cache, 'utf8'));
+    if (typeof c.at === 'number' && Date.now() - c.at < ROOT_TTL_MS) return c.root || null;
+  } catch { /* no cache yet, or unreadable — ask npm */ }
+  let root = null;
+  try {
+    root = execFileSync('npm', ['root', '-g'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], shell: process.platform === 'win32' }).trim() || null;
+  } catch { /* npm unavailable */ }
+  try {
+    fs.mkdirSync(path.dirname(cache), { recursive: true });
+    fs.writeFileSync(cache, JSON.stringify({ root: root, at: Date.now() }));
+  } catch { /* unwritable home — just pay the spawn again next time */ }
+  return root;
 }
 
-function candidates() {
-  const out = [];
-  if (BAKED) out.push(BAKED);
-  const local = fromPkg(dir); if (local) out.push(local);
-  const legacy = fromPkg(path.join(path.dirname(process.execPath), '..', 'lib')); if (legacy) out.push(legacy);
-  const gr = globalRoot(); if (gr) out.push(path.join(gr, '@nanonets', 'graft', 'dist', 'claude'));
-  return out;
+// The version of the package a dist/claude dir belongs to, or null if unreadable.
+function versionOf(distClaude) {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(distClaude, '..', '..', 'package.json'), 'utf8')).version || null;
+  } catch { return null; }
+}
+
+// Numeric-dotted compare of the release part; an unreadable version loses to any known one.
+function newer(a, b) {
+  if (!a) return false;
+  if (!b) return true;
+  const p = (v) => String(v).split('-')[0].split('.').map((n) => Number(n) || 0);
+  const pa = p(a), pb = p(b);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const d = (pa[i] || 0) - (pb[i] || 0);
+    if (d !== 0) return d > 0;
+  }
+  return false;
+}
+
+// The highest-versioned dir in `dirs` that actually contains `name`, or null.
+function best(dirs, name) {
+  let bestDir = null, bestVer = null;
+  for (const d of dirs) {
+    if (!d || !fs.existsSync(path.join(d, name))) continue;
+    const v = versionOf(d);
+    if (bestDir === null || newer(v, bestVer)) { bestDir = d; bestVer = v; }
+  }
+  return bestDir;
 }
 
 function entry(name) {
-  for (const d of candidates()) {
-    const f = path.join(d, name);
-    if (fs.existsSync(f)) return f;
-  }
+  const gr = globalRoot();
+  const hit = best([
+    bakedDir,
+    fromPkg(dir),
+    fromPkg(path.join(path.dirname(process.execPath), '..', 'lib')),
+    gr && path.join(gr, '@nanonets', 'graft', 'dist', 'claude'),
+  ], name);
+  if (hit) return path.join(hit, name);
   return path.join(dir, 'dist', 'claude', name); // last-ditch; import will no-op if absent
 }
 

--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,29 @@
 # Graft — configuration
 #
-# Graft calls an LLM for concept nodes + per-symbol summaries, so an API key is
-# required for the deep pass (`build --deep`). The structural build (`build`,
-# `check`, `ask`, `grep`, `map`, traversal) is deterministic tree-sitter and
-# needs no key.
+# Graft calls an LLM for concept nodes + per-symbol summaries, so the deep pass
+# (`build --deep`) needs a model. The structural build (`build`, `check`, `ask`,
+# `grep`, `map`, traversal) is deterministic tree-sitter and needs nothing.
 #
-# Graft is vendor-neutral: GRAFT_PROVIDER picks the WIRE FORMAT, not a company.
-# Bring your own key from whichever provider you use.
+# There are two ways to give it a model:
+#   1. A SUBSCRIPTION — install the Claude Code CLI, sign in, and set nothing at
+#      all. graft detects it and uses it when no API key is configured.
+#   2. An API KEY — any provider. GRAFT_PROVIDER picks the WIRE FORMAT, not a
+#      company; bring your own key.
 
-# --- Provider (required for `build --deep`) -----------------------------------
+# --- Option 1: your Claude subscription (no key) ------------------------------
+# Requires the Claude Code CLI on PATH, signed in (https://claude.com/claude-code).
+# Auto-detected when no API key is set, so this whole block is usually optional.
+# GRAFT_PROVIDER=claude-cli
+# Model alias or full id. Aliases track the current model, so prefer them.
+# GRAFT_MODEL=sonnet
+# Path to the binary, if it is not on PATH.
+# GRAFT_CLAUDE_BIN=
+# Per-call wall clock in ms (default 300000).
+# GRAFT_CLAUDE_TIMEOUT_MS=300000
+# Per-call spend ceiling in USD (notional on a subscription; a safety valve).
+# GRAFT_CLAUDE_MAX_BUDGET_USD=
+
+# --- Option 2: an API key -----------------------------------------------------
 # Wire format / SDK: "openai" (any OpenAI-compatible endpoint) or "anthropic".
 # GRAFT_PROVIDER=openai
 # Your provider API key.

--- a/.env.example
+++ b/.env.example
@@ -18,9 +18,13 @@
 # GRAFT_MODEL=sonnet
 # Path to the binary, if it is not on PATH.
 # GRAFT_CLAUDE_BIN=
-# Per-call wall clock in ms (default 300000).
+# Per-call wall clock in ms (default 300000). GRAFT_TIMEOUT_MS is the
+# provider-neutral name; this one wins when both are set.
 # GRAFT_CLAUDE_TIMEOUT_MS=300000
-# Per-call spend ceiling in USD (notional on a subscription; a safety valve).
+# Per-call spend ceiling in USD, passed to the CLI as --max-budget-usd. Notional
+# on a subscription: it is a runaway-loop valve, not a bill. A `--deep` build
+# makes one call per file, so this bounds ONE call, not the run.
+# Same thing per invocation: `graft build --deep --max-budget-usd 0.50`.
 # GRAFT_CLAUDE_MAX_BUDGET_USD=
 
 # --- Option 2: an API key -----------------------------------------------------
@@ -28,8 +32,13 @@
 # GRAFT_PROVIDER=openai
 # Your provider API key.
 # GRAFT_API_KEY=
-# Model id, as your provider names it.
-# GRAFT_MODEL=openai/gpt-4o-mini
+# Model id, AS YOUR ENDPOINT NAMES IT — the two spellings are not interchangeable:
+# api.openai.com answers `openai/gpt-4o-mini` with a 404 model_not_found, and that
+# `vendor/slug` form is OpenRouter's addressing scheme. Leave it unset and graft
+# picks the right spelling for the base URL below.
+# GRAFT_MODEL=gpt-4o-mini
+# Per-call wall clock in ms, all providers (default: the SDK's own).
+# GRAFT_TIMEOUT_MS=
 # Base URL for the "openai" wire format — this is how you pick a provider.
 # Leave unset to hit api.openai.com. Examples:
 #   OpenRouter:  https://openrouter.ai/api/v1
@@ -44,6 +53,14 @@
 #   GRAFT_API_KEY=sk-ant-...
 #   GRAFT_MODEL=claude-sonnet-5
 
+# --- Retries (all providers) --------------------------------------------------
+# Retries after a failed call. Default 2. The right number belongs to the
+# ENDPOINT, not to graft: raise it on a hard-rate-limited key (each retry waits
+# out the endpoint's Retry-After, so a --deep build loses files instead of
+# waiting), and set 0 against a local server that may not be running at all,
+# where retrying every file 2× only triples the time to find out.
+# GRAFT_MAX_RETRIES=2
+
 # --- Deprecated (still honored as a fallback) ---------------------------------
 # If GRAFT_API_KEY is unset, these legacy OpenRouter vars are used instead.
 # OPENROUTER_API_KEY=sk-or-...
@@ -51,8 +68,14 @@
 # GRAFT_OPENROUTER_MODEL=openai/gpt-4o-mini
 
 # --- Graph location -----------------------------------------------------------
-# Where the graph lives (default: <repo>/.context)
-# GRAFT_DIR=.context
+# Where the graph lives (default: <repo>/graft).
+#
+# USE AN ABSOLUTE PATH. A relative value is resolved against the CURRENT WORKING
+# DIRECTORY, not the repo root — so `graft build` at the root and `graft ask` from
+# a subdirectory would write and read two different graphs, and the second one
+# reports an empty repo rather than an error. Only set this at all if the default
+# location is a problem (it is git-ignored automatically).
+# GRAFT_DIR=/abs/path/to/graft
 
 # --- Benchmark (bench/) -------------------------------------------------------
 # Per-role model overrides for the benchmark harness.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# The two shims under .claude/helpers/ are GENERATED from src/claude/shim-template.ts
+# and checked in because .claude/settings.json points every hook at them — a clone
+# without them fails with "Cannot find module". test/claude-shim-template.test.ts
+# compares them against the template, which only ever emits \n, so their committed
+# bytes have to stay LF no matter what core.autocrlf says on the contributor's box.
+.claude/helpers/*.cjs text eol=lf
+
+# Fixtures whose bytes are the point of the test.
+*.patch -text

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   test:
-    name: test (${{ matrix.os }})
+    name: test (${{ matrix.os }}, node ${{ matrix.node }})
     # Windows is not redundant coverage here: graft stores repo-relative paths and
     # parses them with `/` by hand, so a platform-separator leak matches nothing
     # rather than erroring. That class of bug is invisible to a posix-only matrix
@@ -19,11 +19,67 @@ jobs:
     # earned it immediately — it caught npx detection never firing on Windows and a
     # seeded worktree silently losing its freshness record. `fail-fast: false` so a
     # Windows-only failure still reports the Linux result.
+    #
+    # The Node dimension used to be pinned to a single '20' while engines said
+    # ">=20" (open-ended) and @types/node is ^26 — tsc happily accepts an API that
+    # only exists in a newer runtime, so what most users actually run (22/24) was
+    # never executed. Pull requests run the FLOOR only (that is where an
+    # engines/dependency break shows up, and it keeps the PR bill at two legs);
+    # push to main fans out to the whole supported range before anything can be
+    # published from it.
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
+        node: ${{ fromJSON(github.event_name == 'push' && '["20","22","24"]' || '["20"]') }}
     runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Guards the promise in engines.node. `commander@15` (node >=22.12) sat in a
+      # package declaring ">=20" for a full release; on an .npmrc with
+      # engine-strict=true that is an install failure, not a warning.
+      - name: Check engine contract
+        run: npm run check:engines
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      # test/ was never type-checked (tsx strips types without checking), so it
+      # starts with a real backlog — 31 errors when this was switched on. Reported,
+      # not gating, until that reaches zero; flipping it to a gate is a one-line
+      # change once it does.
+      - name: Typecheck tests (non-blocking)
+        continue-on-error: true
+        run: npm run typecheck:tests
+
+  package:
+    # Nothing in `test` ever runs the *packaged* artifact: the suite imports src/
+    # through tsx, so anything that only exists in dist/ is untested until after a
+    # publish. That is worst for the breadth tier's .scm queries, which
+    # build-viewer.mjs copies by hand — src/graph/generic.ts falls back to
+    # src/graph/queries when dist/ lacks them, so from a checkout the query is
+    # ALWAYS found, and an installed user just silently loses every generic-tier
+    # language ("degrades to a file node only, never throws"). This job installs
+    # the tarball into a clean prefix and proves the breadth tier still produces
+    # nodes for a language (Rust) that exists only there.
+    name: packaged artifact
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -39,5 +95,64 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Test
-        run: npm test
+      - name: Build
+        run: npm run build
+
+      - name: Assert the tarball carries every runtime asset
+        run: npm run check:package
+
+      - name: Pack and install into a clean prefix
+        run: |
+          npm pack
+          mkdir -p "$RUNNER_TEMP/prefix"
+          npm i -g --prefix "$RUNNER_TEMP/prefix" ./nanonets-graft-*.tgz
+          echo "$RUNNER_TEMP/prefix/bin" >> "$GITHUB_PATH"
+
+      - name: Smoke the installed binary on a generic-tier language
+        run: |
+          graft --version
+          mkdir -p "$RUNNER_TEMP/fixture/src"
+          cat > "$RUNNER_TEMP/fixture/src/lib.rs" <<'RS'
+          pub struct Config { pub name: String }
+          pub fn load() -> Config { parse(); Config { name: String::new() } }
+          fn parse() -> String { String::new() }
+          RS
+          cd "$RUNNER_TEMP/fixture"
+          graft build .
+          node -e '
+            const g = JSON.parse(require("fs").readFileSync("graft/.graph/wiring.json", "utf8"));
+            const rust = g.nodes.filter((n) => n.path.endsWith(".rs") && n.kind !== "file");
+            if (rust.length === 0) {
+              console.error("✗ the packaged build produced no Rust symbols — dist/graph/queries is incomplete");
+              process.exit(1);
+            }
+            console.log(`✓ ${rust.length} Rust symbols from the installed package`);
+          '
+
+  quality:
+    # scripts/graph-quality.mjs advertised itself as a "CI gate" while no workflow
+    # ran it. Dogfooding graft on graft is the cheapest deterministic oracle we
+    # have: a malformed span, a dangling edge or a kind the extractor invented
+    # fails here instead of in a user's graph.
+    name: graph quality (dogfood)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build graft's own graph
+        run: npx tsx src/cli.ts build .
+
+      - name: Assert graph invariants
+        run: node scripts/graph-quality.mjs . --strict

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ graft/
 
 # Session transcripts and prompt traces — local analysis, not product.
 transcripts/
+
+# transient agent worktrees
+.claude/worktrees/

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ _Summary, sources, links, and notes ship today in markdown nodes. The crux ships
 ## What runs where
 
 - **On your machine, no key, no network:** the structural code graph. `graft build` (wiring graph + per-file cards), `graft check`, and `graft ask` are deterministic tree-sitter — they never call a model.
+- **On your Claude subscription, no key:** if the [Claude Code](https://claude.com/claude-code) CLI is installed and signed in, `graft build --deep` just works — graft drives it in headless mode and the run bills against your existing subscription instead of metered API credits. This is the default whenever no API key is configured; force it with `GRAFT_PROVIDER=claude-cli` (`GRAFT_MODEL=sonnet|opus|haiku`). The CLI is invoked with every tool disabled and your own settings, hooks, MCP servers and `CLAUDE.md` excluded, so it is a pure summarization call that cannot touch your repo.
 - **Through your provider key:** the LLM-written parts — `graft build --deep` adds the concept nodes (file summaries + node synthesis) and the per-symbol summaries and cruxes. graft is vendor-neutral: set `GRAFT_PROVIDER` (`openai` for any OpenAI-compatible endpoint, or `anthropic` for the native API), your `GRAFT_API_KEY`, `GRAFT_MODEL`, and — for the `openai` wire format — `GRAFT_BASE_URL` to point at OpenRouter, Fireworks, Groq, a LiteLLM proxy, a local server, or OpenAI itself. Or pass `--provider/--model/--api-key/--base-url` on the command line. (`OPENROUTER_API_KEY` still works as a deprecated fallback.)
 - **No telemetry** and no analytics — the only network calls are the LLM requests you configured.
 
@@ -320,7 +321,7 @@ Where a CLI agent supports user-level `hooks.json`, `init` also installs Graft's
   <br/><sub>edit a file → blast radius appears inline → graph auto-resyncs → confirmed in <code>graft viz</code></sub>
 </p>
 
-`graft init` is idempotent and never clobbers your existing `.claude/settings.json` — it merges its blocks and leaves the rest alone. Want the LLM summaries too? Run `graft build --deep` (with a key) whenever you like; auto-sync will never do it for you.
+`graft init` is idempotent and never clobbers your existing `.claude/settings.json` — it merges its blocks and leaves the rest alone. Want the LLM summaries too? Run `graft build --deep` (with a key, or on your Claude subscription) whenever you like; auto-sync will never do it for you.
 
 ---
 
@@ -329,6 +330,7 @@ Where a CLI agent supports user-level `hooks.json`, `init` also installs Graft's
 ```bash
 graft build [dir]                    # build graft/ from the code at [dir]: wiring graph + per-file cards (no LLM, no key)
 graft build --deep                   # add the LLM layer: concept nodes + per-symbol summary/crux (cached)
+                                     # uses your signed-in Claude Code CLI when no API key is set
 graft build --extensions .ts .py     # only include these code extensions
 graft build --no-reuse               # re-parse every file instead of replaying unchanged ones from cache
 

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ _Summary, sources, links, and notes ship today in markdown nodes. The crux ships
 ## What runs where
 
 - **On your machine, no key, no network:** the structural code graph. `graft build` (wiring graph + per-file cards), `graft check`, and `graft ask` are deterministic tree-sitter — they never call a model.
-- **On your Claude subscription, no key:** if the [Claude Code](https://claude.com/claude-code) CLI is installed and signed in, `graft build --deep` just works — graft drives it in headless mode and the run bills against your existing subscription instead of metered API credits. This is the default whenever no API key is configured; force it with `GRAFT_PROVIDER=claude-cli` (`GRAFT_MODEL=sonnet|opus|haiku`). The CLI is invoked with every tool disabled and your own settings, hooks, MCP servers and `CLAUDE.md` excluded, so it is a pure summarization call that cannot touch your repo.
+- **On your Claude subscription, no key:** if the [Claude Code](https://claude.com/claude-code) CLI is installed and signed in, `graft build --deep` just works — graft drives it in headless mode and the run bills against your existing subscription instead of metered API credits. This is the default whenever no API key is configured; force it with `GRAFT_PROVIDER=claude-cli` (`GRAFT_MODEL=sonnet|opus|haiku`, `GRAFT_CLAUDE_BIN=` if the binary isn't on `PATH`). The CLI is invoked with every tool disabled and your own settings, hooks, MCP servers and `CLAUDE.md` excluded, so it is a pure summarization call that cannot touch your repo. Bound each call with `--max-budget-usd` / `GRAFT_CLAUDE_MAX_BUDGET_USD` and `GRAFT_CLAUDE_TIMEOUT_MS` (default 300000): a `--deep` build makes one call per file, so both ceilings are per call, not per run.
 - **Through your provider key:** the LLM-written parts — `graft build --deep` adds the concept nodes (file summaries + node synthesis) and the per-symbol summaries and cruxes. graft is vendor-neutral: set `GRAFT_PROVIDER` (`openai` for any OpenAI-compatible endpoint, or `anthropic` for the native API), your `GRAFT_API_KEY`, `GRAFT_MODEL`, and — for the `openai` wire format — `GRAFT_BASE_URL` to point at OpenRouter, Fireworks, Groq, a LiteLLM proxy, a local server, or OpenAI itself. Or pass `--provider/--model/--api-key/--base-url` on the command line. (`OPENROUTER_API_KEY` still works as a deprecated fallback.)
 - **No telemetry** and no analytics — the only network calls are the LLM requests you configured.
 
@@ -331,8 +331,16 @@ Where a CLI agent supports user-level `hooks.json`, `init` also installs Graft's
 graft build [dir]                    # build graft/ from the code at [dir]: wiring graph + per-file cards (no LLM, no key)
 graft build --deep                   # add the LLM layer: concept nodes + per-symbol summary/crux (cached)
                                      # uses your signed-in Claude Code CLI when no API key is set
-graft build --extensions .ts .py     # only include these code extensions
+graft build --extensions .ts .py     # index ONLY these extensions — narrows the wiring graph and the --deep pass alike.
+                                     # Persisted to <repo>/.graft/config.json, so later builds, `graft check` and the
+                                     # auto-refresh narrow identically; every build says so while it is in force
+graft build --no-extensions          # forget that narrowing and index everything again
+graft build -j N                     # files summarized in parallel during --deep (default 5; -j 1 to survive a rate limit)
 graft build --no-reuse               # re-parse every file instead of replaying unchanged ones from cache
+graft build --include-dir build      # index a directory graft skips by default (dist, build, vendor, …); repeatable.
+                                     # Persisted to <repo>/.graft/config.json, so later builds and the auto-refresh
+                                     # honour it without the flag; dot-directories are never overridable
+graft build --no-include-dir         # forget that persisted override
 
 graft ask "<task>" [dir]             # query the graph — ranked nodes + exact file:line (no LLM, no key)
 graft ask "<task>" --json            # machine-readable result
@@ -377,7 +385,12 @@ graft upgrade                        # npm install -g the latest published versi
                                      # after upgrading, the next session refreshes this repo's wiring itself
 
 # global
-graft --dir <path>                   # use a context dir other than <repo>/graft
+graft --dir <path>                   # use a context dir other than <repo>/graft (absolute — a relative path is
+                                     # resolved against the cwd, so build and query can disagree)
+graft --provider <name>              # openai | anthropic | claude-cli (env GRAFT_PROVIDER)
+graft --model <id> --api-key <key> --base-url <url>   # env GRAFT_MODEL / GRAFT_API_KEY / GRAFT_BASE_URL
+graft --max-budget-usd <usd>         # claude-cli only: per-CALL spend ceiling (env GRAFT_CLAUDE_MAX_BUDGET_USD).
+                                     # Notional on a subscription — a runaway-loop valve, not a bill
 graft --version, -v                  # print the installed version and exit
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.113.0",
-        "commander": "^15.0.0",
+        "commander": "^14.0.3",
         "dotenv": "^17.4.2",
         "gray-matter": "^4.0.3",
         "openai": "^6.45.0",
@@ -551,12 +551,12 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/commander": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
-      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "license": "MIT",
       "engines": {
-        "node": ">=22.12.0"
+        "node": ">=20"
       }
     },
     "node_modules/d3-dispatch": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,10 @@
     "dev": "tsc -p tsconfig.json --watch",
     "cli": "tsx src/cli.ts",
     "test": "node scripts/run-tests.mjs",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck:tests": "tsc -p tsconfig.test.json",
+    "check:package": "node scripts/check-package-contents.mjs",
+    "check:engines": "node scripts/check-engines.mjs",
     "prepare": "npm run build",
     "prepublishOnly": "npm run build",
     "postinstall": "node scripts/postinstall.mjs"
@@ -56,7 +60,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.113.0",
-    "commander": "^15.0.0",
+    "commander": "^14.0.3",
     "dotenv": "^17.4.2",
     "gray-matter": "^4.0.3",
     "openai": "^6.45.0",
@@ -77,13 +81,5 @@
     "esbuild": "^0.28.1",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3"
-  },
-  "allowScripts": {
-    "tree-sitter@0.21.1": true,
-    "tree-sitter-typescript@0.23.2": true,
-    "tree-sitter-python@0.21.0": true,
-    "tree-sitter-go@0.23.4": true,
-    "tree-sitter-javascript@0.23.1": true,
-    "tree-sitter-java@0.23.5": true
   }
 }

--- a/scripts/check-engines.mjs
+++ b/scripts/check-engines.mjs
@@ -1,0 +1,96 @@
+/**
+ * Asserts no shipped dependency demands a newer Node than this package promises.
+ *
+ *   node scripts/check-engines.mjs [--json]
+ *
+ * The bug this exists to prevent shipped once already: package.json promised
+ * `"node": ">=20"` while `commander@15` (a direct, top-of-cli import) declared
+ * `>=22.12.0`, and the only Node the matrix ever ran was 20 — so the one
+ * combination CI validated was the one npm marks unsupported. Users on Node 20
+ * got EBADENGINE on `npm i -g @nanonets/graft`, and an .npmrc with
+ * `engine-strict=true` (common in corporate setups) turned that warning into a
+ * hard install failure.
+ *
+ * Only runtime deps count: a devDependency wanting a newer Node inconveniences
+ * contributors, it does not break an install of the published package. Reads the
+ * lockfile rather than node_modules so it gives the same answer on a machine that
+ * never ran `npm i`.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+/**
+ * Lowest Node version a semver range admits, as a comparable [major, minor, patch].
+ * Ranges here are the handful npm packages actually publish in `engines.node`
+ * (">=20", ">=22.12.0", "^18 || >=20", ">=14 <21"), so taking the SMALLEST lower
+ * bound across the or-clauses is both correct and enough — a package that accepts
+ * old Node via any clause is not a threat to our floor.
+ */
+export function minVersion(range) {
+  if (!range || range === "*") return null;
+  const clauses = String(range).split("||");
+  let best = null;
+  for (const clause of clauses) {
+    const m = /(?:>=|\^|~|>)?\s*v?(\d+)(?:\.(\d+))?(?:\.(\d+))?/.exec(clause.trim());
+    if (!m) continue;
+    // `>N` means the floor is the next version up; treat it as N.0.1-ish by
+    // bumping the patch, which is all the comparison below needs.
+    const bump = /^\s*>[^=]/.test(clause) ? 1 : 0;
+    const v = [Number(m[1]), Number(m[2] ?? 0), Number(m[3] ?? 0) + bump];
+    if (!best || cmp(v, best) < 0) best = v;
+  }
+  return best;
+}
+
+function cmp(a, b) {
+  for (let i = 0; i < 3; i++) if (a[i] !== b[i]) return a[i] - b[i];
+  return 0;
+}
+
+/**
+ * Runtime lock entries whose Node floor is above `declaredRange`.
+ * `lockPackages` is package-lock.json's `packages` map. Pure, so a test can feed
+ * it a synthetic lock instead of waiting for a real bad dependency to land.
+ */
+export function engineViolations(lockPackages, declaredRange) {
+  const floor = minVersion(declaredRange);
+  if (!floor) return [];
+  const bad = [];
+  for (const [path, entry] of Object.entries(lockPackages ?? {})) {
+    if (!path || entry?.dev || entry?.optional) continue; // "" is the root package
+    const want = entry?.engines?.node;
+    if (!want) continue;
+    const need = minVersion(want);
+    if (need && cmp(need, floor) > 0) {
+      bad.push({ package: path.replace(/^node_modules\//, ""), version: entry.version, requires: want });
+    }
+  }
+  return bad.sort((a, b) => a.package.localeCompare(b.package));
+}
+
+function main() {
+  const pkg = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8"));
+  const lock = JSON.parse(readFileSync(join(repoRoot, "package-lock.json"), "utf8"));
+  const declared = pkg.engines?.node;
+  const bad = engineViolations(lock.packages, declared);
+
+  if (process.argv.includes("--json")) {
+    console.log(JSON.stringify({ declared, violations: bad }, null, 2));
+  } else {
+    console.log(`engines — package declares node ${declared}`);
+    for (const b of bad) console.log(`  ✗ ${b.package}@${b.version} requires node ${b.requires}`);
+    if (!bad.length) console.log("  runtime dependencies: OK ✓");
+  }
+  if (bad.length) {
+    console.error(
+      `✗ ${bad.length} runtime dependency(ies) need a newer Node than engines.node (${declared}).\n` +
+      `  Either pin them back or raise engines.node and the CI matrix together.`,
+    );
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main();

--- a/scripts/check-package-contents.mjs
+++ b/scripts/check-package-contents.mjs
@@ -1,0 +1,93 @@
+/**
+ * Asserts the publishable tarball actually carries the runtime assets that tsc
+ * does not emit.
+ *
+ *   node scripts/check-package-contents.mjs [--json]
+ *
+ * Why this exists: the generic (breadth) tier's `.scm` queries and the viewer
+ * bundle are produced by scripts/build-viewer.mjs, not by tsc, and their absence
+ * is SILENT. src/graph/generic.ts resolves `dist/graph/queries` first and falls
+ * back to `src/graph/queries`, so anything running from a checkout (every test,
+ * every dev run) finds the query even when dist/ never got it — and an installed
+ * user gets `loadQuery() -> null`, a skipped grammar and, per generic.ts, a
+ * "file node only (never throws)". The whole breadth tier can vanish from a
+ * published release without one error line. Same class of failure for
+ * dist/viewer/app.js, which `graft viz` serves.
+ *
+ * So: read the file list npm would publish and require those assets by name,
+ * plus one .scm per query in src/graph/queries — a partial copy is as broken as
+ * no copy, and only a parity check catches it.
+ */
+import { execFileSync } from "node:child_process";
+import { readdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+/** Entries every tarball must contain regardless of what is in src/. */
+export const REQUIRED_FILES = [
+  "dist/cli.js",
+  "dist/index.js",
+  "dist/index.d.ts",
+  "dist/viewer/app.js",
+  "dist/viewer/index.html",
+  "dist/viewer/style.css",
+];
+
+/**
+ * Which required entries are missing from `packedFiles` (posix paths, as
+ * `npm pack --json` reports them). `queryNames` is the list of .scm files that
+ * exist in src/graph/queries; each must have a dist/graph/queries twin.
+ * Pure, so the test can drive it with a hand-built file list.
+ */
+export function missingFromPack(packedFiles, queryNames) {
+  const have = new Set(packedFiles.map((f) => f.replace(/\\/g, "/")));
+  const missing = REQUIRED_FILES.filter((f) => !have.has(f));
+  for (const q of queryNames) {
+    const want = `dist/graph/queries/${q}`;
+    if (!have.has(want)) missing.push(want);
+  }
+  return missing;
+}
+
+/** The .scm queries the breadth tier expects to find at runtime. */
+export function queryFileNames(root = repoRoot) {
+  return readdirSync(join(root, "src", "graph", "queries")).filter((f) => f.endsWith(".scm")).sort();
+}
+
+/** `npm pack --dry-run --json` file list, without writing a tarball. */
+export function packedFileList(root = repoRoot) {
+  // `--ignore-scripts` so this never re-triggers `prepare` (a full rebuild) just
+  // to ask npm what it would ship; CI builds before calling us.
+  // `shell: true` on Windows only: since the CVE-2024-27980 fix, execFile refuses
+  // to spawn a `.cmd` (npm is npm.cmd there) without a shell and dies with EINVAL.
+  // The argv is a fixed literal, so there is nothing to inject.
+  const out = execFileSync(
+    process.platform === "win32" ? "npm.cmd" : "npm",
+    ["pack", "--dry-run", "--json", "--ignore-scripts"],
+    { cwd: root, encoding: "utf8", stdio: ["ignore", "pipe", "inherit"], shell: process.platform === "win32" },
+  );
+  // npm can prefix notices before the JSON payload; take the array.
+  const start = out.indexOf("[");
+  const parsed = JSON.parse(out.slice(start));
+  return (parsed[0]?.files ?? []).map((f) => f.path.replace(/\\/g, "/"));
+}
+
+function main() {
+  const files = packedFileList();
+  const missing = missingFromPack(files, queryFileNames());
+  if (process.argv.includes("--json")) {
+    console.log(JSON.stringify({ files: files.length, missing }, null, 2));
+  } else {
+    console.log(`package contents — ${files.length} files`);
+    for (const m of missing) console.log(`  ✗ missing ${m}`);
+  }
+  if (missing.length) {
+    console.error(`✗ ${missing.length} runtime asset(s) missing from the tarball — run \`npm run build\``);
+    process.exit(1);
+  }
+  console.log("  runtime assets: OK ✓");
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main();

--- a/scripts/graph-quality.mjs
+++ b/scripts/graph-quality.mjs
@@ -8,110 +8,129 @@
  * asserts structural INVARIANTS that must always hold:
  *   - no dangling edge endpoints (every source is a node; every target is a node
  *     or a deliberately-unresolved external string)
- *   - valid spans (`Lx-Ly`, x<=y, within file line count where known)
+ *   - well-formed spans (`Lx-Ly`, x<=y)
  *   - unique node ids; non-empty names; kinds in the allowed set
  *   - no self-loop call edges
- * Exits non-zero with --strict when any invariant fails (CI gate).
+ * Exits non-zero with --strict when any invariant fails; ci.yml runs exactly that
+ * over graft's own graph, so this file is a live gate rather than a claim.
+ *
+ * The vocabulary sets below duplicate src/graph/invariants.ts on purpose (see the
+ * note there: the CLI report has to work against a stale or missing dist/). They
+ * are exported so test/graph-quality-script.test.ts can assert the two copies —
+ * and the `Kind`/`Relation`/`Confidence` unions they mirror — have not drifted;
+ * before that guard, adding a kind to types.ts made this script report a
+ * false-positive `bad kind` on every real graph.
  */
 import { readFileSync, existsSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const KINDS = new Set(["file","class","function","method","interface","type","enum","struct","module","constant","variable"]);
-const RELATIONS = new Set(["contains","calls","imports","references","implements","extends"]);
-const CONFIDENCE = new Set(["lsp_resolved","lsp_dispatch","extracted","inferred"]);
+export const KINDS = new Set(["file","class","function","method","interface","type","enum","struct","module","constant","variable"]);
+export const RELATIONS = new Set(["contains","calls","imports","references","implements","extends"]);
+export const CONFIDENCE = new Set(["lsp_resolved","lsp_dispatch","extracted","inferred"]);
 
-const arg = process.argv[2] ?? ".";
-const json = process.argv.includes("--json");
-const strict = process.argv.includes("--strict");
-const wpath = arg.endsWith(".json") ? arg
-  : [join(arg, "graft", ".graph", "wiring.json"), join(arg, "graft", "wiring.json")].find(existsSync);
-if (!wpath || !existsSync(wpath)) { console.error(`no graph found at ${arg} (run \`graft build\` first)`); process.exit(2); }
+/** Shape + invariant report for an already-parsed graph object. Pure. */
+export function analyze(g, wpath) {
+  const nodes = g.nodes ?? [], edges = g.edges ?? [];
+  const ids = new Set(nodes.map((n) => n.id));
 
-const g = JSON.parse(readFileSync(wpath, "utf8"));
-const nodes = g.nodes ?? [], edges = g.edges ?? [];
-const ids = new Set(nodes.map((n) => n.id));
+  const bump = (m, k) => m.set(k, (m.get(k) ?? 0) + 1);
+  const byKind = new Map(), byOrigin = new Map(), byRel = new Map(), byConf = new Map();
+  for (const n of nodes) { bump(byKind, n.kind); bump(byOrigin, n.origin ?? "?"); }
+  for (const e of edges) { bump(byRel, e.relation); bump(byConf, e.confidence); }
 
-const bump = (m, k) => m.set(k, (m.get(k) ?? 0) + 1);
-const byKind = new Map(), byOrigin = new Map(), byRel = new Map(), byConf = new Map();
-for (const n of nodes) { bump(byKind, n.kind); bump(byOrigin, n.origin ?? "?"); }
-for (const e of edges) { bump(byRel, e.relation); bump(byConf, e.confidence); }
-
-// ── invariants ──
-const problems = [];
-const seen = new Set();
-for (const n of nodes) {
-  if (seen.has(n.id)) problems.push(`dup id: ${n.id}`); seen.add(n.id);
-  if (!n.name || !String(n.name).trim()) problems.push(`empty name: ${n.id}`);
-  if (!KINDS.has(n.kind)) problems.push(`bad kind '${n.kind}': ${n.id}`);
-  const m = /^L(\d+)-L(\d+)$/.exec(n.span ?? "");
-  if (!m) problems.push(`bad span '${n.span}': ${n.id}`);
-  else if (Number(m[1]) > Number(m[2])) problems.push(`inverted span ${n.span}: ${n.id}`);
-}
-// an edge target may be a node id OR a deliberately-unresolved external string
-// (import specifier / bare heritage name); only calls/references/contains must
-// point at real nodes.
-let dangling = 0, selfLoops = 0, unresolvedExternal = 0;
-for (const e of edges) {
-  if (!RELATIONS.has(e.relation)) problems.push(`bad relation '${e.relation}'`);
-  if (!CONFIDENCE.has(e.confidence)) problems.push(`bad confidence '${e.confidence}'`);
-  if (!ids.has(e.source)) { problems.push(`dangling source: ${e.source}`); dangling++; }
-  const targetIsNode = ids.has(e.target);
-  if (!targetIsNode) {
-    if (e.relation === "imports" || e.relation === "extends" || e.relation === "implements") unresolvedExternal++;
-    else { problems.push(`dangling ${e.relation} target: ${e.source} → ${e.target}`); dangling++; }
+  // ── invariants ──
+  const problems = [];
+  const seen = new Set();
+  for (const n of nodes) {
+    if (seen.has(n.id)) problems.push(`dup id: ${n.id}`); seen.add(n.id);
+    if (!n.name || !String(n.name).trim()) problems.push(`empty name: ${n.id}`);
+    if (!KINDS.has(n.kind)) problems.push(`bad kind '${n.kind}': ${n.id}`);
+    const m = /^L(\d+)-L(\d+)$/.exec(n.span ?? "");
+    if (!m) problems.push(`bad span '${n.span}': ${n.id}`);
+    else if (Number(m[1]) > Number(m[2])) problems.push(`inverted span ${n.span}: ${n.id}`);
   }
-  if (e.relation === "calls" && e.source === e.target) selfLoops++;
+  // an edge target may be a node id OR a deliberately-unresolved external string
+  // (import specifier / bare heritage name); only calls/references/contains must
+  // point at real nodes.
+  let dangling = 0, selfLoops = 0, unresolvedExternal = 0;
+  for (const e of edges) {
+    if (!RELATIONS.has(e.relation)) problems.push(`bad relation '${e.relation}'`);
+    if (!CONFIDENCE.has(e.confidence)) problems.push(`bad confidence '${e.confidence}'`);
+    if (!ids.has(e.source)) { problems.push(`dangling source: ${e.source}`); dangling++; }
+    const targetIsNode = ids.has(e.target);
+    if (!targetIsNode) {
+      if (e.relation === "imports" || e.relation === "extends" || e.relation === "implements") unresolvedExternal++;
+      else { problems.push(`dangling ${e.relation} target: ${e.source} → ${e.target}`); dangling++; }
+    }
+    if (e.relation === "calls" && e.source === e.target) selfLoops++;
+  }
+
+  // ── resolution / connectivity metrics ──
+  const calls = edges.filter((e) => e.relation === "calls");
+  const resolvedCalls = calls.filter((e) => ids.has(e.target)).length;
+  const withEdge = new Set();
+  for (const e of edges) { if (e.relation !== "contains") { withEdge.add(e.source); if (ids.has(e.target)) withEdge.add(e.target); } }
+  const symbolNodes = nodes.filter((n) => n.kind !== "file");
+  const orphans = symbolNodes.filter((n) => !withEdge.has(n.id)).length;
+
+  return {
+    graph: wpath,
+    nodes: nodes.length,
+    symbolNodes: symbolNodes.length,
+    edges: edges.length,
+    byKind: Object.fromEntries([...byKind].sort((a,b)=>b[1]-a[1])),
+    byOrigin: Object.fromEntries(byOrigin),
+    byRelation: Object.fromEntries(byRel),
+    byConfidence: Object.fromEntries(byConf),
+    resolution: {
+      calls: calls.length,
+      resolvedToNode: resolvedCalls,
+      resolvedPct: calls.length ? Math.round((resolvedCalls / calls.length) * 100) : null,
+      unresolvedExternalImports: unresolvedExternal,
+    },
+    connectivity: {
+      orphanSymbolNodes: orphans,
+      orphanPct: symbolNodes.length ? Math.round((orphans / symbolNodes.length) * 100) : null,
+    },
+    invariants: {
+      ok: problems.length === 0,
+      danglingEdges: dangling,
+      selfLoopCalls: selfLoops,
+      violations: problems.length,
+      sample: problems.slice(0, 15),
+    },
+  };
 }
 
-// ── resolution / connectivity metrics ──
-const calls = edges.filter((e) => e.relation === "calls");
-const resolvedCalls = calls.filter((e) => ids.has(e.target)).length;
-const withEdge = new Set();
-for (const e of edges) { if (e.relation !== "contains") { withEdge.add(e.source); if (ids.has(e.target)) withEdge.add(e.target); } }
-const symbolNodes = nodes.filter((n) => n.kind !== "file");
-const orphans = symbolNodes.filter((n) => !withEdge.has(n.id)).length;
+function main() {
+  const arg = process.argv[2] ?? ".";
+  const json = process.argv.includes("--json");
+  const strict = process.argv.includes("--strict");
+  const wpath = arg.endsWith(".json") ? arg
+    : [join(arg, "graft", ".graph", "wiring.json"), join(arg, "graft", "wiring.json")].find(existsSync);
+  if (!wpath || !existsSync(wpath)) { console.error(`no graph found at ${arg} (run \`graft build\` first)`); process.exit(2); }
 
-const report = {
-  graph: wpath,
-  nodes: nodes.length,
-  symbolNodes: symbolNodes.length,
-  edges: edges.length,
-  byKind: Object.fromEntries([...byKind].sort((a,b)=>b[1]-a[1])),
-  byOrigin: Object.fromEntries(byOrigin),
-  byRelation: Object.fromEntries(byRel),
-  byConfidence: Object.fromEntries(byConf),
-  resolution: {
-    calls: calls.length,
-    resolvedToNode: resolvedCalls,
-    resolvedPct: calls.length ? Math.round((resolvedCalls / calls.length) * 100) : null,
-    unresolvedExternalImports: unresolvedExternal,
-  },
-  connectivity: {
-    orphanSymbolNodes: orphans,
-    orphanPct: symbolNodes.length ? Math.round((orphans / symbolNodes.length) * 100) : null,
-  },
-  invariants: {
-    ok: problems.length === 0,
-    danglingEdges: dangling,
-    selfLoopCalls: selfLoops,
-    violations: problems.length,
-    sample: problems.slice(0, 15),
-  },
-};
+  const report = analyze(JSON.parse(readFileSync(wpath, "utf8")), wpath);
 
-if (json) { console.log(JSON.stringify(report, null, 2)); }
-else {
-  const p = report;
-  console.log(`graph-quality — ${p.graph}`);
-  console.log(`  nodes ${p.nodes} (${p.symbolNodes} symbols) · edges ${p.edges}`);
-  console.log(`  kinds:      ${Object.entries(p.byKind).map(([k,v])=>`${k}=${v}`).join(" ")}`);
-  console.log(`  origin:     ${Object.entries(p.byOrigin).map(([k,v])=>`${k}=${v}`).join(" ")}`);
-  console.log(`  relations:  ${Object.entries(p.byRelation).map(([k,v])=>`${k}=${v}`).join(" ")}`);
-  console.log(`  confidence: ${Object.entries(p.byConfidence).map(([k,v])=>`${k}=${v}`).join(" ")}`);
-  console.log(`  calls resolved: ${p.resolution.resolvedToNode}/${p.resolution.calls} (${p.resolution.resolvedPct}%)`);
-  console.log(`  orphan symbols: ${p.connectivity.orphanSymbolNodes}/${p.symbolNodes} (${p.connectivity.orphanPct}%)`);
-  console.log(`  INVARIANTS: ${p.invariants.ok ? "OK ✓" : `FAIL ✗ (${p.invariants.violations} violations, ${p.invariants.danglingEdges} dangling)`}`);
-  if (!p.invariants.ok) for (const s of p.invariants.sample) console.log(`     - ${s}`);
-  if (p.invariants.selfLoopCalls) console.log(`  note: ${p.invariants.selfLoopCalls} self-loop calls`);
+  if (json) { console.log(JSON.stringify(report, null, 2)); }
+  else {
+    const p = report;
+    console.log(`graph-quality — ${p.graph}`);
+    console.log(`  nodes ${p.nodes} (${p.symbolNodes} symbols) · edges ${p.edges}`);
+    console.log(`  kinds:      ${Object.entries(p.byKind).map(([k,v])=>`${k}=${v}`).join(" ")}`);
+    console.log(`  origin:     ${Object.entries(p.byOrigin).map(([k,v])=>`${k}=${v}`).join(" ")}`);
+    console.log(`  relations:  ${Object.entries(p.byRelation).map(([k,v])=>`${k}=${v}`).join(" ")}`);
+    console.log(`  confidence: ${Object.entries(p.byConfidence).map(([k,v])=>`${k}=${v}`).join(" ")}`);
+    console.log(`  calls resolved: ${p.resolution.resolvedToNode}/${p.resolution.calls} (${p.resolution.resolvedPct}%)`);
+    console.log(`  orphan symbols: ${p.connectivity.orphanSymbolNodes}/${p.symbolNodes} (${p.connectivity.orphanPct}%)`);
+    console.log(`  INVARIANTS: ${p.invariants.ok ? "OK ✓" : `FAIL ✗ (${p.invariants.violations} violations, ${p.invariants.danglingEdges} dangling)`}`);
+    if (!p.invariants.ok) for (const s of p.invariants.sample) console.log(`     - ${s}`);
+    if (p.invariants.selfLoopCalls) console.log(`  note: ${p.invariants.selfLoopCalls} self-loop calls`);
+  }
+  if (strict && !report.invariants.ok) process.exit(1);
 }
-if (strict && !report.invariants.ok) process.exit(1);
+
+// Only run the CLI when invoked as one — the drift test imports this module for
+// its constants, and a top-level `process.exit(2)` would kill the test runner.
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main();

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -5,7 +5,11 @@ try {
   const { join } = await import('node:path');
   const dir = process.env.INIT_CWD || process.cwd();
   if (existsSync(join(dir, '.claude', 'helpers', 'graft-statusline.cjs'))) process.exit(0);
-  console.log('\n  Graft installed. Run `npx graft init` to enable the Claude Code integration (statusline + hooks + auto-sync).\n');
+  // Scoped, and `-y`: bare `npx graft` resolves to the UNSCOPED `graft` package on
+  // the registry — someone else's code entirely. This line is the first thing a new
+  // user copies, and the same form was revoked from the settings allowlist
+  // (REVOKED_ALLOW_ENTRIES in src/claude/settings-merge.ts) for exactly that reason.
+  console.log('\n  Graft installed. Run `npx -y @nanonets/graft init` to enable the Claude Code integration (statusline + hooks + auto-sync).\n');
 } catch {
   /* never fail an install */
 }

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -10,34 +10,110 @@
  *
  * Enumerating the files here instead means `npm test` behaves identically in
  * cmd.exe, PowerShell, bash and CI, on any supported Node.
+ *
+ * The runner also forwards its own arguments, because "run one file" used to cost
+ * the whole suite: ~50 files, several of which spawn the real CLI or the MCP
+ * server as a subprocess, is over a minute per edit. `npm test -- graph-map`
+ * (or `-- test/graph-map.test.ts`, or `-- graph --test-name-pattern=posix`)
+ * narrows the run; with no arguments the behaviour is exactly what CI has always
+ * done — every file, sorted.
  */
 import { readdirSync } from "node:fs";
 import { spawnSync } from "node:child_process";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const testDir = join(repoRoot, "test");
 
+// Node's test flags that take their value as a SEPARATE argv entry. Without this
+// list `--test-name-pattern posix` would leave "posix" looking like a file
+// selector, and the runner would refuse to start over an argument the user
+// meant for Node.
+const FLAGS_TAKING_A_VALUE = new Set([
+  "--test-name-pattern",
+  "--test-skip-pattern",
+  "--test-reporter",
+  "--test-reporter-destination",
+  "--test-concurrency",
+  "--test-shard",
+  "--test-timeout",
+]);
+
+/**
+ * Split the runner's own argv into node flags and test-file selectors, then
+ * resolve the selectors against the files on disk.
+ *
+ * Selectors are matched most-specific-first — full path, then file name, then
+ * name without the `.test.ts` suffix, and only then a substring — so
+ * `graph-map` picks exactly `graph-map.test.ts` even though `graph-map` is also
+ * a substring of nothing else, while a loose `graph` still fans out to the whole
+ * graph family. Returns `{ error }` instead of exiting so this stays testable.
+ */
+export function planRun(argv, allFiles) {
+  const nodeArgs = [];
+  const selectors = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    // A bare `--` is npm's own separator leaking through on some shells.
+    if (a === "--") continue;
+    if (a.startsWith("-")) {
+      nodeArgs.push(a);
+      if (FLAGS_TAKING_A_VALUE.has(a) && i + 1 < argv.length) nodeArgs.push(argv[++i]);
+      continue;
+    }
+    selectors.push(a);
+  }
+
+  if (selectors.length === 0) return { files: allFiles, nodeArgs };
+
+  const files = [];
+  for (const sel of selectors) {
+    const norm = sel.replace(/\\/g, "/");
+    const byPath = allFiles.filter((f) => f.replace(/\\/g, "/").endsWith(norm));
+    const byName = allFiles.filter((f) => basename(f) === norm || basename(f) === `${norm}.test.ts`);
+    const chosen = byName.length ? byName
+      : byPath.length ? byPath
+      : allFiles.filter((f) => basename(f).includes(norm));
+    if (chosen.length === 0) return { error: `no test file matches '${sel}'` };
+    for (const f of chosen) if (!files.includes(f)) files.push(f);
+  }
+  // Keep the deterministic order of the full run rather than the order the user
+  // happened to type the selectors in.
+  return { files: allFiles.filter((f) => files.includes(f)), nodeArgs };
+}
+
 // Sorted so a failure is reported in the same order on every platform and run.
-const files = readdirSync(testDir)
+const allFiles = readdirSync(testDir)
   .filter((f) => f.endsWith(".test.ts"))
   .sort()
   .map((f) => join(testDir, f));
 
-if (files.length === 0) {
-  console.error(`✗ no test files found in ${testDir}`);
-  process.exit(1);
-}
+// Importing this module (the arg-parsing test does) must not run the suite.
+const invokedDirectly = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (invokedDirectly) {
+  if (allFiles.length === 0) {
+    console.error(`✗ no test files found in ${testDir}`);
+    process.exit(1);
+  }
 
-const result = spawnSync(process.execPath, ["--import", "tsx", "--test", ...files], {
-  cwd: repoRoot,
-  stdio: "inherit",
-});
+  const plan = planRun(process.argv.slice(2), allFiles);
+  if (plan.error) {
+    console.error(`✗ ${plan.error}`);
+    console.error(`  available: ${allFiles.map((f) => basename(f, ".test.ts")).join(", ")}`);
+    process.exit(1);
+  }
 
-if (result.error) {
-  console.error(`✗ could not start the test runner: ${result.error.message}`);
-  process.exit(1);
+  const result = spawnSync(
+    process.execPath,
+    ["--import", "tsx", "--test", ...plan.nodeArgs, ...plan.files],
+    { cwd: repoRoot, stdio: "inherit" },
+  );
+
+  if (result.error) {
+    console.error(`✗ could not start the test runner: ${result.error.message}`);
+    process.exit(1);
+  }
+  // A signal-killed run reports null status; treat anything non-zero as failure.
+  process.exit(result.status ?? 1);
 }
-// A signal-killed run reports null status; treat anything non-zero as failure.
-process.exit(result.status ?? 1);

--- a/src/ai/crux.ts
+++ b/src/ai/crux.ts
@@ -14,7 +14,7 @@
  * sees each symbol's neighbours, which sharpens the summaries. Line numbers are
  * consumed once, at write time, to slice the crux text verbatim from source.
  */
-import type { ChatModel } from "./llm/types.js";
+import { isTruncated, type ChatModel } from "./llm/types.js";
 import type { Kind } from "../graph/types.js";
 
 /** One definition we want described, located by its line span within the file. */
@@ -78,24 +78,40 @@ const SYMBOLS_SCHEMA = {
 /** Cap the file text sent per request so one huge file can't blow the context. */
 const MAX_CODE_CHARS = 18_000;
 
-function numberLines(source: string): string {
-  const clipped =
-    source.length > MAX_CODE_CHARS ? `${source.slice(0, MAX_CODE_CHARS)}\n… (truncated)` : source;
-  return clipped
-    .split("\n")
-    .map((line, i) => `${i + 1}\t${line}`)
-    .join("\n");
+/**
+ * The numbered slice of the file the model will actually see, and the subset of
+ * targets that lives inside it.
+ *
+ * The filtering is the load-bearing part. The clip is by CHARACTERS (~450 lines
+ * at 18k) while the targets carry spans over the WHOLE file, so on a 1200-line
+ * file the prompt used to demand a crux for `L900-L950` — lines the model was
+ * never shown. It cannot refuse (the tool call is forced), so it invents a range;
+ * enrich.ts then clamps that range to the node's span and slices the FULL source,
+ * writing crux code that reads as grounded and is not. A symbol past the window
+ * is simply not asked about, which enrich.ts records as `pending` — the honest
+ * state, and the one a later run can still fix.
+ */
+function clipToWindow(input: FileCruxInput): { body: string; targets: NodeRef[] } {
+  const whole = input.source.length <= MAX_CODE_CHARS;
+  const lines = (whole ? input.source : input.source.slice(0, MAX_CODE_CHARS)).split("\n");
+  // A char-wise cut lands mid-line; that fragment is not a line the model can reason about.
+  if (!whole && lines.length > 1) lines.pop();
+  const numbered = lines.map((line, i) => `${i + 1}\t${line}`).join("\n");
+  return {
+    body: whole ? numbered : `${numbered}\n… (truncated)`,
+    targets: whole ? input.nodes : input.nodes.filter((n) => n.endLine <= lines.length),
+  };
 }
 
-function userContent(input: FileCruxInput): string {
-  const targets = input.nodes
+function userContent(input: FileCruxInput, body: string, targets: NodeRef[]): string {
+  const list = targets
     .map(
       (n) =>
         `- id=${n.id} | ${n.kind} | lines L${n.startLine}-L${n.endLine}` +
         (n.signature ? ` | ${n.signature}` : ""),
     )
     .join("\n");
-  return `FILE: ${input.path}\n\n${numberLines(input.source)}\n\nTARGETS:\n${targets}`;
+  return `FILE: ${input.path}\n\n${body}\n\nTARGETS:\n${list}`;
 }
 
 /** Normalize the tool's parsed argument object into a {@link NodeCrux} list. */
@@ -119,9 +135,18 @@ export class ChatCruxSummarizer implements CruxSummarizer {
 
   async describeFile(input: FileCruxInput): Promise<NodeCrux[]> {
     if (input.nodes.length === 0) return [];
+    const { body, targets } = clipToWindow(input);
+    // Every requested symbol sits past the truncation point. Sending the request
+    // anyway costs a full call whose only possible answers are invented — and
+    // enrich.ts retries a file whose targets came back missing, so it would cost
+    // that twice.
+    if (targets.length === 0) return [];
     const res = await this.model.create({
       temperature: 0,
       maxTokens: 8192,
+      // Structured extraction over a file already in front of the model: thinking
+      // would eat the same 8192 tokens the per-symbol answers have to fit in.
+      thinking: { kind: "disabled" },
       tools: [
         {
           name: RECORD_TOOL,
@@ -132,9 +157,15 @@ export class ChatCruxSummarizer implements CruxSummarizer {
       responseFormat: { kind: "tool", name: RECORD_TOOL },
       messages: [
         { role: "system", content: SYSTEM_PROMPT },
-        { role: "user", content: userContent(input) },
+        { role: "user", content: userContent(input, body, targets) },
       ],
     });
+    // A turn cut off before its tool_use block closed parses as zero symbols,
+    // which enrich.ts cannot tell apart from "the model skipped these" — so it
+    // silently marks them pending and eats the cost. Say what actually happened.
+    if (isTruncated(res)) {
+      throw new Error(`crux truncated at maxTokens (stop_reason=${res.stopReason}) — ${targets.length} symbols requested for ${input.path}`);
+    }
     return parseResults(res.toolCalls[0]?.args as { symbols?: unknown } | undefined);
   }
 }

--- a/src/ai/llm/anthropic.ts
+++ b/src/ai/llm/anthropic.ts
@@ -26,6 +26,23 @@ export interface AnthropicChatModelOptions {
   model: string;
   baseUrl?: string;
   label?: string;
+  /**
+   * Extra default headers. Not for api.anthropic.com — for the gateways that
+   * speak the Messages API and demand a header of their own to route or bill.
+   * `ChatModelConfig` has always accepted headers for every provider; this
+   * adapter used to be the one that silently dropped them.
+   */
+  headers?: Record<string, string>;
+  /**
+   * Per-request wall clock in ms. The SDK's own default is 10 MINUTES, which for
+   * a repo-wide `--deep` means one stalled endpoint can pin a worker for ten
+   * minutes per file — the run looks hung rather than failed.
+   */
+  timeoutMs?: number;
+  /** Retries after a failed request (SDK default 2). The SDK honours the
+   * endpoint's `Retry-After` between them, which is what makes raising this the
+   * right answer to a rate-limited key rather than a way to hammer it harder. */
+  maxRetries?: number;
   /** Inject a pre-built client (tests pass a stub; production omits it). */
   client?: Anthropic;
 }
@@ -41,7 +58,15 @@ export class AnthropicChatModel implements ChatModel {
   constructor(opts: AnthropicChatModelOptions) {
     this.model = opts.model;
     this.label = opts.label ?? `${PROVIDER}:${opts.model}`;
-    this.client = opts.client ?? new Anthropic({ apiKey: opts.apiKey, baseURL: opts.baseUrl });
+    this.client =
+      opts.client ??
+      new Anthropic({
+        apiKey: opts.apiKey,
+        baseURL: opts.baseUrl,
+        defaultHeaders: opts.headers,
+        ...(opts.timeoutMs !== undefined ? { timeout: opts.timeoutMs } : {}),
+        ...(opts.maxRetries !== undefined ? { maxRetries: opts.maxRetries } : {}),
+      });
   }
 
   async create(req: ChatRequest): Promise<ChatResponse> {
@@ -78,6 +103,7 @@ export class AnthropicChatModel implements ChatModel {
       max_tokens: req.maxTokens ?? DEFAULT_MAX_TOKENS,
       messages,
       ...(system.length ? { system } : {}),
+      ...(req.thinking ? { thinking: toThinkingConfig(req.thinking) } : {}),
     };
     // temperature is intentionally NOT forwarded — current models reject it.
 
@@ -138,6 +164,16 @@ export class AnthropicChatModel implements ChatModel {
       },
     };
   }
+}
+
+/**
+ * The neutral thinking flag → the Messages API's `thinking` block. Sending it at
+ * all is the point: with the field ABSENT, current Claude models default to
+ * adaptive thinking and spend `max_tokens` on reasoning before any text or
+ * tool_use appears, so a 2048-token summarize can come back empty.
+ */
+function toThinkingConfig(t: NonNullable<ChatRequest["thinking"]>): Anthropic.ThinkingConfigParam {
+  return t.kind === "enabled" ? { type: "enabled", budget_tokens: t.budgetTokens } : { type: "disabled" };
 }
 
 function toAnthropicTool(t: ToolSpec): Anthropic.Tool {

--- a/src/ai/llm/claude-cli.ts
+++ b/src/ai/llm/claude-cli.ts
@@ -72,6 +72,10 @@ export interface ClaudeCliChatModelOptions {
   timeoutMs?: number;
   /** Optional spend ceiling passed through as `--max-budget-usd`. */
   maxBudgetUsd?: number;
+  /** Retries after a transient failure (default {@link DEFAULT_MAX_RETRIES}).
+   * `0` fails on the first error — the right setting when the CLI is not signed
+   * in on this machine at all and every attempt will fail the same way. */
+  maxRetries?: number;
   /** Inject a runner (tests stub it; production omits it). */
   run?: ClaudeCliRunner;
 }
@@ -97,12 +101,15 @@ export class ClaudeCliChatModel implements ChatModel {
   private runner: ClaudeCliRunner;
   private timeoutMs: number;
   private maxBudgetUsd?: number;
+  private maxRetries: number;
 
   constructor(opts: ClaudeCliChatModelOptions) {
     this.model = opts.model;
     this.label = opts.label ?? `${PROVIDER}:${opts.model}`;
     this.timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.maxBudgetUsd = opts.maxBudgetUsd;
+    // `?? DEFAULT` and not `|| DEFAULT`: 0 is the meaningful "don't retry" value.
+    this.maxRetries = Math.max(0, opts.maxRetries ?? DEFAULT_MAX_RETRIES);
     this.runner = opts.run ?? defaultRunner(opts.bin);
   }
 
@@ -164,14 +171,15 @@ export class ClaudeCliChatModel implements ChatModel {
    */
   private async invoke(prompt: string): Promise<CliEnvelope> {
     let lastErr: unknown;
-    for (let attempt = 0; attempt < TRANSIENT_ATTEMPTS; attempt++) {
+    const attempts = this.maxRetries + 1;
+    for (let attempt = 0; attempt < attempts; attempt++) {
       try {
         return await this.invokeOnce(prompt);
       } catch (err) {
         lastErr = err;
         const msg = err instanceof Error ? err.message : String(err);
-        if (attempt === TRANSIENT_ATTEMPTS - 1 || !isTransient(msg)) throw err;
-        await sleep(BACKOFF_MS[attempt]);
+        if (attempt === attempts - 1 || !isTransient(msg)) throw err;
+        await sleep(backoffMs(attempt));
       }
     }
     throw lastErr;
@@ -216,8 +224,18 @@ export class ClaudeCliChatModel implements ChatModel {
 
 // --- transient-failure policy ------------------------------------------------
 
-const TRANSIENT_ATTEMPTS = 3;
+/** Retries after the first attempt. Matches the OpenAI/Anthropic SDK default, so
+ * one `maxRetries` means the same number of calls whichever provider is in use. */
+const DEFAULT_MAX_RETRIES = 2;
 const BACKOFF_MS = [1_000, 5_000];
+
+/** Backoff before retry `attempt` (0-based). Beyond the tabulated pair it doubles
+ * and caps at a minute: a configured `maxRetries: 8` must not turn into a fixed
+ * 5s poll against an endpoint that is telling us to slow down. */
+function backoffMs(attempt: number): number {
+  const last = BACKOFF_MS[BACKOFF_MS.length - 1];
+  return BACKOFF_MS[attempt] ?? Math.min(60_000, last * 2 ** (attempt - BACKOFF_MS.length + 1));
+}
 
 /**
  * Retry only what a retry can fix. Quota exhaustion and a missing/expired login

--- a/src/ai/llm/claude-cli.ts
+++ b/src/ai/llm/claude-cli.ts
@@ -1,0 +1,488 @@
+/**
+ * Subscription transport: drives the locally installed `claude` CLI in headless
+ * mode instead of calling an HTTP API with a key.
+ *
+ * `--deep` was gated on GRAFT_API_KEY, so a developer already paying for a Claude
+ * subscription still had to buy separate API credits to get concept nodes and
+ * per-symbol summaries. Claude Code's headless mode (`claude -p`) authenticates
+ * through the same OAuth session as the interactive CLI, so shelling out to it
+ * turns that existing subscription into a usable transport — no key anywhere.
+ *
+ * The CLI is a coding AGENT, not a completions endpoint, so this adapter narrows
+ * it back down to one. Every flag below is load-bearing:
+ *   - `--tools ""` removes every built-in tool, so a turn is prompt → text and the
+ *     model physically cannot touch the filesystem while summarizing.
+ *   - `--setting-sources ""`, `--strict-mcp-config` and `--disable-slash-commands`
+ *     keep the user's own hooks, MCP servers and skills out of the run.
+ *   - `--system-prompt` REPLACES Claude Code's agent system prompt. That is also
+ *     what keeps CLAUDE.md out: a personal "always answer in Portuguese" memory
+ *     would otherwise silently rewrite every summary written into the graph.
+ *   - `--no-session-persistence` stops thousands of one-shot summaries from being
+ *     recorded as resumable sessions on disk.
+ *
+ * Two things the HTTP adapters get for free are unavailable here:
+ *   - Structured output. There is no `tool_choice`, so {@link ChatRequest.responseFormat}
+ *     is emulated: the schema is stated in the prompt and the reply is parsed back
+ *     into a synthetic {@link ToolCall}, with one corrective retry. Callers
+ *     (synthesize, crux) see the same shape they get from Anthropic or OpenAI.
+ *   - `temperature` and `maxTokens`. No flag exposes either; both are dropped.
+ *     graft only ever asks for temperature 0, and the drift that costs is small
+ *     next to not needing a key at all.
+ *
+ * The prompt travels over STDIN, never argv — a 24k-char file summary would blow
+ * the 32767-char Windows command-line limit — which also keeps every argument
+ * short and quote-free, so the cmd.exe shim path below stays safe.
+ */
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import type { ChatModel, ChatRequest, ChatResponse, Message, ToolCall, Usage } from "./types.js";
+
+const PROVIDER = "claude-cli";
+const JSON_TOOL = "emit_json";
+const DEFAULT_TIMEOUT_MS = 300_000;
+
+/**
+ * Replaces Claude Code's agent system prompt. Deliberately short and quote-free:
+ * the caller's real system prompt is far too big (and too quote-heavy) to be safe
+ * as an argv entry, so it rides in the stdin envelope instead.
+ */
+const HARNESS_SYSTEM_PROMPT =
+  "You are a precise documentation and analysis engine, not a conversational assistant. " +
+  "Follow the INSTRUCTIONS block exactly and answer only about the INPUT block. " +
+  "Emit the requested artifact and nothing else: no preamble, no sign-off, no markdown fences.";
+
+export interface ClaudeCliResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+/** Injectable process runner — tests pass a stub so nothing is ever spawned. */
+export type ClaudeCliRunner = (args: string[], stdin: string, timeoutMs: number) => Promise<ClaudeCliResult>;
+
+export interface ClaudeCliChatModelOptions {
+  /** Model alias or full id (`sonnet`, `opus`, `claude-sonnet-5`, …). */
+  model: string;
+  /** Path to the CLI. Default: resolved from PATH (env GRAFT_CLAUDE_BIN wins). */
+  bin?: string;
+  label?: string;
+  /** Per-call wall clock. Default 300s — a crux pass over a big file is slow. */
+  timeoutMs?: number;
+  /** Optional spend ceiling passed through as `--max-budget-usd`. */
+  maxBudgetUsd?: number;
+  /** Inject a runner (tests stub it; production omits it). */
+  run?: ClaudeCliRunner;
+}
+
+/** The `claude -p --output-format json` envelope, narrowed to what we consume. */
+interface CliEnvelope {
+  type?: string;
+  subtype?: string;
+  is_error?: boolean;
+  result?: string;
+  stop_reason?: string | null;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    cache_read_input_tokens?: number;
+    cache_creation_input_tokens?: number;
+  };
+}
+
+export class ClaudeCliChatModel implements ChatModel {
+  readonly label: string;
+  private model: string;
+  private runner: ClaudeCliRunner;
+  private timeoutMs: number;
+  private maxBudgetUsd?: number;
+
+  constructor(opts: ClaudeCliChatModelOptions) {
+    this.model = opts.model;
+    this.label = opts.label ?? `${PROVIDER}:${opts.model}`;
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.maxBudgetUsd = opts.maxBudgetUsd;
+    this.runner = opts.run ?? defaultRunner(opts.bin);
+  }
+
+  async create(req: ChatRequest): Promise<ChatResponse> {
+    const fmt = req.responseFormat ?? { kind: "text" };
+    const schema = schemaFor(req, fmt);
+    const prompt = buildPrompt(req.messages, schema);
+
+    let env = await this.invoke(prompt);
+    let text = (env.result ?? "").trim();
+
+    // Structured output is prompt-enforced, not wire-enforced, so a reply can come
+    // back with prose around the JSON. Retry ONCE, quoting the bad reply back — far
+    // cheaper than failing a 5000-file build on one malformed response.
+    let parsed: unknown;
+    if (fmt.kind !== "text") {
+      parsed = extractJson(text);
+      if (parsed === undefined) {
+        env = await this.invoke(retryPrompt(prompt, text));
+        text = (env.result ?? "").trim();
+        parsed = extractJson(text);
+      }
+      if (parsed === undefined) {
+        throw new Error(
+          `claude CLI did not return parseable JSON for ${fmt.kind === "tool" ? fmt.name : "json"} output. ` +
+            `Got: ${text.slice(0, 200)}${text.length > 200 ? "…" : ""}`,
+        );
+      }
+    }
+
+    const toolCalls: ToolCall[] = [];
+    if (fmt.kind === "tool") {
+      toolCalls.push({ id: `${PROVIDER}_1`, name: fmt.name, args: parsed });
+      text = "";
+    } else if (fmt.kind === "json") {
+      text = JSON.stringify(parsed);
+    }
+
+    return {
+      text,
+      toolCalls,
+      usage: normalizeUsage(env.usage),
+      stopReason: env.stop_reason ?? null,
+      assistant: {
+        role: "assistant",
+        content: text,
+        toolCalls: toolCalls.length ? toolCalls : undefined,
+      },
+    };
+  }
+
+  /**
+   * Transport-level retry. A `--deep` build is thousands of sequential calls over
+   * hours, so a single blip — an overloaded upstream, a dropped connection, one
+   * slow file hitting the wall clock — would otherwise silently cost that file its
+   * summary. Only failures classified transient are retried; a bad login or an
+   * exhausted quota fails immediately, because sleeping on those just turns a
+   * clear error into a slow one.
+   */
+  private async invoke(prompt: string): Promise<CliEnvelope> {
+    let lastErr: unknown;
+    for (let attempt = 0; attempt < TRANSIENT_ATTEMPTS; attempt++) {
+      try {
+        return await this.invokeOnce(prompt);
+      } catch (err) {
+        lastErr = err;
+        const msg = err instanceof Error ? err.message : String(err);
+        if (attempt === TRANSIENT_ATTEMPTS - 1 || !isTransient(msg)) throw err;
+        await sleep(BACKOFF_MS[attempt]);
+      }
+    }
+    throw lastErr;
+  }
+
+  private async invokeOnce(prompt: string): Promise<CliEnvelope> {
+    const args = [
+      "-p",
+      "--output-format",
+      "json",
+      "--model",
+      this.model,
+      "--tools",
+      "", // no filesystem, no network, no shell — this is a completions call
+      "--system-prompt",
+      HARNESS_SYSTEM_PROMPT,
+      "--setting-sources",
+      "", // no user/project settings ⇒ no hooks, no stray permissions
+      "--strict-mcp-config",
+      "--disable-slash-commands",
+      "--no-session-persistence",
+    ];
+    if (this.maxBudgetUsd !== undefined) args.push("--max-budget-usd", String(this.maxBudgetUsd));
+
+    const res = await this.runner(args, prompt, this.timeoutMs);
+    if (res.code !== 0) {
+      throw new Error(
+        `claude CLI exited with code ${res.code ?? "null"}: ${(res.stderr || res.stdout).trim().slice(0, 400)}`,
+      );
+    }
+
+    const env = parseEnvelope(res.stdout);
+    if (!env) {
+      throw new Error(`claude CLI returned no JSON envelope: ${res.stdout.trim().slice(0, 200)}`);
+    }
+    if (env.is_error) {
+      throw new Error(`claude CLI reported an error: ${(env.result ?? env.subtype ?? "unknown").slice(0, 400)}`);
+    }
+    return env;
+  }
+}
+
+// --- transient-failure policy ------------------------------------------------
+
+const TRANSIENT_ATTEMPTS = 3;
+const BACKOFF_MS = [1_000, 5_000];
+
+/**
+ * Retry only what a retry can fix. Quota exhaustion and a missing/expired login
+ * are deliberately absent: both persist for far longer than any backoff here, and
+ * the user needs to see them now rather than after three sleeps per file.
+ */
+const TRANSIENT = /\b(overloaded|rate.?limit|429|50[0234]|timed out|timeout|ETIMEDOUT|ECONNRESET|ECONNREFUSED|EAI_AGAIN|socket hang up|network|temporarily)\b/i;
+const PERMANENT = /\b(usage limit|not found on PATH|invalid api key|\/login|unauthorized|401|403|credit balance)\b/i;
+
+export function isTransient(message: string): boolean {
+  if (PERMANENT.test(message)) return false;
+  return TRANSIENT.test(message);
+}
+
+// Deliberately NOT unref'd: an unref'd backoff lets Node exit while the retry is
+// still pending, which would end a build mid-flight instead of resuming it.
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+// --- prompt assembly ---------------------------------------------------------
+
+/**
+ * The schema the reply must satisfy. `tool` format borrows the named tool's own
+ * parameter schema, so synthesize/crux keep one schema definition rather than
+ * maintaining a second copy for this provider.
+ */
+function schemaFor(req: ChatRequest, fmt: NonNullable<ChatRequest["responseFormat"]>): unknown {
+  if (fmt.kind === "tool") return req.tools?.find((t) => t.name === fmt.name)?.parameters ?? { type: "object" };
+  if (fmt.kind === "json") return { type: "object" };
+  return undefined;
+}
+
+/** Flatten the neutral message list into one stdin document. */
+function buildPrompt(messages: Message[], schema: unknown): string {
+  const system = messages.filter((m) => m.role === "system").map((m) => m.content.trim()).filter(Boolean);
+  const rest = messages.filter((m) => m.role !== "system");
+
+  const body =
+    rest.length === 1 && rest[0].role === "user"
+      ? rest[0].content
+      : rest
+          .map((m) => {
+            const head = m.role === "tool" ? `TOOL RESULT (${m.toolCallId ?? ""})` : m.role.toUpperCase();
+            const calls = m.toolCalls?.length ? `\n${JSON.stringify(m.toolCalls)}` : "";
+            return `### ${head}\n${m.content}${calls}`;
+          })
+          .join("\n\n");
+
+  const parts: string[] = [];
+  if (system.length) parts.push(`<INSTRUCTIONS>\n${system.join("\n\n")}\n</INSTRUCTIONS>`);
+  parts.push(`<INPUT>\n${body}\n</INPUT>`);
+  if (schema !== undefined) {
+    parts.push(
+      "<OUTPUT_FORMAT>\n" +
+        "Reply with a SINGLE JSON object and nothing else. No prose before or after it, " +
+        "no markdown code fences, no explanation. It must validate against this JSON Schema:\n" +
+        JSON.stringify(schema) +
+        "\n</OUTPUT_FORMAT>",
+    );
+  }
+  return parts.join("\n\n");
+}
+
+function retryPrompt(original: string, bad: string): string {
+  return (
+    `${original}\n\n<RETRY>\nYour previous reply could not be parsed as JSON. It began:\n` +
+    `${bad.slice(0, 300)}\n\nReply again with ONLY the JSON object — first character "{", last character "}".\n</RETRY>`
+  );
+}
+
+// --- response parsing --------------------------------------------------------
+
+/**
+ * `--output-format json` prints one object, but a stray warning line on stdout
+ * would break a naive JSON.parse — so fall back to the last JSON-looking line.
+ */
+function parseEnvelope(stdout: string): CliEnvelope | undefined {
+  const trimmed = stdout.trim();
+  if (!trimmed) return undefined;
+  try {
+    return JSON.parse(trimmed) as CliEnvelope;
+  } catch {
+    // fall through
+  }
+  const lines = trimmed.split(/\r?\n/).filter((l) => l.trim().startsWith("{"));
+  for (let i = lines.length - 1; i >= 0; i--) {
+    try {
+      return JSON.parse(lines[i]) as CliEnvelope;
+    } catch {
+      continue;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Pull one JSON value out of a model reply. Handles the two ways a prompt-enforced
+ * schema leaks: a markdown fence around the object, and prose either side of it.
+ * Brace scanning is string- and escape-aware so a `}` inside a summary can't end
+ * the object early. Returns undefined when nothing parses.
+ */
+export function extractJson(text: string): unknown {
+  const stripped = text.replace(/^\s*```(?:json)?\s*/i, "").replace(/\s*```\s*$/, "").trim();
+  for (const candidate of [stripped, text]) {
+    try {
+      return JSON.parse(candidate);
+    } catch {
+      // fall through to brace scanning
+    }
+    const start = candidate.indexOf("{");
+    if (start === -1) continue;
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+    for (let i = start; i < candidate.length; i++) {
+      const ch = candidate[i];
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (ch === "\\") {
+        if (inString) escaped = true;
+        continue;
+      }
+      if (ch === '"') {
+        inString = !inString;
+        continue;
+      }
+      if (inString) continue;
+      if (ch === "{") depth++;
+      else if (ch === "}") {
+        depth--;
+        if (depth === 0) {
+          try {
+            return JSON.parse(candidate.slice(start, i + 1));
+          } catch {
+            break;
+          }
+        }
+      }
+    }
+  }
+  return undefined;
+}
+
+/** The CLI already reports uncached input separately, matching graft's convention. */
+function normalizeUsage(u: CliEnvelope["usage"]): Usage {
+  return {
+    input: u?.input_tokens ?? 0,
+    output: u?.output_tokens ?? 0,
+    cacheRead: u?.cache_read_input_tokens ?? 0,
+    cacheCreate: u?.cache_creation_input_tokens ?? 0,
+  };
+}
+
+// --- process plumbing --------------------------------------------------------
+
+/**
+ * Resolve the CLI without a shell. Node's spawn only appends `.exe` on Windows,
+ * so PATHEXT is walked by hand — the native installer ships `claude.exe` but an
+ * `npm i -g` install leaves only the `claude.cmd` shim, and missing it would make
+ * this provider look uninstalled on a machine where it works fine.
+ */
+export function resolveClaudeBin(explicit?: string): string | undefined {
+  const name = explicit ?? process.env.GRAFT_CLAUDE_BIN ?? "claude";
+  if (name.includes("/") || name.includes("\\")) return existsSync(name) ? name : undefined;
+
+  const exts =
+    process.platform === "win32"
+      ? [".EXE", ".CMD", ".BAT", ".COM", ""] // .exe first: it spawns without a shim
+      : [""];
+  for (const dir of (process.env.PATH ?? "").split(delimiter)) {
+    if (!dir) continue;
+    for (const ext of exts) {
+      const p = join(dir.replace(/^"|"$/g, ""), name + ext);
+      if (existsSync(p)) return p;
+    }
+  }
+  return undefined;
+}
+
+let cachedAvailable: boolean | undefined;
+
+/** True when the `claude` CLI is installed. Cached — this runs per build, not per file. */
+export function claudeCliAvailable(explicit?: string): boolean {
+  if (explicit ?? process.env.GRAFT_CLAUDE_BIN) return !!resolveClaudeBin(explicit);
+  if (cachedAvailable === undefined) cachedAvailable = !!resolveClaudeBin();
+  return cachedAvailable;
+}
+
+/** Test seam: drop the memoized lookup so a test can flip PATH. */
+export function resetClaudeCliCache(): void {
+  cachedAvailable = undefined;
+}
+
+/**
+ * `cmd.exe` cannot be handed a `.cmd` file through CreateProcess, so an npm shim
+ * has to be run as a command line. Every argument we pass is short and quote-free
+ * (the prompt goes over stdin), so quoting each one is enough.
+ */
+function windowsWrap(bin: string, args: string[]): { file: string; argv: string[]; verbatim: boolean } {
+  const isShim = process.platform === "win32" && /\.(cmd|bat)$/i.test(bin);
+  if (!isShim) return { file: bin, argv: args, verbatim: false };
+  const quote = (s: string) => `"${s.replace(/"/g, '""')}"`;
+  const line = [quote(bin), ...args.map(quote)].join(" ");
+  return { file: process.env.ComSpec ?? "cmd.exe", argv: ["/d", "/s", "/c", `"${line}"`], verbatim: true };
+}
+
+function defaultRunner(bin?: string): ClaudeCliRunner {
+  return (args, stdin, timeoutMs) =>
+    new Promise<ClaudeCliResult>((resolve, reject) => {
+      const resolved = resolveClaudeBin(bin);
+      if (!resolved) {
+        reject(
+          new Error(
+            "claude CLI not found on PATH. Install Claude Code (https://claude.com/claude-code) and sign in " +
+              "with your subscription, set GRAFT_CLAUDE_BIN to its path, or use an API-key provider " +
+              "(GRAFT_PROVIDER=anthropic|openai + GRAFT_API_KEY).",
+          ),
+        );
+        return;
+      }
+
+      const { file, argv, verbatim } = windowsWrap(resolved, args);
+      const child = spawn(file, argv, {
+        // Never the user's repo: cwd is what CLAUDE.md discovery keys off, and a
+        // summarization run must not inherit the project's own agent instructions.
+        cwd: tmpdir(),
+        windowsHide: true,
+        windowsVerbatimArguments: verbatim,
+        env: {
+          ...process.env,
+          // Skip the auxiliary Haiku calls (titles, topic detection): pure overhead
+          // when a "session" is one summary that is never resumed.
+          DISABLE_NON_ESSENTIAL_MODEL_CALLS: "1",
+          CLAUDE_CODE_ENTRYPOINT: "graft",
+        },
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+
+      let stdout = "";
+      let stderr = "";
+      let settled = false;
+      const finish = (fn: () => void) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        fn();
+      };
+
+      const timer = setTimeout(() => {
+        child.kill("SIGKILL");
+        finish(() => reject(new Error(`claude CLI timed out after ${timeoutMs}ms`)));
+      }, timeoutMs);
+      timer.unref?.();
+
+      child.stdout.setEncoding("utf8");
+      child.stderr.setEncoding("utf8");
+      child.stdout.on("data", (d: string) => (stdout += d));
+      child.stderr.on("data", (d: string) => (stderr += d));
+      child.on("error", (err) => finish(() => reject(err)));
+      child.on("close", (code) => finish(() => resolve({ code, stdout, stderr })));
+
+      // A CLI that dies before draining stdin gives us EPIPE; the close handler
+      // already carries the real diagnosis, so swallow it here.
+      child.stdin.on("error", () => {});
+      child.stdin.end(stdin, "utf8");
+    });
+}

--- a/src/ai/llm/factory.ts
+++ b/src/ai/llm/factory.ts
@@ -2,31 +2,58 @@
  * One place that turns resolved config into a {@link ChatModel}. `provider` names
  * the WIRE FORMAT, not a vendor: `openai` speaks the OpenAI-compatible API (point
  * `baseUrl` at OpenRouter, Fireworks, a LiteLLM proxy, Groq, a local server, …),
- * `anthropic` speaks the native Messages API. Adding a vendor is a base URL, not
- * a code change; adding a wire format is one new adapter here.
+ * `anthropic` speaks the native Messages API, and `claude-cli` speaks to the
+ * locally installed Claude Code binary over stdio. Adding a vendor is a base URL,
+ * not a code change; adding a wire format is one new adapter here.
+ *
+ * `claude-cli` is the one provider that takes NO api key — it borrows the CLI's
+ * own signed-in session — so key handling is a per-provider question answered by
+ * {@link providerNeedsKey} rather than an invariant of this factory.
  */
 import type { ChatModel } from "./types.js";
 import { OpenAIChatModel } from "./openai.js";
 import { AnthropicChatModel } from "./anthropic.js";
+import { ClaudeCliChatModel } from "./claude-cli.js";
 
-export type ProviderKind = "openai" | "anthropic";
+export type ProviderKind = "openai" | "anthropic" | "claude-cli";
+
+export const PROVIDER_KINDS: readonly ProviderKind[] = ["openai", "anthropic", "claude-cli"];
+
+/** Whether a provider authenticates with an API key at all. */
+export function providerNeedsKey(provider: ProviderKind): boolean {
+  return provider !== "claude-cli";
+}
 
 export interface ChatModelConfig {
   provider: ProviderKind;
-  apiKey: string;
+  /** Required by every provider except `claude-cli`, which uses its own session. */
+  apiKey?: string;
   model: string;
   baseUrl?: string;
   /** Extra default headers for OpenAI-compatible endpoints (e.g. OpenRouter `X-Title`). */
   headers?: Record<string, string>;
+  /** `claude-cli` only: explicit path to the binary (else resolved from PATH). */
+  bin?: string;
+  /** `claude-cli` only: per-call wall clock in milliseconds. */
+  timeoutMs?: number;
+  /** `claude-cli` only: per-call spend ceiling, passed through as `--max-budget-usd`. */
+  maxBudgetUsd?: number;
 }
 
 export function createChatModel(cfg: ChatModelConfig): ChatModel {
   switch (cfg.provider) {
+    case "claude-cli":
+      return new ClaudeCliChatModel({
+        model: cfg.model,
+        bin: cfg.bin,
+        timeoutMs: cfg.timeoutMs,
+        maxBudgetUsd: cfg.maxBudgetUsd,
+      });
     case "anthropic":
-      return new AnthropicChatModel({ apiKey: cfg.apiKey, model: cfg.model, baseUrl: cfg.baseUrl });
+      return new AnthropicChatModel({ apiKey: requireKey(cfg), model: cfg.model, baseUrl: cfg.baseUrl });
     case "openai":
       return new OpenAIChatModel({
-        apiKey: cfg.apiKey,
+        apiKey: requireKey(cfg),
         model: cfg.model,
         baseUrl: cfg.baseUrl,
         headers: cfg.headers,
@@ -36,4 +63,9 @@ export function createChatModel(cfg: ChatModelConfig): ChatModel {
       throw new Error(`unknown provider: ${String(_exhaustive)}`);
     }
   }
+}
+
+function requireKey(cfg: ChatModelConfig): string {
+  if (!cfg.apiKey) throw new Error(`provider "${cfg.provider}" needs an API key — set GRAFT_API_KEY`);
+  return cfg.apiKey;
 }

--- a/src/ai/llm/factory.ts
+++ b/src/ai/llm/factory.ts
@@ -30,14 +30,29 @@ export interface ChatModelConfig {
   apiKey?: string;
   model: string;
   baseUrl?: string;
-  /** Extra default headers for OpenAI-compatible endpoints (e.g. OpenRouter `X-Title`). */
+  /** Extra default headers, for whichever gateway sits behind `baseUrl` (e.g. OpenRouter `X-Title`). */
   headers?: Record<string, string>;
   /** `claude-cli` only: explicit path to the binary (else resolved from PATH). */
   bin?: string;
-  /** `claude-cli` only: per-call wall clock in milliseconds. */
+  /** Per-call wall clock in milliseconds, for every provider. */
   timeoutMs?: number;
   /** `claude-cli` only: per-call spend ceiling, passed through as `--max-budget-usd`. */
   maxBudgetUsd?: number;
+  /**
+   * Retries after a failed call, for every provider (default 2 — the SDKs' own).
+   *
+   * Worth exposing because the right number is a property of the ENDPOINT, not of
+   * graft: a `--deep` build is one call per file over hours, so on a hard-rate-limited
+   * key 2 retries throws away files that a longer backoff would have summarized, while
+   * against a local server (llama.cpp, Ollama) retrying a refused connection 2× per
+   * file just triples the time it takes to find out nothing is listening. `0` is a
+   * legal value and means "fail on the first error".
+   *
+   * Both SDK adapters honour the endpoint's `Retry-After` header inside these
+   * attempts; `claude-cli` has no headers to read (it is a subprocess) and uses its
+   * own fixed backoff.
+   */
+  maxRetries?: number;
 }
 
 export function createChatModel(cfg: ChatModelConfig): ChatModel {
@@ -48,15 +63,29 @@ export function createChatModel(cfg: ChatModelConfig): ChatModel {
         bin: cfg.bin,
         timeoutMs: cfg.timeoutMs,
         maxBudgetUsd: cfg.maxBudgetUsd,
+        maxRetries: cfg.maxRetries,
       });
     case "anthropic":
-      return new AnthropicChatModel({ apiKey: requireKey(cfg), model: cfg.model, baseUrl: cfg.baseUrl });
+      // headers reach this adapter too: `baseUrl` may point at a gateway that
+      // speaks the Messages API and demands its own header, and dropping the
+      // caller's headers there failed silently (a 401 from the gateway, with
+      // nothing in the config to suggest graft had thrown them away).
+      return new AnthropicChatModel({
+        apiKey: requireKey(cfg),
+        model: cfg.model,
+        baseUrl: cfg.baseUrl,
+        headers: cfg.headers,
+        timeoutMs: cfg.timeoutMs,
+        maxRetries: cfg.maxRetries,
+      });
     case "openai":
       return new OpenAIChatModel({
         apiKey: requireKey(cfg),
         model: cfg.model,
         baseUrl: cfg.baseUrl,
         headers: cfg.headers,
+        timeoutMs: cfg.timeoutMs,
+        maxRetries: cfg.maxRetries,
       });
     default: {
       const _exhaustive: never = cfg.provider;

--- a/src/ai/llm/openai.ts
+++ b/src/ai/llm/openai.ts
@@ -24,6 +24,16 @@ export interface OpenAIChatModelOptions {
   label?: string;
   /** Extra default headers (e.g. OpenRouter's `X-Title`). */
   headers?: Record<string, string>;
+  /**
+   * Per-request wall clock in ms. The SDK's own default is 10 MINUTES, which for
+   * a repo-wide `--deep` means one stalled endpoint can pin a worker for ten
+   * minutes per file — the run looks hung rather than failed.
+   */
+  timeoutMs?: number;
+  /** Retries after a failed request (SDK default 2). The SDK honours the
+   * endpoint's `Retry-After` between them, which is what makes raising this the
+   * right answer to a rate-limited key rather than a way to hammer it harder. */
+  maxRetries?: number;
   /** Inject a pre-built client (tests pass a stub; production omits it). */
   client?: OpenAI;
 }
@@ -98,6 +108,8 @@ export class OpenAIChatModel implements ChatModel {
         apiKey: opts.apiKey,
         baseURL: opts.baseUrl,
         defaultHeaders: opts.headers,
+        ...(opts.timeoutMs !== undefined ? { timeout: opts.timeoutMs } : {}),
+        ...(opts.maxRetries !== undefined ? { maxRetries: opts.maxRetries } : {}),
       });
   }
 

--- a/src/ai/llm/types.ts
+++ b/src/ai/llm/types.ts
@@ -91,6 +91,16 @@ export interface ChatRequest {
   temperature?: number;
   /** Max output tokens. Required by Anthropic; adapters supply a default. */
   maxTokens?: number;
+  /**
+   * Extended reasoning, when the provider has it. Omitting this inherits the
+   * provider's own default, which on current Claude models is ADAPTIVE thinking —
+   * and thinking is billed against the same `maxTokens` as the answer. A caller
+   * asking for structured extraction under a tight budget must say
+   * `{ kind: "disabled" }` explicitly or risk spending the whole budget on
+   * reasoning and getting an empty turn back. Providers with no thinking mode
+   * (the OpenAI wire format) ignore this.
+   */
+  thinking?: { kind: "disabled" } | { kind: "enabled"; budgetTokens: number };
 }
 
 export interface ChatResponse {
@@ -101,6 +111,25 @@ export interface ChatResponse {
   stopReason: string | null;
   /** The assistant turn as a neutral message — push straight back into `messages`. */
   assistant: Message;
+}
+
+/**
+ * The wire values that mean "I ran out of output budget mid-answer": `length` on
+ * the OpenAI wire format, `max_tokens` on the Messages API and the Claude CLI.
+ */
+const TRUNCATED_STOP_REASONS = new Set(["length", "max_tokens"]);
+
+/**
+ * Did the model get cut off before it finished?
+ *
+ * Every engine op MUST ask, because a truncated turn is not a cheap failure: the
+ * partial (often empty) text gets written into the content-hash cache and is
+ * replayed as a hit forever, and a turn cut before its `tool_use` block parses as
+ * "the model had nothing to say" rather than as an error. Both look like success
+ * at the call site and neither is ever retried.
+ */
+export function isTruncated(res: ChatResponse): boolean {
+  return res.stopReason !== null && TRUNCATED_STOP_REASONS.has(res.stopReason);
 }
 
 /**

--- a/src/ai/providers.ts
+++ b/src/ai/providers.ts
@@ -2,7 +2,7 @@ import type { Summarizer } from "./summarize.js";
 import type { Synthesizer } from "./synthesize.js";
 import type { CruxSummarizer } from "./crux.js";
 import type { ChatModel } from "./llm/types.js";
-import { providerNeedsKey, type ProviderKind } from "./llm/factory.js";
+import { PROVIDER_KINDS, providerNeedsKey, type ProviderKind } from "./llm/factory.js";
 import { claudeCliAvailable } from "./llm/claude-cli.js";
 
 /**
@@ -30,10 +30,13 @@ export interface EngineConfig {
   baseUrl?: string;
   /** `claude-cli` only: path to the binary. Env: GRAFT_CLAUDE_BIN. Default: PATH lookup. */
   bin?: string;
-  /** `claude-cli` only: per-call timeout in ms. Env: GRAFT_CLAUDE_TIMEOUT_MS. */
+  /** Per-call timeout in ms, all providers. Env: GRAFT_TIMEOUT_MS (or GRAFT_CLAUDE_TIMEOUT_MS). */
   timeoutMs?: number;
   /** `claude-cli` only: per-call spend ceiling. Env: GRAFT_CLAUDE_MAX_BUDGET_USD. */
   maxBudgetUsd?: number;
+  /** Retries after a failed call, all providers. Env: GRAFT_MAX_RETRIES. Default 2.
+   * `0` is legal and means "fail on the first error". */
+  maxRetries?: number;
 
   // --- advanced: bring your own components ---
   /** Override the whole transport (skips provider/apiKey/baseUrl). */
@@ -57,6 +60,7 @@ export interface ResolvedConfig {
   bin?: string;
   timeoutMs?: number;
   maxBudgetUsd?: number;
+  maxRetries?: number;
   /** True when the key came from the deprecated OPENROUTER_* fallback. */
   usedLegacyEnv: boolean;
   /** True when no provider was named and the local Claude CLI was picked for you. */
@@ -69,14 +73,24 @@ export interface ResolvedConfig {
 
 const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
 
-/** Per-provider default model. */
+/**
+ * Per-provider default model, named the way that provider's OWN endpoint names
+ * it. `openai` therefore defaults to the bare `gpt-4o-mini`: with no `baseUrl`
+ * the SDK talks to api.openai.com, and the `vendor/slug` form this used to carry
+ * is OpenRouter's addressing scheme — api.openai.com answers it with a 404
+ * `model_not_found`. That made the most obvious setup of all (an OpenAI key in
+ * GRAFT_API_KEY and nothing else) fail on every single call of a `--deep` run.
+ */
 export const DEFAULT_MODELS: Record<ProviderKind, string> = {
-  openai: "openai/gpt-4o-mini",
+  openai: "gpt-4o-mini",
   anthropic: "claude-sonnet-5",
   // An alias, not a pinned id: the CLI maps it to the current Sonnet, so a graft
   // release never has to ship a new version to follow a model refresh.
   "claude-cli": "sonnet",
 };
+
+/** Same model, in OpenRouter's `vendor/slug` addressing. */
+const OPENROUTER_DEFAULT_MODEL = "openai/gpt-4o-mini";
 
 export const DEFAULTS = {
   provider: "openai" as ProviderKind,
@@ -97,25 +111,36 @@ export function resolveConfig(config: EngineConfig = {}): ResolvedConfig {
   // gets a working `--deep` instead of an error telling them to go buy a key. It
   // only fires when NO key is configured, so an existing key-based setup keeps
   // resolving to the same provider it always did.
-  const named = config.provider ?? (env.GRAFT_PROVIDER as ProviderKind | undefined);
+  const named = validProvider(config.provider ?? env.GRAFT_PROVIDER);
   const autoDetectedProvider = !named && !apiKey && claudeCliAvailable(config.bin ?? env.GRAFT_CLAUDE_BIN);
   const provider = named ?? (autoDetectedProvider ? "claude-cli" : DEFAULTS.provider);
-
-  const model =
-    config.model ?? env.GRAFT_MODEL ?? env.GRAFT_OPENROUTER_MODEL ?? DEFAULT_MODELS[provider];
 
   let baseUrl = config.baseUrl ?? env.GRAFT_BASE_URL ?? env.OPENROUTER_BASE_URL;
   // Back-compat: an existing setup with only OPENROUTER_API_KEY keeps hitting
   // OpenRouter without any config change.
   if (!baseUrl && provider === "openai" && usedLegacyEnv) baseUrl = OPENROUTER_BASE_URL;
 
-  const headers =
-    provider === "openai" && baseUrl?.includes("openrouter.ai")
-      ? { "X-Title": "graft" }
-      : undefined;
+  const isOpenRouter = provider === "openai" && !!baseUrl?.includes("openrouter.ai");
+  // The default model has to follow the endpoint, because the two spell the same
+  // model differently — see DEFAULT_MODELS. Resolved AFTER baseUrl for that
+  // reason; an explicit GRAFT_MODEL is never second-guessed.
+  const model =
+    config.model ??
+    env.GRAFT_MODEL ??
+    env.GRAFT_OPENROUTER_MODEL ??
+    (isOpenRouter ? OPENROUTER_DEFAULT_MODEL : DEFAULT_MODELS[provider]);
 
-  const timeoutMs = config.timeoutMs ?? numeric(env.GRAFT_CLAUDE_TIMEOUT_MS);
+  const headers = isOpenRouter ? { "X-Title": "graft" } : undefined;
+
+  // GRAFT_CLAUDE_TIMEOUT_MS predates the provider-neutral name and stays the more
+  // specific override, so a setup that already tuned it keeps its value.
+  const timeoutMs = config.timeoutMs ?? numeric(env.GRAFT_CLAUDE_TIMEOUT_MS) ?? numeric(env.GRAFT_TIMEOUT_MS);
   const maxBudgetUsd = config.maxBudgetUsd ?? numeric(env.GRAFT_CLAUDE_MAX_BUDGET_USD);
+  // Its own parser: `numeric` rejects 0 (right for a budget or a timeout, where 0
+  // means "unset"), but 0 retries is a deliberate, useful setting — fail on the
+  // first error instead of sleeping three times per file against an endpoint that
+  // is never going to answer.
+  const maxRetries = config.maxRetries ?? nonNegativeInt(env.GRAFT_MAX_RETRIES);
 
   return {
     contextDir: config.contextDir ?? env.GRAFT_DIR,
@@ -127,6 +152,7 @@ export function resolveConfig(config: EngineConfig = {}): ResolvedConfig {
     bin: config.bin ?? env.GRAFT_CLAUDE_BIN,
     timeoutMs,
     maxBudgetUsd,
+    maxRetries,
     autoDetectedProvider,
     usedLegacyEnv,
     chatModel: config.chatModel,
@@ -136,10 +162,42 @@ export function resolveConfig(config: EngineConfig = {}): ResolvedConfig {
   };
 }
 
+/**
+ * Reject an unknown provider HERE, where the user's typo is still in hand.
+ *
+ * A bare cast let `GRAFT_PROVIDER=gemini` through the whole resolution: the model
+ * silently became `undefined` (despite `ResolvedConfig.model: string`), the
+ * manifest recorded `gemini:undefined`, and the only complaint arrived from the
+ * factory's exhaustiveness guard — which names neither the env var nor the legal
+ * values. The message doubles as the fix, because "gemini" is usually not a typo
+ * but a misreading of what `provider` selects.
+ */
+function validProvider(v: string | undefined): ProviderKind | undefined {
+  // `GRAFT_PROVIDER=` in a .env file arrives as "" — that is "unset", not a typo,
+  // and it must keep falling through to the auto-detection below it.
+  if (!v) return undefined;
+  if ((PROVIDER_KINDS as readonly string[]).includes(v)) return v as ProviderKind;
+  throw new Error(
+    `GRAFT_PROVIDER="${v}" is not one of ${PROVIDER_KINDS.join(", ")}.\n` +
+      "  `provider` names the WIRE FORMAT, not a vendor — for Gemini, Groq, Fireworks, DeepSeek,\n" +
+      "  a LiteLLM proxy or a local server, keep GRAFT_PROVIDER=openai and point GRAFT_BASE_URL at\n" +
+      "  their OpenAI-compatible endpoint (plus GRAFT_MODEL for that endpoint's model id).",
+  );
+}
+
 function numeric(v: string | undefined): number | undefined {
   if (!v) return undefined;
   const n = Number(v);
   return Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
+/** `numeric`, but 0 counts — see the `maxRetries` comment in resolveConfig. Note
+ * `!v` still discards `""` (an unset var in a .env file), which is what we want;
+ * `"0"` is truthy as a string and reaches the parse. */
+function nonNegativeInt(v: string | undefined): number | undefined {
+  if (!v) return undefined;
+  const n = Number(v);
+  return Number.isInteger(n) && n >= 0 ? n : undefined;
 }
 
 /**

--- a/src/ai/providers.ts
+++ b/src/ai/providers.ts
@@ -2,7 +2,8 @@ import type { Summarizer } from "./summarize.js";
 import type { Synthesizer } from "./synthesize.js";
 import type { CruxSummarizer } from "./crux.js";
 import type { ChatModel } from "./llm/types.js";
-import type { ProviderKind } from "./llm/factory.js";
+import { providerNeedsKey, type ProviderKind } from "./llm/factory.js";
+import { claudeCliAvailable } from "./llm/claude-cli.js";
 
 /**
  * User-facing configuration. Anything omitted falls back to environment
@@ -11,8 +12,9 @@ import type { ProviderKind } from "./llm/factory.js";
  * graft is vendor-neutral: `provider` names only the WIRE FORMAT, not a company.
  * `openai` speaks the OpenAI-compatible API — point `baseUrl` at OpenRouter,
  * Fireworks, a LiteLLM proxy, Groq, a local server, or OpenAI itself, and pass
- * your own key. `anthropic` speaks the native Messages API. Any LLM-backed
- * operation needs an API key.
+ * your own key. `anthropic` speaks the native Messages API. `claude-cli` drives a
+ * locally installed, already-signed-in Claude Code binary and needs NO key — it
+ * is the one provider that runs on a subscription instead of metered credits.
  */
 export interface EngineConfig {
   /** Where the graph lives. Env: GRAFT_DIR. Default: `<repo>/.context`. */
@@ -26,6 +28,12 @@ export interface EngineConfig {
   model?: string;
   /** Base URL for OpenAI-compatible endpoints. Env: GRAFT_BASE_URL. */
   baseUrl?: string;
+  /** `claude-cli` only: path to the binary. Env: GRAFT_CLAUDE_BIN. Default: PATH lookup. */
+  bin?: string;
+  /** `claude-cli` only: per-call timeout in ms. Env: GRAFT_CLAUDE_TIMEOUT_MS. */
+  timeoutMs?: number;
+  /** `claude-cli` only: per-call spend ceiling. Env: GRAFT_CLAUDE_MAX_BUDGET_USD. */
+  maxBudgetUsd?: number;
 
   // --- advanced: bring your own components ---
   /** Override the whole transport (skips provider/apiKey/baseUrl). */
@@ -46,8 +54,13 @@ export interface ResolvedConfig {
   model: string;
   baseUrl?: string;
   headers?: Record<string, string>;
+  bin?: string;
+  timeoutMs?: number;
+  maxBudgetUsd?: number;
   /** True when the key came from the deprecated OPENROUTER_* fallback. */
   usedLegacyEnv: boolean;
+  /** True when no provider was named and the local Claude CLI was picked for you. */
+  autoDetectedProvider: boolean;
   chatModel?: ChatModel;
   synthesizer?: Synthesizer;
   summarizer?: Summarizer;
@@ -60,6 +73,9 @@ const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
 export const DEFAULT_MODELS: Record<ProviderKind, string> = {
   openai: "openai/gpt-4o-mini",
   anthropic: "claude-sonnet-5",
+  // An alias, not a pinned id: the CLI maps it to the current Sonnet, so a graft
+  // release never has to ship a new version to follow a model refresh.
+  "claude-cli": "sonnet",
 };
 
 export const DEFAULTS = {
@@ -70,12 +86,20 @@ export const DEFAULTS = {
 /** Merge user config with environment variables and defaults. */
 export function resolveConfig(config: EngineConfig = {}): ResolvedConfig {
   const env = process.env;
-  const provider = config.provider ?? (env.GRAFT_PROVIDER as ProviderKind | undefined) ?? DEFAULTS.provider;
 
   const explicitKey = config.apiKey ?? env.GRAFT_API_KEY;
   const legacyKey = env.OPENROUTER_API_KEY;
   const apiKey = explicitKey ?? legacyKey;
   const usedLegacyEnv = !explicitKey && !!legacyKey;
+
+  // Provider choice is explicit-first, then inferred. The inference exists so the
+  // common case — a developer with a Claude subscription and no API credits —
+  // gets a working `--deep` instead of an error telling them to go buy a key. It
+  // only fires when NO key is configured, so an existing key-based setup keeps
+  // resolving to the same provider it always did.
+  const named = config.provider ?? (env.GRAFT_PROVIDER as ProviderKind | undefined);
+  const autoDetectedProvider = !named && !apiKey && claudeCliAvailable(config.bin ?? env.GRAFT_CLAUDE_BIN);
+  const provider = named ?? (autoDetectedProvider ? "claude-cli" : DEFAULTS.provider);
 
   const model =
     config.model ?? env.GRAFT_MODEL ?? env.GRAFT_OPENROUTER_MODEL ?? DEFAULT_MODELS[provider];
@@ -90,6 +114,9 @@ export function resolveConfig(config: EngineConfig = {}): ResolvedConfig {
       ? { "X-Title": "graft" }
       : undefined;
 
+  const timeoutMs = config.timeoutMs ?? numeric(env.GRAFT_CLAUDE_TIMEOUT_MS);
+  const maxBudgetUsd = config.maxBudgetUsd ?? numeric(env.GRAFT_CLAUDE_MAX_BUDGET_USD);
+
   return {
     contextDir: config.contextDir ?? env.GRAFT_DIR,
     provider,
@@ -97,10 +124,45 @@ export function resolveConfig(config: EngineConfig = {}): ResolvedConfig {
     model,
     baseUrl,
     headers,
+    bin: config.bin ?? env.GRAFT_CLAUDE_BIN,
+    timeoutMs,
+    maxBudgetUsd,
+    autoDetectedProvider,
     usedLegacyEnv,
     chatModel: config.chatModel,
     synthesizer: config.synthesizer,
     summarizer: config.summarizer,
     cruxSummarizer: config.cruxSummarizer,
   };
+}
+
+function numeric(v: string | undefined): number | undefined {
+  if (!v) return undefined;
+  const n = Number(v);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
+/**
+ * Can this config actually reach a model? One answer for every caller — the CLI's
+ * pre-flight warning and the engine's hard error used to each spell out "needs a
+ * key", which silently became wrong the moment a keyless provider existed.
+ *
+ * Returns undefined when the config is usable, or the reason it is not.
+ */
+export function credentialProblem(cfg: ResolvedConfig): string | undefined {
+  if (cfg.chatModel || (cfg.synthesizer && cfg.summarizer && cfg.cruxSummarizer)) return undefined;
+  if (!providerNeedsKey(cfg.provider)) {
+    if (claudeCliAvailable(cfg.bin)) return undefined;
+    return (
+      `GRAFT_PROVIDER=${cfg.provider} needs the Claude Code CLI, which is not on PATH.\n` +
+      "  Install it from https://claude.com/claude-code and sign in with your subscription,\n" +
+      "  or point GRAFT_CLAUDE_BIN at the binary."
+    );
+  }
+  if (cfg.apiKey) return undefined;
+  return (
+    "No API key. Set GRAFT_API_KEY (and GRAFT_PROVIDER / GRAFT_BASE_URL / GRAFT_MODEL for your\n" +
+    "  provider), or install the Claude Code CLI and run with GRAFT_PROVIDER=claude-cli to use\n" +
+    "  your Claude subscription instead of a key."
+  );
 }

--- a/src/ai/summarize.ts
+++ b/src/ai/summarize.ts
@@ -1,4 +1,4 @@
-import type { ChatModel } from "./llm/types.js";
+import { isTruncated, type ChatModel } from "./llm/types.js";
 
 /**
  * Turns one source-code file into a short prose summary for the knowledge graph.
@@ -41,11 +41,21 @@ export class ChatSummarizer implements Summarizer {
     const res = await this.model.create({
       temperature: 0,
       maxTokens: 2048,
+      // 2048 tokens is a generous budget for 3-8 sentences of prose and a very
+      // thin one for reasoning. Left unset, current Claude models think first and
+      // can burn the whole budget before writing a word.
+      thinking: { kind: "disabled" },
       messages: [
         { role: "system", content: SYSTEM_PROMPT },
         { role: "user", content: userContent(code, opts.path) },
       ],
     });
+    // A cut-off turn must throw, not return its prefix: the caller caches this
+    // string by content hash, so a half-summary (or the empty string) would be
+    // replayed as a cache hit on every future build of an unchanged file.
+    if (isTruncated(res)) {
+      throw new Error(`summary truncated at maxTokens (stop_reason=${res.stopReason}) — raise the budget or shrink the file`);
+    }
     return res.text.trim();
   }
 }

--- a/src/ai/synthesize.ts
+++ b/src/ai/synthesize.ts
@@ -6,7 +6,7 @@
  * incidental identifier. Each node is attributed to the source files it is
  * grounded in, so provenance (and staleness) stays exact.
  */
-import type { ChatModel } from "./llm/types.js";
+import { isTruncated, type ChatModel } from "./llm/types.js";
 
 /** A directed edge to another node, by node name (resolved to a slug later). */
 export interface SynthLink {
@@ -133,6 +133,9 @@ export class ChatSynthesizer implements Synthesizer {
     const res = await this.model.create({
       temperature: 0,
       maxTokens: 8192,
+      // Structured extraction under a fixed budget: thinking would be billed
+      // against the same 8192 tokens the node list has to fit in.
+      thinking: { kind: "disabled" },
       tools: [
         {
           name: RECORD_TOOL,
@@ -146,6 +149,13 @@ export class ChatSynthesizer implements Synthesizer {
         { role: "user", content: userContent(files) },
       ],
     });
+    // A batch cut short is NOT "the model found nothing here": the tool_use block
+    // never closed. Returning [] would cache an empty synthesis for this batch key
+    // and, in a run where every batch truncates, hand the caller a graph with no
+    // nodes at all — which the reconciler reads as "delete everything".
+    if (isTruncated(res)) {
+      throw new Error(`synthesis truncated at maxTokens (stop_reason=${res.stopReason}) — try a smaller batch budget`);
+    }
     const call = res.toolCalls[0];
     if (!call) return [];
     // `args` is already a parsed object — no JSON.parse.

--- a/src/ask/ask.ts
+++ b/src/ask/ask.ts
@@ -34,6 +34,7 @@ import { rankScopesAndFuse } from "./fuse.js";
 import { personalizedPageRank } from "./graphrank.js";
 import { readSourceFile } from "../util/source.js";
 import { counts, tokenize, type AskIndex, type AskIndexDoc } from "./index-file.js";
+import { formatCount } from "../util/num.js";
 
 export interface AskHit {
   kind: "concept" | "symbol" | "caller" | "callee";
@@ -995,9 +996,9 @@ function askSavingsLine(r: AskResult, body: string): string {
   const saved = base - pack;
   const pct = Math.round((saved / base) * 100);
   return (
-    `[graft] tokens saved ≈ ${saved.toLocaleString()} (${pct}%) — this pack ≈ ` +
-    `${pack.toLocaleString()} tok vs reading the ${r.saved.files} source file(s) whole ≈ ` +
-    `${base.toLocaleString()} tok. Estimate (baseline = those files read in full).` +
+    `[graft] tokens saved ≈ ${formatCount(saved)} (${pct}%) — this pack ≈ ` +
+    `${formatCount(pack)} tok vs reading the ${r.saved.files} source file(s) whole ≈ ` +
+    `${formatCount(base)} tok. Estimate (baseline = those files read in full).` +
     SAVINGS_TURN_NUDGE
   );
 }

--- a/src/ask/ask.ts
+++ b/src/ask/ask.ts
@@ -27,7 +27,7 @@ import {
   scopesHereClause,
   scopesOfGraph,
 } from "../graph/scopes.js";
-import { normalizePathPrefix } from "../util/paths.js";
+import { normalizePathPrefix, toPosixPath } from "../util/paths.js";
 import { resolveSymbol } from "../graph/traverse.js";
 import type { EdgeV1, GraphV1, NodeV1, Relation } from "../graph/types.js";
 import { rankScopesAndFuse } from "./fuse.js";
@@ -236,6 +236,29 @@ function subjectWords(query: string): string[] {
   return [...new Set(query.split(/[^A-Za-z0-9_.]+/).filter(Boolean))];
 }
 
+/**
+ * The words that EXPRESS the structural intent, and so can never BE its
+ * subject. `INCOMING`/`OUTGOING` above already consumed them; leaving them in
+ * the candidate list lets the question's own grammar hijack the answer.
+ *
+ * The failure is not hypothetical and not rare: `resolveSymbol` matches
+ * case-insensitively and by id suffix (`#calls`, `.calls`), so in any repo with
+ * a method or field named `calls`/`uses`/`imports` — which describes most graph
+ * or HTTP-client code, this repo included — "who calls run" resolves `calls`
+ * (same length as `run`, and stable sort keeps the earlier word) and answers
+ * "callers / references of calls". The user asked about `run` and got a
+ * confident answer about something else entirely.
+ */
+const INTENT_WORDS = new Set([
+  "call", "calls", "caller", "callers", "called", "calling",
+  "use", "uses", "used", "using", "usage",
+  "import", "imports", "imported", "importing",
+  "depend", "depends", "depend_on", "dependency", "dependencies",
+  "reference", "references", "referenced",
+  "who", "what", "which", "where", "does", "do", "is", "are", "the", "a", "an",
+  "into", "by", "on", "of", "from", "to", "in", "and", "or",
+]);
+
 /** Resolve the query's structural subject via {@link resolveSymbol}, trying
  * each word longest-first — the intended subject of a structural query is
  * usually the most specific (longest) identifier-shaped word, never a short
@@ -254,7 +277,17 @@ function subjectWords(query: string): string[] {
  * today — and if nothing survives for ANY word, `subjects.length === 0`
  * naturally falls through to the existing loud fallthrough note. */
 function findSubjectNodes(query: string, graph: GraphV1, inPrefix?: string): { nodes: NodeV1[]; tried: string } {
-  const words = subjectWords(query).sort((a, b) => b.length - a.length);
+  const all = subjectWords(query);
+  // Intent words are dropped, not merely deprioritized — but only when
+  // something else survives, so a degenerate query like "who calls calls" can
+  // still resolve rather than falling through with nothing to try.
+  const candidates = all.filter((w) => !INTENT_WORDS.has(w.toLowerCase()));
+  const pool = candidates.length ? candidates : all;
+  // Ties on length break toward the word that appeared LAST: English puts the
+  // object at the end ("what does the gate import" — `gate` and `import` are
+  // both 6 letters, and it is `gate` that is being asked about).
+  const order = new Map(pool.map((w, i) => [w, i]));
+  const words = [...pool].sort((a, b) => b.length - a.length || order.get(b)! - order.get(a)!);
   for (const w of words) {
     let nodes = resolveSymbol(graph, w);
     if (inPrefix) nodes = nodes.filter((n) => pathUnderPrefix(n.path, inPrefix));
@@ -316,15 +349,25 @@ function structural(query: string, graph: GraphV1, limit: number, inPrefix?: str
   if (hits.length === 0) return { fallthroughNote: fallthroughNoteFor(subjects[0].name) };
 
   hits.sort((a, b) => a.pointer.localeCompare(b.pointer));
+  const subject = subjects[0].name;
+  // Structural hits all score 1, so the `limit` cut falls on a PATH-alphabetical
+  // ordering — there is no "best 5" here, only "the 5 whose paths sort first".
+  // With the MCP default of limit 5, "who calls X" on a symbol with 40 callers
+  // returned 5 and looked complete, and the agent shipped a refactor with 35
+  // callers it never saw. The count is the fix; the ordering is a detail.
+  const dropped = hits.length - limit;
+  const head = outgoing ? `outgoing edges from ${subject}` : `callers / references of ${subject}`;
   return {
     result: {
       query,
       mode: "structural",
-      subject: subjects[0].name,
+      subject,
       hits: hits.slice(0, limit),
-      note: outgoing
-        ? `outgoing edges from ${subjects[0].name}`
-        : `callers / references of ${subjects[0].name}`,
+      note:
+        dropped > 0
+          ? `${head} — showing ${limit} of ${hits.length} (ordered by path, not relevance); ` +
+            `run graft callers '${subject}' for the full list`
+          : head,
     },
   };
 }
@@ -393,6 +436,11 @@ function matchedIdfShare(
   return total > 0 ? matched / total : 0;
 }
 
+/** Exported so callers (and tests) can recognize the degraded-recall state
+ * without string-matching a literal that might drift. */
+export const BODY_INDEX_MISSING_NOTE =
+  "body index missing or stale (graft/.cache/ask-index.json) — matches that exist only inside a definition's code are invisible right now; run `graft build` to restore full recall";
+
 function lexical(query: string, corpus: Corpus, limit: number, graphRank: boolean, inPrefix?: string): AskResult {
   // Binary query terms: a word repeated in a pasted issue body counts once, so a
   // ranty description can't linearly amplify an incidental word.
@@ -445,6 +493,17 @@ function lexical(query: string, corpus: Corpus, limit: number, graphRank: boolea
     if (graph.nodes.every((n) => map.has(n.id))) docById = map;
   }
   const askIndex = docById ? corpus.askIndex : null;
+
+  // The fallback above is graceful, but it is NOT equivalent, and until now it
+  // was invisible. `writeGraph` strips `body_text` from every node it
+  // serializes, so on any graph read back from disk the sidecar's per-doc bags
+  // are the ONLY surviving copy of a symbol's body tokens; without it `body`
+  // collapses to signature + summary and every body-only match disappears.
+  // A missing or stale sidecar (build wrote it to a failed path, a worktree
+  // seed skipped it, a hand-edit desynced the ids) therefore shows up as "ask
+  // is just bad in this repo" rather than as anything diagnosable. Same
+  // never-silent posture grep-cli takes on truncation.
+  const bodyIndexMissing = docById === null && (graph?.nodes.length ?? 0) > 0;
 
   // Symbols AND file nodes are scored: a symbol's body_text is its definition;
   // a file's body_text is the module-level residual (imports/constants not in
@@ -704,9 +763,17 @@ function lexical(query: string, corpus: Corpus, limit: number, graphRank: boolea
     coverageStrong: scored.length && q.size > 0 ? matchedStrongOf.get(scored[0]) ?? 0 : undefined,
     // Zero hits on a genuinely multi-scope graph names the scopes that exist,
     // so a query that missed everywhere still tells the caller where to look.
-    note: scored.length
-      ? undefined
-      : `no matching nodes — try different words, or \`graft build\` if graft/ is empty${scopesHereClause(scopes ?? [])}`,
+    // The degraded-index warning rides alongside it: with no body tokens, zero
+    // hits may well mean "the index lost them", not "the code doesn't say it".
+    note:
+      [
+        scored.length
+          ? null
+          : `no matching nodes — try different words, or \`graft build\` if graft/ is empty${scopesHereClause(scopes ?? [])}`,
+        bodyIndexMissing ? BODY_INDEX_MISSING_NOTE : null,
+      ]
+        .filter(Boolean)
+        .join("\n") || undefined,
   };
 }
 
@@ -878,10 +945,16 @@ export function skeleton(dir: string, file: string, opts: { contextDir?: string 
   const graph = loadGraphCached(outDir);
   if (!graph) return { file, entries: [], note: "no wiring graph — run `graft build` first" };
 
-  let defs = graph.nodes.filter((n) => n.kind !== "file" && n.path === file);
+  // Every `node.path` in the graph is posix. An agent on Windows types (or a
+  // Windows tool hands back) `src\ask\ask.ts`, which equals no node path at
+  // all, and the file falls out the bottom as "no definitions indexed for this
+  // file" — the exact silent-miss `--in` already guards against via
+  // `normalizePathPrefix`. See the header of src/util/paths.ts.
+  const wanted = toPosixPath(file);
+  let defs = graph.nodes.filter((n) => n.kind !== "file" && n.path === wanted);
   if (!defs.length) {
     const matches = new Set(
-      graph.nodes.filter((n) => n.path === file || n.path.endsWith(`/${file}`)).map((n) => n.path),
+      graph.nodes.filter((n) => n.path === wanted || n.path.endsWith(`/${wanted}`)).map((n) => n.path),
     );
     if (matches.size > 1)
       return { file, entries: [], note: `ambiguous — matches: ${[...matches].sort().join(", ")}` };

--- a/src/claude/format.ts
+++ b/src/claude/format.ts
@@ -5,6 +5,7 @@ import type { GraphV1, EdgeV1 } from '../graph/types.js';
 // "did we hit a real name, or match broadly enough to trust anyway" is the same
 // question in both places, and one set of calibrated numbers beats two.
 import { HIGH_FLOOR, STRONG_FLOOR } from '../ask/fuse.js';
+import { formatCount } from "../util/num.js";
 
 const C = {
   indigo: (s: string) => `\x1b[38;2;84;111;255m${s}\x1b[0m`,
@@ -32,7 +33,7 @@ export function renderStatusline(
   const top = [C.muted('◤ ') + C.indigo('graft'), C.text(`${stats.nodeCount} nodes / ${stats.edgeCount} edges`)];
   top.push(freshnessSegment(stats));
   const saved = session?.savedTokens ?? 0;
-  if (saved > 0) top.push(C.indigo(`~${saved.toLocaleString()} tok saved`));
+  if (saved > 0) top.push(C.indigo(`~${formatCount(saved)} tok saved`));
 
   const bottom: string[] = [];
   if (typeof ctx.ctxPct === 'number') bottom.push(C.text(`ctx ${ctx.ctxPct}%`));
@@ -125,9 +126,9 @@ export function formatRetrieval(ask: AskJson, cap = 5): string | null {
   const base = tokensOf(ask.saved!.baselineChars);
   const pct = Math.round((saved / base) * 100);
   return (
-    `${body}\n[graft] tokens saved ≈ ${saved.toLocaleString()} (${pct}%); this pack ≈ ` +
-    `${tokensOf(body.length).toLocaleString()} tok vs reading the ${ask.saved!.files} file(s) whole ≈ ` +
-    `${base.toLocaleString()} tok (estimate).`
+    `${body}\n[graft] tokens saved ≈ ${formatCount(saved)} (${pct}%); this pack ≈ ` +
+    `${formatCount(tokensOf(body.length))} tok vs reading the ${ask.saved!.files} file(s) whole ≈ ` +
+    `${formatCount(base)} tok (estimate).`
   );
 }
 

--- a/src/claude/init.ts
+++ b/src/claude/init.ts
@@ -1,7 +1,8 @@
-import { mkdirSync, writeFileSync, readFileSync, chmodSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { mkdirSync, writeFileSync, readFileSync, chmodSync, existsSync } from 'node:fs';
+import { join, dirname, isAbsolute, relative, resolve, sep } from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { mergeGraftSettings } from './settings-merge.js';
+import { priorAllowOffers } from '../upkeep.js';
 import { statuslineShim, hooksShim } from './shim-template.js';
 import { skillTemplate } from './skill-template.js';
 import { claudeDistDir } from './paths.js';
@@ -46,6 +47,58 @@ export function buildGraphIfMissing(dir: string, opts: { build?: boolean; cliPat
   }
 }
 
+/**
+ * Write only when the bytes actually differ.
+ *
+ * `runInit` is not just an explicit `graft init` any more: the version stamp lives
+ * under the git-ignored `graft/.cache/`, so every fresh clone looks unstamped and
+ * the session-start hook re-runs these writes on the first session. The files it
+ * rewrites (`settings.json`, both shims, `SKILL.md`) ARE committed — the epilogue
+ * tells people to `git add .claude` — so an unconditional write handed every
+ * colleague a dirty working tree before they had typed anything. Same bytes, same
+ * mtime, no diff.
+ */
+function writeIfChanged(path: string, content: string): boolean {
+  try { if (readFileSync(path, 'utf8') === content) return false; } catch { /* absent or unreadable → write */ }
+  writeFileSync(path, content);
+  return true;
+}
+
+/**
+ * The settings object to merge into: `{}` when there is no file, the parsed object
+ * when there is one, and the sentinel `'unparseable'` when a file exists but graft
+ * cannot read it — the one case where the only safe move is to write nothing.
+ *
+ * A non-object at the top level (`[]`, `"x"`, `null`) counts as unparseable too:
+ * spreading one into the merge produces a settings.json Claude Code cannot load,
+ * which is the same data loss by another route.
+ */
+function readSettings(path: string): Record<string, any> | 'unparseable' {
+  if (!existsSync(path)) return {};
+  let parsed: unknown;
+  try { parsed = JSON.parse(readFileSync(path, 'utf8')); } catch { return 'unparseable'; }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return 'unparseable';
+  return parsed as Record<string, any>;
+}
+
+/**
+ * What to bake into the shims as their primary candidate.
+ *
+ * Absolute for a normal install — that is the whole point, the shims find graft
+ * with zero guesswork. But when graft's own `dist/claude` sits INSIDE the repo
+ * being wired (running `graft init` in a graft checkout), an absolute path is one
+ * developer's home directory committed into `.claude/helpers/*.cjs` for everyone
+ * else to pull: exactly the scar `hosts/mcp-config.ts` refuses to repeat for the
+ * MCP launcher. A repo-relative path is identical on every machine, and the shim
+ * resolves it against `CLAUDE_PROJECT_DIR` at runtime.
+ */
+export function bakedRef(dir: string): string {
+  const dist = claudeDistDir();
+  const rel = relative(resolve(dir), dist);
+  if (!rel || rel.startsWith('..') || isAbsolute(rel)) return dist;
+  return rel.split(sep).join('/'); // posix separators: the same shim text on both platforms
+}
+
 export interface InitResult {
   settingsPath: string;
   shims: string[];
@@ -54,6 +107,11 @@ export interface InitResult {
   mcp: McpWrite;
   warnings: string[];
   built: boolean;
+  /** The `permissions.allow` entries this run proposed for `.claude/settings.json`,
+   * for the caller to record in the wiring stamp — that record is what stops the
+   * NEXT init from re-adding a grant the user deleted. Empty when settings.json was
+   * left untouched (unparseable), because then nothing was proposed at all. */
+  offeredAllow: string[];
 }
 
 export function runInit(dir: string, opts: { build?: boolean; cliPath?: string } = {}): InitResult {
@@ -63,22 +121,38 @@ export function runInit(dir: string, opts: { build?: boolean; cliPath?: string }
   mkdirSync(dirname(statusline), { recursive: true });
 
   const settingsPath = settings;
-  let existing: Record<string, any> = {};
-  try { existing = JSON.parse(readFileSync(settingsPath, 'utf8')); } catch { /* none/invalid → start fresh */ }
-  const { merged, warnings } = mergeGraftSettings(existing);
-  writeFileSync(settingsPath, `${JSON.stringify(merged, null, 2)}\n`);
+  const warnings: string[] = [];
+  // An existing settings.json that does not parse is the user's file with a typo in
+  // it — a BOM, a trailing comma, a `//` comment — not an absent file. Treating the
+  // two the same meant `{}` went into the merge and the write below replaced their
+  // permissions, env, model, hooks and statusLine with graft's defaults, with no
+  // backup and no way back. The other hosts already refuse this write
+  // (`mergeJsonKey` → 'skipped-unparseable'); so does this one now.
+  const existing = readSettings(settingsPath);
+  let offeredAllow: string[] = [];
+  if (existing === 'unparseable') {
+    warnings.push(`${settingsPath} is not valid JSON — left untouched. Fix it (or move it aside) and re-run \`graft init\`; the graft statusline and hooks stay unwired until then.`);
+  } else {
+    // What a previous init here already proposed. Read from the stamp/memo rather
+    // than inferred from the file, because "absent" alone cannot tell a grant the
+    // user deleted from one this graft version has simply never offered.
+    const merged = mergeGraftSettings(existing, { offeredBefore: priorAllowOffers(dir) });
+    warnings.push(...merged.warnings);
+    offeredAllow = merged.offeredAllow;
+    writeIfChanged(settingsPath, `${JSON.stringify(merged.merged, null, 2)}\n`);
+  }
 
   const sl = statusline;
   const hk = hooks;
-  const bakedDir = claudeDistDir(); // absolute <pkg>/dist/claude — the shims' primary resolution path
-  writeFileSync(sl, statuslineShim(bakedDir)); chmodSync(sl, 0o755);
-  writeFileSync(hk, hooksShim(bakedDir)); chmodSync(hk, 0o755);
+  const baked = bakedRef(dir); // <pkg>/dist/claude — the shims' primary resolution candidate
+  writeIfChanged(sl, statuslineShim(baked)); chmodSync(sl, 0o755);
+  writeIfChanged(hk, hooksShim(baked)); chmodSync(hk, 0o755);
 
   // Install the graft skill — the piece that redirects the agent to graft/ before it
   // greps source. Overwritten each run (graft owns this file), like the shims above.
   const skillPath = skill;
   mkdirSync(dirname(skillPath), { recursive: true });
-  writeFileSync(skillPath, skillTemplate());
+  writeIfChanged(skillPath, skillTemplate());
 
   // Register the graft MCP server in the project's .mcp.json so Claude Code
   // exposes graft_find_code/graft_trace_calls/etc. as tools — the same keyed merge the
@@ -86,5 +160,5 @@ export function runInit(dir: string, opts: { build?: boolean; cliPath?: string }
   const mcp = mergeJsonKey('claude', mcpTarget, 'mcpServers', serverEntry());
 
   const built = buildGraphIfMissing(dir, opts);
-  return { settingsPath, shims: [sl, hk], skill: skillPath, mcp, warnings, built };
+  return { settingsPath, shims: [sl, hk], skill: skillPath, mcp, warnings, built, offeredAllow };
 }

--- a/src/claude/settings-merge.ts
+++ b/src/claude/settings-merge.ts
@@ -2,16 +2,29 @@ type Json = Record<string, any>;
 
 const SL_CMD = 'node "${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-statusline.cjs"';
 const FOOTER = 'graft/[\\w./-]+\\.md';
-// Every form graft is actually invoked as. 'graft:*' covers a global install;
-// the other two cover a repo working on graft itself (or any consumer running it
-// from a checkout), where the binary is not on PATH under that name. A retrieval
-// call that raises a permission prompt loses to grep, which never does.
-const ALLOW_ENTRIES = [
+// Every form graft is actually invoked as. 'graft:*' covers a global install; the
+// npx form covers a machine without one; the last two cover a repo working on graft
+// itself (or any consumer running it from a checkout), where the binary is not on
+// PATH under that name. A retrieval call that raises a permission prompt loses to
+// grep, which never does.
+//
+// The npx entry is scoped to the package name on purpose. `npx graft` resolves to
+// the UNSCOPED `graft` package on the registry — someone else's code entirely — and
+// this list is written into `.claude/settings.json`, the shared, committed file, so
+// the grant reaches everyone who pulls. Auto-approving "download and run whatever
+// npm currently serves under the name `graft`" is not a grant graft gets to make on
+// a team's behalf; auto-approving its own published package is.
+export const ALLOW_ENTRIES = [
   'Bash(graft:*)',
-  'Bash(npx graft:*)',
+  'Bash(npx -y @nanonets/graft:*)',
   'Bash(graft-dev:*)',
   'Bash(node dist/cli.js:*)',
 ];
+
+// Grants an older graft added that this one takes back. Dropped on every merge, so
+// the fix reaches repos already wired — a refresh runs on the next version bump,
+// and a stale entry sitting in a committed settings.json is precisely the problem.
+const REVOKED_ALLOW_ENTRIES = ['Bash(npx graft:*)'];
 
 function hookCmd(arg: string): string {
   return `node "\${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-hooks.cjs" ${arg}`;
@@ -43,7 +56,19 @@ function isGraftHookEntry(entry: Json): boolean {
   return JSON.stringify(entry ?? '').includes('graft-hooks.cjs');
 }
 
-export function mergeGraftSettings(existing: Json): { merged: Json; warnings: string[] } {
+/**
+ * @param opts.offeredBefore  Allow entries a PREVIOUS graft init already proposed
+ *   for this repo (recorded in the wiring stamp). Any of them now missing from
+ *   `permissions.allow` was taken out deliberately, so it is not re-added — a
+ *   permission the user revoked coming back on every version bump is graft
+ *   overruling a decision, and `.claude/settings.json` is committed, so it comes
+ *   back for the whole team. Entries NOT in this list have never been offered here
+ *   (a new graft version, or a first init) and are proposed normally.
+ */
+export function mergeGraftSettings(
+  existing: Json,
+  opts: { offeredBefore?: readonly string[] } = {},
+): { merged: Json; warnings: string[]; offeredAllow: string[] } {
   const merged: Json = { ...(existing ?? {}) };
   const warnings: string[] = [];
 
@@ -69,11 +94,19 @@ export function mergeGraftSettings(existing: Json): { merged: Json; warnings: st
   // headless/subagent runs hard-deny Bash by default; without an allowlist entry
   // `graft ask`'s own Bash calls (and the skill it installs) can't run out-of-box.
   merged.permissions = { ...(merged.permissions ?? {}) };
-  const allow = Array.isArray(merged.permissions.allow) ? [...merged.permissions.allow] : [];
+  const prior: unknown[] = Array.isArray(merged.permissions.allow) ? merged.permissions.allow : [];
+  const allow = prior.filter((e) => !REVOKED_ALLOW_ENTRIES.includes(e as string));
+  const revoked = new Set(opts.offeredBefore ?? []);
   for (const entry of ALLOW_ENTRIES) {
-    if (!allow.includes(entry)) allow.push(entry);
+    // Offered before and gone now ⇒ removed on purpose. Nothing else deletes an
+    // entry from this array: graft only ever appends, and the one list it does
+    // delete from (REVOKED_ALLOW_ENTRIES) is a different set entirely.
+    if (!allow.includes(entry) && !revoked.has(entry)) allow.push(entry);
   }
   merged.permissions.allow = allow;
 
-  return { merged, warnings };
+  // Everything this version proposes, recorded whether or not it ended up in the
+  // file — an entry skipped above was offered by an EARLIER run, and forgetting
+  // that would re-offer it on the next one, which is the whole defect.
+  return { merged, warnings, offeredAllow: [...ALLOW_ENTRIES] };
 }

--- a/src/claude/shim-template.ts
+++ b/src/claude/shim-template.ts
@@ -2,30 +2,40 @@
 // job is to locate the installed `@nanonets/graft` package's `dist/claude/<entry>.js` and
 // call into it — so the real logic lives in the package and upgrades with it.
 //
-// Candidates, cheapest first (no subprocess for 1–3):
-//   1. `bakedDir`   — the absolute `dist/claude` graft was running from at init time.
-//                     Correct with zero guesswork for whoever ran `graft init`.
+// Candidates, all four compared against each other:
+//   1. `BAKED`      — the `dist/claude` graft was running from at init time. Absolute for a
+//                     normal install; RELATIVE when it sits inside the repo being wired (see
+//                     `bakedRef` in init.ts), so graft's own checkout stops committing a shim
+//                     with one developer's home directory in it.
 //   2. repo node_modules — a local dev-dep install.
-//   3. `execDir/../lib`  — the cheap legacy guess (covers nvm / classic prefix layout).
-//   4. `npm root -g`     — authoritative global dir, layout-agnostic. Only shelled out to
-//                     when 1–3 all miss; queried on demand — no on-disk cache, which on a
-//                     shared machine would be a world-writable path an attacker could point
-//                     at their own code for us to import.
+//   3. `execDir/../lib`  — the cheap legacy guess (nvm / classic posix prefix).
+//   4. `npm root -g`     — authoritative global dir, layout-agnostic, and on Windows the only
+//                     one that finds anything at all: a global install lands in
+//                     `%APPDATA%\npm\node_modules`, and candidate 3 resolves to
+//                     `C:\Program Files\lib`, which does not exist.
 //
 // Among the candidates that exist we take the HIGHEST VERSION, not the first hit. First-hit
-// silently pinned users to a stale graft forever: `bakedDir` points into one Node install's
+// silently pinned users to a stale graft forever: `BAKED` points into one Node install's
 // global node_modules, so switching Node versions (nvm/volta) or moving the install leaves
 // the old directory on disk and still winning, and `npm i -g @nanonets/graft@latest`
 // upgrades a directory the shim never looks at. The upgrade appeared to work and changed
 // nothing — the shim kept loading the version from whenever `graft init` was last run.
+//
+// Candidate 4 has to be IN that comparison, not a fallback behind it. It used to be reached
+// only when 1–3 all missed, and `BAKED` almost always exists — so the authoritative global
+// directory was in practice never consulted, and the "upgrade changes nothing" bug survived
+// the fix that was supposed to kill it, most visibly on Windows where 3 never resolves.
 function shim(entryFile: string, call: string, bakedDir: string): string {
   return `#!/usr/bin/env node
 const path = require('path');
 const fs = require('fs');
+const os = require('os');
 const { pathToFileURL } = require('url');
 const { execFileSync } = require('child_process');
 const dir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+// Relative when graft's dist lives inside this repo; path.resolve leaves an absolute one be.
 const BAKED = ${JSON.stringify(bakedDir)};
+const bakedDir = BAKED ? path.resolve(dir, BAKED) : null;
 
 // The dist/claude dir of @nanonets/graft resolved from a base whose node_modules is searched.
 function fromPkg(base) {
@@ -35,12 +45,28 @@ function fromPkg(base) {
   } catch { return null; }
 }
 
-// The global node_modules dir per npm (handles Homebrew/Windows/volta). Queried on demand.
+// The global node_modules dir per npm (handles Homebrew/Windows/volta).
+//
+// Asking npm costs a subprocess (~0.5s), and this file runs on every hook and every
+// statusline render, so the answer is cached for a day. Under the user's own ~/.graft,
+// beside graft's update check — NOT a world-writable path like /tmp, where a co-tenant
+// on a shared machine could point the cache at their own code for us to import.
+const ROOT_TTL_MS = 24 * 60 * 60 * 1000;
 function globalRoot() {
+  const cache = path.join(os.homedir(), '.graft', 'npm-root.json');
   try {
-    const root = execFileSync('npm', ['root', '-g'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], shell: process.platform === 'win32' }).trim();
-    return root || null;
-  } catch { return null; /* npm unavailable */ }
+    const c = JSON.parse(fs.readFileSync(cache, 'utf8'));
+    if (typeof c.at === 'number' && Date.now() - c.at < ROOT_TTL_MS) return c.root || null;
+  } catch { /* no cache yet, or unreadable — ask npm */ }
+  let root = null;
+  try {
+    root = execFileSync('npm', ['root', '-g'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], shell: process.platform === 'win32' }).trim() || null;
+  } catch { /* npm unavailable */ }
+  try {
+    fs.mkdirSync(path.dirname(cache), { recursive: true });
+    fs.writeFileSync(cache, JSON.stringify({ root: root, at: Date.now() }));
+  } catch { /* unwritable home — just pay the spawn again next time */ }
+  return root;
 }
 
 // The version of the package a dist/claude dir belongs to, or null if unreadable.
@@ -75,13 +101,14 @@ function best(dirs, name) {
 }
 
 function entry(name) {
-  // Cheap candidates first, and only shell out to npm when every one of them misses.
-  const cheap = [BAKED, fromPkg(dir), fromPkg(path.join(path.dirname(process.execPath), '..', 'lib'))];
-  const hit = best(cheap, name);
-  if (hit) return path.join(hit, name);
   const gr = globalRoot();
-  const global = gr && path.join(gr, '@nanonets', 'graft', 'dist', 'claude');
-  if (global && fs.existsSync(path.join(global, name))) return path.join(global, name);
+  const hit = best([
+    bakedDir,
+    fromPkg(dir),
+    fromPkg(path.join(path.dirname(process.execPath), '..', 'lib')),
+    gr && path.join(gr, '@nanonets', 'graft', 'dist', 'claude'),
+  ], name);
+  if (hit) return path.join(hit, name);
   return path.join(dir, 'dist', 'claude', name); // last-ditch; import will no-op if absent
 }
 

--- a/src/cli-epilogue.ts
+++ b/src/cli-epilogue.ts
@@ -4,6 +4,7 @@
  * so the exact text — spacing is hand-aligned, not incidental — can be
  * unit-tested without spawning the CLI.
  */
+import { formatCount } from "./util/num.js";
 
 // The widest line (index 4, tied with index 2 at 26 chars) gets the live
 // node/edge stats appended, when a graph exists.
@@ -47,7 +48,7 @@ export function formatInitEpilogue(opts: InitEpilogueOptions): string {
 
   const wordmark = WORDMARK_LINES.map((l) => (tty ? indigo(l) : l));
   if (graphBuilt && nodes !== undefined && edges !== undefined) {
-    const stats = `  ${nodes.toLocaleString("en-US")} nodes · ${edges.toLocaleString("en-US")} edges`;
+    const stats = `  ${formatCount(nodes)} nodes · ${formatCount(edges)} edges`;
     wordmark[STATS_LINE_INDEX] += tty ? muted(stats) : stats;
   }
 

--- a/src/cli-meta.ts
+++ b/src/cli-meta.ts
@@ -47,14 +47,38 @@ export interface NpmViewResult {
   version?: string;
 }
 
+/**
+ * True on Windows, where `npm` exists only as the `npm.cmd`/`npm.ps1` shim npm's
+ * own installer writes. `spawnSync` appends `.exe` and nothing else, so a bare
+ * `spawnSync("npm", …)` fails with ENOENT before it ever reaches the network —
+ * and every npm-shaped feature dies with it: `graft version` reported "unreachable
+ * (offline?)" on a perfectly online machine, `graft upgrade` exited 1 with
+ * `spawnSync npm ENOENT`, and `refreshUpdateCache` cached `latest: null` once a day
+ * forever, so the update nudge could never fire on the whole platform.
+ * `globalRoot` below already carried this flag; the other two call sites did not.
+ *
+ * Handing the shim's absolute path to `spawnSync` is NOT an alternative: since the
+ * CVE-2024-27980 patch, Node refuses to CreateProcess a `.cmd`/`.bat` directly
+ * (EINVAL). Going through `cmd.exe` is the supported route, which is what this is.
+ * Every argument we pass is a literal or a package name we control, never user
+ * input, so there is nothing here for `cmd.exe` to reinterpret.
+ */
+const NPM_NEEDS_SHELL = process.platform === "win32";
+
 /** `npm view <pkg> version`, offline-safe: any failure (no npm, no network,
- * timeout) resolves to `{ ok: false }` rather than throwing. */
-export function getNpmViewVersion(pkgName: string = PKG_NAME, timeoutMs = 2000): NpmViewResult {
+ * timeout) resolves to `{ ok: false }` rather than throwing.
+ *
+ * The 10s default is not generous, it is honest: a cold `npm view` measured 9.4s on
+ * a Windows dev box, and the old 2s cap turned "slow registry" into "offline" for
+ * everyone on it. The hot caller is the detached `_update-check` child, which
+ * nobody is waiting on, so the extra ceiling costs a user nothing. */
+export function getNpmViewVersion(pkgName: string = PKG_NAME, timeoutMs = 10000): NpmViewResult {
   try {
     const res = spawnSync("npm", ["view", pkgName, "version"], {
       encoding: "utf8",
       timeout: timeoutMs,
       windowsHide: true,
+      shell: NPM_NEEDS_SHELL,
     });
     if (res.error || res.signal || res.status !== 0) return { ok: false };
     const version = res.stdout?.trim();
@@ -140,9 +164,22 @@ export function runUpgrade(moduleUrl: string): UpgradeResult {
   if (isRunningViaNpx(moduleUrl)) {
     return { ran: false, ok: true, oldVersion };
   }
-  const res = spawnSync("npm", ["install", "-g", `${PKG_NAME}@latest`], { stdio: "inherit" });
+  // Same shim story as `getNpmViewVersion` — see NPM_NEEDS_SHELL. Without it this
+  // command could not succeed even once on Windows, which is the platform whose
+  // users are most likely to reach for `graft upgrade` instead of npm directly.
+  const res = spawnSync("npm", ["install", "-g", `${PKG_NAME}@latest`], {
+    stdio: "inherit",
+    shell: NPM_NEEDS_SHELL,
+  });
   if (res.error || (res.status ?? 1) !== 0) {
-    return { ran: true, ok: false, oldVersion, errorMessage: res.error?.message };
+    // Through a shell there is no `res.error` to quote — cmd.exe reports the
+    // failure itself and exits non-zero — so say what we actually know.
+    return {
+      ran: true,
+      ok: false,
+      oldVersion,
+      errorMessage: res.error?.message ?? `npm exited with status ${res.status ?? "unknown"}`,
+    };
   }
   const newVersion = readGlobalInstalledVersion(PKG_NAME) ?? getNpmViewVersion(PKG_NAME).version ?? oldVersion;
   return { ran: true, ok: true, oldVersion, newVersion };

--- a/src/cli-meta.ts
+++ b/src/cli-meta.ts
@@ -89,15 +89,58 @@ export function getNpmViewVersion(pkgName: string = PKG_NAME, timeoutMs = 10000)
   }
 }
 
-/** Pure formatter for `graft version` — no I/O, easy to unit-test. */
+/**
+ * Order two semver strings: negative when `a` is older, 0 when equal, positive
+ * when `a` is newer. Unparseable input sorts as 0.0.0 rather than throwing —
+ * this only ever decides what to PRINT, and a malformed version is not worth
+ * failing `graft version` over.
+ *
+ * Prerelease handling is the one subtlety: `1.2.0-rc.1` precedes `1.2.0`, so a
+ * release-candidate install is never told it is ahead of the release it precedes.
+ */
+export function compareVersions(a: string, b: string): number {
+  const parse = (v: string) => {
+    const [core = "", pre = ""] = String(v).trim().replace(/^v/, "").split("-", 2);
+    const nums = core.split(".").map((n) => Number.parseInt(n, 10) || 0);
+    return { nums: [nums[0] ?? 0, nums[1] ?? 0, nums[2] ?? 0], pre };
+  };
+  const x = parse(a);
+  const y = parse(b);
+  for (let i = 0; i < 3; i++) {
+    if (x.nums[i] !== y.nums[i]) return x.nums[i] - y.nums[i];
+  }
+  if (x.pre === y.pre) return 0;
+  // A prerelease is BELOW the same core release; between two prereleases, order
+  // them lexically, which matches how rc.1 / rc.2 are actually written.
+  if (!x.pre) return 1;
+  if (!y.pre) return -1;
+  return x.pre < y.pre ? -1 : 1;
+}
+
+/**
+ * Pure formatter for `graft version` — no I/O, easy to unit-test.
+ *
+ * The comparison is semver, not string equality. Equality alone reported ANY
+ * difference as "run graft upgrade", including the case where the installed
+ * build is NEWER than the registry — a fork, an rc, or a local `npm link`. That
+ * advice is actively destructive there, because `graft upgrade` installs
+ * `@latest` and would replace the newer build with the older published one.
+ */
 export function formatVersionReport(current: string, latest: NpmViewResult): string {
   const lines = [`graft ${current}`];
   if (!latest.ok || !latest.version) {
     lines.push("latest: unreachable (offline?)");
-  } else if (latest.version === current) {
+    return lines.join("\n");
+  }
+  const cmp = compareVersions(latest.version, current);
+  if (cmp === 0) {
     lines.push(`latest on npm: ${current} ✓ up to date`);
-  } else {
+  } else if (cmp > 0) {
     lines.push(`latest on npm: ${latest.version} — run graft upgrade`);
+  } else {
+    lines.push(
+      `latest on npm: ${latest.version} — this build is newer, so \`graft upgrade\` would downgrade it`,
+    );
   }
   return lines.join("\n");
 }
@@ -133,17 +176,28 @@ export function readGlobalInstalledVersion(pkgName: string = PKG_NAME): string |
 }
 
 export interface UpgradeResult {
-  /** True when `npm install -g` actually ran (false for the npx no-op path). */
+  /** True when `npm install -g` actually ran (false for the npx and refused paths). */
   ran: boolean;
   ok: boolean;
   /** Present when ran=true and the install failed. */
   errorMessage?: string;
   oldVersion?: string;
   newVersion?: string;
+  /** Set when the install was refused because it would have been a downgrade. */
+  refused?: { latest: string };
 }
 
 /** Pure formatter for a finished upgrade — no I/O, easy to unit-test. */
 export function formatUpgradeReport(result: UpgradeResult): string {
+  // Before the `ran` check, not after: a refusal also never ran, and reporting
+  // it as the npx no-op would hide the reason.
+  if (result.refused) {
+    return (
+      `graft ${result.oldVersion ?? "?"} is newer than ${result.refused.latest} on npm — nothing to upgrade to.\n` +
+      `Installing @latest would REPLACE this build with the older published one.\n` +
+      `If that is what you want: graft upgrade --force`
+    );
+  }
   if (!result.ran) {
     return (
       "running via npx — npx already fetches the latest graft on every run.\n" +
@@ -159,10 +213,21 @@ export function formatUpgradeReport(result: UpgradeResult): string {
 /** Runs `npm install -g @nanonets/graft@latest` (inheriting stdio so the user
  * sees npm's own progress/errors), then re-reads the freshly installed
  * version. No-ops with guidance when running via npx. */
-export function runUpgrade(moduleUrl: string): UpgradeResult {
+export function runUpgrade(moduleUrl: string, opts: { force?: boolean } = {}): UpgradeResult {
   const oldVersion = readCurrentVersion(moduleUrl);
   if (isRunningViaNpx(moduleUrl)) {
     return { ran: false, ok: true, oldVersion };
+  }
+  // Refuse to "upgrade" onto an older published version. `@latest` is a tag, not
+  // a maximum, so on a fork, an rc, or an `npm link`ed checkout this command
+  // silently replaces the newer build with the registry's. When the local version
+  // cannot be read there is nothing to compare against, so the install proceeds
+  // exactly as it did before.
+  if (!opts.force && oldVersion) {
+    const latest = getNpmViewVersion();
+    if (latest.ok && latest.version && compareVersions(latest.version, oldVersion) < 0) {
+      return { ran: false, ok: true, oldVersion, refused: { latest: latest.version } };
+    }
   }
   // Same shim story as `getNpmViewVersion` — see NPM_NEEDS_SHELL. Without it this
   // command could not succeed even once on Windows, which is the platform whose

--- a/src/cli-open.ts
+++ b/src/cli-open.ts
@@ -1,0 +1,48 @@
+/**
+ * Handing a URL to the desktop's browser — `graft viz --open`'s last step, and the
+ * one place the CLI launches a program it neither ships nor can check for.
+ *
+ * Split out of `cli.ts` because the failure it guards is invisible until it isn't:
+ * `ChildProcess` is an `EventEmitter`, and an `'error'` event with no listener is
+ * re-thrown as an uncaughtException. `xdg-open` does not exist in WSL without a
+ * desktop, in a container, or on a headless server, so the ENOENT arrived one tick
+ * after `graft viz` printed its URL and killed the process — taking the viz server
+ * with it, on the machines where a served URL is the *only* way to see the graph.
+ * There is no `process.on('uncaughtException')` anywhere in this codebase to catch
+ * it, which is the right choice and also why this listener has to exist.
+ *
+ * Failing to open a browser is not a failure of `graft viz`: the URL is already on
+ * screen and the server is already serving. Report and carry on.
+ */
+import { spawn } from "node:child_process";
+
+/** The platform's "open this thing with whatever handles it" command. */
+export function browserOpener(): string {
+  if (process.platform === "darwin") return "open";
+  // `start` is a cmd.exe builtin, not an executable — hence the shell below.
+  if (process.platform === "win32") return "start";
+  return "xdg-open";
+}
+
+export interface OpenOptions {
+  /** Override the platform default (tests, and anyone with a $BROWSER opinion). */
+  opener?: string;
+  /** Override the platform default; `start` needs a shell, the others do not. */
+  shell?: boolean;
+  /** What to say when the opener can't be launched at all. */
+  onError?: (err: Error) => void;
+}
+
+/**
+ * Launch the browser opener, detached, and never let its failure reach the caller.
+ * Returns nothing to await on purpose — the point is that `graft viz` moves on.
+ */
+export function openInBrowser(url: string, opts: OpenOptions = {}): void {
+  const shell = opts.shell ?? process.platform === "win32";
+  const child = spawn(opts.opener ?? browserOpener(), [url], { stdio: "ignore", detached: true, shell });
+  const report =
+    opts.onError ??
+    (() => console.error(`· couldn't open a browser automatically — open ${url} yourself (the server is running).`));
+  child.on("error", report);
+  child.unref();
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,10 +5,10 @@
  * workspace parent (≥2 git children) federates query commands across children.
  */
 import "dotenv/config";
-import { Command } from "commander";
+import { Command, InvalidArgumentError } from "commander";
 import { join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { Graft } from "./engine.js";
+import { CODE_EXTENSIONS, Graft } from "./engine.js";
 import { credentialProblem, resolveConfig, type EngineConfig } from "./ai/providers.js";
 import type { ProviderKind } from "./ai/llm/factory.js";
 import { formatCheckReport } from "./context/check.js";
@@ -21,7 +21,7 @@ import { loadGraphCached } from "./graph/load.js";
 import { ensureFreshChildren, ensureFreshGraph, refreshNote } from "./graph/refresh.js";
 import { isWorkspaceBuildRoot, readWorkspace } from "./graph/workspace.js";
 import { nearestGraftRoot } from "./graph/root.js";
-import { unsupportedExtensions, supportedExtensions } from "./graph/source-files.js";
+import { supportedExtensions } from "./graph/source-files.js";
 import { discoverWorkspaceChildren } from "./graph/scopes.js";
 import {
   runWorkspaceAsk,
@@ -36,7 +36,9 @@ import { planInit, selectedWrites } from "./hosts/plan.js";
 import { formatNonInteractiveHelp, formatPlan, runPicker } from "./cli-picker.js";
 import { homedir } from "node:os";
 import { formatUpgradeReport, formatVersionReport, getNpmViewVersion, readCurrentVersion, runUpgrade } from "./cli-meta.js";
-import { writeBuildConfig } from "./util/state.js";
+import { assertRepoDir } from "./ingest/fs.js";
+import { readExtensions, readIncludeDirs, writeBuildConfig } from "./util/state.js";
+import { formatCount } from "./util/num.js";
 import { formatUpdateNudge, maybeRefreshInBackground, readUpdateCache, refreshUpdateCache, writeStamp } from "./upkeep.js";
 
 const program = new Command();
@@ -54,7 +56,13 @@ program
   )
   .option("--model <id>", "model id for the LLM pass (env GRAFT_MODEL)")
   .option("--api-key <key>", "provider API key (env GRAFT_API_KEY); not used by claude-cli")
-  .option("--base-url <url>", "OpenAI-compatible endpoint URL (env GRAFT_BASE_URL)");
+  .option("--base-url <url>", "OpenAI-compatible endpoint URL (env GRAFT_BASE_URL)")
+  .option(
+    "--max-budget-usd <usd>",
+    "claude-cli only: per-call spend ceiling in USD, passed to the CLI as --max-budget-usd " +
+      "(env GRAFT_CLAUDE_MAX_BUDGET_USD). Notional on a subscription — a runaway-loop valve, not a bill",
+    budgetUsd,
+  );
 
 interface GlobalOpts {
   dir?: string;
@@ -62,6 +70,24 @@ interface GlobalOpts {
   model?: string;
   apiKey?: string;
   baseUrl?: string;
+  maxBudgetUsd?: number;
+}
+
+/**
+ * `--max-budget-usd`, rejected AT THE FLAG rather than deep inside the provider.
+ *
+ * The value is spent per call, on a `--deep` run that makes one call per file, so
+ * the two ways to get it wrong are the two that matter: a non-number becomes `NaN`
+ * and silently disables the ceiling the user asked for, and `0` reads as "no
+ * budget" to the Claude CLI rather than "spend nothing". Both would surface as an
+ * unexplained bill or an unexplained failure, hours in.
+ */
+function budgetUsd(value: string): number {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) {
+    throw new InvalidArgumentError(`expected a positive number of dollars, got "${value}"`);
+  }
+  return n;
 }
 
 /** Config drawn from the global CLI flags (env + defaults fill the rest). */
@@ -73,25 +99,43 @@ function cliConfig(): EngineConfig {
     model: o.model,
     apiKey: o.apiKey,
     baseUrl: o.baseUrl,
+    // The env var (GRAFT_CLAUDE_MAX_BUDGET_USD) was the only way to set this, which
+    // is the wrong shape for a per-run safety valve: it is decided per invocation,
+    // like -j, not per machine.
+    maxBudgetUsd: o.maxBudgetUsd,
   };
 }
 
 const engineFrom = (): Graft => new Graft(cliConfig());
 
 /**
- * Warn (never fail) when a user's `-e` extension has no parser, so it is never a silent
- * no-op — `graft build -e ".vue"` used to accept it, index nothing, and exit 0. The
- * supported set is listed so `-e` also answers "what is actually supported".
+ * Warn (never fail) when a user's `-e` extension will not be read, so it is never a
+ * silent no-op — `graft build -e ".vue"` used to accept it, index nothing, and exit 0.
+ *
+ * Two lists, because `-e` now narrows two layers that do not claim the same
+ * extensions: the wiring graph filters on `supportedExtensions()` (both parser
+ * tiers), the `--deep` concept pass on `CODE_EXTENSIONS` (`context/build.ts`).
+ * `.vue` is in neither — that build indexes nothing at all and is the loud case.
+ * `.zig` is in the first only — the wiring graph indexes it and the concept pass
+ * silently sees zero files, which is the quiet case this exists for: an extension
+ * used to be checked against one list and filtered by the other, so `graft build
+ * --deep -e ".zig"` passed validation and then produced no concepts, saying nothing.
  */
 function warnUnsupportedExtensions(exts?: string[]): void {
   if (!exts?.length) return;
-  const bad = unsupportedExtensions(exts);
-  if (bad.length === 0) return;
-  for (const e of bad) {
-    const shown = e.trim().startsWith(".") ? e.trim() : `.${e.trim()}`;
-    console.error(`⚠ -e "${shown}": no parser registered for this extension — ignoring it.`);
+  const norm = exts.map((e) => (e.trim().startsWith(".") ? e.trim() : `.${e.trim()}`).toLowerCase());
+  const indexed = new Set(supportedExtensions());
+  const read = new Set(CODE_EXTENSIONS);
+  const noParser = norm.filter((e) => !indexed.has(e));
+  const deepOnly = norm.filter((e) => indexed.has(e) && !read.has(e));
+  for (const e of noParser) {
+    console.error(`⚠ -e "${e}": graft has no parser for this extension — nothing will be indexed for it.`);
   }
-  console.error(`  supported: ${supportedExtensions().join(" ")}`);
+  for (const e of deepOnly) {
+    console.error(`⚠ -e "${e}": indexed in the wiring graph, but the --deep concept pass doesn't read it.`);
+  }
+  if (noParser.length) console.error(`  graft indexes: ${supportedExtensions().join(" ")}`);
+  if (deepOnly.length) console.error(`  the --deep pass reads: ${CODE_EXTENSIONS.join(" ")}`);
 }
 
 /** Text for the omitted-`[dir]` case, shared by every query command's help. */
@@ -184,7 +228,12 @@ program
   )
   .argument("[dir]", "repository root", ".")
   .option("--deep", "run the LLM pass: concept nodes (graft/*.md) + per-symbol summary/crux")
-  .option("-e, --extensions <exts...>", 'code extensions to include (e.g. ".ts" ".py"); an extension with no parser is ignored with a warning that lists the supported set')
+  .option(
+    "-e, --extensions <exts...>",
+    'index only these code extensions (e.g. ".ts" ".py") — narrows both the wiring graph and the --deep concept pass; ' +
+      "persisted, so later builds, `graft check` and the hooks/refresh path narrow identically without the flag",
+  )
+  .option("--no-extensions", "forget the persisted -e narrowing and go back to indexing every supported extension")
   .option("-j, --concurrency <n>", "files summarized in parallel during --deep (default 5)")
   .option("--no-reuse", "re-parse every file instead of replaying unchanged ones from the extraction cache")
   .option("--lsp", "add compiler-grade call edges via a language server if one is installed (opt-in, slower; e.g. rust-analyzer, clangd)")
@@ -195,23 +244,46 @@ program
     (val: string, prev: string[]) => [...prev, val],
     [] as string[],
   )
-  .action(async (dir: string, opts: { deep?: boolean; extensions?: string[]; concurrency?: string; reuse?: boolean; lsp?: boolean; includeDir?: string[] }) => {
+  .option("--no-include-dir", "forget the persisted --include-dir override and go back to skipping every SKIP_DIRS name")
+  .action(async (dir: string, opts: { deep?: boolean; extensions?: string[] | false; concurrency?: string; reuse?: boolean; lsp?: boolean; includeDir?: string[] | false }) => {
     const concurrency = opts.concurrency ? Math.max(1, Number(opts.concurrency)) : undefined;
     if (opts.concurrency && !Number.isFinite(concurrency)) {
       console.error(`✗ --concurrency must be a number, got "${opts.concurrency}"`);
       process.exit(1);
     }
-    warnUnsupportedExtensions(opts.extensions);
+    // `false` is `--no-extensions` (clear the override), never a list to apply.
+    const exts = Array.isArray(opts.extensions) ? opts.extensions : undefined;
+    warnUnsupportedExtensions(exts);
     // Persisted BEFORE the build itself runs, so this invocation's walks (and
     // every later no-flag build / hooks refresh) see it identically — the
     // walkDir call sites read it from state, not from a threaded option.
-    if (opts.includeDir && opts.includeDir.length > 0) {
+    const buildDir = resolve(dir);
+    // …which is why the argument has to be checked HERE and not left to the walk:
+    // the persist below mkdir's recursively, so `graft build ./typo --include-dir x`
+    // created ./typo/.graft/config.json and only then reported that ./typo does not
+    // exist. Same wording as the walk's own check — one message, two entry points.
+    assertRepoDir(buildDir);
+    if (opts.includeDir === false) {
+      // The way back out. The override governs every future build in this repo and
+      // every hooks-driven refresh, but no invocation could ever write the empty
+      // list (the branch below is guarded on a non-empty one), so the only way to
+      // undo it was to hand-edit a `.graft/config.json` nothing had told the user
+      // existed. `--no-include-dir` is that command.
+      writeBuildConfig(buildDir, { includeDirs: [] });
+      console.error("· cleared this repo's persisted --include-dir override");
+    } else if (opts.includeDir && opts.includeDir.length > 0) {
       // --include-dir takes bare SKIP_DIRS-style directory NAMES (shouldSkipDir
       // compares a single path segment), never paths, and dot-dirs are never
       // overridable at all (see the option's own help text) — reject anything
       // else up front instead of silently persisting a value that can never
       // match a real directory name.
       for (const name of opts.includeDir) {
+        // An empty name passed both checks below and persisted `[""]`, which no
+        // path segment can equal: inert junk, in a file with no reader.
+        if (name.trim() === "") {
+          console.error("✗ --include-dir: expected a directory name, got an empty string");
+          process.exit(1);
+        }
         if (name.startsWith(".")) {
           console.error(`✗ --include-dir "${name}": dot-directories are never overridable`);
           process.exit(1);
@@ -221,7 +293,36 @@ program
           process.exit(1);
         }
       }
-      writeBuildConfig(resolve(dir), { includeDirs: opts.includeDir });
+      writeBuildConfig(buildDir, { includeDirs: opts.includeDir });
+    }
+    // `-e` is persisted for the same reason and one sharper: the freshness probe and
+    // the pre-query refresh never see a flag, so an unpersisted narrowing was undone
+    // by the first `graft ask` (every excluded file read as new → a wide rebuild).
+    if (opts.extensions === false) {
+      writeBuildConfig(buildDir, { extensions: [] });
+      console.error("· cleared this repo's persisted -e narrowing");
+    } else if (exts && exts.length > 0) {
+      writeBuildConfig(buildDir, { extensions: exts });
+    }
+    // Announced on every build, not only the one that set it: a persisted override
+    // changes what the whole repo indexes, survives indefinitely, and is otherwise
+    // completely invisible — the flag that wrote it may have been typed months ago
+    // by someone else.
+    const persistedDirs = readIncludeDirs(buildDir);
+    if (persistedDirs) {
+      console.error(
+        `· --include-dir override active: ${[...persistedDirs].join(", ")} ` +
+          "(clear it with `graft build --no-include-dir`)",
+      );
+    }
+    // Read back rather than reused from the flag: this is the value every layer of
+    // THIS build must agree on, whether it was typed now or months ago.
+    const persistedExts = readExtensions(buildDir);
+    if (persistedExts) {
+      console.error(
+        `· -e narrowing active: only ${persistedExts.join(" ")} is indexed ` +
+          "(clear it with `graft build --no-extensions`)",
+      );
     }
     const engine = engineFrom();
     const fmt = (o: Record<string, number>) =>
@@ -258,19 +359,34 @@ program
     if (isWorkspaceBuildRoot(buildRoot, buildGlobalDir)) {
       await runWorkspaceBuild(buildRoot, {
         deep: !!deep,
-        extensions: opts.extensions,
+        // The flag as typed, not the parent's persisted value: a workspace parent
+        // holds no sources of its own, so the narrowing belongs in each CHILD's
+        // state (where its own later rebuilds and refreshes will read it), exactly
+        // as `--include-dir` is forwarded below.
+        extensions: exts,
         concurrency,
         childConfig: cliConfig(),
         override: buildGlobalDir,
-        includeDirs: opts.includeDir,
+        // `false` is `--no-include-dir`, already applied to this repo's config
+        // above; there is nothing left to forward to the children.
+        includeDirs: opts.includeDir || undefined,
       });
       return;
     }
 
+    // Everything either phase reported as `✗`. Collected rather than counted on
+    // the spot because the concept pass lives in a branch and the exit code has to
+    // account for both.
+    const failures: string[] = [];
+
     // --deep: concept nodes first, then the wiring graph links cards up to them.
     if (deep) {
       const c = await engine.init(dir, {
-        extensions: opts.extensions,
+        extensions: persistedExts,
+        // The concept pass is where a --deep build spends most of its calls, so
+        // `-j 1` that stopped at the wiring graph's Tier-2 pass fixed nothing for
+        // the user who set it to survive a rate limit.
+        concurrency,
         onProgress: ({ phase, index, total, file }) =>
           process.stderr.write(
             `\r${phase === "summarize" ? "reading" : "writing"} concepts ${index + 1}/${total}: ${file.slice(0, 40).padEnd(40)}`,
@@ -281,11 +397,13 @@ program
         `✓ concepts: ${c.nodes} nodes, ${c.links} links from ${c.files} files (${c.summarized} read, ${c.cached} cached)`,
       );
       for (const e of c.errors) console.error(`✗ ${e}`);
+      failures.push(...c.errors);
     }
 
     // Wiring graph — always; LLM meaning only with --deep.
     const g = await engine.graph(dir, {
       llm: deep,
+      extensions: persistedExts,
       concurrency,
       reuse: opts.reuse,
       lsp: opts.lsp,
@@ -302,12 +420,38 @@ program
     if (deep) {
       const m = g.meaning;
       console.log(`  meaning: ${m.computed} computed, ${m.cached} cached, ${m.stale} stale, ${m.pending} pending`);
+      // What the run actually spent. Every adapter normalizes this and nothing used
+      // to report it, so the only way to find out what a repo-wide --deep cost was
+      // to go and read the provider's dashboard afterwards. Tokens, not dollars:
+      // see `Graft.usage()` for why a price would be a made-up number.
+      const u = engine.usage();
+      if (u.calls > 0) {
+        const cached = u.cacheRead + u.cacheCreate;
+        console.log(
+          `  llm: ${formatCount(u.calls)} calls, ${formatCount(u.input)} input + ${formatCount(u.output)} output tokens` +
+            (cached > 0 ? ` (${formatCount(cached)} cached)` : ""),
+        );
+      }
     }
     console.log(`  → ${g.contextDir}`);
     for (const e of g.errors) console.error(`✗ ${e}`);
+    failures.push(...g.errors);
 
     const rel = relative(process.cwd(), g.contextDir) || "graft";
     console.log(`  ${rel}/ is git-ignored (added automatically) — a local cache; teammates run \`graft build\` to get their own.`);
+
+    // A build that printed `✗` lines and then exited 0 read as a clean success to
+    // everything that judges by status and not by stderr: CI, `graft build && …`,
+    // the init path, the hooks. Those lines are files that never made it into the
+    // graph (unreadable, unparseable) or summaries the model never returned — a
+    // graph missing exactly what nobody was told to look for. The output is still
+    // written and still useful, so this is `exitCode`, not an abort: the partial
+    // graph stays, the run is just no longer reported as complete.
+    // `runWorkspaceBuild` already does the same for a failed child repo.
+    if (failures.length > 0) {
+      console.error(`✗ ${failures.length} error(s) — the graph above is incomplete`);
+      process.exitCode = 1;
+    }
   });
 
 program
@@ -323,19 +467,31 @@ program
   .option("--no-graph-rank", "rank by lexical relevance only, without the graph-connectivity re-rank (ablation/eval)")
   .option(...NO_REFRESH_FLAG)
   .action(async (query: string, dirArg: string | undefined, opts: { limit: string; source?: boolean; full?: boolean; in?: string; json?: boolean; refresh?: boolean; graphRank?: boolean }) => {
+    // Validated here, in the same shape `--max-dirs` and `--depth` use, and BEFORE
+    // `refreshBefore` so a typo doesn't cost a rebuild. `ask` guards its limit with
+    // `?? 8`, which only covers null/undefined — a NaN from `Number("all")` sailed
+    // through into `slice(0, NaN)`, and an empty slice is reported as "no matching
+    // nodes — try different words", blaming the query for a bad flag. `-n 0` and
+    // `-n -1` produced the same lie.
+    const limit = parseInt(opts.limit, 10);
+    if (!Number.isFinite(limit) || limit <= 0) {
+      console.error(`✗ -n/--limit must be a positive integer, got "${opts.limit}"`);
+      process.exit(1);
+      return;
+    }
     const dir = queryRoot(dirArg);
     await refreshBefore(dir, opts);
     const askGlobalDir = program.opts<GlobalOpts>().dir;
     if (readWorkspace(dir, askGlobalDir)) {
       runWorkspaceAsk(dir, askGlobalDir, query, {
-        limit: Number(opts.limit), source: opts.source, full: opts.full, in: opts.in, json: opts.json,
+        limit, source: opts.source, full: opts.full, in: opts.in, json: opts.json,
       });
       return;
     }
     const engine = engineFrom();
     let r;
     try {
-      r = engine.ask(dir, query, { limit: Number(opts.limit), source: opts.source, full: opts.full, in: opts.in, graphRank: opts.graphRank });
+      r = engine.ask(dir, query, { limit, source: opts.source, full: opts.full, in: opts.in, graphRank: opts.graphRank });
     } catch (err) {
       console.error(`✗ ${err instanceof Error ? err.message : String(err)}`);
       process.exit(1);
@@ -370,19 +526,25 @@ program
   .command("check")
   .description("Fail if graft/ is stale relative to the code (for CI)")
   .argument(...DIR_ARG)
-  .option("-e, --extensions <exts...>", "code extensions to include")
+  .option("-e, --extensions <exts...>", "code extensions to include (defaults to the repo's persisted `graft build -e` narrowing)")
   .option("--json", "output the drift as JSON")
   .action(async (dirArg: string | undefined, opts: { extensions?: string[]; json?: boolean }) => {
     warnUnsupportedExtensions(opts.extensions);
     const dir = queryRoot(dirArg);
+    assertRepoDir(dir); // a typo'd [dir] is a named argument, not an ENOENT four frames down
     const checkGlobalDir = program.opts<GlobalOpts>().dir;
     if (readWorkspace(dir, checkGlobalDir)) {
       await runWorkspaceCheck(dir, checkGlobalDir);
       return;
     }
     const engine = engineFrom();
-    const r = engine.check(dir, { extensions: opts.extensions });
-    const g = await engine.checkGraph(dir); // graph.json is only judged when it exists
+    // Falls back to what the BUILD narrowed to. Both layers, exactly as on the build
+    // side: a graph built under `-e .ts` holds no Python nodes, and a check that
+    // enumerated every language would report each excluded file as `added` forever —
+    // drift that no `graft build` would ever "fix", because it isn't drift.
+    const checkExts = opts.extensions ?? readExtensions(dir);
+    const r = engine.check(dir, { extensions: checkExts });
+    const g = await engine.checkGraph(dir, { extensions: checkExts }); // graph.json is only judged when it exists
 
     // A layer that IS present must be in sync; a never-built layer (keyless
     // build skips the markdown layer) is informational, not a failure.
@@ -418,9 +580,9 @@ program
     const dir = queryRoot(dirArg);
     const { existsSync } = await import("node:fs");
     const { resolve, basename } = await import("node:path");
-    const { spawn } = await import("node:child_process");
     const { fileURLToPath } = await import("node:url");
     const { contextDirFor } = await import("./context/node-file.js");
+    const { openInBrowser } = await import("./cli-open.js");
     const { startVizServer } = await import("./viz/serve.js");
 
     const root = resolve(dir);
@@ -438,10 +600,9 @@ program
       repoName: basename(root),
     });
     console.log(`graft viz → ${srv.url}  (ctrl-c to stop)`);
-    if (opts.open) {
-      const opener = process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open";
-      spawn(opener, [srv.url], { stdio: "ignore", detached: true, shell: process.platform === "win32" }).unref();
-    }
+    // Never fatal: on a headless box there is no opener to spawn, and the URL above
+    // is the whole point of the command. See `cli-open.ts`.
+    if (opts.open) openInBrowser(srv.url);
   });
 
 program
@@ -518,7 +679,10 @@ program
       const globalOpts = program.opts<{ dir?: string }>();
       if (readWorkspace(dir, globalOpts.dir)) {
         runWorkspaceGrep(dir, globalOpts.dir, pattern, {
-          ignoreCase: opts.ignoreCase, fixed: opts.fixed, json: opts.json,
+          // `--in` used to stop here: federation forwarded ignoreCase/fixed only,
+          // so at a workspace root the flag was accepted, dropped, and every repo
+          // searched — a wider answer than the user asked for, silently.
+          ignoreCase: opts.ignoreCase, fixed: opts.fixed, in: opts.in, json: opts.json,
         });
         return;
       }
@@ -597,6 +761,10 @@ program
       return;
     }
     const repo = resolve(dir);
+    // Before the picker, not after: `init` writes agent files, hooks and a stamp
+    // into this path, and a typo would have created the whole tree — after asking
+    // the user which agents to wire into it.
+    assertRepoDir(repo);
     const explicit = Array.isArray(opts.agents) ? opts.agents : undefined;
 
     if (explicit) {
@@ -626,11 +794,19 @@ program
       const picked = await runPicker(plan, repo, home);
       if (picked === null) {
         console.error("· cancelled — nothing written");
+        // Non-zero on every path that writes nothing, so `graft init && <next step>`
+        // stops instead of continuing as if the repo were wired. Only `--dry-run`
+        // and `--list-agents` write nothing *and* succeed — they were asked a
+        // question, not told to install. The no-TTY path below is the one that
+        // actually bites: in Git Bash / MSYS without winpty `stdin.isTTY` is false,
+        // so a plain interactive `graft init` lands there and used to exit 0.
+        process.exitCode = 1;
         return;
       }
       ids = picked;
     } else {
       console.error(formatNonInteractiveHelp(detectedIds));
+      process.exitCode = 1;
       return;
     }
 
@@ -653,6 +829,7 @@ program
     }
     if (ids.length === 0) {
       console.error("· no agents selected — nothing written");
+      process.exitCode = 1;
       return;
     }
 
@@ -696,9 +873,15 @@ function wireTarget(
   },
 ): void {
     const { home, cliPath, plan, wantClaude, opts } = ctx;
+    // Recorded in the stamp below so the NEXT init can tell a permission the user
+    // deleted from one that was never offered here. Undefined when Claude Code
+    // wasn't wired this run — writeStamp then carries the previous record forward
+    // instead of erasing it.
+    let offeredAllow: string[] | undefined;
 
     if (wantClaude) {
       const res = runInit(repo, { build: opts.build, cliPath });
+      offeredAllow = res.offeredAllow;
       console.error(`✓ wrote ${res.settingsPath}`);
       for (const s of res.shims) console.error(`✓ wrote ${s}`);
       console.error(`✓ wrote ${res.skill}`);
@@ -736,11 +919,19 @@ function wireTarget(
     // them on a mismatch, so an `npm i -g` upgrade reaches the hooks/skill/rules
     // too — not just the binary. The flags ride along so a refresh replays the
     // user's choices (notably --no-global) instead of overriding them.
-    writeStamp(repo, currentVersion, ids, {
-      global: opts.global !== false,
-      mcp: opts.mcp !== false,
-      hooks: opts.hooks !== false,
-    });
+    writeStamp(
+      repo,
+      currentVersion,
+      ids,
+      {
+        global: opts.global !== false,
+        mcp: opts.mcp !== false,
+        hooks: opts.hooks !== false,
+      },
+      undefined,
+      undefined, // the real homedir(): the memo is deliberately machine-global
+      offeredAllow,
+    );
 
     // Every host's wiring points at graft/, so the graph is built whatever was
     // selected — not only when Claude Code is in the list (runInit does its own).

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -214,8 +214,9 @@ program
 program
   .command("upgrade")
   .description("Upgrade the globally installed graft to the latest version on npm")
-  .action(() => {
-    const result = runUpgrade(import.meta.url);
+  .option("--force", "install @latest even when it is OLDER than this build (a fork, an rc, a linked checkout)")
+  .action((opts: { force?: boolean }) => {
+    const result = runUpgrade(import.meta.url, { force: opts.force });
     console.log(formatUpgradeReport(result));
     if (result.ran && !result.ok) process.exit(1);
   });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,7 +9,7 @@ import { Command } from "commander";
 import { join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Graft } from "./engine.js";
-import { resolveConfig, type EngineConfig } from "./ai/providers.js";
+import { credentialProblem, resolveConfig, type EngineConfig } from "./ai/providers.js";
 import type { ProviderKind } from "./ai/llm/factory.js";
 import { formatCheckReport } from "./context/check.js";
 import { formatGraphCheckReport } from "./graph/check.js";
@@ -47,9 +47,13 @@ program
   .description("Build a repo's context graph as linked markdown, and keep it in sync with the code.")
   .version(currentVersion, "-v, --version")
   .option("--dir <path>", "context graph directory (default: <repo>/graft)")
-  .option("--provider <name>", "LLM wire format: openai | anthropic (env GRAFT_PROVIDER)")
+  .option(
+    "--provider <name>",
+    "LLM wire format: openai | anthropic | claude-cli (env GRAFT_PROVIDER). " +
+      "claude-cli drives your signed-in Claude Code CLI — a subscription, no API key",
+  )
   .option("--model <id>", "model id for the LLM pass (env GRAFT_MODEL)")
-  .option("--api-key <key>", "provider API key (env GRAFT_API_KEY)")
+  .option("--api-key <key>", "provider API key (env GRAFT_API_KEY); not used by claude-cli")
   .option("--base-url <url>", "OpenAI-compatible endpoint URL (env GRAFT_BASE_URL)");
 
 interface GlobalOpts {
@@ -226,15 +230,20 @@ program
         .map(([k, n]) => `${n} ${k}`)
         .join(", ");
 
-    // --deep needs a key; without one, degrade to the $0 structural build.
+    // --deep needs a reachable model; without one, degrade to the $0 structural build.
     let deep = opts.deep;
     const resolved = resolveConfig(cliConfig());
-    if (deep && !resolved.apiKey) {
+    const problem = deep ? credentialProblem(resolved) : undefined;
+    if (problem) {
       deep = false;
+      console.error(`⚠ falling back to the structural build (no LLM summaries).\n  ${problem}`);
+    }
+    // Say so out loud: the run costs subscription usage, not API credits, and the
+    // user never asked for this provider — they just had the CLI installed.
+    if (deep && resolved.autoDetectedProvider) {
       console.error(
-        "⚠ no API key set — falling back to the structural build (no LLM summaries).\n" +
-          "  Set GRAFT_API_KEY (and GRAFT_PROVIDER / GRAFT_BASE_URL / GRAFT_MODEL for your\n" +
-          "  provider) and re-run `graft build --deep` to add concept nodes and summaries.",
+        `→ no API key found; using your signed-in Claude Code CLI (${resolved.model}).\n` +
+          "  Set GRAFT_API_KEY to use a metered provider instead.",
       );
     }
     if (deep && resolved.usedLegacyEnv) {

--- a/src/context/build.ts
+++ b/src/context/build.ts
@@ -47,6 +47,9 @@ export const CODE_EXTENSIONS = [
 /** Char budget of summary text per synthesis call (keeps each call in-context). */
 const BATCH_CHAR_BUDGET = 48_000;
 
+/** Files summarized at once. Matches graph/enrich.ts, so one `-j` means one thing. */
+const DEFAULT_CONCURRENCY = 5;
+
 export interface BuildProgress {
   phase: "summarize" | "synthesize" | "write";
   index: number;
@@ -61,6 +64,13 @@ export interface BuildOptions {
   extensions?: string[];
   /** Human label for the model, recorded in the manifest (e.g. "openrouter:openai/gpt-4o-mini"). */
   model: string;
+  /**
+   * Files summarized in parallel (one LLM call each). Default
+   * {@link DEFAULT_CONCURRENCY}. This is the knob `-j` is documented to turn: a
+   * user who sets `-j 1` is usually working around a rate limit or, with the
+   * `claude-cli` provider, avoiding N simultaneous Claude Code processes.
+   */
+  concurrency?: number;
   summarizer: Summarizer;
   synthesizer: Synthesizer;
   onProgress?: (info: BuildProgress) => void;
@@ -123,7 +133,8 @@ export async function buildContext(dir: string, opts: BuildOptions): Promise<Bui
   };
 
   // Phase 1: summarize each file, concurrent, content-hash cached.
-  const work = await mapWithConcurrency(files, 8, async (file, i): Promise<FileWork | undefined> => {
+  const limit = Math.max(1, opts.concurrency ?? DEFAULT_CONCURRENCY);
+  const work = await mapWithConcurrency(files, limit, async (file, i): Promise<FileWork | undefined> => {
     const rel = relPosix(root, file);
     opts.onProgress?.({ phase: "summarize", index: i, total: files.length, file: rel });
     let code: string;
@@ -142,7 +153,16 @@ export async function buildContext(dir: string, opts: BuildOptions): Promise<Bui
       return { rel, hash, summary: hit.summary };
     }
     try {
-      const summary = await opts.summarizer.summarize(code, { path: rel });
+      const summary = (await opts.summarizer.summarize(code, { path: rel })).trim();
+      // An empty summary is a failure wearing a success's clothes — a truncated
+      // turn, a refusal, a model that answered with whitespace. Caching it makes
+      // it PERMANENT (the next run hits `hit.hash === hash` and replays the
+      // empty string) and phase 2 filters the file out of synthesis forever,
+      // with no error and no counter to show it happened.
+      if (!summary) {
+        result.errors.push(`${rel}: model returned an empty summary`);
+        return { rel, hash };
+      }
       cache.summaries[rel] = { hash, summary };
       result.summarized++;
       return { rel, hash, summary };
@@ -164,20 +184,39 @@ export async function buildContext(dir: string, opts: BuildOptions): Promise<Bui
   const batches = batchBySize(summarized, BATCH_CHAR_BUDGET);
   result.batches = batches.length;
 
+  // Phase 1 is already paid for — thousands of calls on a large repo — and until
+  // now it lived only in memory until AFTER synthesis. One 429 on batch 3 of 40
+  // threw the whole thing away and the next run repaid every summarize call.
+  saveCache(outDir, cache);
+
   const synthNodes: SynthNode[] = [];
+  let synthFailures = 0;
   for (let b = 0; b < batches.length; b++) {
     opts.onProgress?.({ phase: "synthesize", index: b, total: batches.length, file: `batch ${b + 1}` });
     const key = batchKey(batches[b], hashByPath);
     let nodes = cache.synth[key];
     if (!nodes) {
-      nodes = await opts.synthesizer.synthesize(batches[b]);
+      try {
+        nodes = await opts.synthesizer.synthesize(batches[b]);
+      } catch (err) {
+        // Record and keep going: the batches that DO succeed are cached below,
+        // so a retry only repays the ones that failed.
+        result.errors.push(`synthesis batch ${b + 1}/${batches.length}: ${errMsg(err)}`);
+        synthFailures++;
+        continue;
+      }
       cache.synth[key] = nodes;
     }
     synthNodes.push(...nodes);
   }
   // Drop cache entries for batches we no longer produce, so it can't grow forever.
+  // A batch that FAILED has no entry, and must not be given an empty one: `[]` is
+  // a legitimate cached answer ("this batch yields no nodes"), so writing it here
+  // would turn a transient 429 into a permanent cache hit that never retries.
   cache.synth = Object.fromEntries(
-    batches.map((batch) => [batchKey(batch, hashByPath), cache.synth[batchKey(batch, hashByPath)] ?? []]),
+    batches
+      .map((batch) => [batchKey(batch, hashByPath), cache.synth[batchKey(batch, hashByPath)]] as const)
+      .filter((entry): entry is readonly [string, SynthNode[]] => entry[1] !== undefined),
   );
   saveCache(outDir, cache);
 
@@ -239,6 +278,32 @@ export async function buildContext(dir: string, opts: BuildOptions): Promise<Bui
     };
   });
   nodes.sort((a, b) => a.slug.localeCompare(b.slug));
+
+  // Phase 5 is all-or-nothing on disk, and this is the gate.
+  //
+  // The write below is a RECONCILIATION: every existing `graft/*.md` whose slug
+  // isn't in `nodes` is deleted, and the manifest is replaced with this run's
+  // roster. That is only correct when `nodes` is a complete picture of the repo.
+  // It is not, in two cases that cost nothing to hit — an expired key, a wrong
+  // model id, a 429 storm — and both used to end with an empty `nodes`:
+  //   - every summarize call failed, so phase 2 had nothing to synthesize;
+  //   - a synthesis batch failed, so part of the repo is missing from the roster.
+  // The old code deleted the whole concept layer and still exited 0. graft/ is
+  // git-ignored (there is no `git checkout` back), and node-file.ts promises that
+  // whatever a human writes under `## Notes` survives regeneration — so the loss
+  // is permanent and includes hand-written text. Bail before touching anything;
+  // the summaries are already cached, so the retry is cheap.
+  //
+  // An empty repo is NOT this case: no files means zero errors, and pruning
+  // everything is the right answer there.
+  const phase1Wiped = processed.length > 0 && summarized.length === 0;
+  if (phase1Wiped || synthFailures > 0) {
+    result.errors.push(
+      `concept layer left untouched: ${phase1Wiped ? "no file was summarized" : `${synthFailures} synthesis batch(es) failed`}` +
+        " — existing graft/*.md and their notes were kept as-is",
+    );
+    return result;
+  }
 
   const liveSlugs = new Set(nodes.map((n) => n.slug));
   for (const slug of existingNodeSlugs(outDir)) {

--- a/src/context/node-file.ts
+++ b/src/context/node-file.ts
@@ -22,7 +22,7 @@
  * LLM and without re-reading every node body.
  */
 import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import matter from "gray-matter";
 import { contentHash, normalizeName } from "../util/id.js";
 import { relPosix, stripTrailingSlashes } from "../util/paths.js";
@@ -99,9 +99,18 @@ export function digestSources(sources: SourceRef[]): string {
 
 /** Absolute path of the `graft/` directory for a repo root. Visible (not
  * dot-prefixed) on purpose: default ripgrep skips hidden dirs, so the agent's
- * grep/ls/find reflex must be able to land on the graph. */
+ * grep/ls/find reflex must be able to land on the graph.
+ *
+ * The override is `resolve`d because the return value is contractually absolute and
+ * every consumer relies on it being so: `listSourceFiles` excludes the output dir
+ * with `f.startsWith(outDir)` against absolute walk results, and `ensureGitignored`
+ * / `ensureSearchable` decide whether the dir is even inside the repo via
+ * `relPosix(root, contextDir)`. Hand a relative `--dir`/`GRAFT_DIR` (and
+ * `.env.example` suggests exactly one) straight through and both silently invert:
+ * the prefix test never matches, so graft indexes its own output, and the ignore
+ * files get written for a path relative to the process's cwd rather than the repo. */
 export function contextDirFor(root: string, override?: string): string {
-  if (override) return override;
+  if (override) return resolve(override);
   return join(root, "graft");
 }
 

--- a/src/context/savings.ts
+++ b/src/context/savings.ts
@@ -13,6 +13,7 @@
  * map — routes through {@link savingsFor} + {@link withSavings} here.
  */
 import type { GraphV1 } from '../graph/types.js';
+import { formatCount } from "../util/num.js";
 
 export interface Savings {
   /** How many source files the baseline covers. */
@@ -74,9 +75,9 @@ export function savingsLine(body: string, saved: Savings | undefined): string {
   const delta = base - pack;
   const pct = Math.round((delta / base) * 100);
   return (
-    `[graft] tokens saved ≈ ${delta.toLocaleString()} (${pct}%) — this output ≈ ` +
-    `${pack.toLocaleString()} tok vs reading the ${saved.files} file(s) it covers whole ≈ ` +
-    `${base.toLocaleString()} tok (estimate).` +
+    `[graft] tokens saved ≈ ${formatCount(delta)} (${pct}%) — this output ≈ ` +
+    `${formatCount(pack)} tok vs reading the ${saved.files} file(s) it covers whole ≈ ` +
+    `${formatCount(base)} tok (estimate).` +
     SAVINGS_TURN_NUDGE
   );
 }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -10,7 +10,7 @@
  * the sync. This class wires the configured LLM provider into the build/check
  * pipelines; an API key is required for any LLM-backed operation.
  */
-import { resolveConfig, type EngineConfig, type ResolvedConfig } from "./ai/providers.js";
+import { credentialProblem, resolveConfig, type EngineConfig, type ResolvedConfig } from "./ai/providers.js";
 import { ChatSynthesizer, type Synthesizer } from "./ai/synthesize.js";
 import { ChatSummarizer, type Summarizer } from "./ai/summarize.js";
 import { ChatCruxSummarizer, type CruxSummarizer } from "./ai/crux.js";
@@ -116,18 +116,17 @@ export class Graft {
   private chatModel(): ChatModel {
     if (this.cfg.chatModel) return this.cfg.chatModel;
     if (this._chatModel) return this._chatModel;
-    if (!this.cfg.apiKey) {
-      throw new Error(
-        "No API key. Set GRAFT_API_KEY (and GRAFT_PROVIDER / GRAFT_BASE_URL / GRAFT_MODEL " +
-          "for your provider) to build or summarize the graph.",
-      );
-    }
+    const problem = credentialProblem(this.cfg);
+    if (problem) throw new Error(problem);
     this._chatModel = createChatModel({
       provider: this.cfg.provider,
       apiKey: this.cfg.apiKey,
       model: this.cfg.model,
       baseUrl: this.cfg.baseUrl,
       headers: this.cfg.headers,
+      bin: this.cfg.bin,
+      timeoutMs: this.cfg.timeoutMs,
+      maxBudgetUsd: this.cfg.maxBudgetUsd,
     });
     return this._chatModel;
   }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -28,6 +28,12 @@ export type { BuildResult, BuildProgress, CheckResult, GraphBuildResult, GraphCh
 export interface InitOptions {
   /** Code extensions to include. Default: {@link CODE_EXTENSIONS}. */
   extensions?: string[];
+  /** Max files summarized in parallel during the concept pass — the library face
+   * of `graft build -j`. Without it the flag reached only the wiring graph's
+   * Tier-2 pass, so `-j 1` (set to survive a rate limit, or to avoid N
+   * simultaneous `claude-cli` processes) still fired 5 concurrent calls through
+   * the whole concept phase, which is where a `--deep` build spends most of them. */
+  concurrency?: number;
   /** Progress callback for long builds. */
   onProgress?: (info: BuildProgress) => void;
 }
@@ -36,9 +42,25 @@ export interface CheckRunOptions {
   extensions?: string[];
 }
 
+/** Token totals for everything one {@link Graft} instance sent to the model.
+ * `input` is uncached input only — the adapters already separate it from
+ * `cacheRead`/`cacheCreate`, which are billed at different rates by every
+ * provider that has them. */
+export interface RunUsage {
+  calls: number;
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheCreate: number;
+}
+
 export interface GraphRunOptions {
   /** Run the Tier-2 LLM meaning pass (summary + crux). Absent → Tier-1 only. */
   llm?: boolean;
+  /** Narrow the indexed file set to these extensions (`graft build -e`). Pass the
+   * same value to {@link Graft.checkGraph} or the check reports the excluded files
+   * as drift. */
+  extensions?: string[];
   /** Max files summarized in parallel during the LLM pass. */
   concurrency?: number;
   /** Replay unchanged files from the extraction cache (default true). */
@@ -60,6 +82,7 @@ export class Graft {
     return buildContext(dir, {
       contextDir: this.cfg.contextDir,
       extensions: opts.extensions,
+      concurrency: opts.concurrency,
       model: this.modelLabel(),
       summarizer: this.summarizer(),
       synthesizer: this.synthesizer(),
@@ -74,8 +97,8 @@ export class Graft {
 
   /** Report whether the committed `graph.json` is in sync with the code (Tier-1 diff).
    * Async because the breadth tier warms WASM grammars before re-extraction. */
-  checkGraph(dir: string): Promise<GraphCheckResult> {
-    return checkGraph(dir, { contextDir: this.cfg.contextDir });
+  checkGraph(dir: string, opts: CheckRunOptions = {}): Promise<GraphCheckResult> {
+    return checkGraph(dir, { contextDir: this.cfg.contextDir, extensions: opts.extensions });
   }
 
   /**
@@ -87,6 +110,7 @@ export class Graft {
     return buildGraph(dir, {
       contextDir: this.cfg.contextDir,
       summarizer: opts.llm ? this.cruxSummarizer() : undefined,
+      extensions: opts.extensions,
       concurrency: opts.concurrency,
       reuse: opts.reuse,
       lsp: opts.lsp,
@@ -111,14 +135,33 @@ export class Graft {
   }
 
   private _chatModel?: ChatModel;
+  private _usage: RunUsage = { calls: 0, input: 0, output: 0, cacheRead: 0, cacheCreate: 0 };
+
+  /**
+   * What this engine instance has spent so far, in tokens.
+   *
+   * Every adapter normalizes `Usage` carefully (uncached input separated from cache
+   * reads and cache writes) and every op then dropped it on the floor, so a `--deep`
+   * build over a 5000-file repo could not tell you afterwards how many calls it made,
+   * let alone what they cost. Counted HERE, by wrapping the transport once, rather
+   * than threaded through summarize/synthesize/crux — those three would each have to
+   * remember, and a fourth op would silently not count.
+   *
+   * Tokens, not dollars: prices are per-model, change without notice, and are not
+   * knowable at all for `claude-cli` (a subscription) or for whatever gateway sits
+   * behind a custom base URL. A wrong number here would be worse than none.
+   */
+  usage(): RunUsage {
+    return { ...this._usage };
+  }
 
   /** The configured transport, or a clear error telling the user how to set a key. */
   private chatModel(): ChatModel {
-    if (this.cfg.chatModel) return this.cfg.chatModel;
     if (this._chatModel) return this._chatModel;
+    if (this.cfg.chatModel) return (this._chatModel = this.metered(this.cfg.chatModel));
     const problem = credentialProblem(this.cfg);
     if (problem) throw new Error(problem);
-    this._chatModel = createChatModel({
+    this._chatModel = this.metered(createChatModel({
       provider: this.cfg.provider,
       apiKey: this.cfg.apiKey,
       model: this.cfg.model,
@@ -127,8 +170,28 @@ export class Graft {
       bin: this.cfg.bin,
       timeoutMs: this.cfg.timeoutMs,
       maxBudgetUsd: this.cfg.maxBudgetUsd,
-    });
+      maxRetries: this.cfg.maxRetries,
+    }));
     return this._chatModel;
+  }
+
+  /** The transport with a token counter around it. A wrapper rather than a
+   * subclass, because the thing being wrapped may be a caller's own `chatModel`
+   * — an object this engine did not construct and must not change. */
+  private metered(inner: ChatModel): ChatModel {
+    const totals = this._usage;
+    return {
+      label: inner.label,
+      async create(req) {
+        const res = await inner.create(req);
+        totals.calls++;
+        totals.input += res.usage.input;
+        totals.output += res.usage.output;
+        totals.cacheRead += res.usage.cacheRead;
+        totals.cacheCreate += res.usage.cacheCreate;
+        return res;
+      },
+    };
   }
 
   private synthesizer(): Synthesizer {

--- a/src/graph/build.ts
+++ b/src/graph/build.ts
@@ -18,7 +18,7 @@ import { basename, dirname, resolve } from "node:path";
 import { walkDir } from "../ingest/fs.js";
 import { contextDirFor, ensureGitignored, ensureSearchable } from "../context/node-file.js";
 import { extractFile, languageLabelOf, languageOf, type RawEdge } from "./extract.js";
-import { extractGeneric, genericLangOf, warmGenericGrammars } from "./generic.js";
+import { extractGeneric, genericLangOf, unavailableGrammars, warmGenericGrammars } from "./generic.js";
 import { contentHash } from "../util/id.js";
 import { relPosix } from "../util/paths.js";
 import { readSourceFile } from "../util/source.js";
@@ -74,6 +74,11 @@ export interface GraphBuildOptions {
   /** Replay unchanged files from the extraction cache instead of re-parsing them
    * (default true). False forces a cold parse of the whole repo. */
   reuse?: boolean;
+  /** Narrow the indexed file set to these extensions (`graft build -e`). Absent →
+   * every language graft has a grammar for. Applied in {@link listSourceFiles}, the
+   * single enumeration this build is made of, so the fingerprint and the extraction
+   * cache describe exactly the same set the graph does. */
+  extensions?: string[];
   /** Write only what a query reads — the graph, the `ask` sidecar, the freshness
    * record — and skip the markdown projections and the `.gitignore` touch. Set by
    * the pre-query refresh (`graph/refresh.ts`); an explicit `graft build` never
@@ -153,7 +158,7 @@ export async function buildGraph(
   // resolution must agree on the same Git-ignore-aware working-tree view —
   // including the repo's persisted `--include-dir` override.
   const repoFiles = walkDir(root, readIncludeDirs(root));
-  const files = listSourceStats(root, outDir, repoFiles);
+  const files = listSourceStats(root, outDir, repoFiles, opts.extensions);
   const discoveredScopes = discoverScopes(root, repoFiles);
 
   const nodes: NodeV1[] = [];
@@ -183,9 +188,34 @@ export async function buildGraph(
   // Breadth tier: WASM grammars load asynchronously, so warm the ones this repo
   // needs ONCE here (buildGraph is async) before the synchronous parse loop below
   // can call extractGeneric. Depth-tier (native) grammars need no warmup.
-  await warmGenericGrammars(
-    new Set(files.map((f) => genericLangOf(f.abs)?.name).filter((n): n is string => !!n)),
+  //
+  // The `languageOf(...) === null` filter is what keeps the warmup honest about which
+  // files actually REACH the breadth tier. `.java` is claimed by both registries and the
+  // depth tier always wins in the loop below (`lang ? null : genericLangOf(...)`), so
+  // without it every build of every Java repo instantiated a multi-MB Java wasm and
+  // compiled queries/java.scm for a code path that can never run.
+  const breadthLangs = new Set(
+    files
+      .filter((f) => languageOf(f.abs) === null)
+      .map((f) => genericLangOf(f.abs)?.name)
+      .filter((n): n is string => !!n),
   );
+  await warmGenericGrammars(breadthLangs);
+  // A breadth language whose grammar could not be loaded still "extracts" — as a file
+  // node and nothing else. Reporting it in `meta.languages` anyway made the banner claim
+  // `[dart]` over a repo where not one dart symbol had been indexed, which reads as a
+  // broken query rather than a missing grammar. Name the gap once, and leave the
+  // language out of the roster it did not earn.
+  const noGrammar = new Set(unavailableGrammars(breadthLangs));
+  for (const lang of noGrammar) errors.push(`${lang}: no grammar available — indexed as file-only`);
+
+  // Only the Tier-2 meaning pass reads the source text again (`enrichGraph` returns
+  // before touching `sources` when there is no summarizer), so filling this map on a
+  // Tier-1 build — the default, and every pre-query refresh — retained the whole repo's
+  // text for nothing. JS strings are UTF-16, so a 200 MB monorepo pinned ~400 MB until
+  // the build returned, and the refresh path paid it on every query that saw drift, even
+  // when every single file came from the memo.
+  const keepSources = !!opts.summarizer;
 
   files.forEach((f, i) => {
     const rel = f.rel;
@@ -195,6 +225,9 @@ export async function buildGraph(
     const lang = languageOf(f.abs);
     const generic = lang ? null : genericLangOf(f.abs);
     const label = languageLabelOf(f.abs) ?? generic?.name ?? "unknown";
+    // …unless the breadth grammar it needs isn't there, in which case this file yields a
+    // file node and no symbols, and claiming the language would be a lie (see above).
+    const indexed = !generic || !noGrammar.has(generic.name);
     const cached = priorExtract.files[rel];
 
     // Every file is read and hashed, every build — only the *parse* is memoized.
@@ -227,7 +260,7 @@ export async function buildGraph(
     const hash = contentHash(source);
     if (cached && hash === cached.hash) {
       entries[rel] = { ...cached, size: f.size, mtimeMs: f.mtimeMs };
-      sources.set(rel, source);
+      if (keepSources) sources.set(rel, source);
       reused++;
       if (cached.error) {
         errors.push(cached.error); // this file failed to parse last time too
@@ -235,7 +268,7 @@ export async function buildGraph(
       }
       nodes.push(...cached.nodes);
       rawEdges.push(...cached.rawEdges);
-      langs.add(label);
+      if (indexed) langs.add(label);
       return;
     }
 
@@ -246,8 +279,8 @@ export async function buildGraph(
         : extractGeneric(rel, source, generic!.name);
       nodes.push(...fileNodes);
       rawEdges.push(...fileEdges);
-      sources.set(rel, source);
-      langs.add(label);
+      if (keepSources) sources.set(rel, source);
+      if (indexed) langs.add(label);
       entries[rel] = { size: f.size, mtimeMs: f.mtimeMs, hash, nodes: fileNodes, rawEdges: fileEdges };
     } catch (err) {
       const message = `${rel}: parse failed — ${err instanceof Error ? err.message : String(err)}`;

--- a/src/graph/check.ts
+++ b/src/graph/check.ts
@@ -40,6 +40,12 @@ export interface GraphCheckResult {
 
 export interface GraphCheckOptions {
   contextDir?: string;
+  /** The same `-e` narrowing the build ran under. It has to be passed here too:
+   * a graph built from `-e .ts` holds no Python nodes, so a check that enumerated
+   * every language would re-extract the .py files, find their ids missing from the
+   * committed graph, and report them as `added` — permanent phantom drift that
+   * `graft build` (run without the flag) would then "fix" by widening the graph. */
+  extensions?: string[];
 }
 
 // async: the breadth tier's WASM grammars load asynchronously and must be warmed
@@ -70,9 +76,20 @@ export async function checkGraph(
   }
 
   // Freshly extract Tier-1 nodes from the code on disk (same file set as build).
-  const sourceFiles = listSourceFiles(root, outDir);
+  const sourceFiles = listSourceFiles(root, outDir, undefined, opts.extensions);
+  // Same `languageOf(...) === null` filter buildGraph warms behind, and it has to be
+  // the same one: `.java` is claimed by both registries and the loop below always
+  // gives the file to the depth tier (`lang ? null : genericLangOf(...)`), so warming
+  // its breadth grammar loaded a multi-MB wasm and compiled queries/java.scm on every
+  // `graft check` of every Java repo for a code path that can never run — and `check`
+  // runs in CI, on the hook path, and before every stale-graph query.
   await warmGenericGrammars(
-    new Set(sourceFiles.map((f) => genericLangOf(f)?.name).filter((n): n is string => !!n)),
+    new Set(
+      sourceFiles
+        .filter((f) => languageOf(f) === null)
+        .map((f) => genericLangOf(f)?.name)
+        .filter((n): n is string => !!n),
+    ),
   );
   const current = new Map<string, string>(); // id → body_hash
   for (const file of sourceFiles) {

--- a/src/graph/extract-cache.ts
+++ b/src/graph/extract-cache.ts
@@ -25,6 +25,7 @@
  */
 import { readFileSync, readdirSync, rmSync, statSync } from "node:fs";
 import { createHash } from "node:crypto";
+import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 import { dirname, extname, join } from "node:path";
 import { CACHE_DIR } from "../context/node-file.js";
@@ -147,7 +148,8 @@ function computeStamp(): string | null {
     // `.js` when running from `dist/`, `.ts` under tsx — take the extension from
     // our own filename rather than guessing which layout we're in.
     const dir = dirname(self);
-    const hashed = stampDir(dir, extname(self), packageVersion(dir) ?? "");
+    const version = `${packageVersion(dir) ?? ""}|${grammarVersions()}`;
+    const hashed = stampDir(dir, extname(self), version);
     if (hashed) return hashed;
     // Couldn't read the modules (bundled into one file, say). The version alone is
     // a weaker identity — it can't see a local edit — but it still turns over on
@@ -157,6 +159,64 @@ function computeStamp(): string | null {
   } catch {
     return null;
   }
+}
+
+/** The grammars whose version changes what a parse produces — the depth tier's four
+ * native ones, the wasm bundle the breadth tier loads, and the runtime that loads it. */
+const GRAMMAR_PKGS = [
+  "tree-sitter",
+  "tree-sitter-typescript",
+  "tree-sitter-python",
+  "tree-sitter-go",
+  "tree-sitter-java",
+  "tree-sitter-wasms",
+  "web-tree-sitter",
+] as const;
+
+/**
+ * The RESOLVED versions of the tree-sitter grammars, folded into the extractor identity.
+ *
+ * The docblock above says graft's own package version covers a grammar upgrade. It does
+ * not: every grammar dependency is declared as a `^` range, so a plain `npm i` can pull
+ * `tree-sitter-typescript@0.23.9` under an unchanged graft version — and from that moment
+ * every replayed cache entry is a parse no current build would produce, with nothing to
+ * notice it. Reading each installed package's own `version` is the only thing that tracks
+ * what is actually loaded. Unreadable ones become a stable `absent` marker rather than
+ * churning the stamp on every process.
+ */
+function grammarVersions(): string {
+  const req = createRequire(import.meta.url);
+  return GRAMMAR_PKGS.map((p) => `${p}@${depVersion(req, p)}`).join(",");
+}
+
+function depVersion(req: NodeJS.Require, pkg: string): string {
+  const read = (path: string): string | null => {
+    try {
+      const j = JSON.parse(readFileSync(path, "utf8")) as { name?: string; version?: string };
+      return j.name === pkg ? (j.version ?? null) : null;
+    } catch {
+      return null;
+    }
+  };
+  try {
+    const direct = read(req.resolve(`${pkg}/package.json`));
+    if (direct) return direct;
+  } catch {
+    /* the package's `exports` map may not expose ./package.json — climb from its entry */
+  }
+  try {
+    let dir = dirname(req.resolve(pkg));
+    for (let i = 0; i < 6; i++) {
+      const v = read(join(dir, "package.json"));
+      if (v) return v;
+      const up = dirname(dir);
+      if (up === dir) break;
+      dir = up;
+    }
+  } catch {
+    /* not installed in this environment */
+  }
+  return "absent";
 }
 
 /**
@@ -174,7 +234,26 @@ export function stampDir(dir: string, ext: string, version = ""): string | null 
     h.update(f); // a rename is a change, even at identical content
     h.update(readFileSync(join(dir, f)));
   }
+  // The breadth tier's extraction is DEFINED by `queries/<lang>.scm`, which the module
+  // sweep above cannot see: it's a subdirectory, and .scm is not the module extension.
+  // So fixing queries/c.scm changes every C node in every graph while leaving every file
+  // this function hashed byte-identical — the stamp held, `readExtractCache` accepted the
+  // pre-fix entries, and no build ever re-parsed. Missing (a bundle shipped without the
+  // query dir) folds in nothing and leaves the stamp exactly where it was.
+  for (const q of readQueryDir(join(dir, "queries"))) {
+    h.update(q);
+    h.update(readFileSync(join(dir, "queries", q)));
+  }
   return h.digest("hex").slice(0, 16);
+}
+
+/** The `.scm` files in a queries directory, sorted; empty when there is no such dir. */
+function readQueryDir(dir: string): string[] {
+  try {
+    return readdirSync(dir).filter((f) => f.endsWith(".scm")).sort();
+  } catch {
+    return [];
+  }
 }
 
 /** graft's own version, or null when it can't be read. */

--- a/src/graph/extract.ts
+++ b/src/graph/extract.ts
@@ -192,10 +192,17 @@ const KINDS_BY_LANG: Record<Language, Record<string, Kind>> = {
  * Java is the reason this is a set rather than a string: `method_invocation` and
  * `object_creation_expression` (`new Foo()`) are separate node types, and a Java
  * codebase's constructor calls are a large share of its real edges.
+ *
+ * `new_expression` is here for the same reason Java's `object_creation_expression` is:
+ * `new Foo()` is how a TS/JS module actually depends on a class, and it is NOT a
+ * `call_expression`, so before this no raw edge existed for it at all. The only path
+ * left was `references`, which needs a NAMED import — meaning a class instantiated in
+ * its own file was invisible, and instantiating an imported class produced a weaker
+ * edge than calling a function from the same module did.
  */
 const CALL_TYPES: Record<Language, ReadonlySet<string>> = {
-  typescript: new Set(["call_expression"]),
-  tsx: new Set(["call_expression"]),
+  typescript: new Set(["call_expression", "new_expression"]),
+  tsx: new Set(["call_expression", "new_expression"]),
   python: new Set(["call"]),
   go: new Set(["call_expression"]),
   java: new Set(["method_invocation", "object_creation_expression"]),
@@ -269,7 +276,13 @@ export function extractFile(rel: string, source: string, lang: Language): Extrac
       exported: true,
       origin: "ast",
       body_hash: contentHash(source),
-      chars: source.length,
+      // BYTES, not UTF-16 code units. types.ts documents `chars` as "byte length of the
+      // WHOLE file" and generic.ts writes `Buffer.byteLength`, so `source.length` here
+      // made the same field mean two different things across the two tiers. The `ask`
+      // savings estimate divides it by 4 for a token count and compares tiers directly:
+      // an accented or CJK-heavy .py file under-reported against an equivalent .rs one.
+      // ASCII source is identical either way, which is exactly why it went unnoticed.
+      chars: Buffer.byteLength(source),
       summary_state: "pending",
       summary: null,
       crux: null,
@@ -363,7 +376,14 @@ function walk(node: Parser.SyntaxNode, ctx: WalkCtx, out: NodeV1[], edges: RawEd
     // class heritage — in Java an interface may also `extends`, and a record/enum
     // may `implements`, so every type declaration is a heritage site, not just a class.
     const javaTypeDecl = ctx.lang === "java" && JAVA_TYPE_KINDS.has(desc.kind);
-    if (desc.kind === "class" || javaTypeDecl) edges.push(...heritageEdges(node, id, ctx));
+    // A TS `interface X extends Y` is a heritage site too. Gating on `class` alone left
+    // interface hierarchies — the actual type backbone of a typed TS codebase — with no
+    // `extends` edges at all, while Java's and Python's had them.
+    const tsInterfaceDecl =
+      (ctx.lang === "typescript" || ctx.lang === "tsx") && desc.kind === "interface";
+    if (desc.kind === "class" || javaTypeDecl || tsInterfaceDecl) {
+      edges.push(...heritageEdges(node, id, ctx));
+    }
 
     const enclosingClass =
       desc.kind === "class" || javaTypeDecl
@@ -402,6 +422,18 @@ function walk(node: Parser.SyntaxNode, ctx: WalkCtx, out: NodeV1[], edges: RawEd
       // Java only: the call site's argument count, to pick the right overload.
       const argCount = ctx.lang === "java" ? javaArgCount(node) : undefined;
       if (argCount !== undefined) callEdge.argCount = argCount;
+      // When the callee is a NAMED IMPORT, the source states exactly which module and
+      // which exported name it meant — so hand both to the resolver instead of making it
+      // guess from the bare name. This is what keeps `new Repo()` on an imported class
+      // from being dropped the moment some other `Repo` exists elsewhere in the repo:
+      // bare-name resolution treats a globally ambiguous name as unknowable, and here it
+      // isn't. Member calls are excluded — the name is a property of a receiver, not the
+      // imported binding itself.
+      const importedCallee = callee.viaMember ? undefined : ctx.importedSymbols.get(callee.name);
+      if (importedCallee) {
+        callEdge.name = importedCallee.name;
+        callEdge.specifier = importedCallee.specifier;
+      }
       const recvType = resolveRecvType(callee.receiver, ctx);
       edges.push(recvType ? { ...callEdge, recvType } : callEdge);
     }
@@ -521,12 +553,25 @@ function isFunctionBoundary(node: Parser.SyntaxNode): boolean {
 function isDirectCallee(node: Parser.SyntaxNode, callTypes: ReadonlySet<string>): boolean {
   const parent = node.parent;
   if (!parent || !callTypes.has(parent.type)) return false;
-  return parent.childForFieldName("function") === node || parent.childForFieldName("name") === node;
+  return (
+    parent.childForFieldName("function") === node ||
+    parent.childForFieldName("name") === node ||
+    // TS `new Foo()` spells its callee in a `constructor` field; without this the same
+    // instantiation would emit both a `calls` and a `references` edge for one syntax.
+    parent.childForFieldName("constructor") === node
+  );
 }
 
 /** Definition/declaration identifiers name a new binding; they do not use one. */
 function isDeclarationName(node: Parser.SyntaxNode): boolean {
   const parent = node.parent;
+  // A JSX element's TAG is its parent's `name` field — `<Button />` is a
+  // `jsx_self_closing_element` whose `name` is the identifier `Button` — so the field
+  // test below classified the single most common use of an imported symbol in a .tsx
+  // file as a declaration and silently dropped it. `<Button/>` is not a call_expression
+  // either, so nothing else picked it up: in a React/Next app that meant most real
+  // inter-file dependencies were missing and every component looked like an orphan.
+  if (parent?.type.startsWith("jsx_")) return false;
   return parent?.childForFieldName("name") === node;
 }
 
@@ -706,12 +751,50 @@ function heritageEdges(node: Parser.SyntaxNode, classId: string, ctx: WalkCtx): 
           : null;
     if (!relation) continue;
     for (const t of clause.namedChildren) {
-      if (t.type === "identifier" || t.type === "type_identifier") {
-        edges.push({ source: classId, relation, name: t.text, file: ctx.rel });
-      }
+      const name = heritageNameOf(t);
+      if (name) edges.push({ source: classId, relation, name, file: ctx.rel });
+    }
+  }
+  // An interface's supertypes do NOT live under a `class_heritage`: tree-sitter-typescript
+  // hangs an `extends_type_clause` directly off the `interface_declaration`, so looking
+  // only for `class_heritage` above found nothing for every interface in the repo.
+  for (const clause of node.namedChildren) {
+    if (clause.type !== "extends_type_clause") continue;
+    for (const t of clause.namedChildren) {
+      const name = heritageNameOf(t);
+      if (name) edges.push({ source: classId, relation: "extends", name, file: ctx.rel });
     }
   }
   return edges;
+}
+
+/**
+ * The type a heritage-clause element names, or null when it doesn't name one plainly.
+ *
+ * tree-sitter spells the same supertype differently by clause: an `extends_clause` on a
+ * class holds an EXPRESSION (`identifier`), while `implements_clause` and
+ * `extends_type_clause` hold TYPES (`type_identifier`) — so both spellings count.
+ *
+ * `Foo<T>` arrives as a `generic_type`, which matched neither and so dropped the whole
+ * supertype: `implements Repository<User>` had no edge, and generic base types are the
+ * norm in the TS code that has interfaces at all. Only the base name is taken — the type
+ * ARGUMENTS are not supertypes, and emitting `User` there would be a fabricated edge.
+ *
+ * An expression form (`class A extends mixin(Base)`) stays null on purpose: which of the
+ * names in it is the supertype is a guess, and this extractor does not guess.
+ */
+function heritageNameOf(node: Parser.SyntaxNode): string | null {
+  if (node.type === "identifier" || node.type === "type_identifier") return node.text;
+  if (node.type === "generic_type") {
+    const base = node.childForFieldName("name");
+    return base ? heritageNameOf(base) : null;
+  }
+  if (node.type === "nested_type_identifier") {
+    // `extends ns.Base` — the trailing segment is the type; the namespace is not.
+    const last = node.namedChildren.at(-1);
+    return last?.type === "type_identifier" ? last.text : null;
+  }
+  return null;
 }
 
 /** Every `type_identifier` under a heritage clause, so `implements A, B<C>` yields
@@ -750,6 +833,21 @@ function calleeName(
     // conservative: an unmatched name (e.g. a static import) resolves to nothing.
     if (!obj) return { name: nameNode.text, viaMember: true, receiver: "this" };
     return { name: nameNode.text, viaMember: true, receiver: javaReceiver(obj) };
+  }
+
+  // TS/JS `new Foo()` — the constructed type is the target, and it lives in a
+  // `constructor` field rather than the `function` field the shared lookup below reads.
+  // `new pkg.Foo()` yields the trailing segment; anything more exotic (`new klass()` on
+  // a variable, `new (pick())()`) names no type we can stand behind, so it drops.
+  if (node.type === "new_expression") {
+    const ctor = node.childForFieldName("constructor");
+    if (!ctor) return null;
+    if (ctor.type === "identifier") return { name: ctor.text, viaMember: false };
+    if (ctor.type === "member_expression") {
+      const prop = ctor.childForFieldName("property");
+      return prop ? { name: prop.text, viaMember: false } : null;
+    }
+    return null;
   }
 
   const fn = node.childForFieldName("function");

--- a/src/graph/generic.ts
+++ b/src/graph/generic.ts
@@ -39,17 +39,26 @@ export interface GenericLang {
 }
 
 /** The breadth registry. Add a row + a queries/<name>.scm to support a language.
- * Extensions here must NOT collide with the depth tier's EXTENSIONS (extract.ts). */
+ * Extensions here must NOT collide with the depth tier's EXTENSIONS (extract.ts) —
+ * with ONE deliberate, documented exception, `java` (see its row). */
 export const GENERIC_LANGS: readonly GenericLang[] = [
   { name: "rust", exts: [".rs"], wasm: "rust" },
+  // The exception to the no-collision rule above, and it is a TEST FIXTURE, not a
+  // language graft indexes this way: `.java` belongs to the depth tier (extract.ts),
+  // which always wins in build.ts (`lang ? null : genericLangOf(...)`), so
+  // `extractGeneric` never sees a .java file in a real build. The row exists because
+  // test/generic-extract.test.ts uses Java as its method-heavy example for the
+  // breadth tier's call-kind widening. Callers computing what to WARM must filter out
+  // depth-tier files first, or every Java repo loads a multi-MB wasm for nothing.
   { name: "java", exts: [".java"], wasm: "java" },
   { name: "c", exts: [".c", ".h"], wasm: "c" },
   { name: "cpp", exts: [".cpp", ".cc", ".cxx", ".hpp", ".hh"], wasm: "cpp" },
   { name: "ruby", exts: [".rb"], wasm: "ruby" },
   { name: "php", exts: [".php"], wasm: "php" },
   { name: "c_sharp", exts: [".cs"], wasm: "c_sharp" },
-  // These ship a tags.scm (calls + symbols); ocaml/zig have none and use the
-  // node-kind walker fallback (symbols only) — still one row, zero query.
+  // The rows above and the next four ship a queries/<name>.scm (calls + symbols).
+  // ocaml, zig and dart have none and use the node-kind walker fallback (symbols only,
+  // no call edges) — still one row, zero query.
   { name: "kotlin", exts: [".kt", ".kts"], wasm: "kotlin" },
   { name: "scala", exts: [".scala", ".sc"], wasm: "scala" },
   { name: "swift", exts: [".swift"], wasm: "swift" },
@@ -85,7 +94,15 @@ const KIND: Record<string, Kind> = {
 
 // Loaded grammars + compiled tags queries, keyed by graft lang name. Populated by
 // warmGenericGrammars; read synchronously by extractGeneric.
-interface Loaded { language: unknown; query: unknown | null }
+//
+// The Parser is built ONCE per language and kept here. web-tree-sitter's Parser, Tree
+// and Query all live in the WASM heap, which V8's GC knows nothing about: a Parser
+// constructed per file (and a Tree never `.delete()`d) is leaked for the life of the
+// process. On a repo with thousands of breadth-tier files that grows monotonically
+// through build.ts's whole parse loop and ends in hundreds of MB or an outright
+// `Cannot enlarge memory arrays`. Rebuilding the parser per file was pure waste anyway
+// — the grammar it is set to never changes.
+interface Loaded { language: unknown; query: unknown | null; parser: TsParser }
 const loaded = new Map<string, Loaded>();
 let tsMod: typeof import("web-tree-sitter") | null = null;
 let initPromise: Promise<void> | null = null;
@@ -140,7 +157,9 @@ export async function warmGenericGrammars(langNames: Iterable<string>): Promise<
       if (scm) {
         try { query = new Query(language, scm); } catch { query = null; }
       }
-      loaded.set(name, { language, query });
+      const parser = new tsMod.Parser();
+      parser.setLanguage(language as never);
+      loaded.set(name, { language, query, parser: parser as unknown as TsParser });
     } catch {
       /* grammar failed to instantiate — skip; files extract as file-only */
     }
@@ -150,6 +169,21 @@ export async function warmGenericGrammars(langNames: Iterable<string>): Promise<
 /** True if a grammar has been warmed for this lang (else extractGeneric is file-only). */
 export function isWarm(langName: string): boolean {
   return loaded.has(langName);
+}
+
+/**
+ * Of `langNames`, the breadth languages that have NO usable grammar after a warmup —
+ * their files extract to a file node and nothing else.
+ *
+ * A missing wasm and a grammar that fails to instantiate are both swallowed silently by
+ * {@link warmGenericGrammars} (correctly: neither should fail a build), and the caller
+ * had no way to notice. So a build over a repo whose `dart` wasm isn't in the bundle
+ * announced `[dart]` in its language banner having indexed exactly zero dart symbols —
+ * which reads as "graft is broken at querying dart", not "graft has no dart grammar
+ * here". Call this after warming and report the gap instead of claiming coverage.
+ */
+export function unavailableGrammars(langNames: Iterable<string>): string[] {
+  return [...new Set(langNames)].filter((n) => !loaded.has(n)).sort();
 }
 
 const PARSE_CHUNK = 16384; // <32KB slices — same tree-sitter limit workaround as extract.ts
@@ -163,7 +197,7 @@ function fileNode(rel: string, source: string): NodeV1 {
   };
 }
 
-interface Def { id: string; startIndex: number; endIndex: number }
+export interface Def { id: string; startIndex: number; endIndex: number }
 
 /** Extract a single generic-tier file. Synchronous; needs the grammar pre-warmed.
  * Uses the grammar's compiled tags.scm when present (symbols + call edges);
@@ -172,19 +206,61 @@ interface Def { id: string; startIndex: number; endIndex: number }
 export function extractGeneric(rel: string, source: string, langName: string): ExtractResult {
   const nodes: NodeV1[] = [fileNode(rel, source)];
   const rawEdges: RawEdge[] = [];
-  const entry = loaded.get(langName);
+  const lang = headerGrammarFor(rel, source, langName);
+  const entry = loaded.get(lang);
   if (!entry || !tsMod) return { nodes, rawEdges };
 
-  let tree;
+  let tree: TsTree | null;
   try {
-    const parser = new tsMod.Parser();
-    parser.setLanguage(entry.language as never);
-    tree = parser.parse((i: number) => source.slice(i, i + PARSE_CHUNK));
+    tree = entry.parser.parse((i: number) => source.slice(i, i + PARSE_CHUNK));
   } catch {
     return { nodes, rawEdges };
   }
   if (!tree) return { nodes, rawEdges };
+  try {
+    return extractFromTree(tree.rootNode, rel, source, lang, nodes, rawEdges);
+  } finally {
+    // The one place a Tree can be released: every early return above happens before one
+    // exists, and every path below funnels through here. Without it each parsed file
+    // leaves its whole syntax tree resident in the WASM heap forever (see `Loaded`).
+    tree.delete();
+  }
+}
 
+/**
+ * The grammar a `.h` file should actually be parsed with.
+ *
+ * The registry maps an extension to exactly one grammar and `.h` is claimed by C — but
+ * in a C++ project the headers are precisely where the classes, templates and namespaces
+ * live, and c.scm has no `class_specifier` and no `namespace` pattern at all. Those
+ * symbols simply did not exist in the graph (while resolve.ts happily treated the same
+ * `.h` as a valid `#include` target), and templates additionally produced ERROR nodes.
+ *
+ * The extension cannot decide this — the same `.h` is C in one repo and C++ in the next
+ * — so the content does. The `loaded.has("cpp")` gate is what keeps this safe: the cpp
+ * grammar is warmed only when the repo has real C++ sources, so a pure-C project can
+ * never be routed away from the C parse it had.
+ *
+ * Known seam: adding a repo's FIRST `.cpp` file flips this decision for headers whose
+ * own bytes did not move, and the extraction memo is keyed on bytes — so those headers
+ * keep their C parse until they are edited or the memo turns over. Re-parsing the whole
+ * repo on that transition is not worth the machinery; `graft build --no-reuse` settles it.
+ */
+const CPP_HEADER = /^[ \t]*(?:template\s*<|namespace\s+[\w{]|class\s+\w|public:|private:|protected:|using\s+namespace\b)/m;
+function headerGrammarFor(rel: string, source: string, langName: string): string {
+  if (langName !== "c" || !rel.toLowerCase().endsWith(".h")) return langName;
+  return loaded.has("cpp") && CPP_HEADER.test(source) ? "cpp" : langName;
+}
+
+function extractFromTree(
+  root: TsNode,
+  rel: string,
+  source: string,
+  langName: string,
+  nodes: NodeV1[],
+  rawEdges: RawEdge[],
+): ExtractResult {
+  const entry = loaded.get(langName)!;
   const minted = new Set<string>([rel]);
   const lines = source.split("\n");
   const defs: Def[] = [];
@@ -216,16 +292,16 @@ export function extractGeneric(rel: string, source: string, langName: string): E
   };
 
   if (entry.query) {
-    tagsExtract(entry.query, tree.rootNode as TsNode, rel, mkDef, defs, rawEdges);
+    tagsExtract(entry.query, root, rel, mkDef, defs, rawEdges);
   } else {
-    walkExtract(tree.rootNode as TsNode, mkDef); // no tags.scm → symbols only
+    walkExtract(root, mkDef); // no tags.scm → symbols only
   }
   // The preprocessor is invisible to tags.scm, but in C/C++ a local `#include "x.h"`
   // IS the dependency graph — capture it as a file→file import. Likewise a Rust
   // `use crate::…` is an in-crate module dependency.
-  if (langName === "c" || langName === "cpp") extractIncludes(tree.rootNode as TsNode, rel, rawEdges);
-  else if (langName === "rust") extractUses(tree.rootNode as TsNode, rel, rawEdges);
-  else if (langName === "php") extractPhpUses(tree.rootNode as TsNode, rel, rawEdges);
+  if (langName === "c" || langName === "cpp") extractIncludes(root, rel, rawEdges);
+  else if (langName === "rust") extractUses(root, rel, rawEdges);
+  else if (langName === "php") extractPhpUses(root, rel, rawEdges);
   return { nodes, rawEdges };
 }
 
@@ -357,22 +433,57 @@ function tagsExtract(
          "reference.implementation" in cap || "reference.module" in cap) && cap.name)
       refs.push({ name: cap.name.text, at: cap.name.startIndex });
   }
-  // innermost enclosing definition of a token at byte offset `at`
-  const enclosing = (at: number) =>
-    defs
-      .filter((d) => d.startIndex <= at && at < d.endIndex)
-      .sort((a, b) => (a.endIndex - a.startIndex) - (b.endIndex - b.startIndex))[0];
-  for (const c of calls) {
+  const callEnc = enclosingDefs(defs, calls.map((c) => c.at));
+  for (let i = 0; i < calls.length; i++) {
+    const c = calls[i];
     if (defNameAt.has(c.at)) continue;
-    const enc = enclosing(c.at);
+    const enc = callEnc[i];
     rawEdges.push({ source: enc ? enc.id : rel, relation: "calls", file: rel, name: c.name });
   }
-  for (const r of refs) {
+  const refEnc = enclosingDefs(defs, refs.map((r) => r.at));
+  for (let i = 0; i < refs.length; i++) {
+    const r = refs[i];
     if (defNameAt.has(r.at)) continue;
-    const enc = enclosing(r.at);
+    const enc = refEnc[i];
     if (!enc) continue; // a reference with no enclosing definition has no sound source
     rawEdges.push({ source: enc.id, relation: "references", file: rel, name: r.name });
   }
+}
+
+/**
+ * The innermost definition enclosing each of `offsets`, positionally.
+ *
+ * The obvious per-token `defs.filter(contains).sort(bySize)[0]` is O(D·C) and allocates
+ * two arrays PER TOKEN. On a generated file — a 100k-line C# API client, Rust bindings,
+ * compiled protobuf — that is ~15k definitions against ~50k call sites: 750M comparisons
+ * and 50k throwaway arrays, tens of seconds inside build.ts's synchronous per-file loop,
+ * for bookkeeping nobody would believe costs anything.
+ *
+ * Definition spans come from syntax-tree nodes, so they NEST — no two of them partially
+ * overlap. That is what makes a single ordered sweep sufficient: walk the offsets in
+ * order, push definitions as their start passes, pop them as their end passes, and the
+ * top of the stack is the innermost one still open. O((D+C) log(D+C)) overall.
+ *
+ * Exported so a test can pin the behaviour and the scale directly, without having to
+ * synthesize a 100k-line source file to reach the path.
+ */
+export function enclosingDefs(defs: Def[], offsets: number[]): Array<Def | undefined> {
+  // `.fill` because a bare `new Array(n)` is SPARSE, and a hole is not the same value
+  // as `undefined` to anything that inspects the array (deepEqual, JSON, spread).
+  const out = new Array<Def | undefined>(offsets.length).fill(undefined);
+  if (defs.length === 0) return out;
+  // Ties on startIndex: the wider span is the outer one, so it must be pushed first.
+  const byStart = [...defs].sort((a, b) => a.startIndex - b.startIndex || b.endIndex - a.endIndex);
+  const order = offsets.map((_, i) => i).sort((a, b) => offsets[a] - offsets[b]);
+  const open: Def[] = [];
+  let next = 0;
+  for (const i of order) {
+    const at = offsets[i];
+    while (next < byStart.length && byStart[next].startIndex <= at) open.push(byStart[next++]);
+    while (open.length && open[open.length - 1].endIndex <= at) open.pop();
+    out[i] = open[open.length - 1];
+  }
+  return out;
 }
 
 // Node-type → Kind for the walker fallback. A node is a definition when its type
@@ -427,6 +538,17 @@ function walkExtract(root: TsNode, mkDef: (name: string, kind: Kind, whole: TsNo
     }
   };
   visit(root);
+}
+
+/** The slice of web-tree-sitter's Tree we use. `delete()` is not optional bookkeeping:
+ * it is the only way a tree's WASM-heap memory is ever reclaimed. */
+interface TsTree {
+  rootNode: TsNode;
+  delete(): void;
+}
+
+interface TsParser {
+  parse(input: (index: number) => string): TsTree | null;
 }
 
 interface TsNode {

--- a/src/graph/lsp/client.ts
+++ b/src/graph/lsp/client.ts
@@ -28,6 +28,27 @@ export interface CallHierarchyItem {
 
 const uriOf = (abs: string): string => pathToFileURL(abs).toString();
 
+/**
+ * Windows cannot `CreateProcess` a `.cmd`/`.bat` file, and since the
+ * CVE-2024-27980 patch Node refuses to try (EINVAL) — so the two servers that
+ * install through npm, `typescript-language-server` and `pyright-langserver`, could
+ * not be spawned at all on the platform even once the registry started finding
+ * them. Running the shim as a `cmd.exe` command line is the supported route.
+ *
+ * `shell: true` is deliberately NOT the fix: it would re-parse a path that may
+ * contain spaces (`C:\Program Files\…`) and the server's own args. Quoting each
+ * argument exactly once, ourselves, is what keeps that safe — the same shape
+ * `ai/llm/claude-cli.ts` uses for the `claude` shim.
+ */
+function spawnArgv(command: string, args: string[]): { file: string; argv: string[]; verbatim: boolean } {
+  if (process.platform !== "win32" || !/\.(cmd|bat)$/i.test(command)) {
+    return { file: command, argv: args, verbatim: false };
+  }
+  const quote = (s: string) => `"${s.replace(/"/g, '""')}"`;
+  const line = [quote(command), ...args.map(quote)].join(" ");
+  return { file: process.env.ComSpec ?? "cmd.exe", argv: ["/d", "/s", "/c", `"${line}"`], verbatim: true };
+}
+
 export class LspClient {
   private proc: ChildProcessWithoutNullStreams;
   private conn: MessageConnection;
@@ -42,7 +63,13 @@ export class LspClient {
     private readonly languageId: string,
     private readonly callTimeoutMs = 15000,
   ) {
-    this.proc = spawn(command, args, { cwd: root, stdio: ["pipe", "pipe", "pipe"] });
+    const launch = spawnArgv(command, args);
+    this.proc = spawn(launch.file, launch.argv, {
+      cwd: root,
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsVerbatimArguments: launch.verbatim,
+      windowsHide: true,
+    });
     // ENOENT (bad path) OR an immediate exit (e.g. a rustup shim whose component
     // isn't installed) must fail fast, not hang a request for the full timeout.
     this.proc.on("error", () => { this.spawnFailed = true; });

--- a/src/graph/lsp/registry.ts
+++ b/src/graph/lsp/registry.ts
@@ -3,7 +3,8 @@
  * Only servers whose binary is actually on PATH are eligible; a missing binary
  * simply means that language gets no LSP enrichment (the AST graph stands alone).
  */
-import { execSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { delimiter, isAbsolute, join } from "node:path";
 
 export interface LspServer {
   /** graft language names (as produced by languageLabelOf/genericLangOf) this serves. */
@@ -24,16 +25,53 @@ export const LSP_SERVERS: readonly LspServer[] = [
 ];
 
 const resolved = new Map<string, string | null>();
-/** Resolve a command to its ABSOLUTE path via the login shell's PATH. `spawn`
- * resolves against `process.env.PATH`, which often omits `~/.cargo/bin`,
- * `~/go/bin`, etc. where these servers live — so `command -v` can find a server
- * that `spawn(cmd)` then can't. Spawning the absolute path avoids that mismatch. */
+
+/**
+ * Resolve a command to its ABSOLUTE path by walking PATH ourselves.
+ *
+ * This was `execSync("command -v " + cmd)`, which is a POSIX shell builtin. On
+ * Windows `execSync` goes through `cmd.exe`, which answers "'command' is not
+ * recognized" and throws — so every language resolved to null, `pickServer` returned
+ * null for every language, and `graft build --lsp` was a silent no-op across the
+ * entire platform. Cached in `resolved`, so not even a retry.
+ *
+ * Nothing is lost by dropping the shell. The comment this replaces claimed `command
+ * -v` searched "the login shell's PATH" and so could find servers in `~/.cargo/bin`
+ * that `spawn` would miss — but `execSync` runs `sh -c`, not a login shell, and
+ * inherits `process.env.PATH` exactly like `spawn` does. The real reason to resolve
+ * at all is the absolute path, which this returns.
+ *
+ * PATHEXT matters here as much as it does for `graft` itself: the servers that ship
+ * as npm packages (`typescript-language-server`, `pyright-langserver`) install as
+ * `.cmd` shims, and Node only ever appends `.exe` on its own.
+ */
 function resolveCommand(cmd: string): string | null {
   if (resolved.has(cmd)) return resolved.get(cmd)!;
-  let abs: string | null = null;
-  try { abs = execSync(`command -v ${cmd}`, { encoding: "utf8" }).trim() || null; } catch { abs = null; }
+  const abs = lookPath(cmd);
   resolved.set(cmd, abs);
   return abs;
+}
+
+function lookPath(cmd: string): string | null {
+  // An explicitly-pathed command answers for itself; PATH is not consulted.
+  if (cmd.includes("/") || cmd.includes("\\")) return isAbsolute(cmd) && existsSync(cmd) ? cmd : null;
+  // .EXE first: it spawns without the cmd.exe wrapper `client.ts` has to build for
+  // a shim, so prefer it whenever both forms exist.
+  const exts = process.platform === "win32" ? [".EXE", ".CMD", ".BAT", ".COM", ""] : [""];
+  for (const dir of (process.env.PATH ?? "").split(delimiter)) {
+    if (!dir) continue;
+    const base = dir.replace(/^"|"$/g, ""); // quoted PATH entries are common on Windows
+    for (const ext of exts) {
+      const p = join(base, cmd + ext);
+      if (existsSync(p)) return p;
+    }
+  }
+  return null;
+}
+
+/** Test seam: drop the memoized lookups so a test can flip PATH. */
+export function resetResolvedCommands(): void {
+  resolved.clear();
 }
 
 /** Pick the highest-priority installed server that covers at least one of the

--- a/src/graph/queries/c.scm
+++ b/src/graph/queries/c.scm
@@ -2,7 +2,23 @@
 
 (declaration type: (union_specifier name: (type_identifier) @name)) @definition.class
 
-(function_declarator declarator: (identifier) @name) @definition.function
+; graft: DEFINITIONS only, never prototypes. The upstream pattern is bare
+; `(function_declarator declarator: (identifier) @name)`, which is right for "go to tag"
+; and wrong for a dependency graph: `int run(void);` in a header parses as
+; (declaration (function_declarator (identifier))) and matches it too. With a header +
+; .c pair — i.e. every C project — every function then had TWO nodes of the same name in
+; two different files, resolve.ts saw an ambiguous global match and dropped it, and the
+; result was that only intra-file calls survived anywhere in the repo.
+; Anchoring on function_definition costs the prototypes' nodes, which is the point: the
+; definition is the thing calls should land on.
+(function_definition
+  declarator: (function_declarator declarator: (identifier) @name)) @definition.function
+
+; …and the same through a pointer return type (`char *dup(const char *)`), whose
+; declarator field is a pointer_declarator wrapping the function_declarator.
+(function_definition
+  declarator: (pointer_declarator
+    declarator: (function_declarator declarator: (identifier) @name))) @definition.function
 
 (type_definition declarator: (type_identifier) @name) @definition.type
 

--- a/src/graph/queries/cpp.scm
+++ b/src/graph/queries/cpp.scm
@@ -2,11 +2,28 @@
 
 (declaration type: (union_specifier name: (type_identifier) @name)) @definition.class
 
-(function_declarator declarator: (identifier) @name) @definition.function
+; graft: DEFINITIONS only, never declarations — see the same note in c.scm. A C++
+; project declares each method in the header and defines it in the .cpp, so the upstream
+; unanchored `function_declarator` patterns minted two nodes per function in two files;
+; resolve.ts drops an ambiguous global match, so every cross-file call edge in the
+; project disappeared. Anchoring on function_definition keeps one node per function, at
+; the place its body actually is.
+(function_definition
+  declarator: (function_declarator declarator: (identifier) @name)) @definition.function
 
-(function_declarator declarator: (field_identifier) @name) @definition.function
+(function_definition
+  declarator: (pointer_declarator
+    declarator: (function_declarator declarator: (identifier) @name))) @definition.function
 
-(function_declarator declarator: (qualified_identifier scope: (namespace_identifier) @local.scope name: (identifier) @name)) @definition.method
+; an inline member definition inside a class body (`void draw() { … }`)
+(function_definition
+  declarator: (function_declarator declarator: (field_identifier) @name)) @definition.method
+
+; the out-of-line definition (`void Widget::draw() { … }`)
+(function_definition
+  declarator: (function_declarator
+    declarator: (qualified_identifier scope: (namespace_identifier) @local.scope
+                                      name: (identifier) @name))) @definition.method
 
 (type_definition declarator: (type_identifier) @name) @definition.type
 

--- a/src/graph/refresh.ts
+++ b/src/graph/refresh.ts
@@ -31,7 +31,7 @@
  * too — it copies the parent checkout's graph in (`./seed.ts`) and then treats the
  * difference between the two checkouts as ordinary drift, which is exactly what it is.
  */
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync, rmSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { contextDirFor } from "../context/node-file.js";
 import { acquireLockIn, releaseLockIn } from "../util/state.js";
@@ -103,11 +103,64 @@ export function releaseOnSignal(cache: string): () => void {
   };
 }
 
+/**
+ * The lock file `acquireLockIn` writes. Duplicated from `util/state.ts` rather than
+ * exported from it because only this file has a reason to look *inside* the lock.
+ */
+const LOCK_FILE = ".sync.lock";
+
+/**
+ * Drop a lock whose owning process is gone. Returns true when one was reclaimed.
+ *
+ * `releaseOnSignal` above is the happy path, and it does not cover Windows: the OS
+ * has no SIGTERM, so `child.kill('SIGTERM')` terminates the process outright and
+ * neither the signal handler nor `process.on('exit')` ever runs — verified on Win11
+ * / Node 22, where the file the child created was still there afterwards. A hard
+ * kill (`SIGKILL`, a crash, a laptop that lost power mid-build) does the same thing
+ * on every platform. Either way the lock outlives its owner, and until it ages out
+ * at `LOCK_STALE_MS` — five minutes — every query waits `LOCK_WAIT_MS` and then
+ * answers stale with "a graph rebuild is already in flight". One timed-out prompt
+ * hook was enough to cost five minutes of degraded answers.
+ *
+ * `acquireLockIn` already records `{pid, at}`, so the ownership question is
+ * answerable without waiting: signal 0 checks for a live process without touching
+ * it. Everything unknown is read as "still alive" and left to the mtime rule —
+ * EPERM (a live process we don't own), a malformed file, a pid from another machine
+ * on a shared filesystem. Reclaiming a lock we shouldn't would let two builds write
+ * the same graph at once; declining to reclaim one only costs the old five minutes.
+ */
+export function reclaimDeadLock(cache: string): boolean {
+  const p = join(cache, LOCK_FILE);
+  let pid: unknown;
+  try {
+    pid = (JSON.parse(readFileSync(p, "utf8")) as { pid?: unknown }).pid;
+  } catch {
+    return false; // no lock, or one written by a version that didn't record a pid
+  }
+  if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) return false;
+  if (pid === process.pid) return false; // ours; releasing it here would be a bug
+  try {
+    process.kill(pid, 0);
+    return false; // answered => alive
+  } catch (e: any) {
+    if (e?.code !== "ESRCH") return false; // EPERM and friends: alive, just not ours
+  }
+  try {
+    rmSync(p);
+    return true;
+  } catch {
+    return false; // another process reclaimed it first — either way it's gone
+  }
+}
+
 /** Wait out someone else's rebuild, then take the lock. False when we couldn't. */
 async function waitForLock(cache: string): Promise<boolean> {
   const deadline = Date.now() + LOCK_WAIT_MS;
   for (;;) {
     if (acquireLockIn(cache)) return true;
+    // Only after a failed acquire, so the common path (no lock at all) never reads
+    // the file. Re-checked every poll: the holder can die inside our wait window.
+    if (reclaimDeadLock(cache) && acquireLockIn(cache)) return true;
     if (Date.now() >= deadline) return false;
     await sleep(LOCK_POLL_MS);
   }

--- a/src/graph/resolve.ts
+++ b/src/graph/resolve.ts
@@ -20,6 +20,15 @@ import type { RawEdge } from "./extract.js";
 const IMPORT_EXTS = [".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs", ".py"];
 /** C/C++ source + header extensions, for resolving `#include` targets. */
 const C_EXT = /\.(c|h|cc|cpp|cxx|hpp|hh|hxx|inl|ipp|c\+\+|h\+\+)$/i;
+/** Python source/stub extensions — a different import spelling entirely (see
+ * {@link resolvePythonImport}), so it gets its own resolver rather than the JS one. */
+const PY_EXT = /\.pyi?$/i;
+/** Languages whose bare call syntax can name a TYPE as well as a function: Python's
+ * `Repo()` IS the constructor call, and TS/JS `new Repo()` reaches here with the type as
+ * the callee name. Resolving those against a function-only index dropped every
+ * object-construction edge — the commonest coupling there is between two modules. The
+ * ambiguity rule in {@link resolveName} still refuses to guess between same-named types. */
+const TYPE_CALL_EXT = /\.(py|pyi|ts|tsx|mts|cts|js|jsx|mjs|cjs)$/i;
 
 /** A Go module discovered in the repo: its `module` path from `go.mod` and the repo
  * directory that `go.mod` lives in (posix, `.` for the repo root). A monorepo may hold
@@ -66,6 +75,11 @@ export function resolveEdges(
   // node ids. A `use App\Models\User` names a PSR-4 class whose file mirrors the namespace
   // tail under some (unknown) source root, so the suffix is the portable key.
   const phpFilesBySuffix = new Map<string, string[]>();
+  // Python module resolution: a file's path-suffix (`app/services/mailer.py`,
+  // `services/mailer.py`, …) → its file node ids. An absolute Python import names a
+  // module relative to a sys.path root graft cannot know, so — as with Java and PHP —
+  // the suffix is the portable key.
+  const pyFilesBySuffix = new Map<string, string[]>();
   const hasGoModules = !!opts.goModules?.length;
   for (const n of nodes) {
     if (n.kind === "file") {
@@ -88,6 +102,10 @@ export function resolveEdges(
         const parts = toPosixPath(n.path).split("/");
         for (let i = 0; i < parts.length; i++) push(phpFilesBySuffix, parts.slice(i).join("/"), n.id);
       }
+      if (PY_EXT.test(n.path)) {
+        const parts = toPosixPath(n.path).split("/");
+        for (let i = 0; i < parts.length; i++) push(pyFilesBySuffix, parts.slice(i).join("/"), n.id);
+      }
       {
         const p = toPosixPath(n.path);
         if (p === "lib.rs" || p === "main.rs") rustCrateRoots.push("");
@@ -104,18 +122,21 @@ export function resolveEdges(
     }
   }
 
-  // classParents: class/interface name → its declared base-class names, from raw
-  // `extends` edges (source id's own name → the base name). Used to walk up an
-  // inheritance chain when a receiver's own type has no matching method.
+  // classParents: class/interface NODE ID → its declared base-class names, from raw
+  // `extends` edges. Used to walk up an inheritance chain when a receiver's own type has
+  // no matching method.
+  //
+  // Keyed by node id, not by bare name. Keyed by name, `a/Base.java` (`class Base extends
+  // Foo`) and `b/Base.java` (`class Base extends Bar`) FUSE into
+  // `Base → [Foo, Bar]`, and a `base.handle()` in package `a` climbs into package b's
+  // `Bar.handle` and emits it as an `inferred` call edge. `Base`, `Client`, `Config`,
+  // `Handler` repeated across modules is ordinary, and silently crossing between them
+  // is exactly the guess the rest of this file exists to refuse.
   const classParents = new Map<string, string[]>();
   for (const e of rawEdges) {
     if (e.relation !== "extends" || !e.name) continue;
-    // The declaring class's own bare name — read from its node (keyed by n.name, set
-    // once at mint time) rather than re-derived by slicing e.source, which breaks once
-    // ids can carry a dedup ordinal (A3's `Cache~2`).
-    const ownName = byId.get(e.source)?.name;
-    if (!ownName) continue;
-    push(classParents, ownName, e.name);
+    if (!byId.has(e.source)) continue;
+    push(classParents, e.source, e.name);
   }
 
   const out: EdgeV1[] = [];
@@ -136,13 +157,15 @@ export function resolveEdges(
           ? resolveGoImport(e.specifier, opts.goModules!, goFilesByDir)
           : e.file.endsWith(".java")
             ? resolveJavaImport(e.specifier, javaFilesBySuffix)
-            : C_EXT.test(e.file)
-              ? resolveCInclude(e.specifier, e.file, byId, cFilesBySuffix)
-              : e.file.endsWith(".rs")
-                ? resolveRustUse(e.specifier, e.file, byId, rustCrateRoots)
-                : e.file.endsWith(".php")
-                  ? resolvePhpUse(e.specifier, phpFilesBySuffix)
-                  : resolveImport(e.specifier, e.file, byId);
+            : PY_EXT.test(e.file)
+              ? resolvePythonImport(e.specifier, e.file, byId, pyFilesBySuffix)
+              : C_EXT.test(e.file)
+                ? resolveCInclude(e.specifier, e.file, byId, cFilesBySuffix)
+                : e.file.endsWith(".rs")
+                  ? resolveRustUse(e.specifier, e.file, byId, rustCrateRoots)
+                  : e.file.endsWith(".php")
+                    ? resolvePhpUse(e.specifier, phpFilesBySuffix)
+                    : resolveImport(e.specifier, e.file, byId);
       add(e.source, target, "imports", "extracted");
     } else if (e.relation === "extends" || e.relation === "implements") {
       const kinds: Kind[] = e.relation === "implements" ? ["interface"] : ["class", "interface"];
@@ -171,7 +194,9 @@ export function resolveEdges(
     } else if (e.relation === "calls") {
       if (e.viaMember) {
         if (!e.recvType) continue;
-        const hit = resolveTypedMember(e.recvType, e.name!, e.file, ownerMethod, classParents, e.argCount);
+        const hit = resolveTypedMember(
+          e.recvType, e.name!, e.file, ownerMethod, classParents, perFileName, globalName, e.argCount,
+        );
         if (hit === "ambiguous") continue; // drop — never guess past an ambiguous owner
         if (hit) add(e.source, hit.id, "calls", hit.confidence);
         // No owner-qualified match means the call is unresolved. A unique bare
@@ -180,7 +205,7 @@ export function resolveEdges(
         // vs a compiler-grade oracle) for a 3x count inflation, i.e. noise. See #35.
         continue;
       }
-      // Three cases, because "a bare call" means something different per tier:
+      // Four cases, because "a bare call" means something different per tier and language:
       //
       //  - generic (breadth tier): tags.scm captures ALL calls as bare names, since it
       //    cannot type a receiver. In method-heavy languages those target methods, so
@@ -189,14 +214,35 @@ export function resolveEdges(
       //  - Java (depth tier): an implicit-`this` call is spelled as a member call in
       //    extract.ts, so the only bare call reaching here is `new Foo()`, whose target
       //    is a TYPE. Against the function index every constructor edge would drop.
-      //  - everything else: functions, exactly as before.
+      //  - Python / TS-JS: a bare call can name a type too — `Repo()` IS Python's
+      //    constructor call, and `new Repo()` arrives here with the type as the callee.
+      //    Function-only kinds dropped every object construction in both languages, i.e.
+      //    the single commonest way two modules couple.
+      //  - everything else (Go): functions, exactly as before.
       const srcOrigin = byId.get(e.source)?.origin;
       const callKinds: Kind[] =
         srcOrigin === "generic"
           ? ["function", "method"]
           : e.file.endsWith(".java")
             ? ["class", "struct", "enum", "interface"]
-            : ["function"];
+            : TYPE_CALL_EXT.test(e.file)
+              ? ["function", "class", "struct", "enum"]
+              : ["function"];
+      if (e.specifier) {
+        // The callee is a named import, so the source already states both halves of the
+        // answer — which module, and which exported name. Resolve inside that file and
+        // stop: a globally ambiguous name is NOT ambiguous here, and bare-name resolution
+        // would have dropped it. Anything the import doesn't settle (an external package,
+        // a barrel re-export) falls through to the bare-name path below, unchanged.
+        const targetFile = resolveImport(e.specifier, e.file, byId);
+        const candidates = byId.has(targetFile)
+          ? (perFileName.get(targetFile)?.get(e.name!) ?? []).filter((n) => callKinds.includes(n.kind))
+          : [];
+        if (candidates.length === 1) {
+          add(e.source, candidates[0].id, "calls", "extracted");
+          continue;
+        }
+      }
       const hit = resolveName(e.name!, e.file, callKinds, perFileName, globalName);
       if (hit) add(e.source, hit.id, "calls", hit.confidence); // drop unresolved calls (too noisy)
     }
@@ -221,12 +267,28 @@ function resolveName(
   perFileName: Map<string, Map<string, NodeV1[]>>,
   globalName: Map<string, NodeV1[]>,
 ): { id: string; confidence: EdgeV1["confidence"] } | null {
+  const hit = resolveNamedNode(name, file, kinds, perFileName, globalName);
+  return hit ? { id: hit.node.id, confidence: hit.confidence } : null;
+}
+
+/** {@link resolveName}, returning the NODE rather than just its id — the inheritance
+ * walk needs the declaring file to keep looking a supertype up in its own scope. */
+function resolveNamedNode(
+  name: string,
+  file: string,
+  kinds: Kind[],
+  perFileName: Map<string, Map<string, NodeV1[]>>,
+  globalName: Map<string, NodeV1[]>,
+): { node: NodeV1; confidence: EdgeV1["confidence"] } | null {
   const local = (perFileName.get(file)?.get(name) ?? []).filter((n) => kinds.includes(n.kind));
-  if (local.length) return { id: local[0].id, confidence: "extracted" };
+  if (local.length) return { node: local[0], confidence: "extracted" };
   const global = (globalName.get(name) ?? []).filter((n) => kinds.includes(n.kind));
-  if (global.length === 1) return { id: global[0].id, confidence: "inferred" };
+  if (global.length === 1) return { node: global[0], confidence: "inferred" };
   return null;
 }
+
+/** The kinds an `extends`/`implements` name can land on, when climbing a hierarchy. */
+const TYPE_KINDS: Kind[] = ["class", "interface", "struct", "enum"];
 
 /**
  * Resolve a typed member call (`recvType.name`) against the owner-qualified method
@@ -270,30 +332,48 @@ function resolveTypedMember(
   file: string,
   ownerMethod: Map<string, NodeV1[]>,
   classParents: Map<string, string[]>,
+  perFileName: Map<string, Map<string, NodeV1[]>>,
+  globalName: Map<string, NodeV1[]>,
   argCount?: number,
 ): { id: string; confidence: EdgeV1["confidence"] } | "ambiguous" | null {
   const MAX_DEPTH = 3;
-  const visited = new Set<string>([recvType]);
-  let frontier = [recvType];
+  // A frontier entry is a type name PLUS the file whose scope named it, because
+  // `classParents` is keyed by node id: to climb from `Base` we first have to know WHICH
+  // `Base`, and the only honest answer is the one visible from the file that named it.
+  const visited = new Set<string>([`${file}\0${recvType}`]);
+  let frontier: Array<{ type: string; file: string }> = [{ type: recvType, file }];
   for (let depth = 0; depth <= MAX_DEPTH && frontier.length; depth++) {
-    for (const type of frontier) {
-      const all = ownerMethod.get(`${type}.${name}`);
+    for (const entry of frontier) {
+      const all = ownerMethod.get(`${entry.type}.${name}`);
       if (!all || all.length === 0) continue; // try next ancestor
       const candidates = narrowByArity(all, argCount);
       if (candidates.length === 1) {
         const c = candidates[0];
         return { id: c.id, confidence: c.path === file ? "extracted" : "inferred" };
       }
-      const sameFile = candidates.find((c) => c.path === file);
-      if (sameFile) return { id: sameFile.id, confidence: "extracted" };
-      return "ambiguous"; // several, none same-file — drop and stop
+      // Several classes share this type NAME. The tiebreak is the scope we reached this
+      // level FROM — at depth 0 that is the call site (as before), but on an ancestor it
+      // is the file that declared the supertype. Falling back to the call site's file up
+      // there would let a homonym next to the CALLER hijack a hierarchy declared
+      // somewhere else entirely.
+      const inScope = candidates.find((c) => c.path === entry.file);
+      if (inScope) return { id: inScope.id, confidence: inScope.path === file ? "extracted" : "inferred" };
+      return "ambiguous"; // several, none in scope — drop and stop
     }
-    const next: string[] = [];
-    for (const type of frontier) {
-      for (const parent of classParents.get(type) ?? []) {
-        if (visited.has(parent)) continue;
-        visited.add(parent);
-        next.push(parent);
+    const next: Array<{ type: string; file: string }> = [];
+    for (const entry of frontier) {
+      // Which declaration of `entry.type` this is decides which hierarchy we climb. When
+      // the name resolves to no single type node (unknown, or several homonyms with no
+      // same-file winner), the chain simply STOPS: drop rather than pick a hierarchy.
+      const decl = resolveNamedNode(entry.type, entry.file, TYPE_KINDS, perFileName, globalName);
+      if (!decl) continue;
+      for (const parent of classParents.get(decl.node.id) ?? []) {
+        // The supertype name is looked up from the DECLARING file, not the call site's:
+        // `a/Base.java`'s `extends Foo` means package a's Foo.
+        const key = `${decl.node.path}\0${parent}`;
+        if (visited.has(key)) continue;
+        visited.add(key);
+        next.push({ type: parent, file: decl.node.path });
       }
     }
     frontier = next;
@@ -319,6 +399,68 @@ function resolveImport(spec: string, file: string, byId: Map<string, NodeV1>): s
   ];
   for (const c of candidates) if (byId.has(c)) return c;
   return spec;
+}
+
+/**
+ * Resolve a Python import to the in-repo module file it names, else the raw specifier.
+ *
+ * Python is spelled nothing like JS and was being run through the JS resolver, which
+ * made every Python import edge in every graph point at an external string. The
+ * extractor hands over the specifier verbatim — `.utils`, `..core.db`, `app.services` —
+ * and `posix.join(dir, ".utils")` is `"src/.utils"`: every candidate path it built was
+ * one that cannot exist, so resolution always fell through to `return spec`. Combined
+ * with `collectImportedSymbols` being TS-only (no `references` edges either), a Python
+ * repo's graph had containment and intra-file calls and NO wiring between files at all.
+ *
+ * Two spellings, both translated before any path exists:
+ *   - Relative: leading dots are the depth (`.` = this package, `..` = its parent), and
+ *     `.` inside the tail is the separator. So `..core.db` from `a/b/c.py` is `a/core/db`.
+ *   - Absolute: `app.services.mailer` names a module relative to a sys.path root graft
+ *     cannot know, so it is matched as a path SUFFIX, longest tail first — the same
+ *     root-agnostic strategy `resolveJavaImport`/`resolvePhpUse` already use.
+ *
+ * A module is `<path>.py` (or `.pyi`), a package is `<path>/__init__.py`. An ambiguous
+ * suffix and a climb past the repo root both stay the raw specifier, never a guess.
+ */
+function resolvePythonImport(
+  spec: string,
+  file: string,
+  byId: Map<string, NodeV1>,
+  bySuffix: Map<string, string[]>,
+): string {
+  const dots = /^\.*/.exec(spec)![0].length;
+  const tail = spec.slice(dots).replace(/\./g, "/");
+  if (dots > 0) {
+    let dir = posix.dirname(toPosixPath(file));
+    if (dir === ".") dir = "";
+    // One dot is the importing file's OWN package, so only the dots beyond the first climb.
+    for (let i = 1; i < dots; i++) {
+      if (dir === "") return spec; // climbed out of the repo — nothing in-repo to name
+      dir = posix.dirname(dir);
+      if (dir === ".") dir = "";
+    }
+    const base = [dir, tail].filter(Boolean).join("/");
+    if (base === "") return spec;
+    for (const c of pyModuleFiles(base)) if (byId.has(c)) return c;
+    return spec;
+  }
+  if (tail === "") return spec;
+  const parts = tail.split("/").filter(Boolean);
+  for (let i = 0; i < parts.length; i++) {
+    const sub = parts.slice(i).join("/");
+    for (const cand of pyModuleFiles(sub)) {
+      const hits = bySuffix.get(cand);
+      if (hits && hits.length === 1) return hits[0];
+      if (hits && hits.length > 1) return spec; // ambiguous at the most specific level
+    }
+  }
+  return spec;
+}
+
+/** The file paths a Python module path can name: a module, a stub, or a package's
+ * `__init__`. Order matters — a real module wins over a same-named package. */
+function pyModuleFiles(base: string): string[] {
+  return [`${base}.py`, `${base}/__init__.py`, `${base}.pyi`, `${base}/__init__.pyi`];
 }
 
 /**

--- a/src/graph/source-files.ts
+++ b/src/graph/source-files.ts
@@ -7,10 +7,10 @@
  * {@link listSourceFiles} so its existing importers are unaffected.
  */
 import { statSync } from "node:fs";
-import { resolve } from "node:path";
+import { resolve, sep } from "node:path";
 import { walkDir } from "../ingest/fs.js";
 import { relPosix } from "../util/paths.js";
-import { readIncludeDirs } from "../util/state.js";
+import { readExtensions, readIncludeDirs } from "../util/state.js";
 import { languageOf, depthExtensions } from "./extract.js";
 import { genericLangOf, genericExtensions } from "./generic.js";
 
@@ -43,17 +43,51 @@ export function unsupportedExtensions(exts: string[]): string[] {
  * so every caller that enumerates through here (the fingerprint probe, the
  * hooks/refresh path, none of which ever see a CLI flag) behaves identically
  * to the `graft build --include-dir` invocation that set it.
+ *
+ * `extensions` is `graft build -e`. It reaches here because this is the ONE
+ * enumeration the wiring graph is built from: applied anywhere else, `-e .ts`
+ * narrowed the concept pass while the wiring graph kept indexing every language
+ * graft has a grammar for — the flag said "only include these code extensions"
+ * and the graph the user actually queries ignored it.
+ *
+ * When the caller passes none, the repo's PERSISTED `-e` is read from state here,
+ * exactly as `--include-dir` is above and for a sharper reason: the freshness probe
+ * (`fingerprint.ts`) and the pre-query refresh never see a CLI flag, so an
+ * unpersisted narrowing meant every excluded file counted as new on the next query
+ * and the refresh rebuilt the graph wide again — `-e` would have lasted until the
+ * first `graft ask`. It also makes `graft check` agree with the build that wrote
+ * the graph without anyone having to repeat the flag.
  */
 export function listSourceFiles(
   root: string,
   outDir: string,
   repoFiles: string[] = walkDir(root, readIncludeDirs(resolve(root))),
+  extensions?: string[],
 ): string[] {
+  // Excluding the output dir needs a SEGMENT boundary, not a string prefix: with the
+  // default outDir `<root>/graft`, a bare `startsWith` also swallows the sibling
+  // `graft-tools/` or `graftlib/`, which then never gets indexed and never says why.
+  // This repo already documents the class of bug in `util/paths.ts#pathUnderPrefix`
+  // ("a plain startsWith would let 'frontend' match 'frontend-utils'"); it just never
+  // reached here. `resolve` too, because a relative `--dir` reaches us verbatim and
+  // would otherwise never match the absolute paths the walk produces — making the
+  // output directory itself part of the source set.
+  const out = resolve(outDir);
+  const outPrefix = out + sep;
+  // Empty is treated as absent, not as "index nothing": commander hands `[]` for a
+  // variadic option that was never given, and a build that silently produced an
+  // empty graph would be the worst possible reading of a missing flag.
+  const asked = extensions?.length ? extensions : readExtensions(resolve(root));
+  const wanted = asked?.length ? asked.map(normExt) : undefined;
   // A file is a source file if a depth-tier grammar (languageOf) OR a breadth-tier
   // grammar (genericLangOf) claims its extension. Both must agree here or `build`
   // and `check` would enumerate different sets.
   return repoFiles.filter(
-    (f) => !f.startsWith(outDir) && (languageOf(f) !== null || genericLangOf(f) !== null),
+    (f) =>
+      !(f === out || f.startsWith(outPrefix)) &&
+      (languageOf(f) !== null || genericLangOf(f) !== null) &&
+      // `endsWith`, not `extname`, to match how both registries claim a file.
+      (wanted === undefined || wanted.some((e) => f.toLowerCase().endsWith(e))),
   );
 }
 
@@ -73,9 +107,14 @@ export interface SourceStat {
  * both the freshness probe and the extraction cache. Files that vanish between
  * the walk and the stat are dropped (same fail-soft posture as `walkDir`).
  */
-export function listSourceStats(root: string, outDir: string, repoFiles?: string[]): SourceStat[] {
+export function listSourceStats(
+  root: string,
+  outDir: string,
+  repoFiles?: string[],
+  extensions?: string[],
+): SourceStat[] {
   const out: SourceStat[] = [];
-  for (const abs of listSourceFiles(root, outDir, repoFiles)) {
+  for (const abs of listSourceFiles(root, outDir, repoFiles, extensions)) {
     let s: { size: number; mtimeMs: number };
     try {
       s = statSync(abs);

--- a/src/graph/traverse.ts
+++ b/src/graph/traverse.ts
@@ -15,7 +15,7 @@
 import type { EdgeV1, GraphV1, NodeV1, Relation } from "./types.js";
 import { WALK_RELATIONS } from "./relations.js";
 import { assertPrefixIndexed, pathUnderPrefix } from "./scopes.js";
-import { normalizePathPrefix } from "../util/paths.js";
+import { normalizePathPrefix, toPosixPath } from "../util/paths.js";
 
 /** Which way to walk the wiring graph: `in` = incoming edges (who points at
  * the symbol — callers / blast radius), `out` = outgoing edges (what the symbol
@@ -68,12 +68,19 @@ export function resolveSymbol(graph: GraphV1, query: string, opts: ResolveSymbol
   }
 
   if (matches.length === 0 && looksLikeFilename) {
+    // Every `node.path` in the graph is posix, and this branch compares against
+    // paths, not names — so a native `src\graph\build.ts` (what a Windows shell's
+    // tab-completion produces, and what `graft_trace_calls` invites when its schema
+    // says "a file path also works") equalled no path at all and fell out as "symbol
+    // not found". Same normalization `--in` and `skeleton` already do; see the
+    // header of src/util/paths.ts for why it is keyed to the platform separator.
+    const lowerPath = toPosixPath(query).toLowerCase();
     matches = graph.nodes.filter(
       (n) =>
         n.kind === "file" &&
         (n.name.toLowerCase() === lowerQuery ||
-          n.path.toLowerCase() === lowerQuery ||
-          n.path.toLowerCase().endsWith("/" + lowerQuery)),
+          n.path.toLowerCase() === lowerPath ||
+          n.path.toLowerCase().endsWith("/" + lowerPath)),
     );
   }
 

--- a/src/graph/workspace-cli.ts
+++ b/src/graph/workspace-cli.ts
@@ -38,23 +38,63 @@ export interface WorkspaceBuildOptions {
   includeDirs?: string[];
 }
 
+type ChildBuilder = (childDir: string, childName: string) => Promise<void>;
+
+/**
+ * Wrap a per-child build so ONE failure doesn't cost the whole workspace.
+ *
+ * splitWorkspace builds children in sequence and awaits each, so an uncaught
+ * rejection from child 3 of 12 propagated to `parseAsync().catch` →
+ * `process.exit(1)` and the other nine were never built. The failures that
+ * actually happen here — an expired key, a 429 — are exactly the ones that hit
+ * every child alike, which is the worst possible moment to abandon the queue: a
+ * partial run still delivers the repos that worked.
+ *
+ * `failed` collects the names so the caller can still exit non-zero; swallowing
+ * the error must not also make a half-built workspace look clean to CI.
+ */
+export function keepGoingOnChildFailure(build: ChildBuilder, failed: string[]): ChildBuilder {
+  return async (childDir, childName) => {
+    try {
+      await build(childDir, childName);
+    } catch (err) {
+      failed.push(childName);
+      console.error(`✗ ${childName}/: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  };
+}
+
 /** Build every git child into its own committable `graft/`, then replace the
  * parent's `graft/` with `workspace.json`. Prints the one-time split warning
  * first when migrating away from a mega-graph. */
 export async function runWorkspaceBuild(root: string, opts: WorkspaceBuildOptions): Promise<void> {
-  const buildChild = async (childDir: string, childName: string): Promise<void> => {
+  const failed: string[] = [];
+  const buildChild = keepGoingOnChildFailure(async (childDir, childName) => {
     // Persisted BEFORE the child build itself runs, same as the single-repo
     // `graft build --include-dir` path in cli.ts — so this child's walks (and
     // every later no-flag build of it) see the override identically.
     if (opts.includeDirs && opts.includeDirs.length > 0) {
       writeBuildConfig(childDir, { includeDirs: opts.includeDirs });
     }
+    // Same for `-e`, and for the same reason plus one: the child's own freshness
+    // probe and pre-query refresh never see a flag, so without this the first query
+    // against that child would rebuild it wide again.
+    if (opts.extensions && opts.extensions.length > 0) {
+      writeBuildConfig(childDir, { extensions: opts.extensions });
+    }
     const engine = new Graft({ ...opts.childConfig, contextDir: undefined });
-    if (opts.deep) await engine.init(childDir, { extensions: opts.extensions });
-    const g = await engine.graph(childDir, { llm: opts.deep, concurrency: opts.concurrency });
+    // Both phases get both flags: `-e` narrows what a child indexes at all, and
+    // `-j` is usually set to survive a rate limit — which a workspace build, being
+    // N repos through one key, is the likeliest run of all to hit.
+    if (opts.deep) await engine.init(childDir, { extensions: opts.extensions, concurrency: opts.concurrency });
+    const g = await engine.graph(childDir, {
+      llm: opts.deep,
+      extensions: opts.extensions,
+      concurrency: opts.concurrency,
+    });
     console.log(`✓ ${childName}/: ${g.nodes} nodes, ${g.edges} edges, ${g.cards} cards [${g.languages.join(", ")}]`);
     for (const e of g.errors) console.error(`✗ ${childName}/: ${e}`);
-  };
+  }, failed);
 
   const { children } = await splitWorkspace(
     root,
@@ -70,6 +110,12 @@ export async function runWorkspaceBuild(root: string, opts: WorkspaceBuildOption
   ensureGitignored(root, contextDirFor(root, opts.override));
   console.log(`✓ workspace: ${children.length} repos federated → graft/workspace.json`);
   console.log(`  graft/ is git-ignored — each teammate runs \`graft build\` to regenerate it locally.`);
+  // Continuing past the failures bought a complete run; it must not also make a
+  // half-built workspace look clean to CI or to a `&&` chain in a shell script.
+  if (failed.length > 0) {
+    console.error(`✗ ${failed.length} of ${children.length} repos failed to build: ${failed.join(", ")}`);
+    process.exit(1);
+  }
 }
 
 export function runWorkspaceAsk(
@@ -87,9 +133,13 @@ export function runWorkspaceGrep(
   root: string,
   override: string | undefined,
   pattern: string,
-  opts: { ignoreCase?: boolean; fixed?: boolean; json?: boolean },
+  opts: { ignoreCase?: boolean; fixed?: boolean; in?: string; json?: boolean },
 ): void {
-  const { result, coverage } = federateGrep(root, override, pattern, { ignoreCase: opts.ignoreCase, fixed: opts.fixed });
+  const { result, coverage } = federateGrep(root, override, pattern, {
+    ignoreCase: opts.ignoreCase,
+    fixed: opts.fixed,
+    in: opts.in,
+  });
   if (opts.json) {
     console.log(JSON.stringify(result, null, 2));
     return;

--- a/src/graph/workspace.ts
+++ b/src/graph/workspace.ts
@@ -35,7 +35,7 @@ import { wiringPath } from "./write.js";
 import type { GraphV1 } from "./types.js";
 import { ask, type AskHit, type AskResult } from "../ask/ask.js";
 import { fuseScopes, STRONG_FLOOR, HIGH_FLOOR, type ScopedDoc } from "../ask/fuse.js";
-import { grepGraph, type GrepGroup, type GrepResult } from "../search/grep.js";
+import { grepGraph, DEFAULT_BUDGET_MS, DEFAULT_MAX_HITS, type GrepGroup, type GrepResult } from "../search/grep.js";
 import { formatGrepResult, zeroHitNote } from "../search/grep-cli.js";
 import { withSavings, type Savings } from "../context/savings.js";
 
@@ -305,6 +305,29 @@ export function federateAsk(
   return result;
 }
 
+export interface GrepFederateOptions {
+  ignoreCase?: boolean;
+  fixed?: boolean;
+  /** Narrow to one child (`repoA`) or a path prefix within it (`repoA/src`) — the
+   * same spelling `federateAsk`'s `in` takes, so `--in` means one thing at a
+   * workspace root too. A prefix naming no known child throws, listing the repos.
+   *
+   * Federation used to forward only ignoreCase/fixed, so `graft grep --in repoA`
+   * at a parent searched every repo and said nothing: the caller believes it
+   * scoped the search to one package and reads a result set drawn from all of
+   * them, with the child dir prefixed onto every path making it look deliberate. */
+  in?: string;
+  /** Aggregate hit cap for the WHOLE federated scan (default {@link DEFAULT_MAX_HITS}).
+   * Each child used to get its own 300, so a 12-repo workspace could return 3600
+   * hits from a tool whose contract says 300 — the cap that exists to keep one
+   * tool call from filling the context window. */
+  maxHits?: number;
+  /** Aggregate wall-clock ceiling, same reasoning: a per-child budget multiplies
+   * by the number of repos, and it exists to bound a catastrophic-backtracking
+   * pattern that would otherwise wedge the (single-threaded) MCP server. */
+  budgetMs?: number;
+}
+
 /** Merge every child's `GrepResult` into one, prefixing group paths with the
  * child dir and re-sorting by coupling (inDegree desc, path asc) across repos.
  * In-degree stays each child's own — it comes from that child's graph. */
@@ -312,25 +335,63 @@ export function federateGrep(
   root: string,
   override: string | undefined,
   pattern: string,
-  opts: { ignoreCase?: boolean; fixed?: boolean } = {},
+  opts: GrepFederateOptions = {},
 ): { result: GrepResult; coverage: string } {
   const wg = loadWorkspaceGraphs(root, override);
   const groups: GrepGroup[] = [];
   let filesSearched = 0;
   let totalHits = 0;
-  const truncated = { files: 0, hits: 0 };
+  const truncated: GrepResult["truncated"] = { files: 0, hits: 0 };
   let savedFiles = 0;
   let savedChars = 0;
 
+  // Same `--in` resolution as `federateAsk`: first segment names the child, the
+  // rest is that child's own path prefix.
+  let onlyChild: string | undefined;
+  let childIn: string | undefined;
+  if (opts.in) {
+    const [name, ...rest] = opts.in.replace(/\/+$/, "").split(/[\\/]/);
+    const allChildren = [...wg.loaded.map((l) => l.child), ...wg.missing].sort();
+    if (!allChildren.includes(name)) {
+      throw new Error(`no workspace repo "${name}" - repos: ${allChildren.join(", ")}`);
+    }
+    onlyChild = name;
+    childIn = rest.length ? rest.join("/") : undefined;
+  }
+
+  // Both budgets are spent DOWN across children rather than handed to each in
+  // full. `maxHits: 0` on an exhausted budget is deliberate: grepGraph still
+  // counts what it finds into `truncated.hits`, so the total stays honest instead
+  // of the later repos silently vanishing from the tally.
+  let hitsLeft = opts.maxHits ?? DEFAULT_MAX_HITS;
+  const deadline = Date.now() + (opts.budgetMs ?? DEFAULT_BUDGET_MS);
+  let timedOut = false;
+
   for (const { child, graph } of wg.loaded) {
+    if (onlyChild && child !== onlyChild) continue;
+    const msLeft = deadline - Date.now();
+    if (msLeft <= 0) {
+      // The remaining children were never opened at all — the loudest possible
+      // form of truncation, and exactly what the flag below is for.
+      timedOut = true;
+      break;
+    }
     const r = grepGraph(graph, join(root, child), pattern, {
       ignoreCase: opts.ignoreCase,
       fixed: opts.fixed,
+      in: childIn,
+      maxHits: Math.max(0, hitsLeft),
+      budgetMs: msLeft,
     });
     filesSearched += r.filesSearched;
     totalHits += r.totalHits;
+    hitsLeft -= r.totalHits;
     truncated.files += r.truncated.files;
     truncated.hits += r.truncated.hits;
+    // Rebuilding `truncated` as `{files, hits}` dropped this flag on the floor, so
+    // a workspace grep that gave up on its budget reported "no hits" as though it
+    // had searched everything — the one reading the flag exists to prevent.
+    if (r.truncated.timeout) timedOut = true;
     if (r.saved) {
       savedFiles += r.saved.files;
       savedChars += r.saved.baselineChars;
@@ -343,6 +404,7 @@ export function federateGrep(
       });
     }
   }
+  if (timedOut) truncated.timeout = true;
 
   groups.sort((a, b) => b.inDegree - a.inDegree || a.path.localeCompare(b.path));
   const saved: Savings | undefined = savedChars > 0 ? { files: savedFiles, baselineChars: savedChars } : undefined;

--- a/src/hosts/codex-hooks.ts
+++ b/src/hosts/codex-hooks.ts
@@ -12,7 +12,9 @@ import type { PlannedWrite } from './plan.js';
 export interface HookWrite {
   id: string;
   path: string;
-  action: 'created' | 'updated' | 'unchanged' | 'skipped-unparseable';
+  /** `skipped-absent`: an `onlyIfPresent` install found no graft entry to update,
+   * so nothing was written — see {@link installCodexHooks}. */
+  action: 'created' | 'updated' | 'unchanged' | 'skipped-unparseable' | 'skipped-absent';
 }
 
 function dirExists(p: string): boolean {
@@ -58,6 +60,19 @@ function isGraftEntry(entry: unknown): boolean {
   return JSON.stringify(entry).includes('graft-hooks.cjs');
 }
 
+/** Does this hooks.json already register graft anywhere? Matched on the shim's
+ * filename, the same signature `isGraftEntry` uses to replace an entry — so
+ * "there is something of ours to update" and "this is ours to replace" can never
+ * disagree. Path-independent on purpose: the entry may name another machine's
+ * shim path entirely (a synced ~/.codex), and it is still graft's own. */
+function hasGraftEntry(root: unknown): boolean {
+  const hooks = (root as { hooks?: unknown } | null)?.hooks;
+  if (typeof hooks !== 'object' || hooks === null || Array.isArray(hooks)) return false;
+  return Object.values(hooks as Record<string, unknown>).some(
+    (entries) => Array.isArray(entries) && entries.some(isGraftEntry),
+  );
+}
+
 /**
  * The graft hook entries Codex should carry, mirroring the Claude Code set:
  *   - SessionStart → orientation from `graft/INDEX.md`
@@ -79,20 +94,37 @@ function desiredEntries(): DesiredEntry[] {
   ];
 }
 
-export function installCodexHooks(home: string): HookWrite[] {
+/**
+ * @param opts.onlyIfPresent  Update graft's own entries in `~/.codex/hooks.json`
+ *   if they are already there, and otherwise write nothing at all — not even the
+ *   shim, which would be an orphan file under someone's home directory. This is
+ *   what an UNSOLICITED refresh (a fresh clone of a repo whose wiring was
+ *   committed, with no stamp or memo on this machine) is allowed to do: keeping an
+ *   existing registration pointing at the current shim is maintenance; creating a
+ *   machine-wide hook for a user who never ran `graft init` here is not.
+ */
+export function installCodexHooks(home: string, opts: { onlyIfPresent?: boolean } = {}): HookWrite[] {
   const targets = hookTargets(home);
   if (targets.length === 0) return [];
 
   const shimPath = targets[0].path;
-  const shimWrite = writeOwned('codex-hook-shim', shimPath, hooksShim(claudeDistDir()), 0o755);
   const skipped: HookWrite = { id: 'codex-hooks', path: targets[1].path, action: 'skipped-unparseable' };
 
   const cfgPath = targets[1].path;
   let root: Record<string, any> = {};
+  let unparseable = false;
   const existed = existsSync(cfgPath);
   if (existed) {
-    try { root = JSON.parse(readFileSync(cfgPath, 'utf8')); } catch { return [shimWrite, skipped]; }
+    try { root = JSON.parse(readFileSync(cfgPath, 'utf8')); } catch { unparseable = true; }
   }
+  // Decided BEFORE the shim is written, from the file as it is on disk: the shim
+  // exists only to be pointed at by these entries, so "no entry names graft" has to
+  // mean "leave this machine alone", not "leave a file behind and change nothing".
+  if (opts.onlyIfPresent && !hasGraftEntry(root)) {
+    return [{ id: 'codex-hooks', path: cfgPath, action: 'skipped-absent' }];
+  }
+  const shimWrite = writeOwned('codex-hook-shim', shimPath, hooksShim(claudeDistDir()), 0o755);
+  if (unparseable) return [shimWrite, skipped];
   if (typeof root !== 'object' || root === null || Array.isArray(root)) return [shimWrite, skipped];
   const before = JSON.stringify(root);
   const hooks = (root.hooks ??= {});

--- a/src/hosts/init.ts
+++ b/src/hosts/init.ts
@@ -42,8 +42,10 @@ export function runHostsInit(
     home?: string;
     mcp?: boolean;
     hooks?: boolean;
-    /** false → skip every write outside the repo (the ~/.codex/ targets). */
-    global?: boolean;
+    /** false → skip every write outside the repo (the ~/.codex/ targets);
+     * 'if-present' → update those targets only where graft is already registered
+     * (see `upkeep.ts#refreshOpts`). */
+    global?: boolean | 'if-present';
   } = {},
 ): HostsInitResult {
   const home = opts.home ?? homedir();
@@ -75,10 +77,11 @@ export function runHostsInit(
     opts.mcp === false
       ? []
       : registerMcpConfigs(repo, selected.map((h) => h.id), { home, global: opts.global });
-  // Every hook target is user-level, so --no-global suppresses the lot.
+  // Every hook target is user-level, so --no-global suppresses the lot — and
+  // 'if-present' downgrades it from "install" to "keep an existing install current".
   const hooks =
     opts.hooks === false || opts.global === false || !selected.some((h) => h.id === 'agents')
       ? []
-      : installCodexHooks(home);
+      : installCodexHooks(home, { onlyIfPresent: opts.global === 'if-present' });
   return { written, skipped, unknown, mcp, hooks };
 }

--- a/src/hosts/mcp-config.ts
+++ b/src/hosts/mcp-config.ts
@@ -8,15 +8,17 @@
  * `registerMcpConfigs()` walks that same list to do the writing.
  */
 import { readFileSync, writeFileSync, mkdirSync, existsSync, statSync } from 'node:fs';
-import { spawnSync } from 'node:child_process';
-import { dirname, join } from 'node:path';
+import { delimiter, dirname, join } from 'node:path';
 import { homedir } from 'node:os';
 import type { PlannedWrite } from './plan.js';
 
 export interface McpWrite {
   id: string;
   path: string;
-  action: 'created' | 'updated' | 'unchanged' | 'skipped-unparseable';
+  /** `skipped-absent`: `onlyIfPresent` was asked for and graft is not registered
+   * in this file, so there was nothing to update and creating it was not ours to
+   * do. Distinct from `unchanged`, which means graft IS registered and correct. */
+  action: 'created' | 'updated' | 'unchanged' | 'skipped-unparseable' | 'skipped-absent';
 }
 
 /** A planned MCP write, plus the detail needed to actually perform it. */
@@ -48,9 +50,59 @@ export interface McpTarget extends PlannedWrite {
 const NPX_LAUNCH = { command: 'npx', args: ['-y', '@nanonets/graft', 'mcp'] };
 const BIN_LAUNCH = { command: 'graft', args: ['mcp'] };
 
+/**
+ * Is a `graft` executable resolvable from PATH?
+ *
+ * This used to be `spawnSync('graft', ['--version'])`, which answered "no" on all of
+ * Windows: an `npm i -g` install leaves only the `graft.cmd` shim, `spawnSync`
+ * appends nothing but `.exe`, and the resulting ENOENT reads as "not installed". So
+ * every Windows `graft init` wrote the `npx` launcher the comment above spends a
+ * paragraph arguing against — and because `.mcp.json` is committed, it wrote it for
+ * the whole team, flipping back and forth in the diff as Windows and macOS devs took
+ * turns running init.
+ *
+ * Walking PATH (with PATHEXT on Windows, as `resolveClaudeBin` does) fixes both the
+ * platform bug and the cost: this ran up to seven times per `graft init` — once per
+ * host in `planInit`, again per workspace child — each one a process spawn with a
+ * 5s ceiling, inside a session-start budget of 8s. A handful of `existsSync` calls
+ * replaces all of it.
+ *
+ * Presence is the whole question, deliberately: what gets written is the bare word
+ * `graft`, so all that matters is whether the host will be able to resolve that same
+ * name. Whether the binary is currently healthy enough to answer `--version` is not
+ * something this file can fix by writing `npx` instead.
+ */
+function resolveOnPath(name: string): string | undefined {
+  // .EXE first — it runs without a shim. The empty string covers posix and any
+  // extensionless file a user dropped on PATH themselves.
+  const exts = process.platform === 'win32' ? ['.EXE', '.CMD', '.BAT', '.COM', ''] : [''];
+  for (const dir of (process.env.PATH ?? '').split(delimiter)) {
+    if (!dir) continue;
+    // PATH entries on Windows are frequently quoted; an unstripped quote makes
+    // every join under that entry miss.
+    const base = dir.replace(/^"|"$/g, '');
+    for (const ext of exts) {
+      const p = join(base, name + ext);
+      if (existsSync(p)) return p;
+    }
+  }
+  return undefined;
+}
+
+/** Memoized because `serverEntry` is called from five places and `planInit` fans it
+ * out per host: PATH does not change under a single `graft init`. Never persisted to
+ * disk — the same reason `shim-template.ts` refuses to bake a resolved path into a
+ * file that outlives the run. */
+let onPathMemo: boolean | undefined;
+
 function graftOnPath(): boolean {
-  const r = spawnSync('graft', ['--version'], { stdio: 'ignore', timeout: 5000 });
-  return r.status === 0;
+  if (onPathMemo === undefined) onPathMemo = resolveOnPath('graft') !== undefined;
+  return onPathMemo;
+}
+
+/** Test seam: drop the memoized lookup so a test can flip PATH. */
+export function resetGraftOnPathCache(): void {
+  onPathMemo = undefined;
 }
 
 /**
@@ -77,7 +129,13 @@ function dirExists(p: string): boolean {
   try { return statSync(p).isDirectory(); } catch { return false; }
 }
 
-export function mergeJsonKey(id: string, path: string, topKey: string, entry: object): McpWrite {
+export function mergeJsonKey(
+  id: string,
+  path: string,
+  topKey: string,
+  entry: object,
+  opts: { onlyIfPresent?: boolean } = {},
+): McpWrite {
   let root: Record<string, any> = {};
   const existed = existsSync(path);
   if (existed) {
@@ -87,10 +145,14 @@ export function mergeJsonKey(id: string, path: string, topKey: string, entry: ob
       return { id, path, action: 'skipped-unparseable' };
     }
   }
+  if (opts.onlyIfPresent && !existed) return { id, path, action: 'skipped-absent' };
   const bucket = (root[topKey] ??= {});
   if (typeof bucket !== 'object' || bucket === null || Array.isArray(bucket)) {
     return { id, path, action: 'skipped-unparseable' };
   }
+  // Registering graft for the first time is an INSTALL; re-pointing an entry that
+  // already names graft is maintenance. Only the second one is allowed here.
+  if (opts.onlyIfPresent && bucket.graft === undefined) return { id, path, action: 'skipped-absent' };
   if (JSON.stringify(bucket.graft) === JSON.stringify(entry)) return { id, path, action: 'unchanged' };
   const action = existed ? 'updated' : 'created';
   bucket.graft = entry;
@@ -99,10 +161,14 @@ export function mergeJsonKey(id: string, path: string, topKey: string, entry: ob
   return { id, path, action };
 }
 
-function upsertCodexToml(id: string, path: string): McpWrite {
+function upsertCodexToml(id: string, path: string, opts: { onlyIfPresent?: boolean } = {}): McpWrite {
   const existed = existsSync(path);
   const text = existed ? readFileSync(path, 'utf8') : '';
   if (/^\[mcp_servers\.graft\]$/m.test(text)) return { id, path, action: 'unchanged' };
+  // Append-if-absent is exactly the "absent" half `onlyIfPresent` forbids, so under
+  // it this file is only ever read. (The section carries no version, so a present
+  // one is never stale — which is why the branch above already returns unchanged.)
+  if (opts.onlyIfPresent) return { id, path, action: 'skipped-absent' };
   const { command, args } = serverEntry();
   const argList = args.map((a) => JSON.stringify(a)).join(", ");
   const section = `[mcp_servers.graft]\ncommand = \"${command}\"\nargs = [${argList}]\n`;
@@ -170,13 +236,18 @@ export function mcpTargets(
 export function registerMcpConfigs(
   repo: string,
   ids: string[],
-  opts: { home?: string; global?: boolean } = {},
+  opts: { home?: string; global?: boolean | 'if-present' } = {},
 ): McpWrite[] {
+  // 'if-present' applies ONLY to the out-of-repo targets. A repo-scoped file
+  // (`.cursor/mcp.json`, `opencode.json`) is part of the wiring the refresh exists
+  // to maintain, and creating one there is what `graft init` already decided.
+  const onlyIfPresent = opts.global === 'if-present';
   return mcpTargets(repo, ids, opts)
     .filter((t) => opts.global !== false || t.scope !== 'global')
-    .map((t) =>
-      t.format === 'toml'
-        ? upsertCodexToml(t.id, t.path)
-        : mergeJsonKey(t.id, t.path, t.topKey!, t.entry!),
-    );
+    .map((t) => {
+      const guard = { onlyIfPresent: onlyIfPresent && t.scope === 'global' };
+      return t.format === 'toml'
+        ? upsertCodexToml(t.id, t.path, guard)
+        : mergeJsonKey(t.id, t.path, t.topKey!, t.entry!, guard);
+    });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,13 +27,21 @@ export type { GraphCheckResult, GraphCheckOptions } from "./graph/check.js";
 export type { ContextNode, NodeLink, SourceRef, Manifest } from "./context/node-file.js";
 
 export type { EngineConfig, ResolvedConfig } from "./ai/providers.js";
-export { resolveConfig, DEFAULTS, DEFAULT_MODELS } from "./ai/providers.js";
+export { resolveConfig, credentialProblem, DEFAULTS, DEFAULT_MODELS } from "./ai/providers.js";
 
 // Provider transport, for advanced/custom setups.
 export type { ChatModel, ChatRequest, ChatResponse, Message, ToolSpec, ToolCall, Usage } from "./ai/llm/types.js";
-export { createChatModel, type ProviderKind, type ChatModelConfig } from "./ai/llm/factory.js";
+export {
+  createChatModel,
+  providerNeedsKey,
+  PROVIDER_KINDS,
+  type ProviderKind,
+  type ChatModelConfig,
+} from "./ai/llm/factory.js";
 export { OpenAIChatModel } from "./ai/llm/openai.js";
 export { AnthropicChatModel } from "./ai/llm/anthropic.js";
+export { ClaudeCliChatModel, claudeCliAvailable, resolveClaudeBin } from "./ai/llm/claude-cli.js";
+export type { ClaudeCliChatModelOptions, ClaudeCliRunner, ClaudeCliResult } from "./ai/llm/claude-cli.js";
 
 // Engine ops, for advanced/custom setups.
 export { ChatSynthesizer } from "./ai/synthesize.js";

--- a/src/ingest/fs.ts
+++ b/src/ingest/fs.ts
@@ -59,7 +59,38 @@ export function shouldSkipDir(name: string, includes?: ReadonlySet<string>): boo
  * index it, the same contract as tracked-but-ignored files).
  */
 export function walkDir(dir: string, includes?: ReadonlySet<string>): string[] {
+  assertRepoDir(dir);
   return gitVisibleFiles(dir, includes) ?? walkFilesystem(dir, includes);
+}
+
+/**
+ * Fail on a bad `[dir]` here, where the argument is still named, rather than four
+ * frames down in `readdirSync`.
+ *
+ * `graft build ./typo` used to reach the user as `ENOENT: no such file or directory,
+ * scandir 'C:\...'` — cli.ts's top-level handler prints `err.message` and nothing else,
+ * so the message never mentioned `graft build` or which argument was wrong. Every
+ * command that takes a repo root funnels through this walk, so validating once here
+ * covers `build`, `init` and `check` without each of them remembering to.
+ *
+ * Note the git path can't do this check for us: `gitVisibleFiles` spawns with
+ * `cwd: root`, and a spawn into a nonexistent cwd merely returns an error, which the
+ * walker fail-softs into the filesystem fallback.
+ *
+ * Exported because the walk is not always the FIRST thing a command does with the
+ * argument: `graft build ./typo --include-dir x` persisted a config file first, and
+ * `writeJsonAtomic` mkdir's recursively — so a typo silently created the directory
+ * it was complaining about. cli.ts calls this up front for exactly that reason; the
+ * check stays here so both callers can never disagree on the wording.
+ */
+export function assertRepoDir(dir: string): void {
+  let stat;
+  try {
+    stat = statSync(dir);
+  } catch {
+    throw new Error(`✗ ${dir}: no such directory — pass a repository root`);
+  }
+  if (!stat.isDirectory()) throw new Error(`✗ ${dir}: not a directory — pass a repository root`);
 }
 
 /** Git's canonical working-tree file set, relative to `dir`. Tracked files are
@@ -80,8 +111,19 @@ function gitVisibleFiles(dir: string, includes?: ReadonlySet<string>): string[] 
   if (result.status !== 0 || result.error || typeof result.stdout !== "string") return null;
 
   const out: string[] = [];
+  // `ls-files` prints one line PER INDEX STAGE, so during a merge conflict every
+  // unmerged path arrives three times (stages 1/2/3). Nothing downstream deduplicates:
+  // `listSourceStats` yields three SourceStats with the same `rel`, and build.ts's loop
+  // re-parses and re-pushes the same nodes three times, minting three nodes per id.
+  // `checkGraphInvariants` then reports `duplicate node id`, meta.nodeCount is inflated,
+  // and `ask` scores the same body 3×. The Claude Code `Stop` hook runs a build at the
+  // end of every turn, so this fires on its own in the middle of a conflicted merge.
+  // A Set rather than git's `--deduplicate` flag: that flag needs git >= 2.31 and this
+  // has to hold on whatever git the user has.
+  const seen = new Set<string>();
   for (const rel of result.stdout.split("\0")) {
-    if (!rel || skippedPath(rel, includes)) continue;
+    if (!rel || seen.has(rel) || skippedPath(rel, includes)) continue;
+    seen.add(rel);
     const abs = resolve(root, rel);
     try {
       const stat = lstatSync(abs);

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -12,7 +12,7 @@ import { contextDirFor } from '../context/node-file.js';
 import { resolveSymbol, edgeWalk, type Direction, type EdgeHit } from '../graph/traverse.js';
 import { callersSavings, headerOf, hitLine, looseNoteFor } from '../graph/traverse-cli.js';
 import { withSavings } from '../context/savings.js';
-import { grepGraph } from '../search/grep.js';
+import { grepGraph, type GrepResult } from '../search/grep.js';
 import { formatGrepResult, zeroHitNote } from '../search/grep-cli.js';
 import { buildRepoMap, formatRepoMap } from '../graph/map.js';
 import {
@@ -123,6 +123,35 @@ export const TOOLS: ToolDef[] = [
   },
 ];
 
+/**
+ * The `depth` arg, normalized the SAME way on both the single-graph and the
+ * workspace path.
+ *
+ * `depth: "all"` (or `"full"`) walks the full transitive closure — every
+ * connected source — terminating when no new node is reached. It used to be
+ * honoured only by the single-graph branch; the workspace branch tested
+ * `typeof depth === 'number'` first, so `"all"` fell through to `undefined` and
+ * the walk quietly ran at depth 1. A monorepo user following the tool's own
+ * "pass 'all' … every source that would be affected" got the direct callers
+ * only, and no indication anything was cut — exactly the wrong answer to give
+ * someone about to start a multi-file refactor. `Math.floor(Infinity)` is
+ * `Infinity`, so `federateCallers`' own clamp passes it straight through.
+ */
+export function parseDepth(depth: unknown): number {
+  if (depth === 'all' || depth === 'full') return Number.POSITIVE_INFINITY;
+  if (typeof depth === 'number' && Number.isFinite(depth) && depth >= 1) return Math.floor(depth);
+  return 1;
+}
+
+/** Loud note when a grep gave up on its wall-clock budget: the remaining
+ * indexed files were never searched, so "no hits" here means "gave up", not
+ * "not there". Silence would read as a complete answer. */
+function grepTimeoutNote(timedOut: boolean | undefined): string | null {
+  return timedOut
+    ? '(truncated: search hit its time budget — some indexed files were never searched; narrow with `in` or simplify the pattern)'
+    : null;
+}
+
 /** Render every resolved match's header + edge report (or the loud zero-edge
  * note), one block per match, joined with a blank line — the same grouping
  * `graft callers` uses for multi-match symbols. `showDepth` tags each hit with
@@ -168,7 +197,7 @@ async function callWorkspaceTool(
       if (!symbol) return { text: 'graft_trace_calls requires a symbol', isError: true };
       const { text, found } = federateCallers(root, dirOverride, symbol, {
         direction: args.direction === 'out' ? 'out' : 'in',
-        depth: typeof args.depth === 'number' && Number.isFinite(args.depth) ? args.depth : undefined,
+        depth: parseDepth(args.depth),
         in: typeof args.in === 'string' && args.in ? args.in : undefined,
       });
       return { text, isError: !found };
@@ -176,12 +205,27 @@ async function callWorkspaceTool(
     case 'graft_find_all': {
       const pattern = String(args.pattern ?? '');
       if (!pattern) return { text: 'graft_find_all requires a pattern', isError: true };
-      const { result, coverage } = federateGrep(root, dirOverride, pattern, {
-        ignoreCase: typeof args.ignore_case === 'boolean' ? args.ignore_case : undefined,
-        fixed: typeof args.fixed === 'boolean' ? args.fixed : undefined,
-      });
-      const text = result.totalHits === 0 ? zeroHitNote(result) : formatGrepResult(result);
-      return { text: coverage ? `${text}\n${coverage}` : text, isError: false };
+      // `in` is applied for real now (`federateGrep` narrows to the named child and,
+      // past the first segment, to a path prefix inside it), so this no longer has
+      // to refuse it. It still must never be silently dropped: a caller that
+      // believes it scoped the search to one package and reads a result set drawn
+      // from all of them is the worst of the three outcomes. An unknown first
+      // segment throws, and the catch below renders that as the tool's error.
+      const inArg = typeof args.in === 'string' && args.in ? args.in : undefined;
+      let result: GrepResult;
+      let coverage: string;
+      try {
+        ({ result, coverage } = federateGrep(root, dirOverride, pattern, {
+          ignoreCase: typeof args.ignore_case === 'boolean' ? args.ignore_case : undefined,
+          fixed: typeof args.fixed === 'boolean' ? args.fixed : undefined,
+          in: inArg,
+        }));
+      } catch (err) {
+        return { text: `graft_find_all: ${err instanceof Error ? err.message : String(err)}`, isError: true };
+      }
+      const base = result.totalHits === 0 ? zeroHitNote(result) : formatGrepResult(result);
+      const text = [base, grepTimeoutNote(result.truncated.timeout), coverage].filter(Boolean).join('\n');
+      return { text, isError: false };
     }
     case 'graft_repo_map': {
       const maxDirs = typeof args.max_dirs === 'number' && Number.isFinite(args.max_dirs) && args.max_dirs > 0 ? args.max_dirs : undefined;
@@ -298,14 +342,7 @@ async function callSingleTool(
         const matches = resolveSymbol(w, symbol, inOpt);
         if (matches.length === 0) return { text: unknownSymbolText(symbol), isError: true };
         const direction: Direction = args.direction === 'out' ? 'out' : 'in';
-        // `depth: "all"` (or a huge number) walks the full transitive closure —
-        // every connected source — terminating when no new node is reached.
-        const depth =
-          args.depth === 'all' || args.depth === 'full'
-            ? Number.POSITIVE_INFINITY
-            : typeof args.depth === 'number' && Number.isFinite(args.depth) && args.depth >= 1
-              ? Math.floor(args.depth)
-              : 1;
+        const depth = parseDepth(args.depth);
         const results = matches.map((m) => ({ symbol: m, hits: edgeWalk(w, m, direction, depth) }));
         const byId = new Map(results.map((r) => [r.symbol.id, r.hits]));
         const body = renderMatches(direction, depth > 1, matches, (m) => byId.get(m.id) ?? []);
@@ -322,8 +359,9 @@ async function callSingleTool(
           fixed: typeof args.fixed === 'boolean' ? args.fixed : undefined,
           in: typeof args.in === 'string' && args.in ? args.in : undefined,
         });
-        if (result.totalHits === 0) return { text: zeroHitNote(result), isError: false };
-        return { text: formatGrepResult(result), isError: false };
+        const base = result.totalHits === 0 ? zeroHitNote(result) : formatGrepResult(result);
+        const timeout = grepTimeoutNote(result.truncated.timeout);
+        return { text: timeout ? `${base}\n${timeout}` : base, isError: false };
       }
       case 'graft_repo_map': {
         const w = loadGraphCached(contextDirFor(root, dirOverride));

--- a/src/search/grep-cli.ts
+++ b/src/search/grep-cli.ts
@@ -41,9 +41,14 @@ export function formatGrepHeader(result: GrepResult): string {
 
 /** Loud truncation note — dropped counts are never silent. */
 function truncationNote(result: GrepResult): string | null {
-  const { files, hits } = result.truncated;
-  if (files === 0 && hits === 0) return null;
+  const { files, hits, timeout } = result.truncated;
+  if (files === 0 && hits === 0 && !timeout) return null;
   const parts: string[] = [];
+  // First, because it is the only one that means "files were never looked at":
+  // the other two are counted drops within a complete pass. The MCP side already
+  // surfaced it (`mcp/tools.ts#grepTimeoutNote`); the CLI reported the timeout
+  // as nothing at all, so a scan that gave up looked like a finished one.
+  if (timeout) parts.push("search hit its time budget — some indexed files were never searched");
   if (hits > 0) parts.push(`${hits} more hit${hits === 1 ? "" : "s"} beyond the cap`);
   if (files > 0) parts.push(`${files} indexed file${files === 1 ? "" : "s"} unreadable`);
   return `(truncated: ${parts.join(", ")} — narrow with --in or refine the pattern)`;
@@ -71,8 +76,15 @@ export function formatGrepResult(result: GrepResult): string {
  * otherwise a zero-hit result on a stale graph or wrong root reads as "no
  * matches" when really some files were never searched at all. */
 export function zeroHitNote(result: GrepResult): string {
+  const { files, timeout } = result.truncated;
+  // The timeout case has to replace the sentence, not append to it: "All indexed
+  // code was searched" is FALSE under a timeout, and a zero-hit answer there means
+  // "gave up", not "not there" — the reading that sends someone off believing a
+  // symbol doesn't exist in the repo.
+  if (timeout) {
+    return `no hits yet for "${result.pattern}" — the search hit its time budget after ${result.filesSearched} indexed files and the rest were never searched. This is "gave up", not "not there": narrow with --in, or simplify the pattern (a nested-quantifier regex can backtrack catastrophically on one line)`;
+  }
   const base = `no hits for "${result.pattern}" in ${result.filesSearched} indexed files. The pattern may be too specific — retry graft grep with a bare symbol name or short substring (drop the receiver, full signature, and regex anchors). All indexed code was searched; use raw grep -rn only for genuinely unindexed files (docs, configs, brand-new files)`;
-  const { files } = result.truncated;
   if (files === 0) return base;
   return `${base} — note: ${files} indexed file${files === 1 ? "" : "s"} could not be read (stale graph? run graft build)`;
 }

--- a/src/search/grep.ts
+++ b/src/search/grep.ts
@@ -56,8 +56,10 @@ export interface GrepResult {
   groups: GrepGroup[];
   /** Dropped counts — never silent. `files`: indexed file nodes that
    * couldn't be read from disk. `hits`: matches found beyond `maxHits`,
-   * counted but not collected. */
-  truncated: { files: number; hits: number };
+   * counted but not collected. `timeout`: the scan hit its wall-clock budget
+   * and stopped early, so the remaining indexed files were never searched —
+   * a zero-hit answer under this flag means "gave up", not "not there". */
+  truncated: { files: number; hits: number; timeout?: boolean };
   /** Tokens-saved baseline: the files that had hits, read whole. Undefined
    * when there were no hits or the graph predates file sizing. */
   saved?: Savings;
@@ -73,9 +75,36 @@ export interface GrepOptions {
   /** Stop collecting hits after this many; the rest are tallied into
    * `truncated.hits`. Default 300. */
   maxHits?: number;
+  /** Wall-clock ceiling for the whole scan, in ms. Default
+   * {@link DEFAULT_BUDGET_MS}. Exposed mainly so tests can pick a budget
+   * small enough to observe without burning seconds. */
+  budgetMs?: number;
 }
 
-const DEFAULT_MAX_HITS = 300;
+/** Exported because workspace federation has to spend this ONE budget across the
+ * children rather than give each its own — see `graph/workspace.ts#federateGrep`. */
+export const DEFAULT_MAX_HITS = 300;
+
+/**
+ * Wall-clock ceiling for a single `grepGraph` call.
+ *
+ * The pattern is attacker-controlled in practice: it arrives raw from
+ * `graft_find_all`, i.e. from whatever the model decided to type, and the MCP
+ * server reads its JSON-RPC lines synchronously on the one event loop. A
+ * classic catastrophic-backtracking pattern (`(a+)+$` against a line of a's)
+ * takes exponential time per line, so without a ceiling one tool call wedges
+ * the whole server for minutes — and `notifications/cancelled` is a no-op,
+ * there is nothing to cancel with.
+ *
+ * This bounds the AGGREGATE scan, checked between lines. It cannot interrupt a
+ * single `RegExp.test` already inside the engine — JS has no regex timeout and
+ * `grepGraph` is synchronous by contract (both the CLI and the MCP tool call it
+ * inline) — so one pathological line can still overshoot. What it does buy is
+ * that the cost stops scaling with the repo: the damage is one line's
+ * backtracking instead of one line's backtracking times every line of every
+ * indexed file.
+ */
+export const DEFAULT_BUDGET_MS = 5_000;
 const MAX_HIT_TEXT = 160;
 const SPAN_RE = /^L(\d+)-L(\d+)$/;
 
@@ -95,17 +124,29 @@ interface SymbolSpan {
   end: number;
 }
 
-/** The file's symbol nodes, sorted ascending by span start — the order
- * `enclosingSymbol` scans in to find the innermost containing span. */
-function symbolsOf(graph: GraphV1, path: string): SymbolSpan[] {
-  const out: SymbolSpan[] = [];
+/**
+ * Every file's symbol nodes, bucketed by path and sorted ascending by span
+ * start — the order `enclosingSymbol` scans in to find the innermost
+ * containing span.
+ *
+ * Built ONCE per call rather than re-scanned per file. The per-file version
+ * walked all of `graph.nodes` for each file node, so grouping alone cost
+ * O(files x nodes) — 33k nodes over 3k files (the scale this repo's own ask
+ * index cites) burned ~0.5s of CPU before a single byte was read from disk,
+ * and doubling the repo quadrupled it. Every `graft_find_all` call paid that.
+ */
+function symbolsByPath(graph: GraphV1): Map<string, SymbolSpan[]> {
+  const byPath = new Map<string, SymbolSpan[]>();
   for (const n of graph.nodes) {
-    if (n.kind === "file" || n.path !== path) continue;
+    if (n.kind === "file") continue;
     const b = spanBounds(n.span);
-    if (b) out.push({ node: n, start: b.start, end: b.end });
+    if (!b) continue;
+    let bucket = byPath.get(n.path);
+    if (!bucket) byPath.set(n.path, (bucket = []));
+    bucket.push({ node: n, start: b.start, end: b.end });
   }
-  out.sort((a, b) => a.start - b.start);
-  return out;
+  for (const bucket of byPath.values()) bucket.sort((a, b) => a.start - b.start);
+  return byPath;
 }
 
 /** Innermost symbol containing `line`: among spans that contain it, the one
@@ -152,12 +193,25 @@ export function grepGraph(graph: GraphV1, repoRoot: string, pattern: string, opt
     (n) => n.kind === "file" && (inPrefix === undefined || pathUnderPrefix(n.path, inPrefix)),
   );
 
+  const symbolIndex = symbolsByPath(graph);
   const groups = new Map<string, GrepGroup>();
   let collected = 0;
   let truncatedHits = 0;
   let truncatedFiles = 0;
+  const deadline = Date.now() + (opts.budgetMs ?? DEFAULT_BUDGET_MS);
+  let timedOut = false;
+
+  // Counted as we go rather than taken from `fileNodes.length`: on a timeout
+  // the remaining files were never opened, and reporting them as "searched"
+  // would make the give-up look like a complete pass.
+  let filesSearched = 0;
 
   for (const file of fileNodes) {
+    if (Date.now() > deadline) {
+      timedOut = true;
+      break;
+    }
+    filesSearched++;
     let text: string;
     try {
       const decoded = readSourceFile(join(repoRoot, file.path));
@@ -171,10 +225,20 @@ export function grepGraph(graph: GraphV1, repoRoot: string, pattern: string, opt
       continue;
     }
 
-    const symbols = symbolsOf(graph, file.path);
-    const lines = text.split("\n");
+    const symbols = symbolIndex.get(file.path) ?? [];
+    // `\r?` matters: with git's Windows default (core.autocrlf=true) the whole
+    // working tree is CRLF on disk, and splitting on "\n" alone leaves a
+    // trailing \r on every line. Any end-anchored pattern — `foo$`, `;\s*$`,
+    // `=>\s*{$` — then matches nothing at all, silently, on the platform where
+    // most of the tree looks like that. readSourceFile hands back the bytes
+    // untouched, so the normalization has to happen here.
+    const lines = text.split(/\r?\n/);
 
     for (let i = 0; i < lines.length; i++) {
+      if (Date.now() > deadline) {
+        timedOut = true;
+        break;
+      }
       const raw = lines[i];
       if (!regex.test(raw)) continue;
 
@@ -206,10 +270,12 @@ export function grepGraph(graph: GraphV1, repoRoot: string, pattern: string, opt
 
   return {
     pattern,
-    filesSearched: fileNodes.length,
+    filesSearched,
     totalHits: collected,
     groups: sortedGroups,
-    truncated: { files: truncatedFiles, hits: truncatedHits },
+    truncated: timedOut
+      ? { files: truncatedFiles, hits: truncatedHits, timeout: true }
+      : { files: truncatedFiles, hits: truncatedHits },
     saved: savingsFor(graph, sortedGroups.map((g) => g.path)),
   };
 }

--- a/src/upkeep-run.ts
+++ b/src/upkeep-run.ts
@@ -36,13 +36,34 @@ export interface UpkeepResult {
  * safe to replay — `installCodexHooks` no-ops when `~/.codex` is absent, rewrites
  * only its own entry (matched on `graft-hooks.cjs`), and reports `unchanged` when
  * the bytes match. A user who declined them at init time is honoured via
- * `opts.global`/`opts.hooks`, replayed from the stamp.
+ * `opts.global`/`opts.hooks`, replayed from the stamp (or, when the stamp went with
+ * a `graft/` that is git-ignored, from the machine-global memo beside it).
+ *
+ * Returns init's warnings rather than dropping them: this path — not the CLI — is
+ * how most repos get re-inited, so a warning only the CLI printed (say, "your
+ * settings.json is not valid JSON, left untouched") would never reach the one
+ * person who needs it.
  */
-function rewriteWiring(repo: string, hosts: string[], opts: WiringOpts): void {
-  if (hosts.includes('claude')) runInit(repo, { build: false, cliPath: graftCliPath() });
+function rewriteWiring(
+  repo: string,
+  hosts: string[],
+  opts: WiringOpts,
+): { warnings: string[]; offeredAllow?: string[] } {
+  const warnings: string[] = [];
+  let offeredAllow: string[] | undefined;
+  if (hosts.includes('claude')) {
+    const r = runInit(repo, { build: false, cliPath: graftCliPath() });
+    warnings.push(...r.warnings);
+    // Handed back so `reconcileWiring` can put it in the stamp it writes right
+    // after this returns: that stamp is the only record of which permissions were
+    // ever offered here, and without it the next refresh re-adds the ones the user
+    // deleted — into a file the whole team pulls.
+    offeredAllow = r.offeredAllow;
+  }
   const others = hosts.filter((h) => h !== 'claude');
   if (others.length)
     runHostsInit(repo, { agents: others, global: opts.global, mcp: opts.mcp, hooks: opts.hooks });
+  return { warnings, offeredAllow };
 }
 
 /**
@@ -58,9 +79,18 @@ export function runUpkeep(
 ): UpkeepResult {
   const lines: string[] = [];
   try {
-    const refreshed = reconcileWiring(repo, current, { rewrite: rewriteWiring });
+    const warnings: string[] = [];
+    const refreshed = reconcileWiring(repo, current, {
+      rewrite: (r, h, o) => {
+        const res = rewriteWiring(r, h, o);
+        warnings.push(...res.warnings);
+        return { offeredAllow: res.offeredAllow };
+      },
+      home: opts.home,
+    });
     const refreshLine = formatWiringRefresh(refreshed);
     if (refreshLine) lines.push(refreshLine);
+    for (const w of warnings) lines.push(`⚠ ${w}`);
   } catch { /* fail-soft: wiring refresh is never worth breaking a session for */ }
   try {
     if (opts.background !== false) maybeRefreshInBackground(opts.home);

--- a/src/upkeep.ts
+++ b/src/upkeep.ts
@@ -26,7 +26,8 @@
  */
 import { existsSync, readFileSync } from 'node:fs';
 import { spawn } from 'node:child_process';
-import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+import { join, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { readJson, writeJsonAtomic, cacheDir } from './util/state.js';
 import { HOSTS } from './hosts/registry.js';
@@ -163,8 +164,14 @@ export function formatUpdateNudge(current: string, latest: string | null | undef
  * all true, which is what plain `graft init` does.
  */
 export interface WiringOpts {
-  /** false → never write outside the repo (`--no-global`). */
-  global: boolean;
+  /**
+   * Out-of-repo writes (`~/.codex/hooks.json`, `~/.codex/config.toml`):
+   *   true          write them (a plain `graft init`)
+   *   false         never (`graft init --no-global`)
+   *   'if-present'  UPDATE graft's own entries where they already exist, never
+   *                 create them — see {@link refreshOpts}.
+   */
+  global: boolean | 'if-present';
   /** false → skip MCP server registration (`--no-mcp`). */
   mcp: boolean;
   /** false → skip hook installation (`--no-hooks`). */
@@ -186,11 +193,19 @@ export interface WiringStamp {
   hosts: string[];
   /** The init flags to replay — see {@link WiringOpts}. */
   opts?: Partial<WiringOpts>;
+  /** The `.claude/settings.json` allow entries a previous init PROPOSED here.
+   * One of them missing from the file now means it was removed on purpose, so the
+   * next init leaves it out — see `claude/settings-merge.ts#mergeGraftSettings`.
+   * Absent (an older stamp, or a machine that never ran init here) means "no
+   * record", and every entry is offered as before. */
+  offeredAllow?: string[];
   at: string;
 }
 
 /** Under `graft/.cache/`, beside the other derived state: git-ignored, per-clone,
- * and cheap to lose — a missing stamp just means one idempotent refresh. */
+ * and cheap to lose — a missing stamp just means one idempotent refresh. What must
+ * NOT be lost with it is the user's flags; those are mirrored to
+ * {@link wiringMemoPath}, outside the repo. */
 export function stampPath(repo: string): string {
   return join(cacheDir(repo), 'wiring-stamp.json');
 }
@@ -199,21 +214,84 @@ export function readStamp(repo: string): WiringStamp | null {
   return readJson<WiringStamp>(stampPath(repo));
 }
 
+/**
+ * The same flags, kept a second time OUTSIDE the repo.
+ *
+ * The stamp lives under `graft/.cache/`, which graft adds to `.gitignore` — so it
+ * is absent from every fresh clone and from any repo where someone deleted
+ * `graft/`. With only the stamp, `--no-global` evaporated exactly there: no stamp
+ * meant `DEFAULT_WIRING_OPTS`, and the first session in that clone rewrote
+ * `~/.codex/hooks.json` and `~/.codex/config.toml` — machine-wide files, shared by
+ * every project — for a user who had explicitly said "keep out of ~/.codex".
+ *
+ * Keyed by the repo's absolute path, hashed: the path itself would leak a directory
+ * layout into a filename, and on Windows the same repo reaches us with different
+ * casing and separators from different callers.
+ */
+export function wiringMemoPath(repo: string, home: string = homedir()): string {
+  const key = resolve(repo).replace(/[\\/]+$/, '');
+  const norm = process.platform === 'win32' ? key.toLowerCase().replace(/\\/g, '/') : key;
+  return join(home, '.graft', 'wiring', `${createHash('sha256').update(norm).digest('hex').slice(0, 16)}.json`);
+}
+
+interface WiringMemo {
+  /** Absolute repo path, for a human reading `~/.graft/wiring/` — never matched on. */
+  repo: string;
+  opts: Partial<WiringOpts>;
+  /** Mirrored from the stamp for the same reason the flags are: `graft/` is
+   * git-ignored, so the stamp is gone from every fresh clone and every repo where
+   * someone deleted the graph — and a forgotten offer is a re-added permission. */
+  offeredAllow?: string[];
+  at: string;
+}
+
+export function readWiringMemo(repo: string, home?: string): WiringMemo | null {
+  return readJson<WiringMemo>(wiringMemoPath(repo, home));
+}
+
+/**
+ * The allow entries a previous init already proposed for this repo, or undefined
+ * when nothing here remembers one.
+ *
+ * The distinction undefined vs `[]` matters: `[]` would say "a previous init
+ * offered nothing", which suppresses nothing; undefined says "no record", and the
+ * merge then offers the full set exactly as it did before this existed.
+ */
+export function priorAllowOffers(repo: string, home?: string): string[] | undefined {
+  return readStamp(repo)?.offeredAllow ?? readWiringMemo(repo, home)?.offeredAllow;
+}
+
 export function writeStamp(
   repo: string,
   version: string,
   hosts: string[],
   opts: Partial<WiringOpts> = {},
   at = new Date().toISOString(),
+  home?: string,
+  offeredAllow?: string[],
 ): void {
+  const full = { ...DEFAULT_WIRING_OPTS, ...opts };
+  // Carried over when this run has nothing to say (Claude Code wasn't in `hosts`,
+  // or its settings.json was unparseable so nothing was proposed): dropping the
+  // record would re-offer, on the next init, every permission the user removed.
+  const offered = offeredAllow ?? priorAllowOffers(repo, home);
   try {
     writeJsonAtomic(stampPath(repo), {
       version,
       hosts: [...hosts].sort(),
-      opts: { ...DEFAULT_WIRING_OPTS, ...opts },
+      opts: full,
+      ...(offered ? { offeredAllow: offered } : {}),
       at,
     } satisfies WiringStamp);
   } catch { /* unwritable graft/ — a refresh will just be retried next session */ }
+  try {
+    writeJsonAtomic(wiringMemoPath(repo, home), {
+      repo: resolve(repo),
+      opts: full,
+      ...(offered ? { offeredAllow: offered } : {}),
+      at,
+    } satisfies WiringMemo);
+  } catch { /* unwritable home — the stamp alone still covers the common case */ }
 }
 
 /**
@@ -242,9 +320,10 @@ export interface WiringRefresh {
   from: string;
   to: string;
   hosts: string[];
-  /** True when the refresh included writes outside the repo (`~/.codex/`), so the
-   * caller can say so — a session changing machine-wide config should be visible. */
-  global: boolean;
+  /** Whether the refresh could write outside the repo (`~/.codex/`), so the caller
+   * can say so — a session changing machine-wide config should be visible.
+   * `'if-present'` means it only refreshed entries that were already there. */
+  global: boolean | 'if-present';
 }
 
 /**
@@ -255,12 +334,42 @@ export interface WiringRefresh {
  * rebuild there would stall the agent's first turn), and no-ops when the repo has
  * no graft wiring at all.
  */
+/**
+ * The flags a refresh replays, and how sure we are of them.
+ *
+ * The distinction that matters is "did anyone ever run `graft init` on THIS
+ * machine for this repo". A stamp or a memo says yes — replay what they chose. Both
+ * missing says no: someone cloned a repo whose wiring was committed (the epilogue
+ * tells them to commit it) and opened a session. Rewriting the repo's own files
+ * there is maintenance; CREATING config in `~/.codex` there is graft granting
+ * itself machine-wide config on behalf of a user who never asked for it.
+ *
+ * Hence `'if-present'` rather than a flat `false`. A flat `false` also abandoned the
+ * `~/.codex` entries of every install that predates the stamp: those users DID run
+ * `graft init`, there is simply no record of it on this machine, and nothing else
+ * ever refreshes those files (no skill, rule file or MCP instruction tells an agent
+ * to re-run init) — so an upgrade would leave them pointing at an old shim forever.
+ * Updating an entry that is already there cannot be graft helping itself to
+ * anything: the entry is the user's own earlier "yes", and it names graft.
+ */
+export function refreshOpts(stamp: WiringStamp | null, memo: WiringMemo | null): WiringOpts {
+  if (stamp) return wiringOpts(stamp); // includes a pre-flags stamp: init ran here, wiring everything
+  if (memo) return { ...DEFAULT_WIRING_OPTS, ...memo.opts };
+  return { ...DEFAULT_WIRING_OPTS, global: 'if-present' };
+}
+
 export function reconcileWiring(
   repo: string,
   current: string,
   deps: {
     wired?: (repo: string) => string[];
-    rewrite: (repo: string, hosts: string[], opts: WiringOpts) => void;
+    /** Returns what the rewrite proposed, so the stamp written below records it.
+     * The two used to be independent — this function wrote the stamp AFTER the
+     * rewrite and would have clobbered anything the rewrite tried to record on its
+     * own, so the offer list had to come back through the return value. */
+    rewrite: (repo: string, hosts: string[], opts: WiringOpts) => { offeredAllow?: string[] } | void;
+    /** Overridable so a test never reads or writes the real `~/.graft`. */
+    home?: string;
   },
 ): WiringRefresh | null {
   try {
@@ -274,9 +383,9 @@ export function reconcileWiring(
     const onDisk = (deps.wired ?? wiredHostIds)(repo);
     const hosts = [...new Set([...(stamp?.hosts ?? []), ...onDisk])].sort();
     if (hosts.length === 0) return null; // never wired here — not our business
-    const opts = wiringOpts(stamp);
-    deps.rewrite(repo, hosts, opts);
-    writeStamp(repo, current, hosts, opts);
+    const opts = refreshOpts(stamp, stamp ? null : readWiringMemo(repo, deps.home));
+    const done = deps.rewrite(repo, hosts, opts);
+    writeStamp(repo, current, hosts, opts, undefined, deps.home, done?.offeredAllow);
     return { from: stamp?.version ?? 'unwired', to: current, hosts, global: opts.global };
   } catch {
     return null; // a refresh is an optimization; never fail the caller over it
@@ -286,7 +395,15 @@ export function reconcileWiring(
 export function formatWiringRefresh(r: WiringRefresh | null): string | null {
   if (!r) return null;
   // Name the out-of-repo writes explicitly: those are machine-wide and shared by
-  // every repo, so a user seeing this line should not have to guess what moved.
-  const scope = r.global && r.hosts.includes('agents') ? " (including this machine's ~/.codex config)" : '';
+  // every repo, so a user seeing this line should not have to guess what moved. The
+  // 'if-present' wording is the honest one for an unsolicited refresh — it may have
+  // touched nothing out there at all, and claiming otherwise would be alarming.
+  const codex = r.hosts.includes('agents');
+  const scope =
+    !codex || r.global === false
+      ? ''
+      : r.global === 'if-present'
+        ? " (refreshing this machine's ~/.codex entries where graft was already registered)"
+        : " (including this machine's ~/.codex config)";
   return `· graft refreshed this repo's agent wiring${scope} (written by ${r.from}, now ${r.to}): ${r.hosts.join(', ')}.`;
 }

--- a/src/util/num.ts
+++ b/src/util/num.ts
@@ -1,0 +1,20 @@
+/**
+ * Number formatting for text graft emits.
+ *
+ * `toLocaleString()` with no locale follows the MACHINE's locale, which is the
+ * wrong authority for two of graft's outputs. The savings lines are read by an
+ * LLM and explicitly ask it to sum them across calls; on a pt-BR/de-DE box the
+ * bare call renders 1990 as "1.990", which an agent reads as 1.99 — so the
+ * headline "tokens saved this turn" total comes out ~1000× low. The graph's own
+ * stats are compared across machines and CI, where a separator that moves with
+ * the host makes two identical runs look different.
+ *
+ * One pinned locale for both: the output is a data interchange format that
+ * happens to be human-readable, not localized UI.
+ */
+const FORMATTER = new Intl.NumberFormat("en-US");
+
+/** Thousands-separated integer, identical on every machine. */
+export function formatCount(n: number): string {
+  return FORMATTER.format(Math.round(n));
+}

--- a/src/util/source.ts
+++ b/src/util/source.ts
@@ -6,5 +6,16 @@ export function readSourceFile(path: string): string | null {
   const bytes = readFileSync(path);
   if (bytes[0] === 0xfe && bytes[1] === 0xff) return null;
   if (bytes[0] === 0xff && bytes[1] === 0xfe) return bytes.subarray(2).toString("utf16le");
+  // A UTF-8 BOM has to come off here, not be left for the grammar: U+FEFF is category
+  // Cf, not whitespace, and only the TS/JS and Python grammars list it in `extras`.
+  // Every breadth grammar whose extras are just `/\s/` (Go, Java, C, C#, Rust…) starts
+  // the parse with an ERROR node at offset 0 and recovers unpredictably from there.
+  // This is not exotic on Windows: Visual Studio writes .cs with a BOM by default and
+  // PowerShell 5.1's `Out-File -Encoding utf8` writes one for any file at all. Stripping
+  // it in the single reader also keeps `contentHash` over exactly the bytes we parse,
+  // which is what build/check/fingerprint agreement rests on.
+  if (bytes[0] === 0xef && bytes[1] === 0xbb && bytes[2] === 0xbf) {
+    return bytes.subarray(3).toString("utf8");
+  }
   return bytes.toString("utf8");
 }

--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -74,6 +74,12 @@ export interface BuildConfig {
    * no-flag build — and the fingerprint/refresh path, which never sees CLI
    * flags at all — behave identically to the invocation that set it. */
   includeDirs?: string[];
+  /** `graft build -e` extensions, persisted for the same reason and it matters
+   * more here: `-e` NARROWS the indexed set, and the freshness probe enumerates
+   * the tree with no flags at all. Unpersisted, every excluded file read as new
+   * on the next query, which rebuilt the graph wide again — so the narrowing
+   * lasted exactly until someone ran `graft ask`. Empty means "no override". */
+  extensions?: string[];
 }
 
 /** Local, Git-ignored repository configuration. Kept outside generated
@@ -100,9 +106,15 @@ function ensureBuildConfigIgnored(d: string): void {
 }
 
 export function readBuildConfig(d: string): BuildConfig | null { return readJson<BuildConfig>(buildConfigPath(d)); }
+
+/** Merged over what is already on disk, never replacing it: the fields are set by
+ * different flags of the same command (`--include-dir`, `-e`), so a plain write
+ * would let `graft build --include-dir build` silently drop a persisted `-e`. An
+ * explicit empty array still clears its own field — that is how `--no-include-dir`
+ * and `--no-extensions` undo themselves. */
 export function writeBuildConfig(d: string, c: BuildConfig): void {
   ensureBuildConfigIgnored(d);
-  writeJsonAtomic(buildConfigPath(d), c);
+  writeJsonAtomic(buildConfigPath(d), { ...(readBuildConfig(d) ?? {}), ...c });
 }
 
 /** The persisted `--include-dir` override for repo `d`, as a Set — `undefined`
@@ -113,6 +125,15 @@ export function writeBuildConfig(d: string, c: BuildConfig): void {
 export function readIncludeDirs(d: string): Set<string> | undefined {
   const dirs = readBuildConfig(d)?.includeDirs;
   return dirs && dirs.length ? new Set(dirs) : undefined;
+}
+
+/** The persisted `-e/--extensions` narrowing for repo `d`, or undefined when there
+ * is none. Same contract as {@link readIncludeDirs}: read inside `listSourceFiles`
+ * rather than threaded from the CLI, so the build, the freshness probe, `check`
+ * and the hooks/refresh path enumerate one identical file set. */
+export function readExtensions(d: string): string[] | undefined {
+  const exts = readBuildConfig(d)?.extensions;
+  return exts && exts.length ? exts : undefined;
 }
 // Best-effort read-modify-write; not atomic across concurrent processes, but acceptable
 // for episodic hook writes (worst case is a lost update, not corruption).

--- a/src/viz/serve.ts
+++ b/src/viz/serve.ts
@@ -6,7 +6,10 @@
  *   GET /                  viewer (index.html, app.js, style.css from viewerDir)
  *   GET /api/context-graph assembled from .context/*.md on every request
  *   GET /api/code-graph    .context/graph.json passthrough (404 until generated)
- *   GET /events            SSE; fs.watch on the context dir, debounced 300ms
+ *   GET /events            SSE; fs.watch on the context dir + .graph/, debounced 300ms
+ *
+ * Every route is gated on the Host header first (see `hostAllowed`) — the
+ * loopback bind alone does not keep a rebound browser out.
  */
 import { createServer, type Server, type ServerResponse } from "node:http";
 import { readFileSync, existsSync, watch, type FSWatcher } from "node:fs";
@@ -40,6 +43,25 @@ function sendJson(res: ServerResponse, status: number, body: unknown): void {
   res.end(JSON.stringify(body));
 }
 
+/**
+ * Loopback bind keeps other machines out; it does NOT keep other *sites* out.
+ * Any page the user happens to visit can point a hostname it controls at
+ * 127.0.0.1 (DNS rebinding), and from then on the browser treats
+ * `http://evil.example:PORT/api/code-graph` as same-origin and hands the
+ * response back to the attacker's JS. That endpoint is the whole wiring graph
+ * of a private repo — file paths, signatures, summaries, crux excerpts.
+ *
+ * The Host header is what defeats it: a rebound request still carries the
+ * attacker's hostname, and the browser will not let script forge it. So only
+ * the two names a human can actually have typed are accepted. A request with
+ * no Host at all (HTTP/1.0, raw sockets) is refused too — nothing legitimate
+ * reaches this server without one.
+ */
+function hostAllowed(host: string | undefined, port: number): boolean {
+  if (!host) return false;
+  return host === `127.0.0.1:${port}` || host === `localhost:${port}` || host === `[::1]:${port}`;
+}
+
 function listen(server: Server, port: number): Promise<boolean> {
   return new Promise((resolve, reject) => {
     const onError = (err: NodeJS.ErrnoException) => {
@@ -57,7 +79,17 @@ function listen(server: Server, port: number): Promise<boolean> {
 export async function startVizServer(opts: VizServerOptions): Promise<VizServer> {
   const sseClients = new Set<ServerResponse>();
 
+  // Declared before the handler because the bound port isn't known until the
+  // fallback loop below finishes, and `hostAllowed` has to compare against the
+  // port the browser actually connected to.
+  let port = opts.port;
+
   const server = createServer((req, res) => {
+    if (!hostAllowed(req.headers.host, port)) {
+      res.writeHead(403, { "content-type": "text/plain" });
+      res.end("forbidden: unexpected Host header — open this server as http://127.0.0.1:" + port + "/");
+      return;
+    }
     const path = (req.url ?? "/").split("?")[0];
 
     const asset = STATIC_FILES[path];
@@ -114,7 +146,6 @@ export async function startVizServer(opts: VizServerOptions): Promise<VizServer>
     res.end("not found");
   });
 
-  let port = opts.port;
   let bound = false;
   for (let i = 0; i < PORT_ATTEMPTS && !bound; i++) {
     port = opts.port + i;
@@ -124,22 +155,37 @@ export async function startVizServer(opts: VizServerOptions): Promise<VizServer>
     throw new Error(`no free port in ${opts.port}–${opts.port + PORT_ATTEMPTS - 1}`);
   }
 
-  let watcher: FSWatcher | undefined;
+  const watchers: FSWatcher[] = [];
   let debounce: NodeJS.Timeout | undefined;
+  const notify = (): void => {
+    clearTimeout(debounce);
+    debounce = setTimeout(() => {
+      for (const client of sseClients) client.write("data: change\n\n");
+    }, WATCH_DEBOUNCE_MS);
+  };
+  // TWO non-recursive watchers, not one recursive one. `wiring.json` lives in
+  // `<contextDir>/.graph/`, and a non-recursive watch on the parent never sees
+  // it — so a graph-only rebuild (the `--graph-only` refresh the query path
+  // triggers) left the Code graph tab stale until the user pressed F5, while a
+  // `--deep` build rewrote the `.md` cards in contextDir itself and therefore
+  // appeared to work. `{ recursive: true }` is the obvious fix and the wrong
+  // one: on Linux it only exists from Node 20.13 and throws
+  // ERR_FEATURE_UNAVAILABLE_ON_PLATFORM below that, while package.json promises
+  // node >= 20. Two flat watchers work identically on every supported version.
   if (existsSync(opts.contextDir)) {
-    watcher = watch(opts.contextDir, () => {
-      clearTimeout(debounce);
-      debounce = setTimeout(() => {
-        for (const client of sseClients) client.write("data: change\n\n");
-      }, WATCH_DEBOUNCE_MS);
-    });
+    watchers.push(watch(opts.contextDir, notify));
+    const graphDir = join(opts.contextDir, ".graph");
+    // Missing at startup on a repo built without a wiring graph; a later build
+    // creating .graph/ writes into contextDir too, so the parent watcher still
+    // fires for that first appearance.
+    if (existsSync(graphDir)) watchers.push(watch(graphDir, notify));
   }
 
   return {
     url: `http://127.0.0.1:${port}`,
     close(): Promise<void> {
       clearTimeout(debounce);
-      watcher?.close();
+      for (const w of watchers) w.close();
       for (const client of sseClients) client.end();
       sseClients.clear();
       return new Promise((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));

--- a/test/ask-index.test.ts
+++ b/test/ask-index.test.ts
@@ -14,7 +14,7 @@ import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readFileSync, readdirSyn
 import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { buildGraph } from "../src/graph/build.js";
-import { ask } from "../src/ask/ask.js";
+import { ask, BODY_INDEX_MISSING_NOTE, type AskResult } from "../src/ask/ask.js";
 import { contextDirFor } from "../src/context/node-file.js";
 import { readGraph, wiringPath } from "../src/graph/write.js";
 import { askIndexPath, readAskIndex, tokenize, counts, writeAskIndex } from "../src/ask/index-file.js";
@@ -51,6 +51,26 @@ function makeFixture(): string {
 }
 
 const QUERY = "How does authentication middleware validate incoming API requests?";
+
+/**
+ * The sidecar-parity assertions below are about RANKING — same hits, same
+ * scores — and they predate the degraded-recall warning. Falling back to live
+ * tokenization is no longer indistinguishable on purpose: without the sidecar,
+ * a graph read from disk has no `body_text` at all, so recall genuinely drops
+ * and `ask` now says so in `note` (see BODY_INDEX_MISSING_NOTE). Stripping
+ * `note` before comparing keeps these tests pinned to what they were written
+ * to pin, while `assertDegradedNote` pins the new signal explicitly.
+ */
+function withoutNote(r: AskResult): AskResult {
+  const { note: _note, ...rest } = r;
+  return rest as AskResult;
+}
+
+function assertDegradedNote(r: AskResult): void {
+  assert.ok(r.note, "a sidecar-less run must warn about reduced recall, not degrade silently");
+  assert.match(r.note!, /body index missing or stale/);
+  assert.equal(r.note!.includes(BODY_INDEX_MISSING_NOTE), true);
+}
 
 /**
  * Reconstruct a "fat" wiring.json — body_text present on every node, as EVERY
@@ -150,7 +170,13 @@ test("ask results are IDENTICAL with and without the sidecar (same hits, same sc
     try {
       assert.equal(readAskIndex(outDir), null, "sanity: sidecar is really gone");
       const withoutIndex = ask(dir, QUERY, { source: false });
-      assert.deepEqual(withoutIndex, withIndex, "sidecar vs live fallback must produce identical AskResult");
+      assert.deepEqual(
+        withoutNote(withoutIndex),
+        withoutNote(withIndex),
+        "sidecar vs live fallback must produce identical hits and scores",
+      );
+      assert.equal(withIndex.note, undefined, "a healthy sidecar warns about nothing");
+      assertDegradedNote(withoutIndex);
       assert.ok(withIndex.hits.length > 0, "the fixture query should actually match something");
     } finally {
       writeFileSync(idxPath, backup);
@@ -176,7 +202,8 @@ test("unknown sidecar version falls back to live tokenization without crashing",
 
     assert.equal(readAskIndex(outDir), null, "an unknown version reads as null (fallback signal)");
     const withBadVersion = ask(dir, QUERY, { source: false });
-    assert.deepEqual(withBadVersion, live, "unknown-version sidecar must not change results");
+    assert.deepEqual(withoutNote(withBadVersion), withoutNote(live), "unknown-version sidecar must not change results");
+    assertDegradedNote(withBadVersion);
   } finally {
     rmDir(dir);
   }
@@ -197,7 +224,8 @@ test("a stale sidecar (docCount mismatch) falls back to live tokenization", asyn
     writeFileSync(idxPath, JSON.stringify(raw));
 
     const stale = ask(dir, QUERY, { source: false });
-    assert.deepEqual(stale, live, "a docCount-mismatched sidecar must not change results");
+    assert.deepEqual(withoutNote(stale), withoutNote(live), "a docCount-mismatched sidecar must not change results");
+    assertDegradedNote(stale);
   } finally {
     rmDir(dir);
   }
@@ -216,7 +244,8 @@ test("an unparseable sidecar file falls back to live tokenization", async () => 
 
     assert.equal(readAskIndex(outDir), null);
     const withGarbage = ask(dir, QUERY, { source: false });
-    assert.deepEqual(withGarbage, live);
+    assert.deepEqual(withoutNote(withGarbage), withoutNote(live));
+    assertDegradedNote(withGarbage);
   } finally {
     rmDir(dir);
   }

--- a/test/ask-index.test.ts
+++ b/test/ask-index.test.ts
@@ -20,6 +20,7 @@ import { readGraph, wiringPath } from "../src/graph/write.js";
 import { askIndexPath, readAskIndex, tokenize, counts, writeAskIndex } from "../src/ask/index-file.js";
 import { extractFile, languageOf } from "../src/graph/extract.js";
 import type { GraphV1, NodeV1 } from "../src/graph/types.js";
+import { rmDir } from "./helpers.js";
 
 /** A small multi-file fixture with enough overlapping vocabulary that IDF and
  * BM25 actually differentiate hits, so a parity test on scores is meaningful. */
@@ -124,7 +125,7 @@ test("writeAskIndex + readAskIndex round-trip matches live tokenization exactly"
     const reread = readAskIndex(outDir);
     assert.deepEqual(reread, index, "re-writing an unchanged graph reproduces the same sidecar");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -155,7 +156,7 @@ test("ask results are IDENTICAL with and without the sidecar (same hits, same sc
       writeFileSync(idxPath, backup);
     }
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -177,7 +178,7 @@ test("unknown sidecar version falls back to live tokenization without crashing",
     const withBadVersion = ask(dir, QUERY, { source: false });
     assert.deepEqual(withBadVersion, live, "unknown-version sidecar must not change results");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -198,7 +199,7 @@ test("a stale sidecar (docCount mismatch) falls back to live tokenization", asyn
     const stale = ask(dir, QUERY, { source: false });
     assert.deepEqual(stale, live, "a docCount-mismatched sidecar must not change results");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -217,7 +218,7 @@ test("an unparseable sidecar file falls back to live tokenization", async () => 
     const withGarbage = ask(dir, QUERY, { source: false });
     assert.deepEqual(withGarbage, live);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -247,7 +248,7 @@ test("A3: a duplicate-named definition still gets its own ask-index doc (unique 
     const docIds = new Set(index!.docs.map((d) => d.id));
     for (const id of ids) assert.ok(docIds.has(id), `sidecar missing doc for ${id}`);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -256,7 +257,7 @@ test("readAskIndex returns null when the sidecar is simply missing", () => {
   try {
     assert.equal(readAskIndex(contextDirFor(dir)), null);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -276,7 +277,7 @@ test("readAskIndex returns null when docCount doesn't match docs.length", () => 
     writeFileSync(idxPath, JSON.stringify(corrupted));
     assert.equal(readAskIndex(outDir), null, "docCount !== docs.length must read as null");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -302,7 +303,7 @@ test("a failed sidecar write is recorded in build errors, not fatal", async () =
     assert.ok(graph, "wiring graph should still be written despite the sidecar failure");
     assert.ok(result.cards > 0, "cards should still be written despite the sidecar failure");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -333,7 +334,7 @@ test("ask WITH sidecar: identical hits/scores whether the underlying wiring.json
       "sidecar-driven ask must be identical whether wiring.json is slim or carries body_text",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -368,7 +369,7 @@ test("ask WITHOUT sidecar on a SLIM graph: no crash, body contributions absent, 
     const hit = byName.hits.find((h) => h.title.startsWith("checkout"));
     assert.ok(hit, "name-field matching still works with no sidecar and a slim graph");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -402,6 +403,6 @@ test("ask on an OLD fat graph (body_text present, no sidecar): unchanged behavio
     const hit = r.hits.find((h) => h.title.startsWith("checkout"));
     assert.ok(hit, "an old fat graph with no sidecar must still find a body-only term via node.body_text");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });

--- a/test/ask.test.ts
+++ b/test/ask.test.ts
@@ -814,3 +814,146 @@ test("ask with source inlines the actual span from disk", async () => {
     rmDir(dir);
   }
 });
+
+// ── Structural subject selection: the question's own verbs must not be the answer ──
+
+/** `Tracker.calls` and `Registry.uses` are ordinary members — the kind any
+ * graph, HTTP-client or metrics module has — that happen to be spelled like
+ * the intent verbs `structural()` keys on. `run`/`log` are the real subjects,
+ * and `gate` exists so the equal-length tie-break has something to land on. */
+function verbCollisionFixture(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graft-ask-verbs-"));
+  writeFileSync(
+    join(dir, "collide.ts"),
+    `export class Tracker {\n` +
+      `  calls(): number {\n` +
+      `    return 1;\n` +
+      `  }\n` +
+      `}\n\n` +
+      `export class Registry {\n` +
+      `  uses(): number {\n` +
+      `    return 2;\n` +
+      `  }\n` +
+      `}\n\n` +
+      `export function run(): number {\n` +
+      `  return 3;\n` +
+      `}\n\n` +
+      `export function log(): number {\n` +
+      `  return 4;\n` +
+      `}\n\n` +
+      `export function gate(): number {\n` +
+      `  return 5;\n` +
+      `}\n\n` +
+      `export function auth(): number {\n` +
+      `  return 6;\n` +
+      `}\n\n` +
+      `export function driver(): number {\n` +
+      `  const t = new Tracker();\n` +
+      `  const r = new Registry();\n` +
+      `  return run() + log() + gate() + auth() + t.calls() + r.uses();\n` +
+      `}\n`,
+  );
+  return dir;
+}
+
+test("ask: the intent verb never becomes the subject, even when a symbol is named `calls`", async () => {
+  const dir = verbCollisionFixture();
+  try {
+    await buildGraph(dir);
+    // 'calls' (5) sorts ahead of 'run' (3) by length, and resolveSymbol matches
+    // it against `Tracker.calls` by id suffix — so the question's own verb used
+    // to hijack the answer and ask reported "callers / references of calls".
+    const r = ask(dir, "who calls run");
+    assert.equal(r.mode, "structural");
+    assert.equal(r.subject, "run", "the subject is the thing being asked about, not the verb asking");
+    assert.match(r.note ?? "", /callers \/ references of run/);
+    assert.ok(r.hits.some((h) => h.title === "driver"), "driver calls run and must show up");
+  } finally {
+    rmDir(dir);
+  }
+});
+
+test("ask: `uses` as a member name does not hijack a 'who uses X' question either", async () => {
+  const dir = verbCollisionFixture();
+  try {
+    await buildGraph(dir);
+    const r = ask(dir, "who uses log");
+    assert.equal(r.mode, "structural");
+    assert.equal(r.subject, "log");
+  } finally {
+    rmDir(dir);
+  }
+});
+
+test("ask: an equal-length tie resolves to the object at the end of the sentence, not the first word", async () => {
+  const dir = verbCollisionFixture();
+  try {
+    await buildGraph(dir);
+    // "the auth gate" — `auth` and `gate` are both 4 letters and both resolve,
+    // so length alone can't choose. A stable sort kept the earlier one, which
+    // is the modifier; the head noun (what the question is about) is last.
+    const r = ask(dir, "who calls the auth gate");
+    assert.equal(r.mode, "structural");
+    assert.equal(r.subject, "gate");
+  } finally {
+    rmDir(dir);
+  }
+});
+
+// ── Structural truncation is announced, not silent ─────────────────────────
+
+/** One `target` with 12 callers spread across files, so a small `limit` has to
+ * drop most of them. */
+function manyCallersFixture(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graft-ask-many-"));
+  writeFileSync(join(dir, "target.ts"), `export function target(): number {\n  return 0;\n}\n`);
+  for (let i = 0; i < 12; i++) {
+    writeFileSync(
+      join(dir, `caller${i}.ts`),
+      `import { target } from "./target";\nexport function caller${i}(): number {\n  return target();\n}\n`,
+    );
+  }
+  return dir;
+}
+
+test("ask: a structural answer cut down to `limit` says how many it dropped", async () => {
+  const dir = manyCallersFixture();
+  try {
+    await buildGraph(dir);
+    // Every structural hit scores 1 and they are ordered by path, so this is
+    // not a "top 5" — it is the 5 whose paths sort first. Returning them under
+    // a note that reads like a complete answer is how a refactor ships with
+    // callers nobody looked at.
+    const cut = ask(dir, "who calls target", { limit: 5 });
+    assert.equal(cut.mode, "structural");
+    assert.equal(cut.hits.length, 5);
+    assert.match(cut.note ?? "", /showing 5 of \d+/);
+    assert.match(cut.note ?? "", /ordered by path, not relevance/);
+    assert.match(cut.note ?? "", /graft callers 'target'/);
+    assert.match(formatAsk(cut), /showing 5 of \d+/, "the count has to reach the rendered pack too");
+
+    // Nothing dropped -> the note stays exactly as it was.
+    const whole = ask(dir, "who calls target", { limit: 100 });
+    assert.equal(whole.note, "callers / references of target");
+  } finally {
+    rmDir(dir);
+  }
+});
+
+test("skeleton: a native-separator path resolves like the posix one", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-ask-skel-sep-"));
+  try {
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "src", "api.ts"), `export function first(a: number): number {\n  return a;\n}\n`);
+    await buildGraph(dir);
+    // `node.path` is always posix; `join` produces `src\api.ts` on Windows,
+    // which is what an agent (or a Windows tool) actually types. That used to
+    // compare unequal to every node and report "no definitions indexed".
+    const native = skeleton(dir, join("src", "api.ts"));
+    assert.deepEqual(native.entries.map((e) => e.name), ["first"], native.note ?? "");
+    assert.equal(native.file, "src/api.ts");
+    assert.deepEqual(native, skeleton(dir, "src/api.ts"));
+  } finally {
+    rmDir(dir);
+  }
+});

--- a/test/ask.test.ts
+++ b/test/ask.test.ts
@@ -13,6 +13,7 @@ import { readFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { buildGraph } from "../src/graph/build.js";
 import { ask, formatAsk, skeleton, formatSkeleton, isTestPath } from "../src/ask/ask.js";
+import { rmDir } from "./helpers.js";
 
 test("isTestPath: de-ranks test files, not real source", () => {
   for (const p of ["server/download_test.go", "packages/x/tests/foo.test.tsx", "a/__tests__/b.ts", "src/api.spec.ts", "pkg/foo/bar_test.go"])
@@ -65,7 +66,7 @@ test("test files rank below the source they exercise for a non-test query, but n
     const rt = ask(dir, "tests for downloadChunk stall");
     assert.ok(rt.hits.some((h) => /download\.test\.ts/.test(h.pointer)), "test file surfaces for a test-seeking query");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -94,7 +95,7 @@ test("test de-ranking survives normalization when a test is the strongest lexica
     assert.ok(source >= 0, "implementation hit present");
     assert.ok(testHit === -1 || source < testHit, "implementation ranks above the stronger lexical test match");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -119,7 +120,7 @@ test("ask without source returns pointers but no inlined code", async () => {
     assert.match(hit.pointer, /^math\.ts:L\d+-L\d+$/);
     assert.equal(hit.code, undefined, "no source inlined without the option");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -147,7 +148,7 @@ test("ask --source inlines the crux by default, the whole span with full", async
     assert.match(fullHit.code!, /export function addNumbers/, "full definition span inlined");
     assert.doesNotMatch(fullHit.code!, /rerun with --full/);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -159,7 +160,7 @@ test("ask --source falls back to the span when a node has no crux", async () => 
     const hit = r.hits.find((h) => h.title.startsWith("addNumbers"))!;
     assert.match(hit.code!, /export function addNumbers/);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -182,7 +183,7 @@ test("skeleton lists a file's definitions in span order, matches by basename", a
     assert.match(txt, /L\d+-L\d+ {2}function first/);
     assert.match(skeleton(dir, "nope.ts").note ?? "", /no definitions/);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -199,7 +200,7 @@ test("ask reports coverage: 1.0 when every query term hits, low on mostly-off-co
     assert.ok(chatty.hits.length > 0, "still returns lexical hits");
     assert.ok((chatty.coverage ?? 1) < 0.15, `coverage should be under the floor, got ${chatty.coverage}`);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -220,7 +221,7 @@ test("ask finds a symbol by a term that appears only in its body (body-indexing)
     assert.ok(hit, "checkout is findable via a term that only appears in its body");
     assert.match(hit.pointer, /^pay\.ts:L\d+-L\d+$/);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -240,7 +241,7 @@ test("ask surfaces a file by a term only in its module-level code (file-body ind
     assert.ok(hit, "the file surfaces via a term that lives only in module-level code");
     assert.ok(hit.title.endsWith("· file"), "it is the file node, pointed at the whole file (no span)");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -261,7 +262,7 @@ test("ask indexes a symbol past the 32KB tree-sitter boundary (chunked parse)", 
       "a symbol defined past the 32KB boundary is indexed and findable",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -303,7 +304,7 @@ test("ask: 'who calls Cache.get' resolves via qualified id-suffix (the previousl
       "loadItem calls Cache.get, and must show up as a caller",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -318,7 +319,7 @@ test("ask: structural subject resolves but has zero edges — falls through to l
     assert.match(r.note!, /graft callers 'unusedHelper'/);
     assert.ok(r.hits.length > 0, "lexical fallback still finds the function by name");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -331,7 +332,7 @@ test("ask: structural intent for an unresolvable subject also falls through with
     assert.ok(r.note, "a fallthrough note must be set even when nothing resolved");
     assert.match(r.note!, /structural index: no entries for 'NoSuchSymbolXyz'/);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -347,7 +348,7 @@ test("formatAsk: the structural fallthrough note prints prominently, before any 
     const firstHitIdx = out.search(/\n1\.\s/); // lexical hit numbering starts at "1. "
     assert.ok(firstHitIdx === -1 || noteIdx < firstHitIdx, "the note prints before any hit");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -408,7 +409,7 @@ test("ask on a multi-scope repo: top hits federate both scopes, labeled, with a 
     assert.match(out, /matched in: .*frontend\/ \(\d+\)/, "footer reports frontend's hit count");
     assert.match(out, /matched in: .*backend\/ \(\d+\)/, "footer reports backend's hit count");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -489,7 +490,7 @@ test("cross-seam fix: a monorepo scope with only a body-comment collision is gat
     assert.match(out, /also matched: junk\/ — narrow with --in junk\//, `expected an alsoMatched footer, got:\n${out}`);
     assert.doesNotMatch(out, /\[junk\/\]/, "no junk/-labeled hit anywhere in the rendered output");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -522,7 +523,7 @@ test("ask --in: filters to nodes under the prefix, segment-aware ('widgets' must
       "widgets-extra/ must NOT be pulled in by a naive substring/prefix match",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -567,7 +568,7 @@ test("ask --in: per-scope idf differs from global — a term's rank flips relati
       "filtered to proj/, zzzcommonword_b (now the locally-rare term) overtakes zzzraretoken (now locally-common)",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -580,7 +581,7 @@ test("ask --in: unknown/no-match prefix throws a scope-enumerating error", async
       /nothing indexed under "wrong\/" — scopes here: .*frontend\/.*backend\/.* \(or any path prefix\)/,
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -596,7 +597,7 @@ test("ask --in: unknown prefix on a single-scope repo throws without a scopes-he
       return true;
     });
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -619,7 +620,7 @@ test("CLI: `graft ask --in <unknown>` exits 1 with the scope-enumerating error o
     assert.match(threw!.stderr ?? "", /✗ nothing indexed under "wrong\/"/);
     assert.match(threw!.stderr ?? "", /scopes here:.*frontend\/.*backend\//);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -632,7 +633,7 @@ test("ask: a zero-hit query on a multi-scope graph appends scope enumeration to 
     assert.match(r.note ?? "", /no matching nodes — try different words/);
     assert.match(r.note ?? "", /scopes here: .*frontend\/.*backend\//);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -650,7 +651,7 @@ test("ask --in on the multi-scope fixture: filtering to one scope carries no sco
     const out = formatAsk(r);
     assert.doesNotMatch(out, /\[frontend\/\] |\[backend\/\] |matched in:|also matched:/);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -686,7 +687,7 @@ test("ask --in: a body-only term is still found when filtered to its own directo
     const hit = r.hits.find((h) => h.title.startsWith("checkout"));
     assert.ok(hit, "checkout must still be findable via its body-only term when --in filters to its OWN directory");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -705,7 +706,7 @@ test("ask --in: a trailing slash is accepted — `--in frontend/` behaves exactl
       "trailing slash must not change which hits are returned",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -752,7 +753,7 @@ test("ask --in: structural queries narrow the resolved subject by prefix, not ju
       "backend's handle/caller must not leak in when --in=frontend",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -770,7 +771,7 @@ test("ask --in: a structural subject that exists ONLY outside the prefix falls t
     assert.ok(r.note, "a fallthrough note must be set");
     assert.match(r.note!, /structural index: no entries for 'handle'/);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -794,7 +795,7 @@ test("regression pin: single-scope ask output is byte-equal with canonical meta.
     assert.equal(canonical, absent, "single-scope output must not drift by a byte");
     assert.doesNotMatch(absent, /matched in:|also matched:|\[\w+\/\] /, "zero new output on single-scope");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -810,6 +811,6 @@ test("ask with source inlines the actual span from disk", async () => {
     // formatAsk renders it as a fenced block so it drops into agent context.
     assert.match(formatAsk(r), /```[\s\S]*return a \+ b;[\s\S]*```/);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });

--- a/test/claude-format.test.ts
+++ b/test/claude-format.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { renderStatusline, incomingEdges, formatBlastRadius, formatRetrieval, formatOrientation, renderSubagent, relevantRetrieval, INJECT_MIN_COVERAGE, NUDGE_CAP } from '../src/claude/format.js';
-import { emptyStats } from '../src/claude/state.js';
+import { emptyStats, type SessionState } from '../src/claude/state.js';
 
 const strip = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '');
 
@@ -93,7 +93,10 @@ const gateAsk = (over: Record<string, unknown> = {}) => ({
   ],
   ...over,
 }) as any;
-const freshSession = () => ({ lastQuery: null, perAgentQuery: {}, graftReads: 0, sourceReads: 0, savedTokens: 0, injectedPointers: [] as string[] });
+// Typed as SessionState, not inferred: `nudges` is deliberately absent so these
+// tests also cover a session file written before that field existed, and only the
+// annotation proves the rest of the fixture still matches what the hook reads.
+const freshSession = (): SessionState => ({ lastQuery: null, perAgentQuery: {}, graftReads: 0, sourceReads: 0, savedTokens: 0, injectedPointers: [] });
 
 test('relevantRetrieval injects on good coverage and records pointers', () => {
   const s = freshSession();
@@ -186,7 +189,7 @@ test('formatOrientation prepends a staleness banner when one is supplied', () =>
 });
 
 test('renderSubagent shows agent name and its last query', () => {
-  const out = strip(renderSubagent('Explore', { lastQuery: null, perAgentQuery: { Explore: 'pkce flow' }, graftReads: 0, sourceReads: 0 }));
+  const out = strip(renderSubagent('Explore', { ...freshSession(), perAgentQuery: { Explore: 'pkce flow' } }));
   assert.match(out, /Explore/);
   assert.match(out, /pkce flow/);
 });

--- a/test/claude-init.test.ts
+++ b/test/claude-init.test.ts
@@ -4,12 +4,14 @@ import assert from 'node:assert/strict';
 // The MCP launch command is resolved from PATH at init time; pin it to the npx
 // form so these expectations are the same on every machine.
 process.env.GRAFT_MCP_NPX = '1';
-import { mkdtempSync, readFileSync, existsSync, writeFileSync, mkdirSync } from 'node:fs';
+import { mkdtempSync, readFileSync, existsSync, writeFileSync, mkdirSync, statSync, utimesSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, isAbsolute } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { execFileSync, spawnSync } from 'node:child_process';
-import { buildGraphIfMissing, runInit } from '../src/claude/init.js';
+import { bakedRef, buildGraphIfMissing, runInit } from '../src/claude/init.js';
 import { formatInitEpilogue } from '../src/cli-epilogue.js';
+import { writeStamp } from '../src/upkeep.js';
 
 function fresh(): string { return mkdtempSync(join(tmpdir(), 'graft-init-')); }
 
@@ -34,7 +36,7 @@ test('runInit scaffolds settings + both shims + the skill (build skipped)', () =
   const s = JSON.parse(readFileSync(join(d, '.claude', 'settings.json'), 'utf8'));
   assert.ok(s.statusLine.command.includes('graft-statusline.cjs'));
   assert.ok(s.hooks.Stop[0].hooks[0].command.includes('graft-hooks.cjs'));
-  assert.deepEqual(s.permissions.allow, ['Bash(graft:*)', 'Bash(npx graft:*)', 'Bash(graft-dev:*)', 'Bash(node dist/cli.js:*)']);
+  assert.deepEqual(s.permissions.allow, ['Bash(graft:*)', 'Bash(npx -y @nanonets/graft:*)', 'Bash(graft-dev:*)', 'Bash(node dist/cli.js:*)']);
 });
 
 test('runInit overwrites a stale skill file', () => {
@@ -63,7 +65,7 @@ test('runInit is idempotent', () => {
   runInit(d, { build: false });
   const s = JSON.parse(readFileSync(join(d, '.claude', 'settings.json'), 'utf8'));
   assert.equal(s.hooks.PostToolUse.length, 2); // post-edit + tool-savings, not duplicated on re-init
-  assert.deepEqual(s.permissions.allow, ['Bash(graft:*)', 'Bash(npx graft:*)', 'Bash(graft-dev:*)', 'Bash(node dist/cli.js:*)']);
+  assert.deepEqual(s.permissions.allow, ['Bash(graft:*)', 'Bash(npx -y @nanonets/graft:*)', 'Bash(graft-dev:*)', 'Bash(node dist/cli.js:*)']);
 });
 
 test('runInit appends the allowlist to a pre-existing permissions block, preserving unrelated entries', () => {
@@ -72,13 +74,91 @@ test('runInit appends the allowlist to a pre-existing permissions block, preserv
   writeFileSync(join(d, '.claude', 'settings.json'), JSON.stringify({ permissions: { allow: ['Bash(ls)'] } }));
   runInit(d, { build: false });
   const s = JSON.parse(readFileSync(join(d, '.claude', 'settings.json'), 'utf8'));
-  assert.deepEqual(s.permissions.allow, ['Bash(ls)', 'Bash(graft:*)', 'Bash(npx graft:*)', 'Bash(graft-dev:*)', 'Bash(node dist/cli.js:*)']);
+  assert.deepEqual(s.permissions.allow, ['Bash(ls)', 'Bash(graft:*)', 'Bash(npx -y @nanonets/graft:*)', 'Bash(graft-dev:*)', 'Bash(node dist/cli.js:*)']);
 });
 
-test('postinstall prints the nudge in a fresh dir', () => {
+// --- a settings.json graft cannot read is the user's file, not an absent one ----
+
+/** The four repo files runInit owns, in write order. */
+function ownedFiles(d: string): string[] {
+  return [
+    join(d, '.claude', 'settings.json'),
+    join(d, '.claude', 'helpers', 'graft-statusline.cjs'),
+    join(d, '.claude', 'helpers', 'graft-hooks.cjs'),
+    join(d, '.claude', 'skills', 'graft', 'SKILL.md'),
+  ];
+}
+
+test('an unparseable settings.json is left byte-for-byte alone, with a warning', () => {
+  const d = fresh();
+  mkdirSync(join(d, '.claude'), { recursive: true });
+  const p = join(d, '.claude', 'settings.json');
+  // A `//` comment — the single most common way a hand-edited settings.json stops
+  // parsing. Before the guard this whole file was replaced by graft's defaults.
+  const original = '{\n  "model": "opus",\n  // graft cannot parse this\n  "permissions": { "allow": ["Bash(ls)"] }\n}\n';
+  writeFileSync(p, original);
+
+  const r = runInit(d, { build: false });
+  assert.equal(readFileSync(p, 'utf8'), original, "the user's settings survived");
+  assert.equal(r.warnings.length, 1);
+  assert.match(r.warnings[0], /not valid JSON/);
+  // The rest of init still runs: the shims and the skill are graft's own files.
+  assert.ok(existsSync(join(d, '.claude', 'helpers', 'graft-hooks.cjs')));
+});
+
+test('a settings.json holding a non-object is refused too', () => {
+  const d = fresh();
+  mkdirSync(join(d, '.claude'), { recursive: true });
+  const p = join(d, '.claude', 'settings.json');
+  writeFileSync(p, '["not", "an", "object"]');
+  const r = runInit(d, { build: false });
+  assert.equal(readFileSync(p, 'utf8'), '["not", "an", "object"]');
+  assert.match(r.warnings[0], /not valid JSON/);
+});
+
+test('re-init rewrites nothing when nothing changed — a fresh clone must not go dirty', () => {
+  // The stamp that decides whether to refresh lives under the git-ignored
+  // graft/.cache/, so every clone looks unwired and the session-start hook re-runs
+  // these writes. The files are committed, so an unconditional write handed each
+  // colleague a diff in `.claude/` before they typed anything.
+  const d = fresh();
+  runInit(d, { build: false });
+  const stale = new Date(Date.now() - 60_000);
+  for (const f of ownedFiles(d)) utimesSync(f, stale, stale);
+
+  runInit(d, { build: false });
+  for (const f of ownedFiles(d))
+    assert.ok(statSync(f).mtimeMs < Date.now() - 30_000, `${f} was rewritten with identical content`);
+});
+
+test('a changed file is still rewritten', () => {
+  const d = fresh();
+  runInit(d, { build: false });
+  const skill = join(d, '.claude', 'skills', 'graft', 'SKILL.md');
+  writeFileSync(skill, 'clobbered by hand');
+  runInit(d, { build: false });
+  assert.match(readFileSync(skill, 'utf8'), /name: graft/);
+});
+
+test('bakedRef is repo-relative inside graft\'s own checkout, absolute anywhere else', () => {
+  // Absolute is right for a consumer repo — the shim then needs no guesswork. It is
+  // wrong for graft's own checkout: the path would be one developer's home
+  // directory, committed into .claude/helpers/*.cjs for everyone else to pull.
+  const graftCheckout = fileURLToPath(new URL('..', import.meta.url));
+  const ref = bakedRef(graftCheckout);
+  assert.ok(!isAbsolute(ref), `expected a relative ref inside the checkout, got ${ref}`);
+  assert.doesNotMatch(ref, /\\/, 'posix separators, so the committed shim is identical on both platforms');
+  assert.ok(isAbsolute(bakedRef(fresh())), 'a consumer repo still gets the absolute install path');
+});
+
+test('postinstall prints the nudge in a fresh dir, naming the scoped package', () => {
   const d = fresh();
   const out = runPostinstall({ INIT_CWD: d, CI: '' });
-  assert.match(out, /npx graft init/);
+  assert.match(out, /npx -y @nanonets\/graft init/);
+  // Bare `npx graft` resolves to a different author's package on the registry. The
+  // allowlist stopped granting that form; the line users actually copy has to stop
+  // printing it too.
+  assert.doesNotMatch(out, /npx graft /);
 });
 
 test('postinstall is silent when already initialized', () => {
@@ -157,4 +237,33 @@ test('buildGraphIfMissing: an existing graph is left alone', () => {
   writeFileSync(join(dir, 'graft', '.graph', 'wiring.json'), '{}');
   // A bogus cliPath would throw if it were reached; the wiring check short-circuits.
   assert.equal(buildGraphIfMissing(dir, { build: true, cliPath: '/nonexistent/cli.js' }), false);
+});
+
+test('a permission the user removed is not reinstalled by the next init', () => {
+  // End-to-end over the two halves this needs: `runInit` reports what it proposed,
+  // the caller records it in the wiring stamp, and the next `runInit` reads it back.
+  // Without the record, every version bump re-added the entry — into a committed
+  // file, so the team got it back too, and the only recourse was deleting it again
+  // after each upgrade.
+  const d = fresh();
+  const home = fresh();
+  const settingsPath = join(d, '.claude', 'settings.json');
+  const allowOf = () => JSON.parse(readFileSync(settingsPath, 'utf8')).permissions.allow as string[];
+
+  const first = runInit(d, { build: false });
+  assert.ok(allowOf().includes('Bash(graft-dev:*)'));
+  assert.ok(first.offeredAllow.includes('Bash(graft-dev:*)'), 'the run reports what it proposed');
+  writeStamp(d, '1.0.0', ['claude'], {}, undefined, home, first.offeredAllow);
+
+  // The user deletes one grant by hand and commits that.
+  const settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
+  settings.permissions.allow = settings.permissions.allow.filter((e: string) => e !== 'Bash(graft-dev:*)');
+  writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+
+  runInit(d, { build: false });
+  assert.ok(!allowOf().includes('Bash(graft-dev:*)'), 'a deleted grant stays deleted');
+  // The rest of the wiring is still maintained — this is a narrow rule about
+  // permissions, not a reason to stop refreshing the file.
+  assert.ok(allowOf().includes('Bash(graft:*)'));
+  assert.ok(JSON.stringify(JSON.parse(readFileSync(settingsPath, 'utf8')).hooks).includes('graft-hooks.cjs'));
 });

--- a/test/claude-settings-merge.test.ts
+++ b/test/claude-settings-merge.test.ts
@@ -50,41 +50,89 @@ test('re-running is idempotent (no duplicate Graft entries or footer)', () => {
 test('foreign top-level keys survive', () => {
   const { merged } = mergeGraftSettings({ model: 'claude-sonnet-5', permissions: { allow: ['Bash(ls)'] } });
   assert.equal(merged.model, 'claude-sonnet-5');
-  assert.deepEqual(merged.permissions.allow, ['Bash(ls)', 'Bash(graft:*)', 'Bash(npx graft:*)', 'Bash(graft-dev:*)', 'Bash(node dist/cli.js:*)']);
+  assert.deepEqual(merged.permissions.allow, ['Bash(ls)', 'Bash(graft:*)', 'Bash(npx -y @nanonets/graft:*)', 'Bash(graft-dev:*)', 'Bash(node dist/cli.js:*)']);
 });
 
 test('fresh init adds the graft CLI allowlist', () => {
   const { merged } = mergeGraftSettings({});
-  assert.deepEqual(merged.permissions.allow, ['Bash(graft:*)', 'Bash(npx graft:*)', 'Bash(graft-dev:*)', 'Bash(node dist/cli.js:*)']);
+  assert.deepEqual(merged.permissions.allow, ['Bash(graft:*)', 'Bash(npx -y @nanonets/graft:*)', 'Bash(graft-dev:*)', 'Bash(node dist/cli.js:*)']);
 });
 
 test('re-init does not duplicate allowlist entries', () => {
   const once = mergeGraftSettings({}).merged;
   const twice = mergeGraftSettings(once).merged;
-  assert.deepEqual(twice.permissions.allow, ['Bash(graft:*)', 'Bash(npx graft:*)', 'Bash(graft-dev:*)', 'Bash(node dist/cli.js:*)']);
+  assert.deepEqual(twice.permissions.allow, ['Bash(graft:*)', 'Bash(npx -y @nanonets/graft:*)', 'Bash(graft-dev:*)', 'Bash(node dist/cli.js:*)']);
 });
 
 test('pre-existing unrelated allow entries are preserved and ours appended', () => {
   const existing = { permissions: { allow: ['Bash(ls)', 'Bash(git:*)'] } };
   const { merged } = mergeGraftSettings(existing);
-  assert.deepEqual(merged.permissions.allow, ['Bash(ls)', 'Bash(git:*)', 'Bash(graft:*)', 'Bash(npx graft:*)', 'Bash(graft-dev:*)', 'Bash(node dist/cli.js:*)']);
+  assert.deepEqual(merged.permissions.allow, ['Bash(ls)', 'Bash(git:*)', 'Bash(graft:*)', 'Bash(npx -y @nanonets/graft:*)', 'Bash(graft-dev:*)', 'Bash(node dist/cli.js:*)']);
 });
 
 test('a partially-present allowlist gains only what it lacks, in order', () => {
   const existing = { permissions: { allow: ['Bash(graft:*)'] } };
   const { merged } = mergeGraftSettings(existing);
-  assert.deepEqual(merged.permissions.allow, ['Bash(graft:*)', 'Bash(npx graft:*)', 'Bash(graft-dev:*)', 'Bash(node dist/cli.js:*)']);
+  assert.deepEqual(merged.permissions.allow, ['Bash(graft:*)', 'Bash(npx -y @nanonets/graft:*)', 'Bash(graft-dev:*)', 'Bash(node dist/cli.js:*)']);
 });
 
 test('pre-existing allow entries are kept and only the missing ones appended', () => {
-  const existing = { permissions: { allow: ['Bash(graft:*)', 'Bash(npx graft:*)'] } };
+  const existing = { permissions: { allow: ['Bash(graft:*)', 'Bash(npx -y @nanonets/graft:*)'] } };
   const { merged } = mergeGraftSettings(existing);
-  assert.deepEqual(merged.permissions.allow, ['Bash(graft:*)', 'Bash(npx graft:*)', 'Bash(graft-dev:*)', 'Bash(node dist/cli.js:*)']);
+  assert.deepEqual(merged.permissions.allow, ['Bash(graft:*)', 'Bash(npx -y @nanonets/graft:*)', 'Bash(graft-dev:*)', 'Bash(node dist/cli.js:*)']);
+});
+
+test('the unscoped `npx graft` grant an older graft wrote is revoked, not carried forward', () => {
+  // `npx graft` resolves to the UNSCOPED package on the registry — someone else's
+  // code — and this list ships in the committed, team-wide settings.json. A repo
+  // wired before the fix must lose it on the next refresh, or the grant is forever.
+  const existing = { permissions: { allow: ['Bash(ls)', 'Bash(npx graft:*)', 'Bash(git:*)'] } };
+  const { merged } = mergeGraftSettings(existing);
+  assert.ok(!merged.permissions.allow.includes('Bash(npx graft:*)'), 'revoked');
+  assert.deepEqual(merged.permissions.allow, [
+    'Bash(ls)', 'Bash(git:*)',
+    'Bash(graft:*)', 'Bash(npx -y @nanonets/graft:*)', 'Bash(graft-dev:*)', 'Bash(node dist/cli.js:*)',
+  ], "the user's own entries survive; only graft's own stale grant goes");
 });
 
 test('permissions object with no allow key gets one added; other keys preserved', () => {
   const existing = { permissions: { deny: ['Bash(rm:*)'] } };
   const { merged } = mergeGraftSettings(existing);
   assert.deepEqual(merged.permissions.deny, ['Bash(rm:*)']);
-  assert.deepEqual(merged.permissions.allow, ['Bash(graft:*)', 'Bash(npx graft:*)', 'Bash(graft-dev:*)', 'Bash(node dist/cli.js:*)']);
+  assert.deepEqual(merged.permissions.allow, ['Bash(graft:*)', 'Bash(npx -y @nanonets/graft:*)', 'Bash(graft-dev:*)', 'Bash(node dist/cli.js:*)']);
+});
+
+test('an allow entry the user deleted is not re-added once it has been offered', () => {
+  // `.claude/settings.json` is committed, so a grant that comes back on every
+  // version bump comes back for the whole team — and the only way out was to keep
+  // deleting it after every upgrade. `offeredBefore` is the record (kept in the
+  // wiring stamp) that turns "missing" into "removed on purpose".
+  const offeredBefore = mergeGraftSettings({}).offeredAllow;
+  assert.deepEqual(
+    offeredBefore,
+    ['Bash(graft:*)', 'Bash(npx -y @nanonets/graft:*)', 'Bash(graft-dev:*)', 'Bash(node dist/cli.js:*)'],
+    'everything this version proposes is what gets recorded',
+  );
+
+  const kept = ['Bash(ls)', 'Bash(npx -y @nanonets/graft:*)', 'Bash(graft-dev:*)', 'Bash(node dist/cli.js:*)'];
+  const { merged } = mergeGraftSettings({ permissions: { allow: [...kept] } }, { offeredBefore });
+  assert.deepEqual(merged.permissions.allow, kept, 'the deleted entry stays deleted');
+
+  // …but only for entries that were actually offered. One this graft version added
+  // (so it is absent from the record) is a first offer, not a revocation.
+  const older = ['Bash(graft:*)', 'Bash(npx -y @nanonets/graft:*)'];
+  const { merged: widened } = mergeGraftSettings(
+    { permissions: { allow: [...older] } },
+    { offeredBefore: older },
+  );
+  assert.deepEqual(
+    widened.permissions.allow,
+    [...older, 'Bash(graft-dev:*)', 'Bash(node dist/cli.js:*)'],
+    'entries never offered here are still proposed',
+  );
+
+  // No record at all (a first init, or a clone with no stamp) behaves exactly as
+  // before: everything is offered.
+  const { merged: fresh } = mergeGraftSettings({ permissions: { allow: [] } });
+  assert.deepEqual(fresh.permissions.allow, offeredBefore);
 });

--- a/test/claude-shim-resolve.test.ts
+++ b/test/claude-shim-resolve.test.ts
@@ -11,7 +11,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, delimiter } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { hooksShim } from '../src/claude/shim-template.js';
 import { tmpRepo } from './helpers.js';
@@ -31,16 +31,49 @@ function fakeInstall(root: string, name: string, version: string): string {
   return distClaude;
 }
 
-/** Runs the shim with the given baked dir and project dir; returns the version
- * of the install that actually got loaded (or null if none did). */
-function runShim(root: string, bakedDir: string, projectDir: string): string | null {
+/** Pre-answers `npm root -g` in the scratch home, so no case pays for the spawn. */
+function seedNpmRoot(home: string, root: string): void {
+  mkdirSync(join(home, '.graft'), { recursive: true });
+  writeFileSync(join(home, '.graft', 'npm-root.json'), JSON.stringify({ root, at: Date.now() }));
+}
+
+/** An `npm` on PATH whose `root -g` prints `root`, to exercise the real query. */
+function fakeNpm(dir: string, root: string): string {
+  mkdirSync(dir, { recursive: true });
+  if (process.platform === 'win32') writeFileSync(join(dir, 'npm.cmd'), `@echo off\r\necho ${root}\r\n`);
+  else writeFileSync(join(dir, 'npm'), `#!/bin/sh\necho "${root}"\n`, { mode: 0o755 });
+  return dir;
+}
+
+/**
+ * Runs the shim with the given baked dir and project dir; returns the version
+ * of the install that actually got loaded (or null if none did).
+ *
+ * HOME/USERPROFILE point at a scratch dir and the `npm root -g` answer is seeded
+ * there, so the global candidate is exactly what the case says it is — never this
+ * machine's real global install (which would otherwise decide these assertions),
+ * and never a 0.5s npm spawn per case. `npmRoot`/`fakeNpm` override that.
+ */
+function runShim(
+  root: string,
+  bakedDir: string,
+  projectDir: string,
+  opts: { npmRoot?: string; fakeNpm?: string } = {},
+): string | null {
   const shimPath = join(root, 'graft-hooks.cjs');
   const marker = join(root, 'loaded.txt');
+  const home = join(root, 'home');
   writeFileSync(shimPath, hooksShim(bakedDir));
-  const res = spawnSync(process.execPath, [shimPath, 'session-start'], {
-    encoding: 'utf8',
-    env: { ...process.env, MARKER: marker, CLAUDE_PROJECT_DIR: projectDir },
-  });
+  const env: NodeJS.ProcessEnv = { ...process.env, HOME: home, USERPROFILE: home, MARKER: marker, CLAUDE_PROJECT_DIR: projectDir };
+  if (opts.fakeNpm) {
+    // Windows spells it `Path`; leaving both spellings in the child env is a coin flip.
+    const prior = env.PATH ?? '';
+    for (const k of Object.keys(env)) if (k.toLowerCase() === 'path') delete env[k];
+    env.PATH = `${opts.fakeNpm}${delimiter}${prior}`;
+  } else {
+    seedNpmRoot(home, opts.npmRoot ?? join(root, 'no-global-install'));
+  }
+  const res = spawnSync(process.execPath, [shimPath, 'session-start'], { encoding: 'utf8', env });
   assert.equal(res.status, 0, `shim exited ${res.status}: ${res.stderr}`);
   return existsSync(marker) ? readFileSync(marker, 'utf8') : null;
 }
@@ -74,6 +107,45 @@ test('an install with an unreadable version loses to a known one', () => {
   writeFileSync(join(root, 'broken', 'package.json'), 'not json');
   fakeInstall(join(root, 'project', 'node_modules', '@nanonets'), 'graft', '0.9.1');
   assert.equal(runShim(root, broken, join(root, 'project')), '0.9.1');
+});
+
+test('a newer install in the global root wins over an existing baked path', () => {
+  // The regression 0.11.0's version comparison was supposed to fix, but did not:
+  // `entry()` returned on the first cheap candidate that existed, and BAKED almost
+  // always exists — so `npm root -g`, the only candidate that finds a Windows
+  // global install (%APPDATA%\npm\node_modules), never entered the comparison and
+  // `npm i -g @nanonets/graft@latest` still changed nothing.
+  const root = tmpRepo('shim-globalroot');
+  const stale = fakeInstall(root, 'baked', '0.9.1');
+  const globalRoot = join(root, 'global-node-modules');
+  fakeInstall(join(globalRoot, '@nanonets'), 'graft', '0.11.0');
+  mkdirSync(join(root, 'project'), { recursive: true });
+  assert.equal(runShim(root, stale, join(root, 'project'), { npmRoot: globalRoot }), '0.11.0');
+});
+
+test('the global root is queried from npm and the answer cached under the user home', () => {
+  const root = tmpRepo('shim-npmquery');
+  const stale = fakeInstall(root, 'baked', '0.9.1');
+  const globalRoot = join(root, 'global-node-modules');
+  fakeInstall(join(globalRoot, '@nanonets'), 'graft', '0.11.0');
+  mkdirSync(join(root, 'project'), { recursive: true });
+
+  const loaded = runShim(root, stale, join(root, 'project'), { fakeNpm: fakeNpm(join(root, 'bin'), globalRoot) });
+  assert.equal(loaded, '0.11.0');
+  // Cached, not re-asked: this file runs on every hook and every statusline render.
+  const cache = JSON.parse(readFileSync(join(root, 'home', '.graft', 'npm-root.json'), 'utf8'));
+  assert.equal(cache.root, globalRoot);
+  assert.ok(typeof cache.at === 'number');
+});
+
+test('a baked path relative to the project dir resolves against it', () => {
+  // What graft's own checkout commits: BAKED = 'dist/claude', identical on every
+  // machine, instead of the absolute path of whoever last ran `graft init`.
+  const root = tmpRepo('shim-relative');
+  // fakeInstall's layout IS a checkout's: <project>/package.json + <project>/dist/claude.
+  fakeInstall(root, 'project', '0.12.0');
+  fakeInstall(join(root, 'project', 'node_modules', '@nanonets'), 'graft', '0.9.1');
+  assert.equal(runShim(root, 'dist/claude', join(root, 'project')), '0.12.0');
 });
 
 test('no candidate at all exits quietly — a hook must never fail the session', () => {

--- a/test/claude-shim-template.test.ts
+++ b/test/claude-shim-template.test.ts
@@ -1,6 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import vm from 'node:vm';
+import { readFileSync } from 'node:fs';
 import { statuslineShim, hooksShim } from '../src/claude/shim-template.js';
 
 const BAKED = '/opt/graft/dist/claude';
@@ -17,9 +18,13 @@ for (const [name, src] of [['statusline', statuslineShim(BAKED)], ['hooks', hook
     assert.match(src, /fromPkg\(dir\)/);
     // 3. legacy execPath/../lib guess retained
     assert.match(src, /path\.join\(path\.dirname\(process\.execPath\), '\.\.', 'lib'\)/);
-    // 4. npm root -g catch-all, queried on demand (no on-disk cache)
+    // 4. npm root -g, now compared alongside the others rather than used as a
+    //    fallback behind them — see the header comment in shim-template.ts.
     assert.match(src, /execFileSync\('npm', \['root', '-g'\]/);
-    assert.doesNotMatch(src, /tmpdir/); // no predictable temp cache path
+    // Its answer is cached for a day under the user's own home, never in a
+    // world-writable temp dir a co-tenant could point at their own code.
+    assert.match(src, /os\.homedir\(\), '\.graft', 'npm-root\.json'/);
+    assert.doesNotMatch(src, /tmpdir/);
 
     // Highest version wins among the candidates, not first-hit — otherwise the
     // baked path pins the user to whatever graft wired the repo, forever.
@@ -32,6 +37,26 @@ for (const [name, src] of [['statusline', statuslineShim(BAKED)], ['hooks', hook
     assert.match(src, /\.catch\(\(\) => \{/);
   });
 }
+
+test('the shims this repo commits carry no home directory and are the current template', () => {
+  // These two files are in `git ls-files`, and .claude/settings.json — also
+  // committed — points every hook and the statusline at them, so they cannot just
+  // be gitignored: a clone without them fails with "Cannot find module". They were
+  // checked in with `/Users/<someone>/…` baked in and a pre-0.11 first-hit body,
+  // which is the scar the header comment in mcp-config.ts refuses to repeat.
+  for (const [file, expected] of [
+    ['graft-hooks.cjs', hooksShim('dist/claude')],
+    ['graft-statusline.cjs', statuslineShim('dist/claude')],
+  ] as const) {
+    // Compare content, not line endings: git checks these out as CRLF wherever
+    // core.autocrlf is on (every default Windows install), and the template only
+    // ever emits \n. Without this the guard fails for contributors whose shims
+    // are perfectly up to date.
+    const text = readFileSync(new URL(`../.claude/helpers/${file}`, import.meta.url), 'utf8').replace(/\r\n/g, '\n');
+    assert.doesNotMatch(text, /\/Users\/|C:\\+Users\\+|\/home\//, `${file} has a machine's home directory in it`);
+    assert.equal(text, expected, `${file} is out of date — regenerate it from shim-template.ts`);
+  }
+});
 
 test('statusline calls main(); hooks passes the event arg', () => {
   assert.match(statuslineShim(BAKED), /m\.main\(\)/);

--- a/test/claude-state.test.ts
+++ b/test/claude-state.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 import {
   emptyStats, readStats, writeStats, patchStats,
   readSession, writeSession, acquireLock, releaseLock, cacheDir, LOCK_STALE_MS, writeJsonAtomic,
+  type SessionState,
 } from '../src/claude/state.js';
 
 function fresh(): string { return mkdtempSync(join(tmpdir(), 'graft-state-')); }
@@ -24,7 +25,12 @@ test('stats round-trip and patch merge', () => {
 test('session defaults and round-trip', () => {
   const d = fresh();
   const s = readSession(d, 'abc');
-  assert.deepEqual(s, { lastQuery: null, perAgentQuery: {}, graftReads: 0, sourceReads: 0, savedTokens: 0, injectedPointers: [], nudges: 0 });
+  // The expected value is typed rather than a bare literal: `deepEqual` narrows its
+  // first argument to the second's type, so an inline literal would retype `s` to
+  // `{ lastQuery: null, … }` and make the assignments below unassignable — and it
+  // pins the defaults against the real shape instead of a hand-copied one.
+  const defaults: SessionState = { lastQuery: null, perAgentQuery: {}, graftReads: 0, sourceReads: 0, savedTokens: 0, injectedPointers: [], nudges: 0 };
+  assert.deepEqual(s, defaults);
   s.lastQuery = 'pkce'; s.graftReads = 2;
   writeSession(d, 'abc', s);
   assert.equal(readSession(d, 'abc').lastQuery, 'pkce');

--- a/test/cli-flags.test.ts
+++ b/test/cli-flags.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Flag handling at the CLI boundary: the checks that decide whether a command
+ * refuses, warns, or quietly does the wrong thing.
+ *
+ * Every case here used to end in a plausible-looking success. A bad `-n` produced
+ * an empty result list annotated "no matching nodes — try different words", which
+ * blames the query. `graft init` with nothing to write exited 0, so a scripted
+ * `graft init && …` carried on as if the repo were wired. `-e` was validated against
+ * a wider set than the one it is applied against, so an extension could pass the
+ * check and still filter the pass it reaches down to nothing. And a persisted
+ * `--include-dir` could be written but never unwritten.
+ *
+ * Driven through the real CLI because that is where all of it lives — these are
+ * argument-parsing decisions, not library behavior.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { runCli, tmpRepo } from "./helpers.js";
+
+/** A repo with one trivially parseable file, so a real build stays cheap. */
+function tinyRepo(tag: string): string {
+  const d = tmpRepo(tag);
+  writeFileSync(join(d, "main.ts"), "export function main(): number {\n  return 1;\n}\n");
+  return d;
+}
+
+// --- ask -n/--limit -----------------------------------------------------------
+
+test("ask rejects a non-numeric -n instead of answering 'no matching nodes'", () => {
+  const r = runCli(["ask", "anything", tinyRepo("limit"), "-n", "all", "--no-refresh"]);
+  assert.equal(r.status, 1, r.describe());
+  assert.match(r.stderr, /-n\/--limit must be a positive integer, got "all"/, r.describe());
+});
+
+test("ask rejects -n 0 and -n -1, which silently returned nothing", () => {
+  // `slice(0, 0)` and `slice(0, -1)` are both empty or wrong, and `ask`'s `?? 8`
+  // guard covers neither — only null/undefined.
+  for (const n of ["0", "-1"]) {
+    const r = runCli(["ask", "anything", tinyRepo("limit"), "-n", n, "--no-refresh"]);
+    assert.equal(r.status, 1, r.describe());
+    assert.match(r.stderr, /must be a positive integer/, r.describe());
+  }
+});
+
+test("a valid -n is not rejected", () => {
+  // The repo has no graph, so this still fails — but on the graph, not the flag.
+  const r = runCli(["ask", "anything", tinyRepo("limit"), "-n", "3", "--no-refresh"]);
+  assert.doesNotMatch(r.stderr, /--limit/, r.describe());
+});
+
+// --- build -e/--extensions ----------------------------------------------------
+
+// `-e` is variadic, so the directory argument goes FIRST in these — otherwise it
+// is swallowed as another extension.
+
+test("-e warns for an extension the --deep pass cannot read, even one the wiring graph indexes", () => {
+  // `.zig` has a breadth-tier grammar, so it passed the old check against
+  // `supportedExtensions()` — and was then filtered out by `CODE_EXTENSIONS`, the
+  // list `-e` is actually matched against, with nothing said.
+  const r = runCli(["check", tinyRepo("ext"), "-e", ".zig"]);
+  assert.match(r.stderr, /-e "\.zig"/, r.describe());
+  assert.match(r.stderr, /--deep/, r.describe());
+});
+
+test("-e stays quiet for an extension the pass does read", () => {
+  const r = runCli(["check", tinyRepo("ext"), "-e", ".ts", ".py"]);
+  assert.doesNotMatch(r.stderr, /⚠ -e/, r.describe());
+});
+
+test("-e narrows the wiring graph, survives a query's refresh, and can be cleared", () => {
+  const d = tmpRepo("ext-persist");
+  writeFileSync(join(d, "main.ts"), "export function main(): number {\n  return 1;\n}\n");
+  writeFileSync(join(d, "helper.py"), "def helper():\n    return 2\n");
+  const nodePaths = () => {
+    const g = JSON.parse(readFileSync(join(d, "graft", ".graph", "wiring.json"), "utf8"));
+    return (g.nodes as { path: string }[]).map((n) => n.path);
+  };
+
+  const narrowed = runCli(["build", d, "-e", ".ts"]);
+  assert.equal(narrowed.status, 0, narrowed.describe());
+  assert.ok(!nodePaths().some((p) => p.endsWith(".py")), "the flag says 'only include these extensions'");
+  assert.deepEqual(JSON.parse(readFileSync(join(d, ".graft", "config.json"), "utf8")).extensions, [".ts"]);
+
+  // The reason it is persisted rather than a one-shot filter: the freshness probe
+  // and the pre-query refresh never see a flag, so an unpersisted narrowing lasted
+  // exactly until the first query, which rebuilt the graph wide again.
+  const asked = runCli(["ask", "main", d]);
+  assert.equal(asked.status, 0, asked.describe());
+  assert.ok(!nodePaths().some((p) => p.endsWith(".py")), "a query must not silently widen the graph");
+
+  // …and `graft check` reads the same narrowing, so the excluded files are not
+  // reported as drift no `graft build` would ever fix.
+  const checked = runCli(["check", d]);
+  assert.equal(checked.status, 0, checked.describe());
+
+  // The way back out, announced while it is in force (same shape as --include-dir).
+  assert.match(runCli(["build", d]).stderr, /-e narrowing active: only \.ts/);
+  const cleared = runCli(["build", d, "--no-extensions"]);
+  assert.equal(cleared.status, 0, cleared.describe());
+  assert.match(cleared.stderr, /cleared this repo's persisted -e/, cleared.describe());
+  assert.ok(nodePaths().some((p) => p.endsWith(".py")), "everything is indexed again");
+});
+
+// --- a typo'd [dir] -----------------------------------------------------------
+
+test("a [dir] that does not exist is refused before anything is written to it", () => {
+  const missing = join(tmpRepo("dir-typo"), "typo");
+  // The walk validates this too, but it runs LAST: `writeBuildConfig` mkdir's
+  // recursively, so the typo used to create `typo/.graft/config.json` and only
+  // then report that `typo` does not exist.
+  const r = runCli(["build", missing, "--include-dir", "build"]);
+  assert.equal(r.status, 1, r.describe());
+  assert.match(r.stderr, /no such directory/, r.describe());
+  assert.equal(existsSync(missing), false, r.describe());
+
+  const c = runCli(["check", missing]);
+  assert.equal(c.status, 1, c.describe());
+  assert.match(c.stderr, /no such directory/, c.describe());
+
+  const i = runCli(["init", missing, "--yes", "--no-build"], { home: tmpRepo("dir-typo-home") });
+  assert.equal(i.status, 1, i.describe());
+  assert.match(i.stderr, /no such directory/, i.describe());
+  assert.equal(existsSync(missing), false, i.describe());
+});
+
+// --- --max-budget-usd ---------------------------------------------------------
+
+test("--max-budget-usd is accepted as a flag and rejects a value that would disable it", () => {
+  // The ceiling existed only as GRAFT_CLAUDE_MAX_BUDGET_USD, which is the wrong
+  // shape for a per-run valve — it is a property of this invocation, like -j.
+  const ok = runCli(["--max-budget-usd", "5", "build", tinyRepo("budget-ok")]);
+  assert.equal(ok.status, 0, ok.describe());
+
+  for (const bad of ["abc", "0", "-2"]) {
+    const r = runCli(["--max-budget-usd", bad, "build", tinyRepo("budget-bad")]);
+    assert.equal(r.status, 1, r.describe());
+    // `NaN` would silently mean "no ceiling" and `0` means "no budget" to the
+    // Claude CLI, not "spend nothing" — both surface hours later, if at all.
+    assert.match(r.stderr, /max-budget-usd/, r.describe());
+  }
+});
+
+// --- build's exit code --------------------------------------------------------
+
+test("build exits non-zero when it printed errors, and 0 when it printed none", () => {
+  const clean = runCli(["build", tinyRepo("exit-clean")]);
+  assert.equal(clean.status, 0, clean.describe());
+
+  const d = tinyRepo("exit-err");
+  // A directory where the ask sidecar's file goes: `writeFileSync` cannot open it,
+  // which is one of the recoverable failures `buildGraph` collects into `errors`
+  // instead of throwing. Any of them would do — this one is deterministic on every
+  // platform, unlike an unreadable file or a mid-build deletion.
+  mkdirSync(join(d, "graft", ".cache", "ask-index.json"), { recursive: true });
+
+  const r = runCli(["build", d]);
+  // Those `✗` lines are files that never reached the graph, or summaries the model
+  // never returned. Exiting 0 anyway meant CI, `graft build && …`, and the init
+  // path all read an incomplete graph as a clean build.
+  assert.equal(r.status, 1, r.describe());
+  assert.match(r.stderr, /ask-index:/, r.describe());
+  assert.match(r.stderr, /1 error\(s\)/, r.describe());
+  // Still a partial build, not an abort: what did work is on disk.
+  assert.ok(existsSync(join(d, "graft", ".graph", "wiring.json")), r.describe());
+});
+
+// --- build --include-dir ------------------------------------------------------
+
+test("--include-dir can be cleared again, and says so while it is in force", () => {
+  const d = tinyRepo("incl");
+  const cfg = join(d, ".graft", "config.json");
+
+  const set = runCli(["build", d, "--include-dir", "build"]);
+  assert.equal(set.status, 0, set.describe());
+  assert.deepEqual(JSON.parse(readFileSync(cfg, "utf8")).includeDirs, ["build"]);
+  // Persisted overrides govern every later build and every hooks-driven refresh,
+  // so a build under one has to admit it — the flag may have been typed months ago.
+  assert.match(set.stderr, /--include-dir override active: build/, set.describe());
+
+  const cleared = runCli(["build", d, "--no-include-dir"]);
+  assert.equal(cleared.status, 0, cleared.describe());
+  // Before this existed, no invocation could write the empty list: the only way
+  // out was hand-editing a file nothing told you about.
+  assert.deepEqual(JSON.parse(readFileSync(cfg, "utf8")).includeDirs, []);
+  assert.match(cleared.stderr, /cleared/, cleared.describe());
+  assert.doesNotMatch(cleared.stderr, /override active/, cleared.describe());
+});
+
+test("--include-dir rejects an empty name instead of persisting inert junk", () => {
+  const d = tinyRepo("incl-empty");
+  const r = runCli(["build", d, "--include-dir", ""]);
+  assert.equal(r.status, 1, r.describe());
+  assert.match(r.stderr, /--include-dir/, r.describe());
+  // No path segment can ever equal "", so `[""]` would have sat in the config
+  // file forever doing nothing.
+  assert.equal(existsSync(join(d, ".graft", "config.json")), false, r.describe());
+});
+
+// --- init's do-nothing paths --------------------------------------------------
+
+test("init without a TTY and without --agents fails instead of exiting 0", () => {
+  const home = tmpRepo("init-home");
+  const r = runCli(["init", tinyRepo("init"), "--no-build"], { home });
+  // Not exotic: in Git Bash / MSYS without winpty `stdin.isTTY` is false, so a
+  // plain interactive `graft init` lands here. Exiting 0 made `graft init && …`
+  // carry on as though the repo had been wired.
+  assert.equal(r.status, 1, r.describe());
+  assert.match(r.stderr, /no TTY to prompt on/, r.describe());
+});
+
+// The other two nothing-written paths — a cancelled picker and an empty selection —
+// are reachable only from the interactive picker, which needs a raw-mode TTY that a
+// piped child process cannot provide. They carry the same `process.exitCode = 1`.
+
+test("--dry-run and --list-agents still succeed — they were asked a question", () => {
+  const home = tmpRepo("init-home");
+  const dry = runCli(["init", tinyRepo("init"), "--dry-run"], { home });
+  assert.equal(dry.status, 0, dry.describe());
+  const list = runCli(["init", "--list-agents"], { home });
+  assert.equal(list.status, 0, list.describe());
+});

--- a/test/cli-meta.test.ts
+++ b/test/cli-meta.test.ts
@@ -1,15 +1,18 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { chmodSync, readFileSync, writeFileSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
-import { join, resolve, sep } from 'node:path';
+import { delimiter, join, resolve, sep } from 'node:path';
 import {
   formatVersionReport,
   formatUpgradeReport,
   resolvePackageJsonPath,
   readCurrentVersion,
   isRunningViaNpx,
+  getNpmViewVersion,
+  runUpgrade,
 } from '../src/cli-meta.js';
+import { tmpRepo } from './helpers.js';
 
 // --- formatVersionReport: pure formatting, injected npm-view results (no network) ---
 
@@ -86,4 +89,72 @@ test('isRunningViaNpx is false for a regular global install', () => {
     join(sep, 'usr', 'local', 'lib', 'node_modules', '@nanonets', 'graft', 'dist', 'cli.js'),
   ).href;
   assert.equal(isRunningViaNpx(globalPath), false);
+});
+
+// --- the npm invocation itself: a stub `npm` on PATH, no registry, no install ---
+//
+// These are the tests that were missing while every npm-shaped feature was dead on
+// Windows: the file only ever exercised the pure formatters with injected results,
+// so nothing noticed that the results could never be anything but `{ ok: false }`
+// there. `npm` ships as `npm.cmd` on Windows and `spawnSync` only ever appends
+// `.exe`, so the un-shelled call failed with ENOENT before touching the network.
+//
+// The stub is installed under the real name `npm` at the FRONT of PATH, so this
+// exercises exactly the lookup the product code does. On posix it is a `sh` script
+// and these pass with or without the fix; on Windows it is the `.cmd` shim that
+// reproduces the bug, which is why CI runs a windows-latest leg.
+
+/** A directory containing a fake `npm` that answers `view` and nothing else. */
+function stubNpmDir(version: string): string {
+  const dir = tmpRepo('npm-stub');
+  if (process.platform === 'win32') {
+    // `exit /b 0` explicitly: a batch file's exit code is otherwise whatever the
+    // last command left behind, which would make the assertions depend on `echo`.
+    writeFileSync(join(dir, 'npm.cmd'), `@echo off\r\nif "%1"=="view" echo ${version}\r\nexit /b 0\r\n`);
+  } else {
+    const p = join(dir, 'npm');
+    writeFileSync(p, `#!/bin/sh\nif [ "$1" = "view" ]; then echo ${version}; fi\nexit 0\n`);
+    chmodSync(p, 0o755);
+  }
+  return dir;
+}
+
+/** Run `fn` with `dir` prepended to PATH, restoring it afterwards. */
+function withPath<T>(dir: string, fn: () => T): T {
+  const saved = process.env.PATH;
+  process.env.PATH = `${dir}${delimiter}${saved ?? ''}`;
+  try {
+    return fn();
+  } finally {
+    if (saved === undefined) delete process.env.PATH;
+    else process.env.PATH = saved;
+  }
+}
+
+test('getNpmViewVersion actually reaches npm (Windows: through the .cmd shim)', () => {
+  const r = withPath(stubNpmDir('9.9.9'), () => getNpmViewVersion('@nanonets/graft', 30_000));
+  assert.deepEqual(r, { ok: true, version: '9.9.9' });
+});
+
+test('getNpmViewVersion still reports {ok:false} when npm is genuinely absent', () => {
+  // The intended offline answer, and the one the ENOENT bug was masquerading as:
+  // an EMPTY PATH must degrade to `{ok:false}`, not throw and not hang.
+  const saved = process.env.PATH;
+  process.env.PATH = '';
+  try {
+    assert.deepEqual(getNpmViewVersion('@nanonets/graft', 30_000), { ok: false });
+  } finally {
+    if (saved === undefined) delete process.env.PATH;
+    else process.env.PATH = saved;
+  }
+});
+
+test('runUpgrade reports success when npm install -g succeeds', () => {
+  // The stub answers `install` with a plain exit 0 and `root -g` with nothing, so
+  // the new version falls through to the `view` answer — no global install happens.
+  const moduleUrl = pathToFileURL(resolve(process.cwd(), 'src/cli.ts')).href;
+  const r = withPath(stubNpmDir('9.9.9'), () => runUpgrade(moduleUrl));
+  assert.equal(r.ran, true);
+  assert.equal(r.ok, true, `upgrade failed: ${r.errorMessage}`);
+  assert.equal(r.newVersion, '9.9.9');
 });

--- a/test/cli-meta.test.ts
+++ b/test/cli-meta.test.ts
@@ -11,6 +11,7 @@ import {
   isRunningViaNpx,
   getNpmViewVersion,
   runUpgrade,
+  compareVersions,
 } from '../src/cli-meta.js';
 import { tmpRepo } from './helpers.js';
 
@@ -29,6 +30,35 @@ test('formatVersionReport: newer version available', () => {
 test('formatVersionReport: offline / unreachable', () => {
   const out = formatVersionReport('0.4.4', { ok: false });
   assert.equal(out, 'graft 0.4.4\nlatest: unreachable (offline?)');
+});
+
+test('formatVersionReport: a build NEWER than npm is not told to downgrade', () => {
+  // The check used to be `latest === current`, so any difference printed "run
+  // graft upgrade" — advice that destroys a fork, an rc, or an `npm link`ed
+  // checkout, because upgrade installs @latest.
+  const out = formatVersionReport('0.11.0', { ok: true, version: '0.10.1' });
+  assert.doesNotMatch(out, /run graft upgrade/);
+  assert.match(out, /this build is newer/);
+});
+
+test('compareVersions: numeric per part, and a prerelease sits below its release', () => {
+  assert.ok(compareVersions('0.10.1', '0.11.0') < 0);
+  assert.ok(compareVersions('0.11.0', '0.10.1') > 0);
+  assert.equal(compareVersions('1.2.3', '1.2.3'), 0);
+  // String compare would put 0.9.0 above 0.10.0 — the whole point of parsing.
+  assert.ok(compareVersions('0.10.0', '0.9.0') > 0);
+  assert.ok(compareVersions('1.2.0-rc.1', '1.2.0') < 0);
+  assert.ok(compareVersions('1.2.0-rc.2', '1.2.0-rc.1') > 0);
+  assert.equal(compareVersions('v1.2.3', '1.2.3'), 0);
+  assert.equal(compareVersions('garbage', 'garbage'), 0);
+});
+
+test('formatUpgradeReport: a refused downgrade explains itself, not the npx no-op', () => {
+  // A refusal also has ran=false; reporting it as the npx path would hide why.
+  const out = formatUpgradeReport({ ran: false, ok: true, oldVersion: '0.11.0', refused: { latest: '0.10.1' } });
+  assert.match(out, /0\.11\.0 is newer than 0\.10\.1/);
+  assert.match(out, /graft upgrade --force/);
+  assert.doesNotMatch(out, /running via npx/);
 });
 
 // --- formatUpgradeReport: pure formatting, injected upgrade results (no network, no spawn) ---

--- a/test/cli-open.test.ts
+++ b/test/cli-open.test.ts
@@ -1,0 +1,65 @@
+/**
+ * `graft viz --open`'s browser hand-off (`src/cli-open.ts`).
+ *
+ * The failure this pins down is asymmetric: on a desktop the opener always exists
+ * and nothing is ever exercised, while in WSL without a desktop, in a container, or
+ * on a headless server there is no `xdg-open` at all. `ChildProcess` is an
+ * `EventEmitter`, so that ENOENT arrives as an `'error'` event one tick later, and
+ * with no listener Node re-throws it as an uncaughtException — killing the process
+ * immediately after it printed the URL, and taking the viz server down with it. On
+ * exactly the machines where the served URL is the only way to see the graph.
+ *
+ * The opener is overridden explicitly (rather than left to the platform) so this
+ * runs the same on both CI legs: on Windows the default is the `cmd.exe` builtin
+ * `start`, which resolves through a shell and so never emits ENOENT.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { browserOpener, openInBrowser } from "../src/cli-open.js";
+
+const MISSING = "graft-definitely-not-an-installed-opener";
+
+/** Resolves with the error the spawn reported, or rejects if none arrives. */
+function openAndCatch(opener: string): Promise<Error> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("no 'error' event within 5s")), 5000);
+    openInBrowser("http://127.0.0.1:4400/", {
+      opener,
+      // Without a shell the ENOENT surfaces as an 'error' event on every platform,
+      // which is the case being guarded. Through a shell it becomes a non-zero
+      // exit instead — invisible here, and harmless.
+      shell: false,
+      onError: (err) => {
+        clearTimeout(timer);
+        resolve(err);
+      },
+    });
+  });
+}
+
+test("a missing browser opener is reported, not thrown", async () => {
+  const err = await openAndCatch(MISSING);
+  assert.match((err as NodeJS.ErrnoException).code ?? "", /ENOENT/);
+});
+
+test("the process survives the failed open", async () => {
+  // The actual regression: an unhandled 'error' event is an uncaughtException, and
+  // there is no `process.on('uncaughtException')` anywhere in this codebase to
+  // absorb it. If the listener in `openInBrowser` were removed, this test file
+  // would die here rather than reach the assertion.
+  const uncaught: Error[] = [];
+  const trap = (e: Error) => uncaught.push(e);
+  process.on("uncaughtException", trap);
+  try {
+    await openAndCatch(MISSING);
+    await new Promise((r) => setTimeout(r, 200)); // let a stray rethrow land
+    assert.deepEqual(uncaught, []);
+  } finally {
+    process.off("uncaughtException", trap);
+  }
+});
+
+test("the opener matches the platform's convention", () => {
+  const expected = { darwin: "open", win32: "start" }[process.platform as string] ?? "xdg-open";
+  assert.equal(browserOpener(), expected);
+});

--- a/test/cli-refresh-lock.test.ts
+++ b/test/cli-refresh-lock.test.ts
@@ -1,0 +1,94 @@
+/**
+ * The pre-query rebuild lock's crash recovery (`src/graph/refresh.ts`).
+ *
+ * `releaseOnSignal` covers the polite exits. It cannot cover Windows, which has no
+ * SIGTERM: the Claude Code prompt hook runs `graft ask` under a timeout enforced
+ * with `execFileSync`, and there the process is terminated outright — no signal
+ * handler, no `exit` listener, no `finally`. The lock file survives its owner, and
+ * for the next five minutes (`LOCK_STALE_MS`) every query waits out `LOCK_WAIT_MS`
+ * and then answers from the stale graph with "a graph rebuild is already in flight".
+ * A hard kill or a crash does the same on every platform.
+ *
+ * So the owner's liveness, not the file's age, is what these pin down.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { spawn, spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { reclaimDeadLock } from "../src/graph/refresh.js";
+import { acquireLockIn, releaseLockIn } from "../src/util/state.js";
+import { tmpRepo } from "./helpers.js";
+
+const LOCK = ".sync.lock";
+
+function cache(): string {
+  const d = join(tmpRepo("refresh-lock"), "graft", ".cache");
+  mkdirSync(d, { recursive: true });
+  return d;
+}
+
+function writeLock(dir: string, pid: unknown): string {
+  const p = join(dir, LOCK);
+  writeFileSync(p, JSON.stringify({ pid, at: new Date().toISOString() }));
+  return p;
+}
+
+/** A pid that is definitely not running: a child we watched exit. */
+function deadPid(): number {
+  const r = spawnSync(process.execPath, ["-e", ""], { stdio: "ignore" });
+  assert.ok(r.pid, "could not spawn a throwaway child to harvest a dead pid");
+  return r.pid!;
+}
+
+test("a lock left behind by a killed process is reclaimed immediately", () => {
+  const dir = cache();
+  const p = writeLock(dir, deadPid());
+  assert.equal(reclaimDeadLock(dir), true);
+  assert.equal(existsSync(p), false, "the dead owner's lock is removed");
+  // The point of removing it: the next query rebuilds instead of waiting out
+  // LOCK_WAIT_MS and answering from a graph it knows is stale.
+  assert.equal(acquireLockIn(dir), true);
+  releaseLockIn(dir);
+});
+
+test("a lock held by a live process is never reclaimed", async () => {
+  const dir = cache();
+  // A real, live, foreign process — `process.kill(pid, 0)` answering is the whole
+  // signal, so a made-up pid would prove nothing.
+  const child = spawn(process.execPath, ["-e", "setTimeout(() => {}, 30000)"], { stdio: "ignore" });
+  await new Promise((r) => setTimeout(r, 200));
+  try {
+    const p = writeLock(dir, child.pid);
+    assert.equal(reclaimDeadLock(dir), false);
+    assert.equal(existsSync(p), true, "an in-flight rebuild keeps its lock");
+    assert.equal(acquireLockIn(dir), false, "and nobody else gets to build");
+  } finally {
+    child.kill("SIGKILL");
+  }
+});
+
+test("our own lock is left alone", () => {
+  const dir = cache();
+  assert.equal(acquireLockIn(dir), true);
+  const before = readFileSync(join(dir, LOCK), "utf8");
+  assert.equal(reclaimDeadLock(dir), false, "reclaiming the lock we hold would be the bug");
+  assert.equal(readFileSync(join(dir, LOCK), "utf8"), before);
+  releaseLockIn(dir);
+});
+
+test("an unreadable or pid-less lock falls back to the age rule", () => {
+  const dir = cache();
+  // Written by a graft old enough to predate the pid field, or truncated by a
+  // crash mid-write. Unknown ownership must read as "someone else's", not as
+  // permission to delete — LOCK_STALE_MS still ages it out.
+  for (const body of ["{ not json", JSON.stringify({ at: "now" }), JSON.stringify({ pid: "1234" })]) {
+    writeFileSync(join(dir, LOCK), body);
+    assert.equal(reclaimDeadLock(dir), false, `left alone: ${body}`);
+    assert.equal(existsSync(join(dir, LOCK)), true);
+  }
+});
+
+test("no lock at all is not an error", () => {
+  assert.equal(reclaimDeadLock(cache()), false);
+});

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -12,7 +12,7 @@ import { buildContext } from "../src/context/build.js";
 import { checkContext, indexFreshness, staleBanner } from "../src/context/check.js";
 import { contextDirFor, ensureGitignored, ensureSearchable } from "../src/context/node-file.js";
 import { writeBuildConfig } from "../src/util/state.js";
-import { fakeProviders } from "./helpers.js";
+import { fakeProviders, rmDir } from "./helpers.js";
 
 // CLI-spawn helper (same pattern as test/graph-traverse-cli.test.ts) — these tests
 // exercise the real process boundary (exit codes), which a unit-level call into
@@ -74,7 +74,7 @@ test("init builds one markdown node per entity, with links and a manifest", asyn
     assert.equal(manifest.files.length, 2);
     assert.equal(manifest.nodes.length, 3);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -86,7 +86,7 @@ test("check passes immediately after init", async () => {
     assert.equal(r.ok, true);
     assert.equal(r.missing, false);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -97,7 +97,7 @@ test("check reports NO GRAPH when init never ran", () => {
     assert.equal(r.missing, true);
     assert.equal(r.ok, false);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -111,7 +111,7 @@ test("check detects content drift when a source file changes", async () => {
     assert.equal(r.contentDrift.length, 1);
     assert.equal(r.contentDrift[0].path, "auth.ts");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -131,7 +131,7 @@ test("indexFreshness/staleBanner: recorded files gone from disk (the branch-swit
     assert.match(banner ?? "", /ahead of your working tree/, "banner fires when stale");
     assert.match(banner ?? "", /graft grep/, "banner steers to graft grep, not raw grep");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -141,7 +141,7 @@ test("indexFreshness returns null when there is no graph", () => {
     assert.equal(indexFreshness(dir), null);
     assert.equal(staleBanner(null), null);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -154,7 +154,7 @@ test("check detects a new file not yet in the graph (coverage drift)", async () 
     assert.equal(r.ok, false);
     assert.deepEqual(r.coverage, ["new.ts"]);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -190,7 +190,7 @@ test("A5: a persisted --include-dir override reaches context/build.ts's file lis
     assert.deepEqual(check.removed, [], "build/ must not be reported removed — check.ts must see it too");
     assert.deepEqual(check.coverage, [], "build/ must not be reported as new/uncovered — it's already in the manifest");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -208,7 +208,7 @@ test("re-running init clears drift", async () => {
     await buildContext(dir, buildOpts());
     assert.equal(checkContext(dir).ok, true);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -222,7 +222,7 @@ test("human notes below the generated block survive regeneration", async () => {
     await buildContext(dir, buildOpts());
     assert.match(readFileSync(path, "utf8"), /Hand-written note: watch out for retries\./);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -243,7 +243,7 @@ test("graft check: keyless build (no --deep) exits 0 — wiring graph present, m
     assert.match(r.stdout, /wiring graph is the source of truth/);
     assert.match(r.stdout, /graph check: OK/);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -255,7 +255,7 @@ test("graft check: neither layer ever built exits 1", () => {
     assert.match(r.stdout, /NO GRAPH/);
     assert.match(r.stdout, /graft build/);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -280,7 +280,7 @@ test("graft check: keyless build then code changes (wiring stale) exits 1", () =
     assert.equal(r.status, 1, `expected exit 1, got ${r.status}\nstdout: ${r.stdout}\nstderr: ${r.stderr}`);
     assert.match(r.stdout, /graph check: STALE/);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -293,7 +293,7 @@ test("ensureGitignored: creates .gitignore with the graft/ entry when none exist
     assert.match(gi, /^graft\/$/m);
     assert.match(gi, /regenerable, not committed/);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -307,7 +307,7 @@ test("ensureGitignored: appends to an existing .gitignore without clobbering it"
     assert.match(gi, /dist\//);
     assert.match(gi, /^graft\/$/m);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -321,7 +321,7 @@ test("ensureGitignored: idempotent — a second build adds nothing", () => {
     assert.equal(once, twice);
     assert.equal((twice.match(/^graft\/$/gm) ?? []).length, 1);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -332,7 +332,7 @@ test("ensureGitignored: recognizes a pre-existing bare `graft` entry (no slash) 
     ensureGitignored(dir, contextDirFor(dir));
     assert.equal(readFileSync(join(dir, ".gitignore"), "utf8"), "graft\n");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -342,7 +342,7 @@ test("ensureGitignored: no-op when the graph dir is outside the repo root", () =
     ensureGitignored(dir, join(tmpdir(), "somewhere-else-graft"));
     assert.equal(existsSync(join(dir, ".gitignore")), false);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -359,7 +359,7 @@ test("ensureSearchable: re-admits the card tree while excluding the caches", () 
     assert.match(ig, /^graft\/\.graph\/$/m, "and not wiring.json");
     assert.match(ig, /ripgrep reads/, "carries the why, for whoever finds this file");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -375,7 +375,7 @@ test("ensureSearchable: appends to an existing .ignore, and is idempotent", () =
     assert.equal(once, twice);
     assert.equal((twice.match(/^!graft\/$/gm) ?? []).length, 1);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -387,7 +387,7 @@ test("ensureSearchable: leaves a hand-written negation alone", () => {
     ensureSearchable(dir, contextDirFor(dir));
     assert.equal(readFileSync(join(dir, ".ignore"), "utf8"), "# mine\n!graft/\n");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -397,6 +397,6 @@ test("ensureSearchable: no-op when the graph dir is outside the repo root", () =
     ensureSearchable(dir, join(tmpdir(), "somewhere-else-graft"));
     assert.equal(existsSync(join(dir, ".ignore")), false);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -9,10 +9,13 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 import { buildContext } from "../src/context/build.js";
+import { Graft } from "../src/engine.js";
 import { checkContext, indexFreshness, staleBanner } from "../src/context/check.js";
 import { contextDirFor, ensureGitignored, ensureSearchable } from "../src/context/node-file.js";
 import { writeBuildConfig } from "../src/util/state.js";
-import { fakeProviders, rmDir } from "./helpers.js";
+import { fakeProviders, BracketSynthesizer, PassthroughSummarizer, rmDir } from "./helpers.js";
+import type { Summarizer, Synthesizer, SynthNode, FileSummary } from "../src/index.js";
+import type { ChatModel } from "../src/ai/llm/types.js";
 
 // CLI-spawn helper (same pattern as test/graph-traverse-cli.test.ts) — these tests
 // exercise the real process boundary (exit codes), which a unit-level call into
@@ -221,6 +224,250 @@ test("human notes below the generated block survive regeneration", async () => {
     writeFileSync(path, withNote);
     await buildContext(dir, buildOpts());
     assert.match(readFileSync(path, "utf8"), /Hand-written note: watch out for retries\./);
+  } finally {
+    rmDir(dir);
+  }
+});
+
+// --- failure paths: an LLM outage must never cost the user their graph -------
+//
+// graft/ is git-ignored, so anything phase 5 deletes is gone for good — including
+// whatever a human wrote under `## Notes`, which node-file.ts promises to keep
+// verbatim. Every test below drives a REAL failure (an expired key, a rate limit,
+// a truncated turn) through the same summarizer/synthesizer injection seam the
+// engine exposes, and asserts the previous build survived it.
+
+/** Every call fails, the way an expired key or a 429 storm fails: all of them. */
+class FailingSummarizer implements Summarizer {
+  calls = 0;
+  constructor(private message = "401 invalid api key") {}
+  async summarize(): Promise<string> {
+    this.calls++;
+    throw new Error(this.message);
+  }
+}
+
+/** Succeeds at the wire level and returns nothing — a truncated or refused turn. */
+class EmptySummarizer implements Summarizer {
+  async summarize(): Promise<string> {
+    return "   ";
+  }
+}
+
+class FailingSynthesizer implements Synthesizer {
+  async synthesize(): Promise<SynthNode[]> {
+    throw new Error("429 rate limited");
+  }
+}
+
+/** Counts calls so a test can prove the second run paid for nothing. */
+class CountingSummarizer implements Summarizer {
+  calls = 0;
+  private inner = new PassthroughSummarizer();
+  async summarize(code: string, opts: { path: string }): Promise<string> {
+    this.calls++;
+    return this.inner.summarize(code, opts);
+  }
+}
+
+function cacheFile(dir: string): string {
+  return join(dir, "graft", ".cache", "summaries.json");
+}
+
+/**
+ * Edit both fixture files so phase 1 misses the content-hash cache, keeping the
+ * `[[…]]` markup (and therefore the node set) identical. Without this, a rebuild
+ * calls the model zero times and no injected failure can fire at all.
+ */
+function editSources(dir: string): void {
+  writeFileSync(join(dir, "auth.ts"), `// [[Auth Service]] ==depends_on==> [[Token Store]]\nexport const auth = 42;\n`);
+  writeFileSync(join(dir, "billing.ts"), `// [[Billing]] ==uses==> [[Auth Service]]\nexport const billing = 43;\n`);
+}
+
+function readCache(dir: string): { summaries: Record<string, unknown>; synth: Record<string, unknown> } {
+  return JSON.parse(readFileSync(cacheFile(dir), "utf8"));
+}
+
+test("a --deep run where EVERY summary fails leaves the concept layer (and its human notes) untouched", async () => {
+  const dir = makeFixture();
+  try {
+    await buildContext(dir, buildOpts());
+    const path = join(dir, "graft", "billing.md");
+    writeFileSync(path, readFileSync(path, "utf8") + "\nHand-written note: watch out for retries.\n");
+    const manifestBefore = readFileSync(join(dir, "graft", "manifest.json"), "utf8");
+    editSources(dir); // the code moved on; the key expired in the meantime
+
+    const summarizer = new FailingSummarizer();
+    const r = await buildContext(dir, { model: "fake", summarizer, synthesizer: new BracketSynthesizer() });
+
+    assert.equal(summarizer.calls, 2, "each file was still attempted");
+    assert.ok(r.errors.length > 0, "the failure must be reported, not swallowed");
+    assert.match(r.errors.join("\n"), /left untouched/, "and it must say the graph was preserved");
+
+    assert.ok(existsSync(join(dir, "graft", "auth-service.md")), "an outage is not evidence a concept disappeared");
+    assert.match(readFileSync(path, "utf8"), /Hand-written note: watch out for retries\./);
+    assert.equal(readFileSync(join(dir, "graft", "manifest.json"), "utf8"), manifestBefore, "the roster still describes what is on disk");
+    // The layer is internally consistent (drift against the edited code is the
+    // honest signal: `check` should say "rebuild me", not "your concepts are gone").
+    assert.deepEqual(checkContext(dir).indexDrift, []);
+  } finally {
+    rmDir(dir);
+  }
+});
+
+test("a summary that comes back empty is an error, never a cache entry", async () => {
+  const dir = makeFixture();
+  try {
+    // Empty is cached by CONTENT HASH, so caching it once makes it permanent: the
+    // next run hits it, phase 2 filters the file out of synthesis, and the file is
+    // silently absent from the graph forever with no error to explain it.
+    const r = await buildContext(dir, { model: "fake", summarizer: new EmptySummarizer(), synthesizer: new BracketSynthesizer() });
+    assert.equal(r.summarized, 0, "an empty string is not a summary");
+    assert.equal(r.errors.length > 0, true);
+    assert.match(r.errors.join("\n"), /empty summary/);
+    assert.deepEqual(readCache(dir).summaries, {}, "nothing may be written to the content-hash cache");
+  } finally {
+    rmDir(dir);
+  }
+});
+
+test("a synthesis failure keeps the per-file summaries already paid for, and the graph on disk", async () => {
+  const dir = makeFixture();
+  try {
+    await buildContext(dir, buildOpts());
+    editSources(dir);
+
+    // Phase 1 succeeds (N calls, real money on a real repo); phase 2 dies on a 429.
+    const first = new CountingSummarizer();
+    const r = await buildContext(dir, { model: "fake", summarizer: first, synthesizer: new FailingSynthesizer() });
+    assert.equal(r.errors.length > 0, true, "the batch failure must surface");
+    assert.match(r.errors.join("\n"), /synthesis batch/);
+    assert.ok(existsSync(join(dir, "graft", "auth-service.md")), "a partial run must not prune");
+
+    // The retry must be cheap: every summary from the failed run is on disk.
+    const second = new CountingSummarizer();
+    const again = await buildContext(dir, { model: "fake", summarizer: second, synthesizer: new BracketSynthesizer() });
+    assert.equal(second.calls, 0, "phase 1 was persisted before synthesis ran, so nothing is repaid");
+    assert.equal(again.cached, 2);
+    assert.equal(again.nodes, 3, "and the run that finally synthesizes writes the graph normally");
+  } finally {
+    rmDir(dir);
+  }
+});
+
+test("a failed batch is not cached as an empty result — the next run retries it", async () => {
+  const dir = makeFixture();
+  try {
+    await buildContext(dir, { model: "fake", summarizer: new PassthroughSummarizer(), synthesizer: new FailingSynthesizer() });
+    // `[]` is a legitimate cached answer ("this batch yields no nodes"), so writing
+    // one for a batch that 429'd would turn a transient failure into a permanent
+    // cache hit that never calls the model again.
+    assert.deepEqual(readCache(dir).synth, {}, "a batch that never answered has no answer to cache");
+
+    const r = await buildContext(dir, buildOpts());
+    assert.equal(r.nodes, 3, "the retry actually re-ran synthesis");
+  } finally {
+    rmDir(dir);
+  }
+});
+
+test("buildContext honours the concurrency it is given (this is what -j promises)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "ctxgraph-conc-"));
+  try {
+    for (let i = 0; i < 12; i++) writeFileSync(join(dir, `f${i}.ts`), `// [[Thing ${i}]]\nexport const x${i} = ${i};\n`);
+
+    // A user who passes `-j 1` is working around a rate limit — or, with the
+    // claude-cli provider, avoiding N simultaneous Claude Code processes. The
+    // phase-1 loop used to ignore the option entirely and always run 8 in flight.
+    const track = (limit: number) => {
+      let inFlight = 0;
+      let peak = 0;
+      const summarizer: Summarizer = {
+        async summarize(code: string) {
+          peak = Math.max(peak, ++inFlight);
+          await new Promise((r) => setTimeout(r, 5));
+          inFlight--;
+          return code;
+        },
+      };
+      return { summarizer, run: () => buildContext(dir, { model: "fake", concurrency: limit, summarizer, synthesizer: new BracketSynthesizer() }), peak: () => peak };
+    };
+
+    const one = track(1);
+    await one.run();
+    assert.equal(one.peak(), 1, "-j 1 must mean ONE call at a time");
+
+    // A fresh dir: the run above cached every summary, so nothing would be called.
+    rmDir(join(dir, "graft"));
+    const three = track(3);
+    await three.run();
+    assert.equal(three.peak(), 3);
+  } finally {
+    rmDir(dir);
+  }
+});
+
+test("Graft.init forwards the concurrency it is given down to the concept pass", async () => {
+  // The half above proves buildContext honours the option; this proves the option
+  // can be REACHED from the only entry point anyone actually uses. `-j` was parsed
+  // in cli.ts and handed to `engine.graph` alone, so `InitOptions` had no field to
+  // carry it: the flag that exists to survive a rate limit left the phase that
+  // makes the most calls running 5 at a time regardless.
+  const dir = mkdtempSync(join(tmpdir(), "ctxgraph-engine-conc-"));
+  try {
+    for (let i = 0; i < 8; i++) writeFileSync(join(dir, `f${i}.ts`), `// [[Thing ${i}]]\nexport const x${i} = ${i};\n`);
+    let inFlight = 0;
+    let peak = 0;
+    const summarizer: Summarizer = {
+      async summarize(code: string) {
+        peak = Math.max(peak, ++inFlight);
+        await new Promise((r) => setTimeout(r, 5));
+        inFlight--;
+        return code;
+      },
+    };
+    await new Graft({ summarizer, synthesizer: new BracketSynthesizer() }).init(dir, { concurrency: 1 });
+    assert.equal(peak, 1, "-j 1 must mean ONE call at a time through the engine too");
+  } finally {
+    rmDir(dir);
+  }
+});
+
+test("Graft counts the tokens every op spends, including a caller's own chatModel", async () => {
+  // The adapters normalize `Usage` (uncached input kept apart from cache reads and
+  // cache writes, per provider) and every op then discarded it, so a --deep build
+  // over thousands of files could not say afterwards how many calls it had made.
+  // Counted by wrapping the transport once — which has to hold for an INJECTED
+  // chatModel too, since that path skips the factory entirely.
+  const dir = mkdtempSync(join(tmpdir(), "ctxgraph-usage-"));
+  try {
+    for (let i = 0; i < 3; i++) writeFileSync(join(dir, `f${i}.ts`), `// [[Thing ${i}]]\nexport const x${i} = ${i};\n`);
+    const chatModel: ChatModel = {
+      label: "fake:model",
+      async create() {
+        return {
+          text: "a summary",
+          toolCalls: [],
+          usage: { input: 10, output: 5, cacheRead: 2, cacheCreate: 1 },
+          stopReason: "stop",
+          assistant: { role: "assistant" as const, content: "a summary" },
+        };
+      },
+    };
+    const engine = new Graft({ chatModel });
+    assert.deepEqual(engine.usage(), { calls: 0, input: 0, output: 0, cacheRead: 0, cacheCreate: 0 });
+
+    await engine.init(dir);
+    const u = engine.usage();
+    assert.ok(u.calls >= 3, `one call per file at least, got ${u.calls}`);
+    assert.equal(u.input, 10 * u.calls);
+    assert.equal(u.output, 5 * u.calls);
+    assert.equal(u.cacheRead, 2 * u.calls, "cache reads stay separate — they are billed differently");
+    assert.equal(u.cacheCreate, 1 * u.calls);
+    // A copy, not the live counter: a caller holding the result must not watch it move.
+    const snapshot = engine.usage();
+    await engine.init(dir);
+    assert.equal(snapshot.calls, u.calls);
   } finally {
     rmDir(dir);
   }

--- a/test/covers.test.ts
+++ b/test/covers.test.ts
@@ -11,7 +11,7 @@ import { tmpdir } from "node:os";
 import matter from "gray-matter";
 import { buildContext } from "../src/context/build.js";
 import { buildGraph } from "../src/graph/build.js";
-import { fakeProviders } from "./helpers.js";
+import { fakeProviders, rmDir } from "./helpers.js";
 
 function makeFixture(): string {
   const dir = mkdtempSync(join(tmpdir(), "graft-covers-"));
@@ -36,7 +36,7 @@ test("wiring build backfills covers: onto concept nodes", async () => {
     assert.equal(login.kind, "function");
     assert.match(login.at, /^auth\.ts:L\d+-L\d+$/);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -57,7 +57,7 @@ test("patching covers preserves the node's body and other frontmatter", async ()
     assert.deepEqual(after.data.links, before.data.links);
     assert.ok("covers" in after.data && !("covers" in before.data));
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -71,6 +71,6 @@ test("re-running the wiring build leaves covers byte-stable", async () => {
     const second = readFileSync(join(dir, "graft", "auth-service.md"), "utf8");
     assert.equal(second, first);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });

--- a/test/graph-breadth-tier.test.ts
+++ b/test/graph-breadth-tier.test.ts
@@ -1,0 +1,214 @@
+/**
+ * The breadth (generic) tier's machinery, as distinct from "does language X extract"
+ * (test/generic-extract.test.ts): which grammar a file is routed to, which grammars a
+ * build actually loads, how call sites are attributed to their enclosing definition,
+ * and what a build says when a grammar simply isn't there.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  enclosingDefs,
+  extractGeneric,
+  isWarm,
+  unavailableGrammars,
+  warmGenericGrammars,
+  type Def,
+} from "../src/graph/generic.js";
+import { resolveEdges } from "../src/graph/resolve.js";
+import { buildGraph } from "../src/graph/build.js";
+import { checkGraph } from "../src/graph/check.js";
+import { readGraph, wiringPath } from "../src/graph/write.js";
+import type { NodeV1 } from "../src/graph/types.js";
+import type { RawEdge } from "../src/graph/extract.js";
+import { tmpRepo } from "./helpers.js";
+
+function extractAll(files: Record<string, string>, lang: string) {
+  const nodes: NodeV1[] = [];
+  const raw: RawEdge[] = [];
+  for (const [rel, src] of Object.entries(files)) {
+    const r = extractGeneric(rel, src, lang);
+    nodes.push(...r.nodes);
+    raw.push(...r.rawEdges);
+  }
+  return { nodes, raw };
+}
+
+/**
+ * The header/implementation split is universal in C, and the upstream tags.scm pattern
+ * matches a prototype as readily as a definition — so every function had two nodes of
+ * the same name in two files, `resolveName` saw an ambiguous global match, and dropped
+ * it. The visible symptom is that no C project with headers had ANY cross-file call.
+ */
+test("C prototypes in a header are not definitions, so cross-file calls resolve", async () => {
+  await warmGenericGrammars(["c"]);
+  const { nodes, raw } = extractAll(
+    {
+      "src/app.h": "int run(void);\nchar *dup_it(const char *);\n",
+      "src/app.c": "int run(void){ return 0; }\nchar *dup_it(const char *s){ return 0; }\n",
+      "src/other.c": '#include "app.h"\nint go(void){ return run(); }\n',
+    },
+    "c",
+  );
+
+  const named = nodes.filter((n) => n.kind !== "file").map((n) => `${n.path}:${n.name}`).sort();
+  assert.deepEqual(
+    named,
+    ["src/app.c:dup_it", "src/app.c:run", "src/other.c:go"],
+    "one node per function, at its definition — the header's two prototypes mint nothing",
+  );
+
+  const call = resolveEdges(nodes, raw).find((e) => e.relation === "calls" && e.source === "src/other.c#go");
+  assert.ok(call, "the cross-file call must survive resolution");
+  assert.equal(call!.target, "src/app.c#run");
+});
+
+/**
+ * `.h` can only be claimed by one registry row and C claims it — but a C++ project's
+ * headers are exactly where the classes, templates and namespaces live, and c.scm has
+ * no pattern for any of them. Those symbols were simply absent from the graph.
+ */
+test("a C++-looking .h is parsed with the cpp grammar once cpp is warm", async () => {
+  await warmGenericGrammars(["c", "cpp"]);
+  const header = [
+    "#pragma once",
+    "namespace app {",
+    "class Widget {",
+    "public:",
+    "  void draw();",
+    "  int size() const { return 1; }",
+    "};",
+    "}",
+    "",
+  ].join("\n");
+  const names = extractGeneric("src/widget.h", header, "c")
+    .nodes.filter((n) => n.kind !== "file")
+    .map((n) => `${n.kind}:${n.name}`)
+    .sort();
+  assert.deepEqual(names, ["class:Widget", "method:size"], "the C grammar knows no class_specifier at all");
+
+  // …and a plain C header must NOT be dragged along with it, even with cpp warm.
+  const plain = extractGeneric("src/plain.h", "struct Point { int x; };\nint run(void);\n", "c")
+    .nodes.filter((n) => n.kind !== "file")
+    .map((n) => `${n.kind}:${n.name}`);
+  assert.deepEqual(plain, ["class:Point"], "no C++ markers → still the C grammar");
+});
+
+/**
+ * Attribution used to be `defs.filter(contains).sort(bySize)[0]` per token — O(D·C)
+ * with two array allocations per token, which on a generated file (15k defs, 50k call
+ * sites) is 750M comparisons inside build's synchronous loop.
+ */
+test("enclosingDefs picks the innermost definition, including nested ones", () => {
+  const defs: Def[] = [
+    { id: "outer", startIndex: 0, endIndex: 100 },
+    { id: "inner", startIndex: 10, endIndex: 40 },
+    { id: "deepest", startIndex: 20, endIndex: 30 },
+    { id: "sibling", startIndex: 50, endIndex: 70 },
+  ];
+  const offsets = [5, 15, 25, 35, 60, 80, 120];
+  assert.deepEqual(
+    enclosingDefs(defs, offsets).map((d) => d?.id),
+    ["outer", "inner", "deepest", "inner", "sibling", "outer", undefined],
+  );
+  // Order of the offsets must not matter — the sweep sorts internally and writes back
+  // positionally, so a caller can hand them over in document order or any other.
+  assert.deepEqual(
+    enclosingDefs(defs, [...offsets].reverse()).map((d) => d?.id),
+    ["outer", "inner", "deepest", "inner", "sibling", "outer", undefined].reverse(),
+  );
+  assert.deepEqual(enclosingDefs([], [1, 2]), [undefined, undefined]);
+});
+
+test("enclosingDefs stays fast at generated-file scale", () => {
+  // 15k nested-ish definitions and 60k tokens: the quadratic version is ~10^9
+  // comparisons plus 60k array allocations, which took tens of seconds for one file.
+  const defs: Def[] = [];
+  for (let i = 0; i < 15_000; i++) {
+    defs.push({ id: `f${i}`, startIndex: i * 100, endIndex: i * 100 + 90 });
+  }
+  const offsets: number[] = [];
+  for (let i = 0; i < 60_000; i++) offsets.push((i % 15_000) * 100 + 10);
+
+  const started = Date.now();
+  const got = enclosingDefs(defs, offsets);
+  const elapsed = Date.now() - started;
+
+  assert.equal(got[0]?.id, "f0");
+  assert.equal(got[14_999]?.id, "f14999");
+  assert.ok(elapsed < 3_000, `attribution took ${elapsed}ms — the quadratic shape is back`);
+});
+
+/**
+ * `warmGenericGrammars` swallows a missing wasm and a failed grammar on purpose
+ * (neither should fail a build), which left the caller with no way to tell "indexed"
+ * from "indexed as an empty file node".
+ */
+test("unavailableGrammars names the breadth languages with no loaded grammar", async () => {
+  assert.deepEqual(
+    unavailableGrammars(["zig", "solidity"]).sort(),
+    ["solidity", "zig"],
+    "nothing is warm yet in this process",
+  );
+  await warmGenericGrammars(["zig"]);
+  assert.equal(isWarm("zig"), true);
+  assert.deepEqual(unavailableGrammars(["zig", "solidity"]), ["solidity"]);
+  assert.deepEqual(unavailableGrammars([]), []);
+});
+
+/**
+ * `.java` is claimed by BOTH registries and the depth tier always wins the actual
+ * extraction, so warming its breadth grammar loaded a multi-MB wasm and compiled
+ * queries/java.scm on every build of every Java repo, for a path that can never run.
+ */
+test("a build never warms a breadth grammar the depth tier owns", async () => {
+  const d = tmpRepo("breadth-warm-");
+  mkdirSync(join(d, "src"), { recursive: true });
+  writeFileSync(join(d, "src", "App.java"), "public class App {\n  int run() { return 1; }\n}\n");
+  writeFileSync(join(d, "src", "main.py"), "def go():\n    return 1\n");
+
+  await buildGraph(d, { reuse: false });
+  assert.equal(isWarm("java"), false, "the java wasm must never be loaded for a .java file");
+
+  // …and the file is still fully indexed, by the depth tier.
+  const graph = readGraph(wiringPath(join(d, "graft")))!;
+  assert.ok(graph.nodes.some((n) => n.id === "src/App.java#App"), "the depth tier still indexes it");
+  assert.ok(graph.meta.languages.includes("java"), "and it is still reported as a language");
+});
+
+/**
+ * The same filter, on the OTHER caller. `checkGraph` re-runs Tier-1 extraction and so
+ * warms grammars too, but warmed the unfiltered set — and `check` runs in CI, from the
+ * hooks, and before every query that finds the graph stale, so a Java repo paid the
+ * multi-MB wasm load far more often here than on the build path that was fixed first.
+ */
+test("a check never warms a breadth grammar the depth tier owns", async () => {
+  const d = tmpRepo("breadth-warm-check-");
+  mkdirSync(join(d, "src"), { recursive: true });
+  writeFileSync(join(d, "src", "App.java"), "public class App {\n  int run() { return 1; }\n}\n");
+
+  await buildGraph(d, { reuse: false });
+  const r = await checkGraph(d);
+  assert.equal(r.missing, false, "the graph built above is what check reads");
+  assert.equal(isWarm("java"), false, "the java wasm must never be loaded for a .java file");
+  assert.equal(r.ok, true, "and the depth tier still re-extracts it, so nothing reads as drift");
+});
+
+/**
+ * Reusing one parser per language and deleting each tree is invisible in the output by
+ * design — this pins that it stays invisible, since a parser wrongly shared or a tree
+ * deleted too early would corrupt the very next file's extraction.
+ */
+test("repeated extraction through the shared per-language parser is stable", async () => {
+  await warmGenericGrammars(["rust"]);
+  const src = "pub struct Config { name: String }\n\npub fn load() -> Config {\n    parse()\n}\n\nfn parse() -> Config {\n    load()\n}\n";
+  const first = JSON.stringify(extractGeneric("lib.rs", src, "rust"));
+  for (let i = 0; i < 200; i++) {
+    assert.equal(JSON.stringify(extractGeneric("lib.rs", src, "rust")), first, `run ${i} diverged`);
+  }
+  // Interleaving a second language must not disturb the first's parser either.
+  await warmGenericGrammars(["c"]);
+  extractGeneric("a.c", "int f(void){return 1;}\n", "c");
+  assert.equal(JSON.stringify(extractGeneric("lib.rs", src, "rust")), first);
+});

--- a/test/graph-extract-ts.test.ts
+++ b/test/graph-extract-ts.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Depth-tier extraction gaps that made whole classes of TypeScript dependency
+ * invisible: a JSX component use, a `new Foo()`, an `interface X extends Y`. Each
+ * of these is the MOST common way its language feature couples two modules, and each
+ * produced no edge at all — so the symbol on the receiving end read as an orphan.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { extractFile } from "../src/graph/extract.js";
+import { resolveEdges } from "../src/graph/resolve.js";
+import { buildGraph } from "../src/graph/build.js";
+import { readGraph, wiringPath } from "../src/graph/write.js";
+import { tmpRepo } from "./helpers.js";
+
+/** Every raw edge but containment, which is noise for these assertions. */
+function wiring(rel: string, src: string, lang: "typescript" | "tsx") {
+  return extractFile(rel, src, lang).rawEdges.filter((e) => e.relation !== "contains");
+}
+
+test("a JSX component use is a reference, not a declaration name", () => {
+  const edges = wiring(
+    "page.tsx",
+    'import { Button } from "./button.js";\nexport function Page() {\n  return <Button label="go" />;\n}\n',
+    "tsx",
+  );
+  const ref = edges.find((e) => e.relation === "references");
+  assert.ok(ref, `<Button/> must produce a reference edge (got ${JSON.stringify(edges)})`);
+  assert.equal(ref!.source, "page.tsx#Page");
+  assert.equal(ref!.name, "Button");
+  assert.equal(ref!.specifier, "./button.js");
+});
+
+test("a JSX component use wires the two files end to end", async () => {
+  const root = tmpRepo("extract-jsx-");
+  mkdirSync(join(root, "src"), { recursive: true });
+  writeFileSync(join(root, "src", "button.tsx"), "export function Button(): null {\n  return null;\n}\n");
+  writeFileSync(
+    join(root, "src", "page.tsx"),
+    'import { Button } from "./button.js";\nexport function Page(): null {\n  return <Button />;\n}\n',
+  );
+  await buildGraph(root, { reuse: false });
+  const graph = readGraph(wiringPath(join(root, "graft")))!;
+  assert.ok(
+    graph.edges.some(
+      (e) =>
+        e.source === "src/page.tsx#Page" &&
+        e.target === "src/button.tsx#Button" &&
+        e.relation === "references",
+    ),
+    // Without this a React/Next app's component graph is entirely empty: `<Button/>`
+    // is not a call_expression, so the reference path was the only one available.
+    `Page must reference Button (got ${JSON.stringify(graph.edges)})`,
+  );
+});
+
+test("`new Foo()` in the same file is a call edge to the class", () => {
+  const src = "class Repo {\n  find(): number { return 1; }\n}\nexport function make(): Repo {\n  return new Repo();\n}\n";
+  const { nodes, rawEdges } = extractFile("b.ts", src, "typescript");
+  const edges = resolveEdges(nodes, rawEdges);
+  const call = edges.find((e) => e.relation === "calls" && e.source === "b.ts#make");
+  assert.ok(call, "`new Repo()` must produce a call edge — it is not a call_expression");
+  assert.equal(call!.target, "b.ts#Repo");
+  assert.equal(call!.confidence, "extracted");
+});
+
+test("`Foo()` in Python is a call edge to the class it constructs", () => {
+  const src = "class Repo:\n    def find(self):\n        return 1\n\n\ndef make():\n    return Repo()\n";
+  const { nodes, rawEdges } = extractFile("d.py", src, "python");
+  const edges = resolveEdges(nodes, rawEdges);
+  const call = edges.find((e) => e.relation === "calls" && e.source === "d.py#make");
+  assert.ok(call, "Python's `Repo()` IS the constructor call, so it must resolve to the class");
+  assert.equal(call!.target, "d.py#Repo");
+});
+
+test("a `new Foo()` on an imported class resolves through the import, not by bare name", () => {
+  // The import states which module, so a homonym elsewhere in the repo must not make
+  // this ambiguous — bare-name resolution would drop the edge outright.
+  const files: Record<string, string> = {
+    "src/repo.ts": "export class Repo {\n  find(): number { return 1; }\n}\n",
+    "other/repo.ts": "export class Repo {\n  find(): number { return 2; }\n}\n",
+    "src/use.ts": 'import { Repo } from "./repo.js";\nexport function make(): Repo {\n  return new Repo();\n}\n',
+  };
+  const nodes = [], raw = [];
+  for (const [rel, src] of Object.entries(files)) {
+    const r = extractFile(rel, src, "typescript");
+    nodes.push(...r.nodes);
+    raw.push(...r.rawEdges);
+  }
+  const edges = resolveEdges(nodes, raw);
+  const calls = edges.filter((e) => e.relation === "calls" && e.source === "src/use.ts#make");
+  assert.deepEqual(calls.map((e) => e.target), ["src/repo.ts#Repo"]);
+  assert.equal(calls[0].confidence, "extracted", "the import names the file — this is certain, not a guess");
+});
+
+test("`interface X extends Y` produces an extends edge, generics and all", () => {
+  const src = [
+    "interface User { id: number }",
+    "interface Repo<T> { get(): T }",
+    "export interface AdminUser extends User {}",
+    "export interface Both extends User, Repo<User> {}",
+    "export class Impl implements Repo<User> {}",
+    "",
+  ].join("\n");
+  const { nodes, rawEdges } = extractFile("a.ts", src, "typescript");
+  const heritage = rawEdges
+    .filter((e) => e.relation === "extends" || e.relation === "implements")
+    .map((e) => `${e.source.split("#")[1]} ${e.relation} ${e.name}`)
+    .sort();
+  assert.deepEqual(heritage, [
+    "AdminUser extends User",
+    "Both extends Repo",
+    "Both extends User",
+    "Impl implements Repo",
+  ]);
+
+  // …and they resolve to the interface nodes, so the hierarchy is navigable.
+  const edges = resolveEdges(nodes, rawEdges);
+  assert.ok(
+    edges.some((e) => e.source === "a.ts#AdminUser" && e.target === "a.ts#User" && e.relation === "extends"),
+  );
+  // `implements Repo<User>` used to drop entirely: `generic_type` matched neither
+  // `identifier` nor `type_identifier`, so the whole supertype went missing.
+  assert.ok(
+    edges.some((e) => e.source === "a.ts#Impl" && e.target === "a.ts#Repo" && e.relation === "implements"),
+  );
+  // The type ARGUMENT is not a supertype and must never become one.
+  assert.ok(!edges.some((e) => e.source === "a.ts#Impl" && e.target === "a.ts#User"));
+});
+
+test("`chars` on a file node is BYTES, matching types.ts and the breadth tier", () => {
+  // The savings estimate divides this by 4 for a token count and compares nodes from
+  // both tiers; generic.ts writes Buffer.byteLength, so UTF-16 code units here made an
+  // accented .ts file look smaller than an identical .rs one. ASCII hides it entirely.
+  const src = "export const gréé = 'ação';\n";
+  const file = extractFile("acc.ts", src, "typescript").nodes.find((n) => n.kind === "file")!;
+  assert.equal(file.chars, Buffer.byteLength(src));
+  assert.notEqual(file.chars, src.length, "the fixture must actually contain multi-byte characters");
+});

--- a/test/graph-go.test.ts
+++ b/test/graph-go.test.ts
@@ -12,6 +12,7 @@ import { buildGraph } from "../src/graph/build.js";
 import { readGraph, wiringPath } from "../src/graph/write.js";
 import { writeBuildConfig } from "../src/util/state.js";
 import type { GraphV1, NodeV1 } from "../src/graph/types.js";
+import { rmDir } from "./helpers.js";
 
 const MAIN_GO = `package main
 
@@ -92,7 +93,7 @@ test("Go extraction: funcs, methods, structs, interfaces, type aliases", async (
     assert.equal(nodeById(graph!, "main.go#Reader")?.kind, "interface");
     assert.equal(nodeById(graph!, "main.go#ID")?.kind, "type");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -127,7 +128,7 @@ test("Go extraction: call and import edges", async () => {
     );
     assert.ok(external, "fmt should remain an external package string");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -163,7 +164,7 @@ test("Go extraction: go.mod in a subdirectory resolves intra-module imports", as
       "fmt should remain an external package string",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -200,6 +201,6 @@ test("A5: a go.mod under a persisted --include-dir override is found, so imports
     );
     assert.ok(!external, "must not be left as an unresolved external package string once the module is found");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });

--- a/test/graph-include-dir.test.ts
+++ b/test/graph-include-dir.test.ts
@@ -16,6 +16,7 @@ import { execFileSync } from "node:child_process";
 import { readGraph, wiringPath } from "../src/graph/write.js";
 import { probeDrift, isClean } from "../src/graph/fingerprint.js";
 import type { GraphV1 } from "../src/graph/types.js";
+import { rmDir } from "./helpers.js";
 
 function repoWithBuildDir(): string {
   const d = mkdtempSync(join(tmpdir(), "graft-include-dir-"));
@@ -87,14 +88,14 @@ test("A5: deleting the generated graft cache does not delete the persisted inclu
   const d = repoWithBuildDir();
   try {
     runCli(["build", d, "--include-dir", "build"]);
-    rmSync(join(d, "graft"), { recursive: true, force: true });
+    rmDir(join(d, "graft"));
 
     runCli(["build", d]);
     const rebuilt = graphOf(d);
     assert.ok(rebuilt?.nodes.some((n) => n.id === "build/util.ts#fromBuild"));
     assert.equal(existsSync(join(d, ".graft", "config.json")), true);
   } finally {
-    rmSync(d, { recursive: true, force: true });
+    rmDir(d);
   }
 });
 
@@ -111,8 +112,8 @@ test("A5: custom --dir builds keep repository config outside both output directo
     assert.equal(existsSync(join(d, "graft", ".cache", "config.json")), false);
     assert.equal(existsSync(join(out, ".cache", "config.json")), false);
   } finally {
-    rmSync(d, { recursive: true, force: true });
-    rmSync(out, { recursive: true, force: true });
+    rmDir(d);
+    rmDir(out);
   }
 });
 
@@ -132,7 +133,7 @@ test("A5: --include-dir rejects a dot-prefixed name", () => {
     assert.match(r.stderr, /\.github/);
     assert.equal(existsSync(join(d, ".graft", "config.json")), false, "must not persist an invalid value");
   } finally {
-    rmSync(d, { recursive: true, force: true });
+    rmDir(d);
   }
 });
 
@@ -145,7 +146,7 @@ test("A5: --include-dir rejects a value containing a path separator", () => {
     assert.match(r.stderr, /foo\/bar/);
     assert.equal(existsSync(join(d, ".graft", "config.json")), false, "must not persist an invalid value");
   } finally {
-    rmSync(d, { recursive: true, force: true });
+    rmDir(d);
   }
 });
 
@@ -156,7 +157,7 @@ test("A5: --include-dir rejects a value containing a backslash", () => {
     assert.equal(r.status, 1, `expected exit 1, got ${r.status}\nstdout: ${r.stdout}\nstderr: ${r.stderr}`);
     assert.match(r.stderr, /--include-dir/);
   } finally {
-    rmSync(d, { recursive: true, force: true });
+    rmDir(d);
   }
 });
 
@@ -167,6 +168,6 @@ test("A5: a later valid --include-dir still works (validation isn't over-eager)"
     const g = graphOf(d);
     assert.ok(g && g.nodes.some((n) => n.id === "build/util.ts#fromBuild"));
   } finally {
-    rmSync(d, { recursive: true, force: true });
+    rmDir(d);
   }
 });

--- a/test/graph-incremental.test.ts
+++ b/test/graph-incremental.test.ts
@@ -7,6 +7,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
+import { createRequire } from "node:module";
 import { chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
@@ -240,7 +241,11 @@ test("an unreadable file is still recorded, so it can't look new on every probe"
  */
 test("extractorStamp: a real identity for the loaded extraction code", () => {
   const s = extractorStamp();
-  assert.notEqual(s, "unknown", "path resolution must work under both tsx and dist/, or invalidation silently stops");
+  // null is the live failure mode (no identity could be established at all) and it
+  // disables memoization entirely, so it has to be asserted, not assumed; "unknown"
+  // is the superseded sentinel that used to be written into sidecars as a real id.
+  assert.ok(s, "path resolution must work under both tsx and dist/, or invalidation silently stops");
+  assert.notEqual(s, "unknown", "the failure sentinel must never come back as a usable stamp");
   assert.match(s, /^[0-9a-f]{16}$/);
   assert.equal(s, extractorStamp(), "memoized — the cost is paid once per process");
 });
@@ -273,10 +278,67 @@ test("the stamp moves for any module in the extractor directory, not just one", 
   assert.notEqual(stampDir(dir, ".js", "0.8.0"), beforeRename, "a rename at identical content is still a change");
 });
 
+/**
+ * The breadth tier's whole extraction is the `.scm` query — `queries/c.scm` decides
+ * which C nodes exist at all — and it lives in a SUBDIRECTORY with a non-module
+ * extension, so the module sweep above cannot see it. That meant fixing a query left
+ * the stamp identical, `readExtractCache` accepted every pre-fix entry, and the fix
+ * reached nobody until something else in graph/ happened to change.
+ */
+test("the stamp moves when a queries/*.scm changes, not just a module", () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-stamp-scm-"));
+  writeFileSync(join(dir, "extract.js"), "export const a = 1;\n");
+  const noQueries = stampDir(dir, ".js", "0.8.0");
+  assert.ok(noQueries, "a directory with modules has an identity");
+
+  mkdirSync(join(dir, "queries"), { recursive: true });
+  writeFileSync(join(dir, "queries", "c.scm"), "(function_definition) @definition.function\n");
+  const withQuery = stampDir(dir, ".js", "0.8.0");
+  assert.notEqual(withQuery, noQueries, "a query file is part of the extractor's identity");
+  assert.equal(stampDir(dir, ".js", "0.8.0"), withQuery, "stable for identical input");
+
+  writeFileSync(join(dir, "queries", "c.scm"), "(function_declarator) @definition.function\n");
+  const edited = stampDir(dir, ".js", "0.8.0");
+  assert.notEqual(edited, withQuery, "editing a query must invalidate every replayed parse");
+
+  writeFileSync(join(dir, "queries", "notes.txt"), "not a query\n");
+  assert.equal(stampDir(dir, ".js", "0.8.0"), edited, "a non-query file in queries/ must not churn the memo");
+
+  writeFileSync(join(dir, "queries", "cpp.scm"), "(class_specifier) @definition.class\n");
+  assert.notEqual(stampDir(dir, ".js", "0.8.0"), edited, "adding a query for another language counts too");
+});
+
+/**
+ * Every grammar is a `^` dependency, so `npm i` can swap the parser under an unchanged
+ * graft version. The stamp has to move with the grammar it actually loaded, or the memo
+ * replays parses the current parser would no longer produce.
+ */
+test("extractorStamp folds in the resolved grammar versions, not just graft's own", () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-stamp-grammar-"));
+  writeFileSync(join(dir, "extract.js"), "export const a = 1;\n");
+  const req = createRequire(import.meta.url);
+  const tsVersion = JSON.parse(
+    readFileSync(req.resolve("tree-sitter-typescript/package.json"), "utf8"),
+  ).version as string;
+
+  // computeStamp's `version` argument is `<graft version>|<grammar versions>`, so the
+  // grammar half moving must move the stamp exactly as graft's own version does.
+  const before = stampDir(dir, ".js", `0.8.0|tree-sitter-typescript@${tsVersion}`);
+  const after = stampDir(dir, ".js", `0.8.0|tree-sitter-typescript@${tsVersion}-bump`);
+  assert.notEqual(after, before, "a grammar upgrade under an unchanged graft version must invalidate");
+
+  // …and the real stamp really does carry them: the same modules + graft version alone
+  // would collide with the stamp computed from graft's own directory otherwise.
+  assert.match(extractorStamp()!, /^[0-9a-f]{16}$/);
+});
+
 test("a memo written by a different extractor is dropped, not replayed", async () => {
   const d = repo();
   await buildGraph(d);
   const path = extractCachePath(outOf(d));
+  // null here means the stamp failed and no memo was written at all — the test
+  // would then trivially "pass" on an empty cache it never planted anything in.
+  assert.ok(path, "a memo path is required for this test to have a memo to corrupt");
   const cache = JSON.parse(readFileSync(path, "utf8"));
   assert.ok(Object.keys(cache.files).length > 0);
 

--- a/test/graph-incremental.test.ts
+++ b/test/graph-incremental.test.ts
@@ -16,7 +16,7 @@ import { fingerprintPath, isClean, probeDrift, readFingerprint } from "../src/gr
 import { readAskIndex } from "../src/ask/index-file.js";
 import { readGraph, wiringPath } from "../src/graph/write.js";
 import type { GraphV1 } from "../src/graph/types.js";
-import { chmodDenialUnavailable } from "./helpers.js";
+import { chmodDenialUnavailable, rmDir } from "./helpers.js";
 
 const MATH = [
   "export function add(a: number, b: number): number {",
@@ -196,7 +196,7 @@ test("gitignored generated files stay out of the graph, fingerprint, and drift p
     writeFileSync(bundle, "export function generatedBundle(): number { return 2; }\n");
     assert.ok(isClean(probeDrift(d, outOf(d))!), "ignored output changes must not trigger a refresh");
   } finally {
-    rmSync(d, { recursive: true, force: true });
+    rmDir(d);
   }
 });
 

--- a/test/graph-invariants.test.ts
+++ b/test/graph-invariants.test.ts
@@ -18,6 +18,7 @@ import { readGraph, wiringPath } from "../src/graph/write.js";
 import { contextDirFor } from "../src/context/node-file.js";
 import { checkGraphInvariants } from "../src/graph/invariants.js";
 import type { GraphV1 } from "../src/graph/types.js";
+import { rmDir } from "./helpers.js";
 
 // A recursion-free fixture spanning both tiers: main→helper (TS, depth),
 // load→parse (Rust, breadth), Circle implements Shape (PHP, breadth → a
@@ -73,7 +74,7 @@ test("Tier-0: a built multi-tier graph satisfies every structural invariant", as
     assert.deepEqual(problems, [], `no invariant violations (got: ${problems.slice(0, 5).join("; ")})`);
     assert.equal(selfLoopCalls, 0, "a recursion-free fixture has no self-loop calls");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -122,7 +123,7 @@ test("Tier-0: the build is deterministic — two cold builds produce the identic
       assert.ok(g, "graph built");
       return g!;
     } finally {
-      rmSync(dir, { recursive: true, force: true });
+      rmDir(dir);
     }
   };
   // Two separate cold builds of byte-identical source (relative ids, so paths match).

--- a/test/graph-java.test.ts
+++ b/test/graph-java.test.ts
@@ -23,6 +23,7 @@ import { tmpdir } from "node:os";
 import { buildGraph } from "../src/graph/build.js";
 import { readGraph, wiringPath } from "../src/graph/write.js";
 import type { GraphV1, NodeV1 } from "../src/graph/types.js";
+import { rmDir } from "./helpers.js";
 
 const PKG = "src/main/java/com/acme";
 
@@ -135,7 +136,7 @@ test("Java extraction: classes, interfaces, enums, records, methods, constructor
     assert.equal(nodeById(graph!, `${APP_JAVA}#App.greet`)?.kind, "method");
     assert.equal(nodeById(graph!, `${APP_JAVA}#App.App`)?.kind, "method");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -163,7 +164,7 @@ test("Java extraction: visibility comes from the modifier list, not the name", a
       "package-private (no modifier) is not API surface",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -199,7 +200,7 @@ test("Java extraction: call edges — implicit `this`, typed field receiver, con
       "persist should have a constructor edge to Point",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -227,7 +228,7 @@ test("Java extraction: a `var` local states no type, so its member call stays un
       "the constructor edge still resolves, so the dependency is still visible",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -256,7 +257,7 @@ test("Java extraction: extends and implements", async () => {
       "App implements Greeter",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -280,7 +281,7 @@ test("Java extraction: imports resolve by package path; external types stay stri
       "java.util.List should remain an external type string",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -311,7 +312,7 @@ test("Java extraction: a static-member import resolves to its enclosing type", a
       "a static-member import should fall back to its enclosing type's file",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -344,7 +345,7 @@ test("Java extraction: an ambiguous package suffix stays unresolved rather than 
       "an ambiguous suffix must stay an unresolved specifier",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -407,7 +408,7 @@ test("Java overloads: a delegating call resolves to the other overload, not itse
       "and must not call itself",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -431,7 +432,7 @@ test("Java overloads: a variadic candidate is never filtered out by argument cou
       "a 3-argument call should still reach the variadic overload",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -451,6 +452,6 @@ test("Java overloads: same-arity overloads stay unresolved rather than guessing"
     assert.equal(a?.arity, 1);
     assert.equal(b?.arity, 1, "both render overloads have arity 1, so count cannot separate them");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });

--- a/test/graph-load.test.ts
+++ b/test/graph-load.test.ts
@@ -37,6 +37,19 @@ function node(id: string): NodeV1 {
   };
 }
 
+/** A wiring graph the loader would actually meet on disk. The fixtures here used
+ * to be `{ version: 1, nodes, edges } as GraphV1` — a top-level `version` field
+ * GraphV1 does not have, and no `meta` at all, which the cast hid: `writeGraph`
+ * spreads what it is given, so those tests were exercising the loader against a
+ * file no build can produce. */
+function graphOf(nodes: NodeV1[]): GraphV1 {
+  return {
+    meta: { version: 1, nodeCount: nodes.length, edgeCount: 0, languages: ["typescript"] },
+    nodes,
+    edges: [],
+  };
+}
+
 function fixtureDir(): string {
   return mkdtempSync(join(tmpdir(), "graft-load-"));
 }
@@ -51,7 +64,7 @@ function bump(path: string): void {
 
 test("loadGraphCached: two loads of an unchanged file return the same parsed object", () => {
   const dir = fixtureDir();
-  writeGraph({ version: 1, nodes: [node("a")], edges: [] } as GraphV1, dir);
+  writeGraph(graphOf([node("a")]), dir);
   __resetParseCounts();
 
   const g1 = loadGraphCached(dir);
@@ -63,7 +76,7 @@ test("loadGraphCached: two loads of an unchanged file return the same parsed obj
 
 test("loadGraphCached: rewriting the wiring file invalidates the cache", () => {
   const dir = fixtureDir();
-  writeGraph({ version: 1, nodes: [node("a")], edges: [] } as GraphV1, dir);
+  writeGraph(graphOf([node("a")]), dir);
   __resetParseCounts();
 
   const g1 = loadGraphCached(dir);
@@ -72,7 +85,7 @@ test("loadGraphCached: rewriting the wiring file invalidates the cache", () => {
 
   // Rewrite with a changed node, then force a distinct mtime so the cache
   // can't coast on a filesystem with coarse mtime granularity.
-  writeGraph({ version: 1, nodes: [node("b")], edges: [] } as GraphV1, dir);
+  writeGraph(graphOf([node("b")]), dir);
   bump(wiringPath(dir));
 
   const g2 = loadGraphCached(dir);
@@ -92,7 +105,7 @@ test("loadGraphCached: missing file returns null and a later-created file is pic
   const missAgain = loadGraphCached(dir);
   assert.equal(missAgain, null, "missing file must not be negatively cached forever");
 
-  writeGraph({ version: 1, nodes: [node("late")], edges: [] } as GraphV1, dir);
+  writeGraph(graphOf([node("late")]), dir);
   const found = loadGraphCached(dir);
   assert.equal(found?.nodes[0]?.id, "late");
   assert.equal(__parseCount.graph, 1);
@@ -100,7 +113,7 @@ test("loadGraphCached: missing file returns null and a later-created file is pic
 
 test("loadAskIndexCached: caches and invalidates the same way as the graph loader", () => {
   const dir = fixtureDir();
-  const graph = { version: 1, nodes: [node("a"), node("b")], edges: [] } as GraphV1;
+  const graph = graphOf([node("a"), node("b")]);
   writeAskIndex(dir, graph);
   __resetParseCounts();
 
@@ -110,7 +123,7 @@ test("loadAskIndexCached: caches and invalidates the same way as the graph loade
   assert.strictEqual(i1, i2);
   assert.equal(__parseCount.askIndex, 1);
 
-  writeAskIndex(dir, { version: 1, nodes: [node("a")], edges: [] } as GraphV1);
+  writeAskIndex(dir, graphOf([node("a")]));
   bump(askIndexPath(dir));
 
   const i3 = loadAskIndexCached(dir);
@@ -127,18 +140,14 @@ test("callTool: graft_trace_calls on the same dir twice doesn't reparse the grap
   const dir = fixtureDir();
   mkdirSync(join(dir, "src"), { recursive: true });
   writeFileSync(join(dir, "src", "math.ts"), "export function add() { return 1; }\n");
-  const graph: GraphV1 = {
-    version: 1,
-    // A real `buildGraph` always emits a `kind: "file"` node per source file;
-    // include one here too so `graft_trace_calls` with depth (a `resolveSymbol` +
-    // `edgeWalk` walk, the old `graft impact`) can resolve the filename-shaped
-    // query the way it would against a real build.
-    nodes: [
-      { ...node("src/math.ts#add"), path: "src/math.ts" },
-      { ...node("src/math.ts"), kind: "file", path: "src/math.ts", name: "math.ts", signature: null },
-    ],
-    edges: [],
-  } as GraphV1;
+  // A real `buildGraph` always emits a `kind: "file"` node per source file;
+  // include one here too so `graft_trace_calls` with depth (a `resolveSymbol` +
+  // `edgeWalk` walk, the old `graft impact`) can resolve the filename-shaped
+  // query the way it would against a real build.
+  const graph = graphOf([
+    { ...node("src/math.ts#add"), path: "src/math.ts" },
+    { ...node("src/math.ts"), kind: "file", path: "src/math.ts", name: "math.ts", signature: null },
+  ]);
   // graft_trace_calls reads through `contextDirFor(root)`, i.e. `<root>/graft`
   // by default — write the graph there directly rather than round-tripping
   // through a real `graft build`.

--- a/test/graph-python-imports.test.ts
+++ b/test/graph-python-imports.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Python imports resolving to in-repo modules.
+ *
+ * They were being run through the JS resolver, which is nonsense for every Python
+ * spelling there is: `posix.join("app", ".utils")` is `"app/.utils"`, so every
+ * candidate path it built was one that cannot exist and the resolver always fell
+ * through to "external string". Since `collectImportedSymbols` is TS-only there were
+ * no `references` edges either — meaning a Python repo's graph had containment and
+ * intra-file calls and NOT ONE edge between two files.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { extractFile } from "../src/graph/extract.js";
+import { resolveEdges } from "../src/graph/resolve.js";
+import { buildGraph } from "../src/graph/build.js";
+import { readGraph, wiringPath } from "../src/graph/write.js";
+import type { NodeV1 } from "../src/graph/types.js";
+import type { RawEdge } from "../src/graph/extract.js";
+import { tmpRepo } from "./helpers.js";
+
+/** Extract a whole fixture repo of .py files and resolve its edges. */
+function graphOf(files: Record<string, string>) {
+  const nodes: NodeV1[] = [];
+  const raw: RawEdge[] = [];
+  for (const [rel, src] of Object.entries(files)) {
+    const r = extractFile(rel, src, "python");
+    nodes.push(...r.nodes);
+    raw.push(...r.rawEdges);
+  }
+  return resolveEdges(nodes, raw);
+}
+
+const PKG: Record<string, string> = {
+  "app/__init__.py": "",
+  "app/core/__init__.py": "",
+  "app/core/db.py": "def connect():\n    return 1\n",
+  "app/utils.py": "def helper():\n    return 2\n",
+  "app/services/__init__.py": "",
+  "app/services/mailer.py": "def send():\n    return 3\n",
+  "app/services/orders.py": [
+    "from .mailer import send",        // sibling module in this package
+    "from ..utils import helper",      // one package up
+    "from ..core.db import connect",   // one package up, then down a package
+    "from . import mailer",            // the package itself
+    "from app.core import db",         // absolute, by dotted path
+    "import app.utils",                // absolute `import a.b`
+    "import os",                       // stdlib — nothing in-repo to point at
+    "from third_party.thing import x", // external
+    "",
+  ].join("\n"),
+};
+
+test("relative Python imports resolve to the module files they name", () => {
+  const targets = graphOf(PKG)
+    .filter((e) => e.relation === "imports" && e.source === "app/services/orders.py")
+    .map((e) => e.target)
+    .sort();
+
+  assert.ok(targets.includes("app/services/mailer.py"), "`from .mailer import send` → the sibling module");
+  assert.ok(targets.includes("app/utils.py"), "`from ..utils import helper` → one package up");
+  assert.ok(targets.includes("app/core/db.py"), "`from ..core.db import connect` → up then down");
+  assert.ok(
+    targets.includes("app/services/__init__.py"),
+    "`from . import mailer` names this package, whose file is its __init__.py",
+  );
+});
+
+test("absolute Python imports resolve by path suffix, since the sys.path root is unknown", () => {
+  const targets = graphOf(PKG)
+    .filter((e) => e.relation === "imports" && e.source === "app/services/orders.py")
+    .map((e) => e.target);
+
+  assert.ok(targets.includes("app/core/__init__.py"), "`from app.core import db` names the package");
+  assert.ok(targets.includes("app/utils.py"), "`import app.utils` names the module");
+  // Nothing in-repo is called `os` or `third_party`, so both stay raw strings — the
+  // resolver must never invent a file for an out-of-repo module.
+  assert.ok(targets.includes("os"), "stdlib stays an external string");
+  assert.ok(targets.includes("third_party.thing"), "a third-party module stays an external string");
+});
+
+test("a relative import that climbs past the repo root stays a string, never a guess", () => {
+  const edges = graphOf({
+    "a.py": "def f():\n    return 1\n",
+    "b.py": "from ...way.up import thing\n",
+  });
+  const targets = edges.filter((e) => e.relation === "imports" && e.source === "b.py").map((e) => e.target);
+  assert.deepEqual(targets, ["...way.up"]);
+});
+
+test("an ambiguous absolute module suffix is dropped rather than guessed", () => {
+  // Two in-repo files can end in `shared/conf.py`; nothing in `import shared.conf`
+  // says which, so — exactly like the Java and PHP resolvers — it stays a string.
+  const edges = graphOf({
+    "svc_a/shared/conf.py": "X = 1\n",
+    "svc_b/shared/conf.py": "X = 2\n",
+    "main.py": "import shared.conf\n",
+  });
+  const targets = edges.filter((e) => e.relation === "imports" && e.source === "main.py").map((e) => e.target);
+  assert.deepEqual(targets, ["shared.conf"]);
+});
+
+test("a built Python repo has real file→file import edges", async () => {
+  const d = tmpRepo("py-imports-");
+  mkdirSync(join(d, "app", "core"), { recursive: true });
+  writeFileSync(join(d, "app", "__init__.py"), "");
+  writeFileSync(join(d, "app", "core", "__init__.py"), "");
+  writeFileSync(join(d, "app", "core", "db.py"), "def connect():\n    return 1\n");
+  writeFileSync(join(d, "app", "main.py"), "from .core.db import connect\n\n\ndef run():\n    return connect()\n");
+
+  await buildGraph(d, { reuse: false });
+  const graph = readGraph(wiringPath(join(d, "graft")))!;
+  assert.ok(
+    graph.edges.some(
+      (e) => e.source === "app/main.py" && e.target === "app/core/db.py" && e.relation === "imports",
+    ),
+    `main.py must import core/db.py (got ${JSON.stringify(graph.edges.filter((e) => e.relation === "imports"))})`,
+  );
+});

--- a/test/graph-quality-script.test.ts
+++ b/test/graph-quality-script.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Drift guard between the THREE places the graph vocabulary is written down:
+ * the `Kind`/`Relation`/`Confidence` unions in src/graph/types.ts, the sets in
+ * src/graph/invariants.ts, and the standalone copies in scripts/graph-quality.mjs.
+ *
+ * The duplication in the .mjs is deliberate (invariants.ts says so: the CLI report
+ * has to work against a stale or missing dist/), but nothing checked the copies
+ * still agreed. Adding one member to `Kind` — the union has grown twice already,
+ * once for Go's `struct` and once for the generic tier's module/constant/variable —
+ * made the script report `bad kind` on every real graph and exit 1 under --strict,
+ * i.e. a green change turning the CI gate red for a graph that is perfectly valid.
+ *
+ * The unions are read out of the source text because types do not exist at
+ * runtime; invariants.ts is compared by behaviour rather than by export, so the
+ * check keeps working whether or not it ever exposes its sets.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { KINDS, RELATIONS, CONFIDENCE, analyze } from "../scripts/graph-quality.mjs";
+import { checkGraphInvariants } from "../src/graph/invariants.js";
+import type { Confidence, GraphV1, Kind, NodeV1, Relation } from "../src/graph/types.js";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const typesSrc = readFileSync(join(repoRoot, "src", "graph", "types.ts"), "utf8");
+
+/** The string literals of `export type <name> = "a" | "b" | …;`, comments and all. */
+function unionMembers(name: string): string[] {
+  const start = typesSrc.indexOf(`export type ${name} =`);
+  assert.notEqual(start, -1, `no 'export type ${name}' in src/graph/types.ts`);
+  const body = typesSrc.slice(start, typesSrc.indexOf(";", start));
+  return [...body.matchAll(/"([^"]+)"/g)].map((m) => m[1]).sort();
+}
+
+function node(kind: string, id: string): NodeV1 {
+  return {
+    path: "a.ts", id, name: id, kind: kind as Kind, span: "L1-L2",
+    signature: null, exported: true, origin: "ast", body_hash: "h",
+    summary_state: "pending", summary: null, crux: null,
+  } as NodeV1;
+}
+
+function graph(nodes: NodeV1[], edges: GraphV1["edges"] = []): GraphV1 {
+  return { meta: { version: 1, nodeCount: nodes.length, edgeCount: edges.length, languages: [] }, nodes, edges };
+}
+
+test("graph-quality's KINDS matches the Kind union in types.ts", () => {
+  assert.deepEqual([...KINDS].sort(), unionMembers("Kind"));
+});
+
+test("graph-quality's RELATIONS and CONFIDENCE match their unions in types.ts", () => {
+  assert.deepEqual([...RELATIONS].sort(), unionMembers("Relation"));
+  assert.deepEqual([...CONFIDENCE].sort(), unionMembers("Confidence"));
+});
+
+test("graph-quality and invariants.ts accept exactly the same vocabulary", () => {
+  // Behavioural equality: every kind the script allows must also pass the shared
+  // checker, and a kind neither knows must fail in both.
+  const nodes = [...KINDS].map((k, i) => node(String(k), `n${i}`));
+  assert.deepEqual(checkGraphInvariants(graph(nodes)).problems, []);
+  assert.deepEqual(analyze(graph(nodes), "x").invariants.sample, []);
+
+  const bogus = graph([node("macro", "n0")]);
+  assert.match(checkGraphInvariants(bogus).problems.join("\n"), /bad kind 'macro'/);
+  assert.match(analyze(bogus, "x").invariants.sample.join("\n"), /bad kind 'macro'/);
+});
+
+test("both copies agree on relations and confidences", () => {
+  const nodes = [node("function", "a"), node("function", "b")];
+  for (const relation of RELATIONS as Set<Relation>) {
+    for (const confidence of CONFIDENCE as Set<Confidence>) {
+      const g = graph(nodes, [{ source: "a", target: "b", relation, confidence }]);
+      assert.deepEqual(checkGraphInvariants(g).problems, [], `${relation}/${confidence}`);
+      assert.equal(analyze(g, "x").invariants.ok, true, `${relation}/${confidence}`);
+    }
+  }
+  const bad = graph(nodes, [{ source: "a", target: "b", relation: "shadows" as Relation, confidence: "guessed" as Confidence }]);
+  assert.equal(checkGraphInvariants(bad).problems.length, 2);
+  assert.equal(analyze(bad, "x").invariants.violations, 2);
+});
+
+test("importing the script does not run its CLI", () => {
+  // The module used to read process.argv and `process.exit(2)` at import time —
+  // importing it from a test would have killed the runner outright.
+  assert.equal(typeof analyze, "function");
+});

--- a/test/graph-refresh.test.ts
+++ b/test/graph-refresh.test.ts
@@ -220,9 +220,13 @@ test("GRAFT_REFRESH=hash: drift the probe reports is drift the rebuild repairs",
   const staleHash = fp.files["src/math.ts"][2];
   fp.files["src/math.ts"] = [now.size, now.mtimeMs, staleHash];
   writeFileSync(fingerprintPath(outOf(d)), JSON.stringify(fp));
-  const memo = JSON.parse(readFileSync(extractCachePath(outOf(d)), "utf8"));
+  // null when no extractor stamp could be computed, i.e. no memo exists — the
+  // stat-trusting rebuild this test provokes could then never happen.
+  const memoPath = extractCachePath(outOf(d));
+  assert.ok(memoPath, "the memo the rebuild must not trust has to exist for the test to mean anything");
+  const memo = JSON.parse(readFileSync(memoPath, "utf8"));
   Object.assign(memo.files["src/math.ts"], { size: now.size, mtimeMs: now.mtimeMs });
-  writeFileSync(extractCachePath(outOf(d)), JSON.stringify(memo));
+  writeFileSync(memoPath, JSON.stringify(memo));
 
   // Nobody notices without the flag — that's the documented trade-off, and the
   // whole reason the flag exists.

--- a/test/graph-resolve-typed.test.ts
+++ b/test/graph-resolve-typed.test.ts
@@ -133,6 +133,68 @@ test("unresolved member calls cannot inflate map hubs and hotspots (#35)", () =>
   assert.equal(set?.inDegree, 1, "only the owner-qualified FileBindings.set call contributes");
 });
 
+/**
+ * `classParents` used to be keyed by the declaring class's BARE NAME, which fuses the
+ * hierarchies of two same-named classes in different packages: `a/Base` extending `Foo`
+ * and `b/Base` extending `Bar` became `Base → [Foo, Bar]`. A `base.handle()` in package
+ * a then climbed into package b's `Bar.handle` and shipped it as an `inferred` call
+ * edge. `Base`, `Client`, `Config`, `Handler` repeated across modules is ordinary, and
+ * crossing between them silently is exactly the guess the rest of resolve.ts refuses.
+ */
+test("homonymous classes in different packages do not share an inheritance chain", () => {
+  const nodes = [
+    n("a/Base.java", "file"), n("a/Base.java#Base", "class"),
+    n("a/Foo.java", "file"), n("a/Foo.java#Foo", "class"), n("a/Foo.java#Foo.handle", "method"),
+    n("b/Base.java", "file"), n("b/Base.java#Base", "class"),
+    n("b/Bar.java", "file"), n("b/Bar.java#Bar", "class"), n("b/Bar.java#Bar.handle", "method"),
+    n("a/Use.java", "file"), n("a/Use.java#use", "method"),
+  ];
+  const raw: RawEdge[] = [
+    { source: "a/Base.java#Base", relation: "extends", name: "Foo", file: "a/Base.java" },
+    { source: "b/Base.java#Base", relation: "extends", name: "Bar", file: "b/Base.java" },
+    // The call site is in package a, but `Base` is ambiguous across the repo, so there
+    // is no honest answer about whose hierarchy to climb.
+    { source: "a/Use.java#use", relation: "calls", name: "handle", viaMember: true, recvType: "Base", file: "a/Use.java" },
+  ];
+  const calls = resolveEdges(nodes, raw).filter((e) => e.relation === "calls");
+  assert.deepEqual(calls, [], "an ambiguous receiver type must stop the climb, not pick a package");
+});
+
+test("an unambiguous inherited method still resolves through a same-file superclass", () => {
+  // The guard above must not cost recall: when the receiver type resolves to exactly
+  // one class, its own `extends` chain is walked exactly as before.
+  const nodes = [
+    n("a/Base.java", "file"), n("a/Base.java#Base", "class"),
+    n("a/Foo.java", "file"), n("a/Foo.java#Foo", "class"), n("a/Foo.java#Foo.handle", "method"),
+    n("a/Use.java", "file"), n("a/Use.java#use", "method"),
+  ];
+  const raw: RawEdge[] = [
+    { source: "a/Base.java#Base", relation: "extends", name: "Foo", file: "a/Base.java" },
+    { source: "a/Use.java#use", relation: "calls", name: "handle", viaMember: true, recvType: "Base", file: "a/Use.java" },
+  ];
+  const call = resolveEdges(nodes, raw).find((e) => e.relation === "calls");
+  assert.equal(call?.target, "a/Foo.java#Foo.handle");
+});
+
+test("a homonym beside the CALLER cannot hijack an inherited method", () => {
+  // `pkg/Widget` extends `Base`; the call site lives in another package that declares
+  // its own unrelated `Base`. Climbing to the "same file as the caller" candidate would
+  // hand back `other`'s `draw` for a receiver that has nothing to do with it. Two
+  // `Base`s and no way to tell which one `Widget` meant is a drop, not a coin toss.
+  const nodes = [
+    n("pkg/Widget.java", "file"), n("pkg/Widget.java#Widget", "class"),
+    n("pkg/Base.java", "file"), n("pkg/Base.java#Base", "class"), n("pkg/Base.java#Base.draw", "method"),
+    n("other/Use.java", "file"), n("other/Use.java#Base", "class"), n("other/Use.java#Base.draw", "method"),
+    n("other/Use.java#use", "method"),
+  ];
+  const raw: RawEdge[] = [
+    { source: "pkg/Widget.java#Widget", relation: "extends", name: "Base", file: "pkg/Widget.java" },
+    { source: "other/Use.java#use", relation: "calls", name: "draw", viaMember: true, recvType: "Widget", file: "other/Use.java" },
+  ];
+  const calls = resolveEdges(nodes, raw).filter((e) => e.relation === "calls");
+  assert.deepEqual(calls.map((e) => e.target), [], "the caller's own Base is not evidence about Widget's");
+});
+
 // A2: resolve.ts used to derive ownerMethod/classParents keys by slicing `n.id`,
 // which breaks once ids can carry a dedup ordinal (A3). extract.ts now stamps a
 // `owner` field at mint time instead; these tests pin the field's contract and

--- a/test/graph-scopes.test.ts
+++ b/test/graph-scopes.test.ts
@@ -15,6 +15,7 @@ import { readGraph, wiringPath, writeGraph } from "../src/graph/write.js";
 import { loadGraphCached } from "../src/graph/load.js";
 import { writeBuildConfig } from "../src/util/state.js";
 import type { GraphV1 } from "../src/graph/types.js";
+import { rmDir } from "./helpers.js";
 
 function fx(layout: Record<string, string>): string {
   const dir = mkdtempSync(join(tmpdir(), "scopes-"));
@@ -34,7 +35,7 @@ test("frontend/backend markers under one git root -> two scopes", () => {
   assert.deepEqual(scopes.map((s) => s.prefix).sort(), ["backend", "frontend"]);
   assert.equal(scopeOf("frontend/src/app.ts", scopes).label, "frontend");
   assert.equal(scopeOf("README.md", scopes).prefix, "");  // root scope always exists as fallback
-  rmSync(d, { recursive: true, force: true });
+  rmDir(d);
 });
 
 test("workspace globs are intent: packages/* honored, deeper ignored", () => {
@@ -46,7 +47,7 @@ test("workspace globs are intent: packages/* honored, deeper ignored", () => {
   });
   const prefixes = discoverScopes(d).map((s) => s.prefix).sort();
   assert.deepEqual(prefixes, ["packages/cli", "packages/core"]);
-  rmSync(d, { recursive: true, force: true });
+  rmDir(d);
 });
 
 test("gitignored generated workspace directories cannot become scopes (#39)", () => {
@@ -62,7 +63,7 @@ test("gitignored generated workspace directories cannot become scopes (#39)", ()
     execFileSync("git", ["init", "-q"], { cwd: d });
     assert.deepEqual(discoverScopes(d).map((s) => s.prefix), ["packages/app"]);
   } finally {
-    rmSync(d, { recursive: true, force: true });
+    rmDir(d);
   }
 });
 
@@ -70,19 +71,19 @@ test("root-only marker -> canonical single scope", () => {
   const d = fx({ "package.json": "{}", "src/a.ts": "1" });
   const scopes = discoverScopes(d);
   assert.deepEqual(scopes, [{ prefix: "", label: "", markers: ["package.json"] }]);
-  rmSync(d, { recursive: true, force: true });
+  rmDir(d);
 });
 
 test("depth guard: markers 3 levels down ignored without workspace glob", () => {
   const d = fx({ "a/b/c/package.json": "{}", "src/x.ts": "1" });
   assert.equal(discoverScopes(d).length, 1); // root only
-  rmSync(d, { recursive: true, force: true });
+  rmDir(d);
 });
 
 test("nesting collapse keeps shallower candidate", () => {
   const d = fx({ "svc/package.json": "{}", "svc/sub/package.json": "{}", "svc/i.ts": "1" });
   assert.deepEqual(discoverScopes(d).filter((s) => s.prefix).map((s) => s.prefix), ["svc"]);
-  rmSync(d, { recursive: true, force: true });
+  rmDir(d);
 });
 
 test("nesting collapse is layout-deterministic regardless of sibling readdir order (P10)", () => {
@@ -103,7 +104,7 @@ test("nesting collapse is layout-deterministic regardless of sibling readdir ord
         .map((s) => s.prefix)
         .sort();
     } finally {
-      rmSync(d, { recursive: true, force: true });
+      rmDir(d);
     }
   };
   // Normalize the sibling's own name away so the two runs compare structurally:
@@ -126,7 +127,7 @@ test("literal (non-glob) workspace entry resolves as a workspace match", () => {
   });
   const prefixes = discoverScopes(d).map((s) => s.prefix).sort();
   assert.deepEqual(prefixes, ["apps/web", "docs"]);
-  rmSync(d, { recursive: true, force: true });
+  rmDir(d);
 });
 
 test("workspace-under-workspace collapses to the shallower scope (packages/**)", () => {
@@ -137,7 +138,7 @@ test("workspace-under-workspace collapses to the shallower scope (packages/**)",
   });
   const prefixes = discoverScopes(d).map((s) => s.prefix).sort();
   assert.deepEqual(prefixes, ["packages/a"]);
-  rmSync(d, { recursive: true, force: true });
+  rmDir(d);
 });
 
 test("workspace-under-workspace collapse also sweeps markerless dirs under a **-glob", () => {
@@ -148,7 +149,7 @@ test("workspace-under-workspace collapse also sweeps markerless dirs under a **-
   });
   const prefixes = discoverScopes(d).map((s) => s.prefix).sort();
   assert.deepEqual(prefixes, ["packages/a"]); // no markerless packages/a/src* survives
-  rmSync(d, { recursive: true, force: true });
+  rmDir(d);
 });
 
 test("literal + glob workspace overlap collapses to the shallower literal entry", () => {
@@ -159,7 +160,7 @@ test("literal + glob workspace overlap collapses to the shallower literal entry"
   });
   const prefixes = discoverScopes(d).map((s) => s.prefix).sort();
   assert.deepEqual(prefixes, ["apps"]);
-  rmSync(d, { recursive: true, force: true });
+  rmDir(d);
 });
 
 test("discoverWorkspaceChildren finds immediate git children only", () => {
@@ -168,7 +169,7 @@ test("discoverWorkspaceChildren finds immediate git children only", () => {
   mkdirSync(join(d, "repoB/.git"), { recursive: true });
   mkdirSync(join(d, "repoB/vendored/.git"), { recursive: true }); // nested: not a child of d
   assert.deepEqual(discoverWorkspaceChildren(d).sort(), ["repoA", "repoB"]);
-  rmSync(d, { recursive: true, force: true });
+  rmDir(d);
 });
 
 test("A5: discoverScopes finds a marker under a SKIP_DIRS name once persisted via --include-dir state, absent otherwise", () => {
@@ -178,7 +179,7 @@ test("A5: discoverScopes finds a marker under a SKIP_DIRS name once persisted vi
   writeBuildConfig(d, { includeDirs: ["build"] });
   const prefixes = discoverScopes(d).map((s) => s.prefix);
   assert.deepEqual(prefixes, ["build"], "once persisted, build/'s own marker is discovered as a scope");
-  rmSync(d, { recursive: true, force: true });
+  rmDir(d);
 });
 
 function tsFns(n: number): string {
@@ -205,7 +206,7 @@ test("buildGraph wires meta.scopes: substantial scopes survive, tiny scopes merg
     const prefixes = (graph!.meta.scopes ?? []).map((s) => s.prefix).sort();
     assert.deepEqual(prefixes, ["backend", "frontend"]); // tiny (1 symbol) merged into root
   } finally {
-    rmSync(d, { recursive: true, force: true });
+    rmDir(d);
   }
 });
 
@@ -226,6 +227,6 @@ test("old graphs without meta.scopes fall back to the canonical root scope via s
     assert.deepEqual(scopes, [{ prefix: "", label: "", markers: [] }]);
     assert.equal(scopeOf("anything/at/all.ts", scopes).prefix, "");
   } finally {
-    rmSync(d, { recursive: true, force: true });
+    rmDir(d);
   }
 });

--- a/test/graph-seed.test.ts
+++ b/test/graph-seed.test.ts
@@ -22,7 +22,7 @@ import { ensureFreshGraph, refreshNote } from "../src/graph/refresh.js";
 import { mainWorktreeRoot, seedGraph } from "../src/graph/seed.js";
 import { readGraph, wiringPath } from "../src/graph/write.js";
 import { callTool } from "../src/mcp/tools.js";
-import { tmpRepo } from "./helpers.js";
+import { tmpRepo, rmDir } from "./helpers.js";
 
 const MATH = "export function add(a: number, b: number): number {\n  return a + b;\n}\n";
 const MUL = "export function mul(a: number, b: number): number {\n  return a * b;\n}\n";
@@ -212,8 +212,8 @@ test("a git worktree starts with no graph, and one query gives it a correct one"
   // Seeding reads the parent; it must never write to it.
   assert.equal(readFileSync(wiringPath(outOf(main)), "utf8"), parentGraph, "parent graph untouched");
 
-  rmSync(main, { recursive: true, force: true });
-  rmSync(wt, { recursive: true, force: true });
+  rmDir(main);
+  rmDir(wt);
 });
 
 test("a worktree nested inside the repo is seeded too, and isn't double-indexed", async () => {
@@ -238,7 +238,7 @@ test("a worktree nested inside the repo is seeded too, and isn't double-indexed"
     "the parent must not index the worktree's copy of its own files",
   );
 
-  rmSync(main, { recursive: true, force: true });
+  rmDir(main);
 });
 
 test("the MCP tool answers from a seeded worktree instead of refusing", async () => {
@@ -251,8 +251,8 @@ test("the MCP tool answers from a seeded worktree instead of refusing", async ()
   assert.doesNotMatch(res.text, /no graph found/);
   assert.match(res.text, /math\.ts/);
 
-  rmSync(main, { recursive: true, force: true });
-  rmSync(wt, { recursive: true, force: true });
+  rmDir(main);
+  rmDir(wt);
 });
 
 test("GRAFT_NO_SEED leaves the worktree exactly as it was", async () => {
@@ -275,8 +275,8 @@ test("GRAFT_NO_SEED leaves the worktree exactly as it was", async () => {
     delete process.env.GRAFT_NO_SEED;
   }
 
-  rmSync(main, { recursive: true, force: true });
-  rmSync(wt, { recursive: true, force: true });
+  rmDir(main);
+  rmDir(wt);
 });
 
 test("seedGraph declines a --dir override and a checkout that already has a graph", async () => {
@@ -311,8 +311,8 @@ test("seedGraph declines a --dir override and a checkout that already has a grap
   assert.ok(!landed.includes("stats.json"), `borrowed savings do not — ${why}`);
   assert.ok(!landed.includes("session"), `another session's transcripts do not — ${why}`);
 
-  rmSync(main, { recursive: true, force: true });
-  rmSync(wt, { recursive: true, force: true });
+  rmDir(main);
+  rmDir(wt);
 });
 
 test("a plain repo with no parent checkout is left to `graft build`", async () => {
@@ -320,7 +320,7 @@ test("a plain repo with no parent checkout is left to `graft build`", async () =
   const r = await ensureFreshGraph(solo);
   assert.equal(existsSync(wiringPath(outOf(solo))), false, "no surprise full build under a query");
   assert.equal(refreshNote(r), null);
-  rmSync(solo, { recursive: true, force: true });
+  rmDir(solo);
 });
 
 test("`graft build` in a worktree starts from the parent's graph, not from scratch", async () => {
@@ -336,6 +336,6 @@ test("`graft build` in a worktree starts from the parent's graph, not from scrat
   assert.equal(g.parsed, 1, "only the file this checkout changed was re-parsed");
   assert.ok(g.cards > 0, "and the passive surface is rebuilt for this checkout");
 
-  rmSync(main, { recursive: true, force: true });
-  rmSync(wt, { recursive: true, force: true });
+  rmDir(main);
+  rmDir(wt);
 });

--- a/test/graph-source-files.test.ts
+++ b/test/graph-source-files.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Which files a build parses — specifically, that excluding the output directory does
+ * not also exclude its neighbours.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { listSourceFiles } from "../src/graph/source-files.js";
+import { buildGraph } from "../src/graph/build.js";
+import { checkGraph } from "../src/graph/check.js";
+import { readGraph, wiringPath } from "../src/graph/write.js";
+import { tmpRepo } from "./helpers.js";
+
+/**
+ * `!f.startsWith(outDir)` has no segment boundary, so with the default outDir
+ * `<root>/graft` it also swallowed `graft-tools/`, `graftlib/`, `graft.config.ts` —
+ * silently, with no error and no warning. `util/paths.ts#pathUnderPrefix` documents
+ * exactly this class of bug ("'frontend' would match 'frontend-utils'") and fixes it
+ * there; it had simply never reached here.
+ */
+test("the output dir is excluded, but not a sibling whose name merely starts with it", () => {
+  const root = resolve("/repo");
+  const outDir = join(root, "graft");
+  const files = [
+    join(outDir, "wiring.ts"),
+    join(root, "graft-tools", "a.ts"),
+    join(root, "graftlib", "b.ts"),
+    join(root, "src", "c.ts"),
+  ];
+  assert.deepEqual(listSourceFiles(root, outDir, files), [
+    join(root, "graft-tools", "a.ts"),
+    join(root, "graftlib", "b.ts"),
+    join(root, "src", "c.ts"),
+  ]);
+});
+
+test("a relative outDir still excludes the output dir, and only it", () => {
+  // `contextDirFor` resolves its override now, but this stays the defence in depth
+  // for the value arriving relative anyway (a direct library caller, a future path
+  // that skips contextDirFor): compared unresolved against the walker's absolute
+  // paths it never matches, and the output directory becomes part of the source set.
+  const root = process.cwd();
+  const files = [join(root, "graft", "wiring.ts"), join(root, "graft-tools", "a.ts")];
+  assert.deepEqual(listSourceFiles(root, "graft", files), [join(root, "graft-tools", "a.ts")]);
+});
+
+/**
+ * `-e/--extensions` says "only include these code extensions". It reached the concept
+ * pass only, so the wiring graph — the thing every query actually answers from — kept
+ * indexing every language graft has a grammar for, and a user who narrowed a build to
+ * `.ts` still got Python nodes back from `ask`/`grep`/`callers`.
+ */
+test("-e narrows the file set, normalizing a bare/upper-case extension", () => {
+  const root = resolve("/repo");
+  const outDir = join(root, "graft");
+  const files = [join(root, "a.ts"), join(root, "b.py"), join(root, "c.rs")];
+  assert.deepEqual(listSourceFiles(root, outDir, files, [".ts"]), [join(root, "a.ts")]);
+  assert.deepEqual(listSourceFiles(root, outDir, files, ["py", ".RS"]).sort(), [
+    join(root, "b.py"),
+    join(root, "c.rs"),
+  ].sort());
+  // Absent and empty both mean "everything": commander hands `[]` for a variadic
+  // option nobody passed, and reading that as "index nothing" would turn a missing
+  // flag into an empty graph.
+  assert.equal(listSourceFiles(root, outDir, files, []).length, 3);
+  assert.equal(listSourceFiles(root, outDir, files).length, 3);
+});
+
+test("a build under -e indexes only those extensions, and a check under the same -e sees no drift", async () => {
+  const d = tmpRepo("sourcefiles-ext-");
+  mkdirSync(join(d, "src"), { recursive: true });
+  writeFileSync(join(d, "src", "app.ts"), "export function fromTs(): number {\n  return 1;\n}\n");
+  writeFileSync(join(d, "src", "app.py"), "def from_py():\n    return 2\n");
+
+  await buildGraph(d, { reuse: false, extensions: [".ts"] });
+  const graph = readGraph(wiringPath(join(d, "graft")))!;
+  assert.ok(graph.nodes.some((n) => n.id === "src/app.ts#fromTs"), "the named extension is indexed");
+  assert.ok(!graph.nodes.some((n) => n.path.endsWith(".py")), "and nothing else is");
+
+  // The two halves have to agree: a check that enumerated every language would find
+  // the .py definitions missing from the committed graph and report them as `added`
+  // — permanent phantom drift on a build the user narrowed deliberately.
+  const narrowed = await checkGraph(d, { extensions: [".ts"] });
+  assert.equal(narrowed.ok, true, JSON.stringify(narrowed));
+  const wide = await checkGraph(d);
+  assert.ok(wide.added.some((id) => id.startsWith("src/app.py")), "…and without the flag the drift is real");
+});
+
+test("a directory next to the output dir is really indexed by a build", async () => {
+  const d = tmpRepo("sourcefiles-sibling-");
+  mkdirSync(join(d, "graft-tools"), { recursive: true });
+  mkdirSync(join(d, "src"), { recursive: true });
+  writeFileSync(join(d, "graft-tools", "gen.ts"), "export function fromSibling(): number {\n  return 1;\n}\n");
+  writeFileSync(join(d, "src", "app.ts"), "export function fromSrc(): number {\n  return 2;\n}\n");
+
+  await buildGraph(d, { reuse: false });
+  const graph = readGraph(wiringPath(join(d, "graft")))!;
+  assert.ok(
+    graph.nodes.some((n) => n.id === "graft-tools/gen.ts#fromSibling"),
+    "a sibling of the output dir must be indexed like any other directory",
+  );
+  assert.ok(!graph.nodes.some((n) => n.path.startsWith("graft/")), "the output dir itself is still excluded");
+});

--- a/test/graph-sources-retention.test.ts
+++ b/test/graph-sources-retention.test.ts
@@ -1,0 +1,75 @@
+/**
+ * `buildGraph`'s `sources` map exists for one consumer: the Tier-2 meaning pass. It was
+ * filled unconditionally, so a Tier-1 build — the default, and every pre-query refresh —
+ * held the whole repo's text in memory for the length of the build and handed it to a
+ * function that returns before reading it. JS strings are UTF-16, so a 200 MB monorepo
+ * pinned roughly 400 MB for nothing, on every query that saw drift.
+ *
+ * The saving itself is invisible from outside, which is exactly why the guarded path
+ * needs pinning: the map must still be complete whenever a summarizer IS present, and
+ * a Tier-1 build's output must be unchanged.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { buildGraph } from "../src/graph/build.js";
+import { readGraph, wiringPath } from "../src/graph/write.js";
+import type { CruxSummarizer, FileCruxInput, NodeCrux } from "../src/ai/crux.js";
+import { tmpRepo } from "./helpers.js";
+
+/** Records exactly what source text the meaning pass was handed, per file. */
+class RecordingSummarizer implements CruxSummarizer {
+  readonly seen = new Map<string, string>();
+  async describeFile(input: FileCruxInput): Promise<NodeCrux[]> {
+    this.seen.set(input.path, input.source);
+    return input.nodes.map((n) => ({ id: n.id, summary: `about ${n.id}`, crux_start: 0, crux_end: 0 }));
+  }
+}
+
+function fixture(tag: string): string {
+  const d = tmpRepo(tag);
+  mkdirSync(join(d, "src"), { recursive: true });
+  writeFileSync(join(d, "src", "a.ts"), "export function alpha(): number {\n  return 1;\n}\n");
+  writeFileSync(join(d, "src", "b.py"), "def beta():\n    return 2\n");
+  return d;
+}
+
+test("with a summarizer, every parsed file's source still reaches the meaning pass", async () => {
+  const d = fixture("sources-tier2-");
+  const summarizer = new RecordingSummarizer();
+  await buildGraph(d, { reuse: false, summarizer });
+
+  assert.deepEqual([...summarizer.seen.keys()].sort(), ["src/a.ts", "src/b.py"]);
+  assert.match(summarizer.seen.get("src/a.ts")!, /export function alpha/);
+  assert.match(summarizer.seen.get("src/b.py")!, /def beta/);
+
+  const graph = readGraph(wiringPath(join(d, "graft")))!;
+  assert.ok(
+    graph.nodes.some((n) => n.summary_state === "ready" && n.summary?.startsWith("about ")),
+    "the summaries really were written",
+  );
+});
+
+test("a file replayed from the extraction cache still reaches the meaning pass", async () => {
+  // The reuse branch has its own `sources.set` — the memo skips the PARSE, never the
+  // read — so a Tier-2 build on an already-built repo must summarize just the same.
+  const d = fixture("sources-tier2-reuse-");
+  await buildGraph(d);
+  const summarizer = new RecordingSummarizer();
+  const r = await buildGraph(d, { summarizer });
+  assert.ok(r.reused > 0, "the second build must actually be replaying from the memo");
+  assert.deepEqual([...summarizer.seen.keys()].sort(), ["src/a.ts", "src/b.py"]);
+});
+
+test("a Tier-1 build produces the same graph as a Tier-2 one, minus the meaning layer", async () => {
+  const plain = fixture("sources-tier1-");
+  const enriched = fixture("sources-tier1-ref-");
+  const a = await buildGraph(plain, { reuse: false });
+  const b = await buildGraph(enriched, { reuse: false, summarizer: new RecordingSummarizer() });
+
+  assert.equal(a.nodes, b.nodes);
+  assert.equal(a.edges, b.edges);
+  assert.deepEqual(a.byKind, b.byKind);
+  assert.deepEqual(a.errors, []);
+});

--- a/test/graph-traverse-cli.test.ts
+++ b/test/graph-traverse-cli.test.ts
@@ -116,7 +116,12 @@ function ambiguousRepo(): string {
   writeFileSync(join(d, 'src', 'b.ts'), 'export function shared(): number {\n  return 2;\n}\n');
   // A cross-file call to the ambiguous name — resolve.ts drops it rather than
   // guessing which `shared` it means, so NEITHER definition gets a caller edge.
-  writeFileSync(join(d, 'src', 'user.ts'), 'import { shared } from "./a.js";\nexport function use(): number {\n  return shared();\n}\n');
+  //
+  // Deliberately NO import statement. A named import states which module the callee
+  // came from, and resolve.ts now resolves inside that file alone — which makes the
+  // call unambiguous and defeats the very fixture this test needs. An unimported bare
+  // call is the case that genuinely has nothing to go on but the name.
+  writeFileSync(join(d, 'src', 'user.ts'), 'declare function shared(): number;\nexport function use(): number {\n  return shared();\n}\n');
   execFileSync(process.execPath, ['--import', 'tsx', 'src/cli.ts', 'build', d], { stdio: 'pipe' });
   return d;
 }

--- a/test/graph-traverse.test.ts
+++ b/test/graph-traverse.test.ts
@@ -151,6 +151,19 @@ test("resolveSymbol: file nodes are matched as a last resort for filename-shaped
   assert.deepEqual(matches.map((n) => n.id), ["src/file.ts"]);
 });
 
+test("resolveSymbol: a filename query is matched with native separators too", () => {
+  const g = baseGraph();
+  // `graft_trace_calls`'s schema says "a file path also works", and on Windows the
+  // path an agent has in hand (from a tool result, or from tab-completion) is
+  // `src\file.ts` — which matched no `node.path` at all and read as "symbol not
+  // found". `join` rather than a literal `\`, for the same reason the `--in` test
+  // above uses it: normalization is keyed to the platform separator.
+  assert.deepEqual(
+    resolveSymbol(g, join("src", "file.ts")).map((n) => n.id),
+    ["src/file.ts"],
+  );
+});
+
 test("resolveSymbol: unknown symbol returns empty array", () => {
   const g = baseGraph();
   assert.deepEqual(resolveSymbol(g, "NoSuchSymbol"), []);
@@ -226,7 +239,10 @@ test("callersOf / calleesOf: no edges → empty array", () => {
 
 // ── impactOf ─────────────────────────────────────────────────────────────
 
-function diamondGraph(): GraphV1 {
+/** The graph plus the seed node every caller walks from — declared as the pair it
+ * returns. It used to claim `GraphV1` and then double-cast the pair back, so the
+ * annotation and the value disagreed and neither side was checked. */
+function diamondGraph(): { node: NodeV1; graph: GraphV1 } {
   const X = nodeStub({ id: "X", name: "X" });
   const A = nodeStub({ id: "A", name: "A" });
   const B = nodeStub({ id: "B", name: "B" });
@@ -237,7 +253,7 @@ function diamondGraph(): GraphV1 {
       [X, A, B, C],
       [edge("A", "X", "calls"), edge("B", "X", "calls"), edge("C", "A", "calls"), edge("C", "B", "calls")],
     ),
-  } as unknown as { node: NodeV1; graph: GraphV1 };
+  };
 }
 
 test("impactOf: BFS over incoming edges, diamond converges to one hit, deduped at min depth", () => {

--- a/test/graph-workspace-include-dir.test.ts
+++ b/test/graph-workspace-include-dir.test.ts
@@ -19,6 +19,7 @@ import { buildGraph } from "../src/graph/build.js";
 import { readGraph, wiringPath } from "../src/graph/write.js";
 import { writeBuildConfig } from "../src/util/state.js";
 import type { GraphV1 } from "../src/graph/types.js";
+import { rmDir } from "./helpers.js";
 
 function workspaceWithBuildDirs(): string {
   const parent = mkdtempSync(join(tmpdir(), "ws-include-dir-"));
@@ -60,7 +61,7 @@ test("A5: --include-dir on a workspace build reaches every child, which persists
       "child's own persisted include-dir state must survive a no-flag rebuild",
     );
   } finally {
-    rmSync(parent, { recursive: true, force: true });
+    rmDir(parent);
   }
 });
 
@@ -80,6 +81,6 @@ test("A5: a skipped-name workspace child remains discoverable on a later no-flag
     assert.deepEqual(workspace.children, ["app", "build"]);
     assert.equal(readFileSync(join(parent, ".graft", "config.json"), "utf8").includes("build"), true);
   } finally {
-    rmSync(parent, { recursive: true, force: true });
+    rmDir(parent);
   }
 });

--- a/test/graph-write.test.ts
+++ b/test/graph-write.test.ts
@@ -15,6 +15,7 @@ import { buildGraph } from "../src/graph/build.js";
 import { writeGraph, readGraph, wiringPath } from "../src/graph/write.js";
 import { contextDirFor } from "../src/context/node-file.js";
 import type { GraphV1, NodeV1 } from "../src/graph/types.js";
+import { rmDir } from "./helpers.js";
 
 function makeNode(overrides: Partial<NodeV1> = {}): NodeV1 {
   return {
@@ -71,7 +72,7 @@ test("writeGraph strips body_text from the serialized node but keeps every other
     assert.equal(reread!.nodes[0].body_text, undefined);
     assertUniqueIds(graph.nodes);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -89,7 +90,7 @@ test("writeGraph does not mutate the in-memory node — build.ts's sidecar pass 
     assert.equal(graph.nodes[0].body_text, "untouched body text", "graph.nodes must still reference the live object");
     assertUniqueIds(graph.nodes);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -108,7 +109,7 @@ test("a node with no body_text (e.g. a file node) round-trips unchanged", () => 
     assert.equal(raw.nodes[0].kind, "file");
     assertUniqueIds(graph.nodes);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -139,7 +140,7 @@ test("buildGraph: the serialized wiring.json has no body_text key on ANY node", 
     }
     assertUniqueIds(parsed.nodes);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -158,6 +159,6 @@ test("A3 PERMANENT gate: duplicate-named definitions still produce unique node i
     const ids = graph!.nodes.map((n) => n.id);
     assert.ok(ids.includes("dup.ts#helper") && ids.includes("dup.ts#helper~2"), "sanity: the dup actually minted an ordinal id");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });

--- a/test/graphrank.test.ts
+++ b/test/graphrank.test.ts
@@ -17,6 +17,7 @@ import { buildGraph } from "../src/graph/build.js";
 import { ask } from "../src/ask/ask.js";
 import { personalizedPageRank } from "../src/ask/graphrank.js";
 import type { GraphV1, NodeV1, EdgeV1, Relation } from "../src/graph/types.js";
+import { rmDir } from "./helpers.js";
 
 // ── Unit: personalizedPageRank ───────────────────────────────────────────────
 
@@ -209,7 +210,7 @@ test("ask (graphRank off): pure lexical does not favour the connected hit", asyn
       "without graph-rank the connected hit gets no ranking advantage",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -223,7 +224,7 @@ test("ask (graphRank on): connected hit outranks the isolated collision", async 
     assert.ok(iHandler >= 0 && iWidget >= 0, "both same-word hits still present");
     assert.ok(iHandler < iWidget, "the graph-connected fooHandler ranks above isolated fooWidget");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -239,7 +240,7 @@ test("ask (graphRank on): a strongly-connected neighbour is rescued in", async (
       "a helper the query never named is rescued via connectivity",
     );
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -251,6 +252,6 @@ test("ask: graph-rank is on by default (same as graphRank:true)", async () => {
     const on = ask(dir, "foo", { graphRank: true }).hits.map((h) => h.title);
     assert.deepEqual(def, on, "default ordering equals explicit graphRank:true");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -7,7 +7,7 @@
  * than being hand-rolled per file because both carry a platform trap that is
  * invisible until CI runs on Windows: see {@link tmpRepo} and {@link homeEnv}.
  */
-import { mkdtempSync, realpathSync } from "node:fs";
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
 import { spawnSync, type SpawnSyncReturns } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -29,6 +29,25 @@ import type { Summarizer, Synthesizer, SynthNode, SynthLink, FileSummary } from 
  */
 export function tmpRepo(tag: string): string {
   return realpathSync.native(mkdtempSync(join(tmpdir(), `graft-${tag}-`)));
+}
+
+/**
+ * Delete a scratch directory — the `finally` half of {@link tmpRepo}.
+ *
+ * The retries are the point, and they are a Windows trap of the same family as
+ * the one above. POSIX unlinks a path immediately even while a handle is open;
+ * Windows only *marks* the file for deletion and keeps it in its directory until
+ * the last handle closes, so an rmdir racing a just-closed tree-sitter parse, a
+ * child process still exiting, or a virus scanner that opened the file behind
+ * your back fails with ENOTEMPTY/EBUSY/EPERM. Nothing is wrong with the test —
+ * a few milliseconds later the same call succeeds.
+ *
+ * Left bare, this shows up as a *different* test failing on each CI run, which
+ * reads as a real intermittent bug and costs an afternoon to chase. `maxRetries`
+ * is node's own remedy for exactly this.
+ */
+export function rmDir(dir: string): void {
+  rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
 }
 
 /**
@@ -92,9 +111,12 @@ export function runCli(args: string[], opts: { home?: string; timeoutMs?: number
   return res;
 }
 
-/** Summarizer that passes the source through unchanged, so tests control the text. */
+/** Summarizer that passes the source through unchanged, so tests control the text.
+ * Declares `opts` even though it ignores it: dropping the parameter still satisfies
+ * `Summarizer`, but then a test wrapping this one cannot forward the call it
+ * received, and the delegation stops type-checking. */
 export class PassthroughSummarizer implements Summarizer {
-  async summarize(code: string): Promise<string> {
+  async summarize(code: string, _opts?: { path: string }): Promise<string> {
     return code;
   }
 }

--- a/test/hosts-codex-hooks.test.ts
+++ b/test/hosts-codex-hooks.test.ts
@@ -72,6 +72,47 @@ test('foreign hook entries are preserved; stale graft entries replaced', () => {
   assert.ok(!JSON.stringify(entries).includes('/old/'), 'stale graft entry removed');
 });
 
+test('onlyIfPresent: an unsolicited refresh updates an existing entry and creates nothing', () => {
+  // The mode an auto-refresh runs in when this machine has no record that anyone
+  // ever ran `graft init` for the repo (fresh clone of committed wiring). ~/.codex
+  // is machine-wide — shared by every project — so installing there uninvited is
+  // graft granting itself config; re-pointing an entry that already names graft is
+  // maintenance, and nothing else in the product ever does it.
+  const home = fresh();
+  mkdirSync(join(home, '.codex'), { recursive: true });
+
+  const none = installCodexHooks(home, { onlyIfPresent: true });
+  assert.deepEqual(none.map((w) => w.action), ['skipped-absent']);
+  assert.equal(existsSync(join(home, '.codex', 'hooks.json')), false, 'no config created');
+  // Not even the shim: with no entry pointing at it, it is an orphan file left in
+  // someone's home directory.
+  assert.equal(existsSync(join(home, '.codex', 'hooks', 'graft', 'graft-hooks.cjs')), false);
+
+  // A foreign hooks.json is still not ours to add to.
+  writeFileSync(join(home, '.codex', 'hooks.json'), JSON.stringify({
+    hooks: { PostToolUse: [{ matcher: 'Bash', hooks: [{ type: 'command', command: 'other-tool' }] }] },
+  }));
+  const foreign = installCodexHooks(home, { onlyIfPresent: true });
+  assert.deepEqual(foreign.map((w) => w.action), ['skipped-absent']);
+  assert.ok(!readFileSync(join(home, '.codex', 'hooks.json'), 'utf8').includes('graft'));
+
+  // But an entry that names graft — written by an init this machine has forgotten,
+  // or one that predates the stamp entirely — is brought up to date.
+  writeFileSync(join(home, '.codex', 'hooks.json'), JSON.stringify({
+    hooks: { PostToolUse: [
+      { matcher: 'Bash', hooks: [{ type: 'command', command: 'other-tool' }] },
+      { matcher: 'Write', hooks: [{ type: 'command', command: 'node /old/graft-hooks.cjs post-edit' }] },
+    ] },
+  }));
+  const present = installCodexHooks(home, { onlyIfPresent: true });
+  assert.deepEqual(present.map((w) => w.action), ['created', 'updated']);
+  assertRunnableShim(join(home, '.codex', 'hooks', 'graft', 'graft-hooks.cjs'), 'the shim it points at');
+  const after = JSON.parse(readFileSync(join(home, '.codex', 'hooks.json'), 'utf8'));
+  assert.ok(!JSON.stringify(after).includes('/old/'), 'the stale path is gone');
+  assert.ok(after.hooks.PostToolUse.some((e: any) => e.hooks[0].command === 'other-tool'), 'foreign kept');
+  assert.equal(after.hooks.Stop.length, 1, 'and the rest of the set is completed');
+});
+
 test('editedFilePath reads the touched file from BOTH host edit-tool shapes', () => {
   const dir = '/repo';
   // Claude Code: Write/Edit state the absolute path directly

--- a/test/hosts-init.test.ts
+++ b/test/hosts-init.test.ts
@@ -171,16 +171,19 @@ test('global: false keeps the instruction file but skips every ~ write', () => {
  * `HOME`, so on Windows the child read the *runner's* profile and reported
  * whichever agents it happened to have installed instead of the fixture's.
  */
-function cliStderr(repo: string, home: string, extra: string[] = []): string {
+function cliStderr(repo: string, home: string, extra: string[] = [], status = 0): string {
   const res = runCli(['init', repo, '--no-build', ...extra], { home });
-  assert.equal(res.status, 0, res.describe());
+  assert.equal(res.status, status, res.describe());
   return res.stderr ?? '';
 }
 
 test('CLI: no flags and no TTY writes nothing and names the detected agents', () => {
   const home = fresh(); const repo = fresh();
   mkdirSync(join(home, '.cursor'));
-  const out = cliStderr(repo, home);
+  // Exit 1, because nothing was written: `graft init && <next step>` has to stop
+  // rather than proceed as though the repo were wired. The guidance below is what
+  // makes that recoverable, and 0 made it easy to scroll past in automation.
+  const out = cliStderr(repo, home, [], 1);
   assert.match(out, /nothing written/);
   assert.match(out, /detected: claude, cursor/);
   assert.match(out, /graft init --agents claude cursor/);

--- a/test/hosts-mcp-config.test.ts
+++ b/test/hosts-mcp-config.test.ts
@@ -6,8 +6,8 @@ import assert from 'node:assert/strict';
 process.env.GRAFT_MCP_NPX = '1';
 import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import { registerMcpConfigs, serverEntry } from '../src/hosts/mcp-config.js';
+import { delimiter, join } from 'node:path';
+import { registerMcpConfigs, resetGraftOnPathCache, serverEntry } from '../src/hosts/mcp-config.js';
 
 function fresh(): string { return mkdtempSync(join(tmpdir(), 'graft-mcpcfg-')); }
 
@@ -58,6 +58,26 @@ test('agents id: codex TOML + opencode JSON, gated on home dirs', () => {
   assert.deepEqual(again.map((x) => x.action).sort(), ['unchanged', 'unchanged']);
 });
 
+test("global: 'if-present' never creates out-of-repo config, but still wires the repo", () => {
+  // What an unsolicited refresh gets (see upkeep.ts#refreshOpts). ~/.codex/config.toml
+  // is machine-wide; the repo's own opencode.json is part of the wiring being
+  // refreshed, so the mode must not swallow that one too.
+  const repo = fresh(); const home = fresh();
+  mkdirSync(join(home, '.codex'), { recursive: true });
+  mkdirSync(join(home, '.config', 'opencode'), { recursive: true });
+
+  const w = registerMcpConfigs(repo, ['agents'], { home, global: 'if-present' });
+  const byId = new Map(w.map((x) => [x.id, x.action]));
+  assert.equal(byId.get('codex'), 'skipped-absent', 'the machine-wide file is left alone');
+  assert.equal(existsSync(join(home, '.codex', 'config.toml')), false);
+  assert.equal(byId.get('opencode'), 'created', 'the repo-scoped file is still written');
+
+  // Once graft IS registered there, the same mode reports it as ours and current.
+  writeFileSync(join(home, '.codex', 'config.toml'), '[mcp_servers.graft]\ncommand = "graft"\n');
+  const present = registerMcpConfigs(repo, ['agents'], { home, global: 'if-present' });
+  assert.equal(new Map(present.map((x) => [x.id, x.action])).get('codex'), 'unchanged');
+});
+
 test('codex TOML append preserves existing content', () => {
   const repo = fresh(); const home = fresh();
   mkdirSync(join(home, '.codex'), { recursive: true });
@@ -98,4 +118,59 @@ test('serverEntry prefers the installed binary and falls back to npx', () => {
 test('GRAFT_MCP_NPX overrides an installed binary', () => {
   process.env.GRAFT_MCP_NPX = '1';
   assert.equal(serverEntry({ onPath: true }).command, 'npx', 'the escape hatch wins');
+});
+
+// --- the PATH detection itself ---
+//
+// The detection used to spawn `graft --version`, which on Windows meant ENOENT
+// against the `graft.cmd` shim npm installs: BIN_LAUNCH was unreachable on the whole
+// platform and every init committed the slow `npx` form into `.mcp.json`. It also
+// paid a process spawn per call, five call sites deep in the init path.
+
+/** Install a fake `graft` on PATH under whatever name this platform resolves. */
+function stubGraftDir(): string {
+  const dir = fresh();
+  // Contents are irrelevant — the resolver asks whether the name resolves, not
+  // whether the binary runs. `.cmd` is what `npm i -g` leaves on Windows.
+  writeFileSync(join(dir, process.platform === 'win32' ? 'graft.cmd' : 'graft'), '');
+  return dir;
+}
+
+function withEnv(path: string, fn: () => void): void {
+  const savedPath = process.env.PATH;
+  const savedNpx = process.env.GRAFT_MCP_NPX;
+  delete process.env.GRAFT_MCP_NPX;
+  process.env.PATH = path;
+  resetGraftOnPathCache();
+  try {
+    fn();
+  } finally {
+    process.env.PATH = savedPath;
+    if (savedNpx !== undefined) process.env.GRAFT_MCP_NPX = savedNpx;
+    else delete process.env.GRAFT_MCP_NPX;
+    resetGraftOnPathCache();
+  }
+}
+
+test('serverEntry finds an installed graft on PATH (Windows: the .cmd shim)', () => {
+  withEnv(stubGraftDir(), () => {
+    assert.deepEqual(serverEntry(), { command: 'graft', args: ['mcp'] });
+  });
+});
+
+test('serverEntry falls back to npx when nothing named graft is on PATH', () => {
+  withEnv(fresh(), () => {
+    assert.deepEqual(serverEntry(), { command: 'npx', args: ['-y', '@nanonets/graft', 'mcp'] });
+  });
+});
+
+test('the PATH lookup happens once, not once per call site', () => {
+  // `planInit` fans `serverEntry` out per host and per workspace child; the old
+  // implementation paid a 5s-ceiling spawn for every one of them. Emptying PATH
+  // mid-run and still getting the binary form is the observable proof it is cached.
+  withEnv(stubGraftDir(), () => {
+    assert.equal(serverEntry().command, 'graft');
+    process.env.PATH = '';
+    assert.equal(serverEntry().command, 'graft', 'resolved once and remembered');
+  });
 });

--- a/test/ingest-fs.test.ts
+++ b/test/ingest-fs.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import { join, relative } from "node:path";
 import { shouldSkipDir, walkDir, SKIP_DIRS } from "../src/ingest/fs.js";
 import { discoverScopes, discoverWorkspaceChildren } from "../src/graph/scopes.js";
+import { rmDir } from "./helpers.js";
 
 function fixture(tag: string): string {
   const dir = mkdtempSync(join(tmpdir(), `graft-walk-${tag}-`));
@@ -42,7 +43,7 @@ test("walkDir respects root and nested .gitignore rules, including negation", ()
       "src/app.ts",
     ]);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -57,7 +58,7 @@ test("walkDir keeps tracked files that match an ignore rule and untracked visibl
 
     assert.deepEqual(walked(dir), ["tracked.generated.ts", "visible.ts"]);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -70,7 +71,7 @@ test("walkDir retains fixed skips and filesystem fallback outside Git", () => {
 
     assert.deepEqual(walked(dir), ["src/app.ts"]);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -124,7 +125,7 @@ test("A5: walkDir(dir, includes) descends into an included SKIP_DIRS-named direc
     assert.ok(withIncludes.some((f) => f.startsWith("build")), "build/ is walked once included");
     assert.ok(!withIncludes.some((f) => f.startsWith("vendor")), "vendor/ stays skipped — only the named dir is included");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -137,7 +138,7 @@ test("A5: in a Git repo, --include-dir lifts the built-in skip for git-visible f
     assert.ok(!walked(dir).includes("vendor/lib.ts"), "default: vendor/ is skipped by the built-in list");
     assert.deepEqual(walked(dir, new Set(["vendor"])), ["src/app.ts", "vendor/lib.ts"]);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -150,7 +151,7 @@ test("A5: --include-dir does not override gitignore — an ignored directory sta
 
     assert.deepEqual(walked(dir, new Set(["build"])), ["src/app.ts"]);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -201,7 +202,7 @@ test("walkDir and every scopes.ts consumer agree on the skip set: SKIP_DIRS + a 
     for (const name of SKIP_DIRS) assert.ok(!children.includes(name), `discoverWorkspaceChildren must skip ${name}`);
     assert.ok(!children.includes(".hidden"), "discoverWorkspaceChildren must skip the dot-dir");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -220,6 +221,6 @@ test("workspace-glob resolution (scopes.ts's resolveGlob over visible-file dirs)
     for (const name of SKIP_DIRS) assert.ok(!prefixes.includes(name), `the glob must not resolve into ${name}`);
     assert.ok(!prefixes.includes(".hidden"), "the glob must not resolve into the dot-dir");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });

--- a/test/ingest-fs.test.ts
+++ b/test/ingest-fs.test.ts
@@ -62,6 +62,77 @@ test("walkDir keeps tracked files that match an ignore rule and untracked visibl
   }
 });
 
+/**
+ * `git ls-files` prints one line PER INDEX STAGE, so an unmerged path arrives three
+ * times (stages 1/2/3). Nothing downstream deduplicated: the build looped over the
+ * same file three times and pushed three nodes per id, which trips
+ * `checkGraphInvariants`, inflates `meta.nodeCount`, and makes `ask` score one body
+ * 3×. The Claude Code `Stop` hook builds at the end of every turn, so this fired on
+ * its own in the middle of a conflicted merge.
+ */
+test("walkDir returns each file once during a merge conflict, not once per index stage", () => {
+  const dir = fixture("conflict");
+  try {
+    execFileSync("git", ["config", "user.email", "t@example.com"], { cwd: dir });
+    execFileSync("git", ["config", "user.name", "t"], { cwd: dir });
+    write(dir, "a.ts", "export const value = 1;\n");
+    execFileSync("git", ["add", "-A"], { cwd: dir });
+    execFileSync("git", ["commit", "-qm", "base"], { cwd: dir });
+    const base = execFileSync("git", ["rev-parse", "HEAD"], { cwd: dir, encoding: "utf8" }).trim();
+
+    execFileSync("git", ["checkout", "-qb", "other"], { cwd: dir });
+    write(dir, "a.ts", "export const value = 2;\n");
+    execFileSync("git", ["commit", "-qam", "other"], { cwd: dir });
+
+    execFileSync("git", ["checkout", "-q", base], { cwd: dir });
+    execFileSync("git", ["checkout", "-qb", "mine"], { cwd: dir });
+    write(dir, "a.ts", "export const value = 3;\n");
+    execFileSync("git", ["commit", "-qam", "mine"], { cwd: dir });
+
+    try {
+      execFileSync("git", ["merge", "other"], { cwd: dir, stdio: "pipe" });
+      assert.fail("the fixture must actually conflict");
+    } catch {
+      /* the conflict is the point */
+    }
+    const staged = execFileSync("git", ["ls-files", "--cached", "--", "a.ts"], { cwd: dir, encoding: "utf8" })
+      .split("\n")
+      .filter(Boolean);
+    assert.ok(staged.length > 1, `the path must really be unmerged (git printed ${staged.length} line(s))`);
+
+    assert.deepEqual(walked(dir), ["a.ts"]);
+  } finally {
+    rmDir(dir);
+  }
+});
+
+/**
+ * A bad `[dir]` used to surface as `ENOENT: no such file or directory, scandir 'C:\…'`
+ * from four frames down in `readdirSync` — cli.ts prints `err.message` and nothing more,
+ * so the message named neither the command nor the argument that was wrong.
+ */
+test("walkDir rejects a missing or non-directory path with a message that names it", () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-walk-baddir-"));
+  try {
+    const missing = join(dir, "definitely-not-here");
+    assert.throws(() => walkDir(missing), (err: Error) => {
+      assert.match(err.message, /no such directory — pass a repository root/);
+      assert.ok(err.message.includes(missing), "the message must name the argument that was wrong");
+      return true;
+    });
+
+    const file = join(dir, "notes.txt");
+    writeFileSync(file, "not a repo\n");
+    assert.throws(() => walkDir(file), (err: Error) => {
+      assert.match(err.message, /not a directory — pass a repository root/);
+      assert.ok(err.message.includes(file));
+      return true;
+    });
+  } finally {
+    rmDir(dir);
+  }
+});
+
 test("walkDir retains fixed skips and filesystem fallback outside Git", () => {
   const dir = mkdtempSync(join(tmpdir(), "graft-walk-nongit-"));
   try {

--- a/test/llm-adapters.test.ts
+++ b/test/llm-adapters.test.ts
@@ -266,6 +266,52 @@ test("anthropic: reconstructed assistant tool_use carries the object input", asy
   assert.deepEqual(asst.content[0].input, { k: 1 });
 });
 
+test("anthropic: thinking is forwarded when asked, and left absent when not", async () => {
+  // Absent ≠ off. With no `thinking` field, current Claude models run ADAPTIVE
+  // thinking out of the caller's max_tokens, so the ops that need every token for
+  // the answer have to say "disabled" out loud — and the adapter has to send it.
+  const { client, box } = fakeAnthropic(anthropicResp());
+  const m = new AnthropicChatModel({ apiKey: "x", model: "claude-x", client });
+
+  await m.create({ messages: [{ role: "user", content: "hi" }] });
+  assert.equal("thinking" in box.params, false, "unset means 'whatever the model does by default'");
+
+  await m.create({ messages: [{ role: "user", content: "hi" }], thinking: { kind: "disabled" } });
+  assert.deepEqual(box.params.thinking, { type: "disabled" });
+
+  await m.create({ messages: [{ role: "user", content: "hi" }], thinking: { kind: "enabled", budgetTokens: 4096 } });
+  assert.deepEqual(box.params.thinking, { type: "enabled", budget_tokens: 4096 });
+});
+
+// `_options` is the SDK's own record of what it was constructed with. Reading it
+// is the only network-free way to prove the adapter passed something through to a
+// client it builds itself (the `client` injection seam skips construction).
+function sdkOptions(model: unknown): Record<string, unknown> {
+  return (model as { client: { _options: Record<string, unknown> } }).client._options;
+}
+
+test("anthropic: headers and timeout reach the SDK client — a Messages-API gateway needs both", async () => {
+  // ChatModelConfig has always accepted `headers` for every provider; this adapter
+  // was the one that dropped them, so a gateway that speaks the Messages API and
+  // requires its own routing header answered 401 with nothing to point at.
+  const m = new AnthropicChatModel({
+    apiKey: "x",
+    model: "claude-x",
+    baseUrl: "https://gateway.internal/v1",
+    headers: { "X-Tenant": "graft" },
+    timeoutMs: 30_000,
+  });
+  assert.deepEqual(sdkOptions(m).defaultHeaders, { "X-Tenant": "graft" });
+  assert.equal(sdkOptions(m).timeout, 30_000, "the SDK default is 10 minutes — a stalled host would pin a worker that long");
+});
+
+test("openai: timeout reaches the SDK client, and is left to the SDK when unset", async () => {
+  const withTimeout = new OpenAIChatModel({ apiKey: "x", model: "gpt-x", timeoutMs: 45_000 });
+  assert.equal(sdkOptions(withTimeout).timeout, 45_000);
+  const without = new OpenAIChatModel({ apiKey: "x", model: "gpt-x" });
+  assert.equal(sdkOptions(without).timeout, undefined, "no opinion configured → don't invent one");
+});
+
 test("anthropic: json mode forces emit_json and returns serialized text", async () => {
   const resp = anthropicResp({
     content: [{ type: "tool_use", id: "j1", name: "emit_json", input: { correct: true } }],

--- a/test/llm-claude-cli.test.ts
+++ b/test/llm-claude-cli.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Process-free tests for the subscription transport. The adapter takes an
+ * injectable runner, so every case here asserts both directions of the
+ * translation (neutral → argv/stdin, CLI envelope → neutral) without ever
+ * spawning `claude`, hitting the network, or needing a key.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+import { ClaudeCliChatModel, extractJson, isTransient, resolveClaudeBin } from "../src/ai/llm/claude-cli.js";
+import { createChatModel, providerNeedsKey } from "../src/ai/llm/factory.js";
+import { credentialProblem, resolveConfig } from "../src/ai/providers.js";
+import type { ClaudeCliResult } from "../src/ai/llm/claude-cli.js";
+
+/** A path that certainly exists (this file) — stands in for an installed CLI. */
+const REAL_PATH = fileURLToPath(import.meta.url);
+const MISSING_PATH = `${REAL_PATH}.does-not-exist`;
+
+function envelope(over: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    type: "result",
+    subtype: "success",
+    is_error: false,
+    result: "hello",
+    stop_reason: "end_turn",
+    usage: {
+      input_tokens: 70,
+      output_tokens: 20,
+      cache_read_input_tokens: 30,
+      cache_creation_input_tokens: 5,
+    },
+    ...over,
+  });
+}
+
+/** Records every invocation and replays canned stdout, one response per call. */
+function fakeRunner(responses: Array<Partial<ClaudeCliResult> | string>) {
+  const calls: Array<{ args: string[]; stdin: string; timeoutMs: number }> = [];
+  const run = async (args: string[], stdin: string, timeoutMs: number): Promise<ClaudeCliResult> => {
+    calls.push({ args, stdin, timeoutMs });
+    const r = responses[Math.min(calls.length - 1, responses.length - 1)];
+    const base = typeof r === "string" ? { stdout: r } : r;
+    return { code: 0, stdout: "", stderr: "", ...base };
+  };
+  return { run, calls };
+}
+
+/** Read the value that follows a flag in the recorded argv. */
+const flagValue = (args: string[], flag: string) => args[args.indexOf(flag) + 1];
+
+// --- plain text --------------------------------------------------------------
+
+test("claude-cli: text — argv isolates the CLI and usage is normalized", async () => {
+  const { run, calls } = fakeRunner([envelope()]);
+  const m = new ClaudeCliChatModel({ model: "sonnet", run });
+  const res = await m.create({
+    messages: [
+      { role: "system", content: "sys" },
+      { role: "user", content: "hi" },
+    ],
+    temperature: 0,
+  });
+
+  const { args, stdin } = calls[0];
+  assert.equal(flagValue(args, "--model"), "sonnet");
+  assert.equal(flagValue(args, "--output-format"), "json");
+  assert.ok(args.includes("-p"));
+  // The isolation flags are the whole reason this is safe to run over a repo.
+  assert.equal(flagValue(args, "--tools"), "", "every built-in tool must be off");
+  assert.equal(flagValue(args, "--setting-sources"), "", "user hooks/settings must not load");
+  assert.ok(args.includes("--strict-mcp-config"));
+  assert.ok(args.includes("--disable-slash-commands"));
+  assert.ok(args.includes("--no-session-persistence"));
+  // graft's own system prompt rides in stdin; argv carries only the short harness one.
+  assert.ok(!flagValue(args, "--system-prompt").includes("sys"));
+  assert.match(stdin, /<INSTRUCTIONS>\nsys\n<\/INSTRUCTIONS>/);
+  assert.match(stdin, /<INPUT>\nhi\n<\/INPUT>/);
+  assert.ok(!stdin.includes("<OUTPUT_FORMAT>"), "no schema block for a text call");
+
+  assert.equal(res.text, "hello");
+  assert.deepEqual(res.toolCalls, []);
+  assert.equal(res.stopReason, "end_turn");
+  assert.deepEqual(res.usage, { input: 70, output: 20, cacheRead: 30, cacheCreate: 5 });
+  assert.equal(res.assistant.role, "assistant");
+});
+
+test("claude-cli: a single user message is sent verbatim, multi-turn gets role headers", async () => {
+  const { run, calls } = fakeRunner([envelope(), envelope()]);
+  const m = new ClaudeCliChatModel({ model: "sonnet", run });
+
+  await m.create({ messages: [{ role: "user", content: "just this" }] });
+  assert.match(calls[0].stdin, /<INPUT>\njust this\n<\/INPUT>/);
+
+  await m.create({
+    messages: [
+      { role: "user", content: "q" },
+      { role: "assistant", content: "a" },
+      { role: "user", content: "q2" },
+    ],
+  });
+  assert.match(calls[1].stdin, /### USER\nq/);
+  assert.match(calls[1].stdin, /### ASSISTANT\na/);
+});
+
+// --- structured output -------------------------------------------------------
+
+const RECORD_TOOL = {
+  name: "record_graph",
+  description: "Record nodes.",
+  parameters: { type: "object", properties: { nodes: { type: "array" } }, required: ["nodes"] },
+};
+
+const toolReq = {
+  tools: [RECORD_TOOL],
+  responseFormat: { kind: "tool", name: "record_graph" } as const,
+  messages: [{ role: "user" as const, content: "summaries" }],
+};
+
+test("claude-cli: tool format — schema is prompted and the reply becomes a tool call", async () => {
+  const { run, calls } = fakeRunner([envelope({ result: '{"nodes":[{"name":"Auth"}]}' })]);
+  const m = new ClaudeCliChatModel({ model: "sonnet", run });
+  const res = await m.create(toolReq);
+
+  // No tool_choice on this wire, so the schema has to travel in the prompt.
+  assert.match(calls[0].stdin, /<OUTPUT_FORMAT>/);
+  assert.ok(calls[0].stdin.includes('"required":["nodes"]'), "the tool's own schema is inlined");
+
+  assert.equal(res.toolCalls.length, 1);
+  assert.equal(res.toolCalls[0].name, "record_graph");
+  assert.deepEqual(res.toolCalls[0].args, { nodes: [{ name: "Auth" }] });
+  assert.equal(res.text, "", "text is empty when the turn is a forced tool call");
+});
+
+test("claude-cli: json format returns the object re-serialized as text", async () => {
+  const { run } = fakeRunner([envelope({ result: '{"a":1}' })]);
+  const m = new ClaudeCliChatModel({ model: "sonnet", run });
+  const res = await m.create({
+    responseFormat: { kind: "json" },
+    messages: [{ role: "user", content: "x" }],
+  });
+  assert.equal(res.text, '{"a":1}');
+  assert.deepEqual(res.toolCalls, []);
+});
+
+test("claude-cli: a fenced or prose-wrapped object still parses", async () => {
+  for (const raw of [
+    '```json\n{"nodes":[]}\n```',
+    'Here you go:\n{"nodes":[]}\nHope that helps!',
+    '{"nodes":[{"summary":"uses } and { in prose"}]}',
+  ]) {
+    const { run } = fakeRunner([envelope({ result: raw })]);
+    const m = new ClaudeCliChatModel({ model: "sonnet", run });
+    const res = await m.create(toolReq);
+    assert.ok(res.toolCalls[0], `failed to recover JSON from: ${raw}`);
+  }
+});
+
+test("claude-cli: unparseable output retries once, quoting the bad reply back", async () => {
+  const { run, calls } = fakeRunner([
+    envelope({ result: "I'm sorry, I can't do that." }),
+    envelope({ result: '{"nodes":[]}' }),
+  ]);
+  const m = new ClaudeCliChatModel({ model: "sonnet", run });
+  const res = await m.create(toolReq);
+
+  assert.equal(calls.length, 2, "exactly one corrective retry");
+  assert.match(calls[1].stdin, /<RETRY>/);
+  assert.match(calls[1].stdin, /I'm sorry/);
+  assert.deepEqual(res.toolCalls[0].args, { nodes: [] });
+});
+
+test("claude-cli: still unparseable after the retry fails loudly", async () => {
+  const { run, calls } = fakeRunner([envelope({ result: "nope" })]);
+  const m = new ClaudeCliChatModel({ model: "sonnet", run });
+  await assert.rejects(() => m.create(toolReq), /did not return parseable JSON/);
+  assert.equal(calls.length, 2);
+});
+
+// --- failure surfaces --------------------------------------------------------
+
+test("claude-cli: a non-zero exit surfaces stderr, not a JSON parse error", async () => {
+  const { run } = fakeRunner([{ code: 1, stderr: "Invalid API key · Please run /login" }]);
+  const m = new ClaudeCliChatModel({ model: "sonnet", run });
+  await assert.rejects(() => m.create({ messages: [{ role: "user", content: "x" }] }), /Please run \/login/);
+});
+
+test("claude-cli: is_error in the envelope is an error, not an empty summary", async () => {
+  const { run } = fakeRunner([envelope({ is_error: true, result: "usage limit reached" })]);
+  const m = new ClaudeCliChatModel({ model: "sonnet", run });
+  await assert.rejects(() => m.create({ messages: [{ role: "user", content: "x" }] }), /usage limit reached/);
+});
+
+test("isTransient: retries blips, never a login or quota problem", () => {
+  for (const m of ["Overloaded", "rate limit exceeded", "HTTP 503", "claude CLI timed out after 300000ms", "ECONNRESET"]) {
+    assert.equal(isTransient(m), true, m);
+  }
+  // A backoff cannot fix these, and sleeping on them hides the real diagnosis.
+  for (const m of [
+    "usage limit reached",
+    "Invalid API key · Please run /login",
+    "claude CLI not found on PATH",
+    "your credit balance is too low",
+    "rate limit exceeded — usage limit reached", // permanent wins over transient
+  ]) {
+    assert.equal(isTransient(m), false, m);
+  }
+});
+
+test("claude-cli: a transient failure is retried, and the result is kept", async () => {
+  const { run, calls } = fakeRunner([{ code: 1, stderr: "Overloaded" }, envelope()]);
+  const m = new ClaudeCliChatModel({ model: "sonnet", run });
+  const res = await m.create({ messages: [{ role: "user", content: "x" }] });
+  assert.equal(calls.length, 2);
+  assert.equal(res.text, "hello");
+});
+
+test("claude-cli: a permanent failure fails on the first attempt, not after backoff", async () => {
+  const { run, calls } = fakeRunner([{ code: 1, stderr: "Invalid API key · Please run /login" }]);
+  const m = new ClaudeCliChatModel({ model: "sonnet", run });
+  await assert.rejects(() => m.create({ messages: [{ role: "user", content: "x" }] }), /login/);
+  assert.equal(calls.length, 1, "a login problem must surface immediately");
+});
+
+test("claude-cli: a warning line before the envelope does not break parsing", async () => {
+  const { run } = fakeRunner([`warning: something\n${envelope()}`]);
+  const m = new ClaudeCliChatModel({ model: "sonnet", run });
+  const res = await m.create({ messages: [{ role: "user", content: "x" }] });
+  assert.equal(res.text, "hello");
+});
+
+// --- JSON recovery -----------------------------------------------------------
+
+test("extractJson: brace scanning is string- and escape-aware", () => {
+  assert.deepEqual(extractJson('{"s":"a } b"}'), { s: "a } b" });
+  assert.deepEqual(extractJson('{"s":"esc \\" then }"}'), { s: 'esc " then }' });
+  assert.deepEqual(extractJson('pre {"a":{"b":1}} post'), { a: { b: 1 } });
+  assert.equal(extractJson("no json here"), undefined);
+  assert.equal(extractJson('{"unterminated": '), undefined);
+});
+
+// --- wiring ------------------------------------------------------------------
+
+test("factory: claude-cli builds with no key; key providers still demand one", () => {
+  assert.equal(providerNeedsKey("claude-cli"), false);
+  assert.equal(providerNeedsKey("anthropic"), true);
+  const m = createChatModel({ provider: "claude-cli", model: "sonnet", bin: MISSING_PATH });
+  assert.equal(m.label, "claude-cli:sonnet");
+  assert.throws(() => createChatModel({ provider: "anthropic", model: "x" }), /needs an API key/);
+});
+
+test("resolveClaudeBin: an explicit path is trusted only when it exists", () => {
+  assert.equal(resolveClaudeBin(REAL_PATH), REAL_PATH);
+  assert.equal(resolveClaudeBin(MISSING_PATH), undefined);
+});
+
+/** Run `fn` with a scrubbed provider environment, restoring it afterwards. */
+function withEnv(over: Record<string, string | undefined>, fn: () => void): void {
+  const keys = ["GRAFT_PROVIDER", "GRAFT_API_KEY", "OPENROUTER_API_KEY", "GRAFT_MODEL", "GRAFT_CLAUDE_BIN"];
+  const saved = Object.fromEntries(keys.map((k) => [k, process.env[k]]));
+  for (const k of keys) delete process.env[k];
+  for (const [k, v] of Object.entries(over)) if (v !== undefined) process.env[k] = v;
+  try {
+    fn();
+  } finally {
+    for (const k of keys) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k]!;
+    }
+  }
+}
+
+test("resolveConfig: no key + a local CLI picks claude-cli, and says it inferred it", () => {
+  withEnv({ GRAFT_CLAUDE_BIN: REAL_PATH }, () => {
+    const c = resolveConfig();
+    assert.equal(c.provider, "claude-cli");
+    assert.equal(c.model, "sonnet");
+    assert.equal(c.autoDetectedProvider, true);
+    assert.equal(credentialProblem(c), undefined);
+  });
+});
+
+test("resolveConfig: an existing key-based setup is untouched by the new provider", () => {
+  withEnv({ GRAFT_API_KEY: "sk-test", GRAFT_CLAUDE_BIN: REAL_PATH }, () => {
+    const c = resolveConfig();
+    assert.equal(c.provider, "openai", "a configured key must never be silently bypassed");
+    assert.equal(c.autoDetectedProvider, false);
+  });
+});
+
+test("resolveConfig: an explicit provider always wins over inference", () => {
+  withEnv({ GRAFT_PROVIDER: "anthropic", GRAFT_CLAUDE_BIN: REAL_PATH }, () => {
+    const c = resolveConfig();
+    assert.equal(c.provider, "anthropic");
+    assert.equal(c.autoDetectedProvider, false);
+    assert.match(credentialProblem(c)!, /No API key/);
+  });
+});
+
+test("resolveConfig: no key and no CLI keeps the old default and the old complaint", () => {
+  withEnv({ GRAFT_CLAUDE_BIN: MISSING_PATH }, () => {
+    const c = resolveConfig();
+    assert.equal(c.provider, "openai");
+    assert.match(credentialProblem(c)!, /No API key/);
+  });
+});
+
+test("credentialProblem: claude-cli without the binary explains how to fix it", () => {
+  withEnv({ GRAFT_PROVIDER: "claude-cli", GRAFT_CLAUDE_BIN: MISSING_PATH }, () => {
+    const c = resolveConfig();
+    assert.match(credentialProblem(c)!, /not on PATH/);
+  });
+});
+
+test("credentialProblem: an injected chatModel needs no credentials at all", () => {
+  withEnv({ GRAFT_CLAUDE_BIN: MISSING_PATH }, () => {
+    const c = resolveConfig({ chatModel: { label: "stub", create: async () => ({}) as never } });
+    assert.equal(credentialProblem(c), undefined);
+  });
+});

--- a/test/llm-claude-cli.test.ts
+++ b/test/llm-claude-cli.test.ts
@@ -214,6 +214,20 @@ test("claude-cli: a transient failure is retried, and the result is kept", async
   assert.equal(res.text, "hello");
 });
 
+test("claude-cli: maxRetries decides how many attempts a transient failure gets", async () => {
+  // `maxRetries: 0` is the setting for a machine where the CLI is not signed in:
+  // every attempt fails identically, and three of them per file (with backoff)
+  // turns a clear error into a very slow one. The count was a hard-coded 3.
+  const { run, calls } = fakeRunner([
+    { code: 1, stderr: "Overloaded" },
+    { code: 1, stderr: "Overloaded" },
+    envelope(),
+  ]);
+  const m = new ClaudeCliChatModel({ model: "sonnet", run, maxRetries: 0 });
+  await assert.rejects(() => m.create({ messages: [{ role: "user", content: "x" }] }), /Overloaded/);
+  assert.equal(calls.length, 1, "no retry means exactly one call");
+});
+
 test("claude-cli: a permanent failure fails on the first attempt, not after backoff", async () => {
   const { run, calls } = fakeRunner([{ code: 1, stderr: "Invalid API key · Please run /login" }]);
   const m = new ClaudeCliChatModel({ model: "sonnet", run });

--- a/test/llm-ops.test.ts
+++ b/test/llm-ops.test.ts
@@ -15,14 +15,16 @@ import type { ChatModel, ChatRequest, ChatResponse, ToolCall } from "../src/ai/l
 class FakeChatModel implements ChatModel {
   readonly label = "fake:model";
   last?: ChatRequest;
-  constructor(private reply: { text?: string; toolCalls?: ToolCall[] }) {}
+  calls = 0;
+  constructor(private reply: { text?: string; toolCalls?: ToolCall[]; stopReason?: string }) {}
   async create(req: ChatRequest): Promise<ChatResponse> {
     this.last = req;
+    this.calls++;
     return {
       text: this.reply.text ?? "",
       toolCalls: this.reply.toolCalls ?? [],
       usage: { input: 0, output: 0, cacheRead: 0, cacheCreate: 0 },
-      stopReason: "stop",
+      stopReason: this.reply.stopReason ?? "stop",
       assistant: { role: "assistant", content: this.reply.text ?? "" },
     };
   }
@@ -78,4 +80,102 @@ test("structured ops degrade gracefully when the model returns no tool call", as
     }),
     [],
   );
+});
+
+// --- truncation ------------------------------------------------------------
+// A turn cut off at max_tokens looks like success at the call site: summarize
+// returns the partial text (which build.ts then caches by content hash FOREVER),
+// and the structured ops see no closed tool_use block and report "no results" —
+// indistinguishable from a model that had nothing to say, so nothing retries.
+
+test("every op REJECTS a turn the model was cut off from finishing", async () => {
+  const cut = (reason: string) => new FakeChatModel({ text: "half a sum", stopReason: reason });
+
+  // openai wire format says "length"; the Messages API and the Claude CLI say "max_tokens".
+  for (const reason of ["length", "max_tokens"]) {
+    await assert.rejects(
+      () => new ChatSummarizer(cut(reason)).summarize("code", { path: "a.ts" }),
+      /truncated/,
+      `summarize must not return a partial summary on stop_reason=${reason}`,
+    );
+  }
+
+  await assert.rejects(
+    () => new ChatSynthesizer(cut("max_tokens")).synthesize([{ path: "a.ts", summary: "x" }]),
+    /truncated/,
+    "a truncated batch must not be cached as an empty synthesis",
+  );
+
+  await assert.rejects(
+    () =>
+      new ChatCruxSummarizer(cut("max_tokens")).describeFile({
+        path: "a.ts",
+        source: "l1\nl2\n",
+        nodes: [{ id: "s", kind: "function", signature: null, startLine: 1, endLine: 2 }],
+      }),
+    /truncated/,
+    "a truncated crux call must not be reported as 'the model skipped these symbols'",
+  );
+});
+
+test("single-shot ops turn thinking OFF explicitly, instead of inheriting the provider default", async () => {
+  // Current Claude models default to adaptive thinking, and thinking is billed
+  // against the SAME maxTokens as the answer — so a 2048-token summarize can come
+  // back empty with the budget spent on reasoning nobody asked for.
+  const m = new FakeChatModel({ text: "s", toolCalls: [{ id: "1", name: "record_graph", args: { nodes: [] } }] });
+  await new ChatSummarizer(m).summarize("code", { path: "a.ts" });
+  assert.deepEqual(m.last?.thinking, { kind: "disabled" }, "summarize");
+  await new ChatSynthesizer(m).synthesize([{ path: "a.ts", summary: "x" }]);
+  assert.deepEqual(m.last?.thinking, { kind: "disabled" }, "synthesize");
+  await new ChatCruxSummarizer(m).describeFile({
+    path: "a.ts",
+    source: "l1\n",
+    nodes: [{ id: "s", kind: "function", signature: null, startLine: 1, endLine: 1 }],
+  });
+  assert.deepEqual(m.last?.thinking, { kind: "disabled" }, "crux");
+});
+
+// --- crux: targets must live inside the window that was actually sent --------
+
+/** A file long enough to be clipped, whose Nth line is identifiable. */
+function longSource(lines: number): string {
+  return Array.from({ length: lines }, (_, i) => `const v${i + 1} = ${"x".repeat(60)};`).join("\n");
+}
+
+test("crux asks only about symbols inside the clipped window it actually showed", async () => {
+  const source = longSource(600); // ~37k chars — well past the 18k clip
+  const m = new FakeChatModel({ toolCalls: [{ id: "1", name: "record_symbols", args: { symbols: [] } }] });
+  await new ChatCruxSummarizer(m).describeFile({
+    path: "big.ts",
+    source,
+    nodes: [
+      { id: "near", kind: "function", signature: null, startLine: 2, endLine: 5 },
+      { id: "far", kind: "function", signature: null, startLine: 560, endLine: 580 },
+    ],
+  });
+
+  const prompt = m.last?.messages[1].content ?? "";
+  const targets = prompt.slice(prompt.indexOf("TARGETS:"));
+  assert.match(targets, /id=near/, "a symbol inside the window is still asked about");
+  assert.doesNotMatch(
+    targets,
+    /id=far/,
+    "a symbol past the truncation point was never shown — asking for its crux forces the model to invent one",
+  );
+
+  // The line numbers in the prompt must stop where the targets do, or a target's
+  // L-range points at text the model can't see.
+  const lastNumbered = Number(/\n(\d+)\t[^\n]*\n… \(truncated\)/.exec(prompt)?.[1] ?? 0);
+  assert.ok(lastNumbered > 0 && lastNumbered < 600, `expected a truncated numbered window, got ${lastNumbered}`);
+});
+
+test("crux spends NO call at all when every requested symbol is past the window", async () => {
+  const m = new FakeChatModel({ toolCalls: [] });
+  const out = await new ChatCruxSummarizer(m).describeFile({
+    path: "big.ts",
+    source: longSource(600),
+    nodes: [{ id: "far", kind: "function", signature: null, startLine: 560, endLine: 580 }],
+  });
+  assert.deepEqual(out, []);
+  assert.equal(m.calls, 0, "enrich.ts re-asks for missing symbols, so this would have cost two useless calls");
 });

--- a/test/llm-providers.test.ts
+++ b/test/llm-providers.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Config resolution and factory wiring — the layer between "what the user typed"
+ * and "which model id goes on the wire". Everything here is env-only and
+ * network-free.
+ *
+ * (The claude-cli half of resolveConfig — auto-detection, credentialProblem —
+ * lives in llm-claude-cli.test.ts, next to the adapter it exists for.)
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolveConfig, DEFAULT_MODELS } from "../src/ai/providers.js";
+import { createChatModel } from "../src/ai/llm/factory.js";
+
+/** Run `fn` with a scrubbed provider environment, restoring it afterwards. */
+function withEnv(over: Record<string, string | undefined>, fn: () => void): void {
+  const keys = [
+    "GRAFT_PROVIDER", "GRAFT_API_KEY", "OPENROUTER_API_KEY", "GRAFT_MODEL",
+    "GRAFT_OPENROUTER_MODEL", "GRAFT_BASE_URL", "OPENROUTER_BASE_URL",
+    "GRAFT_CLAUDE_BIN", "GRAFT_TIMEOUT_MS", "GRAFT_CLAUDE_TIMEOUT_MS",
+    "GRAFT_MAX_RETRIES",
+  ];
+  const saved = Object.fromEntries(keys.map((k) => [k, process.env[k]]));
+  for (const k of keys) delete process.env[k];
+  for (const [k, v] of Object.entries(over)) if (v !== undefined) process.env[k] = v;
+  try {
+    fn();
+  } finally {
+    for (const k of keys) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k]!;
+    }
+  }
+}
+
+// The most obvious setup in the world — an OpenAI key in GRAFT_API_KEY, nothing
+// else — used to fail on 100% of calls: the default model carried OpenRouter's
+// `vendor/slug` addressing, and api.openai.com answers that with a 404
+// model_not_found. Combined with the concept-layer prune, a total failure like
+// that also deleted graft/*.md.
+test("the default model follows the endpoint: bare id for api.openai.com, vendor/slug for OpenRouter", () => {
+  withEnv({ GRAFT_API_KEY: "sk-test" }, () => {
+    const c = resolveConfig();
+    assert.equal(c.baseUrl, undefined, "no baseUrl means the SDK talks to api.openai.com");
+    assert.equal(c.model, "gpt-4o-mini");
+    assert.doesNotMatch(c.model, /\//, "a vendor/slug id is a 404 on api.openai.com");
+  });
+
+  withEnv({ GRAFT_API_KEY: "sk-test", GRAFT_BASE_URL: "https://openrouter.ai/api/v1" }, () => {
+    const c = resolveConfig();
+    assert.equal(c.model, "openai/gpt-4o-mini", "OpenRouter addresses the same model by vendor/slug");
+    assert.deepEqual(c.headers, { "X-Title": "graft" });
+  });
+
+  // The legacy key implies OpenRouter, so it must imply OpenRouter's id form too.
+  withEnv({ OPENROUTER_API_KEY: "sk-legacy" }, () => {
+    const c = resolveConfig();
+    assert.equal(c.baseUrl, "https://openrouter.ai/api/v1");
+    assert.equal(c.model, "openai/gpt-4o-mini");
+  });
+});
+
+test("an explicit GRAFT_MODEL is never second-guessed, whatever the endpoint", () => {
+  withEnv({ GRAFT_API_KEY: "sk-test", GRAFT_MODEL: "openai/gpt-4o-mini" }, () => {
+    assert.equal(resolveConfig().model, "openai/gpt-4o-mini");
+  });
+  withEnv({ GRAFT_API_KEY: "sk-test", GRAFT_BASE_URL: "https://openrouter.ai/api/v1", GRAFT_MODEL: "qwen-3" }, () => {
+    assert.equal(resolveConfig().model, "qwen-3");
+  });
+});
+
+// A cast let a typo through the entire resolution: model became `undefined`
+// (despite ResolvedConfig.model: string), the manifest recorded "gemini:undefined",
+// and the only complaint came from the factory's exhaustiveness guard — which
+// names neither the variable nor the legal values.
+test("an unknown GRAFT_PROVIDER fails immediately, naming the variable and the way out", () => {
+  withEnv({ GRAFT_PROVIDER: "gemini", GRAFT_API_KEY: "sk-test" }, () => {
+    assert.throws(() => resolveConfig(), (err: Error) => {
+      assert.match(err.message, /GRAFT_PROVIDER="gemini"/);
+      assert.match(err.message, /openai/, "lists the values that do work");
+      assert.match(err.message, /GRAFT_BASE_URL/, "and points at the actual fix for Gemini/Groq/local servers");
+      return true;
+    });
+  });
+  // `GRAFT_PROVIDER=` in a .env is "unset", not a typo.
+  withEnv({ GRAFT_PROVIDER: "", GRAFT_API_KEY: "sk-test" }, () => {
+    assert.equal(resolveConfig().provider, "openai");
+  });
+  // Every legal value still resolves, and each gets its own default model.
+  for (const provider of ["openai", "anthropic", "claude-cli"] as const) {
+    withEnv({ GRAFT_PROVIDER: provider, GRAFT_API_KEY: "sk-test" }, () => {
+      assert.equal(resolveConfig().provider, provider);
+      assert.equal(resolveConfig().model, DEFAULT_MODELS[provider]);
+    });
+  }
+});
+
+test("GRAFT_TIMEOUT_MS applies to every provider, with the claude-specific name still winning", () => {
+  withEnv({ GRAFT_API_KEY: "sk-test", GRAFT_TIMEOUT_MS: "30000" }, () => {
+    assert.equal(resolveConfig().timeoutMs, 30_000);
+  });
+  withEnv({ GRAFT_API_KEY: "sk-test", GRAFT_TIMEOUT_MS: "30000", GRAFT_CLAUDE_TIMEOUT_MS: "600000" }, () => {
+    assert.equal(resolveConfig().timeoutMs, 600_000, "a setup that already tuned the specific knob keeps its value");
+  });
+});
+
+test("GRAFT_MAX_RETRIES is honoured, and 0 means zero rather than 'unset'", () => {
+  // The right number is a property of the endpoint: a rate-limited key wants more
+  // (each retry waits out the Retry-After), a local server that isn't running wants
+  // none. Neither was expressible — the SDK default was the only value there was.
+  withEnv({ GRAFT_API_KEY: "sk-test", GRAFT_MAX_RETRIES: "6" }, () => {
+    assert.equal(resolveConfig().maxRetries, 6);
+  });
+  withEnv({ GRAFT_API_KEY: "sk-test", GRAFT_MAX_RETRIES: "0" }, () => {
+    // The trap this exists for: the shared `numeric` parser drops 0 as falsy, which
+    // is right for a budget or a timeout and exactly wrong here.
+    assert.equal(resolveConfig().maxRetries, 0, "0 retries is a setting, not an unset value");
+  });
+  // Junk and negatives fall back to the SDK default rather than becoming NaN.
+  for (const bad of ["", "many", "-1", "1.5"]) {
+    withEnv({ GRAFT_API_KEY: "sk-test", GRAFT_MAX_RETRIES: bad }, () => {
+      assert.equal(resolveConfig().maxRetries, undefined, bad);
+    });
+  }
+  // An explicit config value still wins over the environment.
+  withEnv({ GRAFT_API_KEY: "sk-test", GRAFT_MAX_RETRIES: "6" }, () => {
+    assert.equal(resolveConfig({ maxRetries: 1 }).maxRetries, 1);
+  });
+});
+
+/** The SDK's own record of its constructor options — see llm-adapters.test.ts. */
+function sdkOptions(model: unknown): Record<string, unknown> {
+  return (model as { client: { _options: Record<string, unknown> } }).client._options;
+}
+
+test("createChatModel hands headers to the anthropic adapter too, not just openai", () => {
+  const headers = { "X-Tenant": "graft" };
+  const anthropic = createChatModel({
+    provider: "anthropic", apiKey: "x", model: "claude-x",
+    baseUrl: "https://gateway.internal/v1", headers, timeoutMs: 20_000,
+  });
+  assert.deepEqual(sdkOptions(anthropic).defaultHeaders, headers);
+  assert.equal(sdkOptions(anthropic).timeout, 20_000);
+
+  const openai = createChatModel({ provider: "openai", apiKey: "x", model: "gpt-x", headers, timeoutMs: 20_000 });
+  assert.deepEqual(sdkOptions(openai).defaultHeaders, headers);
+  assert.equal(sdkOptions(openai).timeout, 20_000);
+});
+
+test("createChatModel forwards maxRetries to both SDK adapters, 0 included", () => {
+  for (const provider of ["openai", "anthropic"] as const) {
+    const m = createChatModel({ provider, apiKey: "x", model: "m", maxRetries: 5 });
+    assert.equal(sdkOptions(m).maxRetries, 5, provider);
+    // 0 must reach the SDK as 0, not be swallowed as "nothing was configured" —
+    // this is the value that says "don't retry a server that isn't there".
+    const none = createChatModel({ provider, apiKey: "x", model: "m", maxRetries: 0 });
+    assert.equal(sdkOptions(none).maxRetries, 0, provider);
+    // Unset stays unset, so the SDK's own default keeps applying.
+    const dflt = createChatModel({ provider, apiKey: "x", model: "m" });
+    assert.equal(sdkOptions(dflt).maxRetries, undefined, provider);
+  }
+});

--- a/test/lsp-enrich-client.test.ts
+++ b/test/lsp-enrich-client.test.ts
@@ -1,0 +1,137 @@
+/**
+ * `LspClient` end to end, against the fake server in `./lsp-enrich-server.mjs`.
+ *
+ * Until now nothing imported `src/graph/lsp/client.ts` at all: the spawn, the
+ * initialize handshake, didOpen, the call-hierarchy pair, the per-request timeout
+ * and the teardown were 177 unexecuted lines on every platform. `lsp-enrich.test.ts`
+ * only ever asserted the degradation path (no server installed → no-op), which is
+ * precisely the path a broken client is indistinguishable from — the whole tier was
+ * dead on Windows and looked exactly like "you have no language server".
+ *
+ * No toolchain is installed for any of this: the fake server is plain Node speaking
+ * the wire protocol, so both CI legs run the same tests.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { writeFileSync } from "node:fs";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { join } from "node:path";
+import { LspClient } from "../src/graph/lsp/client.js";
+import { tmpRepo } from "./helpers.js";
+
+const FAKE_SERVER = fileURLToPath(new URL("./lsp-enrich-server.mjs", import.meta.url));
+
+/** A scratch repo with one source file, since didOpen reads from disk. */
+function repoWithFile(): { root: string; file: string } {
+  const root = tmpRepo("lsp-client");
+  const file = join(root, "main.ts");
+  writeFileSync(file, "export function caller() {\n  callee();\n}\n\nexport function callee() {}\n");
+  return { root, file };
+}
+
+function clientFor(root: string, mode = "full", callTimeoutMs = 5000): LspClient {
+  return new LspClient(process.execPath, [FAKE_SERVER, mode], root, "typescript", callTimeoutMs);
+}
+
+test("initialize → didOpen → call hierarchy → outgoing calls, over real stdio framing", async () => {
+  const { root, file } = repoWithFile();
+  const client = clientFor(root);
+  try {
+    assert.equal(await client.initialize(), true, "handshake completed");
+
+    client.didOpen(file);
+    const items = await client.prepareCallHierarchy(file, { line: 0, character: 16 });
+    assert.equal(items.length, 1);
+    // The server reports how many didOpen notifications it saw. Without it a client
+    // that never sent one would look identical here — and servers answer call
+    // hierarchy on an unopened document with silence, not an error.
+    assert.equal(items[0].name, "caller/opened:1", "the document was opened before it was queried");
+    assert.equal(items[0].uri, pathToFileURL(file).toString());
+
+    const callees = await client.outgoingCalls(items[0]);
+    assert.equal(callees.length, 1);
+    assert.equal(callees[0].name, "callee");
+    // `enrich.ts` maps a callee back to a graft node through this line number, so
+    // the field it actually reads has to survive the round trip.
+    assert.equal(callees[0].selectionRange.start.line, 4);
+  } finally {
+    await client.dispose();
+  }
+});
+
+test("didOpen is idempotent — one notification per document, however often it is called", async () => {
+  const { root, file } = repoWithFile();
+  const client = clientFor(root);
+  try {
+    await client.initialize();
+    // `enrichWithLsp` calls didOpen once per source node, so a file with twenty
+    // functions would otherwise re-send its whole text twenty times.
+    for (let i = 0; i < 5; i++) client.didOpen(file);
+    const items = await client.prepareCallHierarchy(file, { line: 0, character: 16 });
+    assert.equal(items[0].name, "caller/opened:1");
+  } finally {
+    await client.dispose();
+  }
+});
+
+test("a request a server never answers ends at the timeout, not at the build's expense", async () => {
+  const { root, file } = repoWithFile();
+  const client = clientFor(root, "silent", 300);
+  try {
+    assert.equal(await client.initialize(), true);
+    const started = Date.now();
+    assert.deepEqual(await client.prepareCallHierarchy(file, { line: 0, character: 16 }), []);
+    // The point of the timeout: a wedged server degrades the enrichment, it does
+    // not hang `graft build --lsp` forever.
+    assert.ok(Date.now() - started < 5000, "returned on the per-call timeout");
+  } finally {
+    await client.dispose();
+  }
+});
+
+test("a server that never completes the handshake fails initialize instead of hanging", async () => {
+  const { root } = repoWithFile();
+  const client = clientFor(root, "deaf", 300);
+  try {
+    // `initialize` has its own 120s ceiling for cold indexing, so this leans on the
+    // client noticing the process is gone. Kill it and the exit handler must flip
+    // `ready` off — otherwise the whole build waits out two minutes for nothing.
+    const done = client.initialize();
+    await client.dispose();
+    assert.equal(await done, false);
+  } finally {
+    await client.dispose();
+  }
+});
+
+test("a command that does not exist degrades to 'no enrichment', never a crash", async () => {
+  const { root } = repoWithFile();
+  // The contract `enrichWithLsp` relies on: a registry entry pointing at something
+  // unspawnable returns false fast, and the AST graph stands on its own.
+  const client = new LspClient(join(root, "definitely-not-a-language-server"), [], root, "typescript", 300);
+  try {
+    assert.equal(await client.initialize(), false);
+    assert.deepEqual(await client.prepareCallHierarchy(join(root, "main.ts"), { line: 0, character: 0 }), []);
+  } finally {
+    await client.dispose();
+  }
+});
+
+test("a .cmd shim is spawnable (Windows npm-installed servers)", { skip: process.platform !== "win32" }, async () => {
+  const { root, file } = repoWithFile();
+  // `typescript-language-server` and `pyright-langserver` install as `.cmd` shims.
+  // Node cannot CreateProcess one (EINVAL since the CVE-2024-27980 patch), so
+  // handing the resolved path straight to `spawn` failed for every npm-installed
+  // server on the platform — the exact servers a JS/TS repo would have.
+  const shim = join(root, "fake-lsp.cmd");
+  writeFileSync(shim, `@echo off\r\n"${process.execPath}" "${FAKE_SERVER}" full\r\n`);
+  const client = new LspClient(shim, [], root, "typescript", 5000);
+  try {
+    assert.equal(await client.initialize(), true, "the shim spoke LSP through cmd.exe");
+    client.didOpen(file);
+    const items = await client.prepareCallHierarchy(file, { line: 0, character: 16 });
+    assert.equal(items.length, 1);
+  } finally {
+    await client.dispose();
+  }
+});

--- a/test/lsp-enrich-server.mjs
+++ b/test/lsp-enrich-server.mjs
@@ -1,0 +1,93 @@
+/**
+ * A fake language server, for `test/lsp-enrich-client.test.ts`.
+ *
+ * `src/graph/lsp/client.ts` — spawn, initialize handshake, didOpen, call hierarchy,
+ * timeouts, teardown — was executed by no test on any platform, which is how it kept
+ * a Windows-only spawn bug and how the registry above it stayed broken unnoticed.
+ * Standing up a real language server in CI is not an option (each one drags in a
+ * whole toolchain), so this speaks the wire protocol directly: LSP is JSON-RPC over
+ * stdio with `Content-Length` framing, and that is small enough to hand-roll.
+ *
+ * Deliberately dependency-free — no `vscode-jsonrpc` import — so it can be launched
+ * from anywhere, including through a `.cmd` shim in a scratch directory, which is
+ * exactly the case the Windows bug lived in.
+ *
+ * Modes (argv[2]):
+ *   full   — answers everything (the happy path)
+ *   silent — completes `initialize`, then never answers a request again, so the
+ *            client's per-call timeout is what has to end the call
+ *   deaf   — never answers anything, not even `initialize`
+ */
+const mode = process.argv[2] ?? "full";
+
+/** Documents the client has opened, reported back so the test can see didOpen landed. */
+const opened = [];
+
+let buf = Buffer.alloc(0);
+process.stdin.on("data", (chunk) => {
+  buf = Buffer.concat([buf, chunk]);
+  drain();
+});
+
+function drain() {
+  for (;;) {
+    const sep = buf.indexOf("\r\n\r\n");
+    if (sep === -1) return;
+    const m = /content-length:\s*(\d+)/i.exec(buf.subarray(0, sep).toString("ascii"));
+    if (!m) {
+      buf = buf.subarray(sep + 4);
+      continue;
+    }
+    const start = sep + 4;
+    const len = Number(m[1]);
+    if (buf.length < start + len) return; // body still arriving
+    const body = buf.subarray(start, start + len).toString("utf8");
+    buf = buf.subarray(start + len);
+    let msg;
+    try {
+      msg = JSON.parse(body);
+    } catch {
+      continue;
+    }
+    handle(msg);
+  }
+}
+
+function send(id, result) {
+  const json = Buffer.from(JSON.stringify({ jsonrpc: "2.0", id, result }), "utf8");
+  process.stdout.write(`Content-Length: ${json.length}\r\n\r\n`);
+  process.stdout.write(json);
+}
+
+const range = (line) => ({ start: { line, character: 0 }, end: { line, character: 10 } });
+
+function handle(msg) {
+  if (mode === "deaf") return;
+  if (msg.id === undefined) {
+    if (msg.method === "textDocument/didOpen") opened.push(msg.params.textDocument.uri);
+    return; // every other notification is noise we are allowed to drop
+  }
+  if (msg.method === "initialize") {
+    send(msg.id, { capabilities: { textDocumentSync: 1, callHierarchyProvider: true } });
+    return;
+  }
+  if (mode === "silent") return;
+  switch (msg.method) {
+    case "textDocument/prepareCallHierarchy": {
+      const uri = msg.params.textDocument.uri;
+      // The name carries the didOpen count: the client has no way to ask, and a
+      // request that silently skipped didOpen would otherwise look identical.
+      send(msg.id, [{ name: `caller/opened:${opened.length}`, kind: 12, uri, range: range(0), selectionRange: range(0) }]);
+      return;
+    }
+    case "callHierarchy/outgoingCalls": {
+      const uri = msg.params.item.uri;
+      send(msg.id, [
+        { to: { name: "callee", kind: 12, uri, range: range(4), selectionRange: range(4) }, fromRanges: [] },
+      ]);
+      return;
+    }
+    default:
+      send(msg.id, null);
+  }
+}

--- a/test/lsp-enrich.test.ts
+++ b/test/lsp-enrich.test.ts
@@ -6,9 +6,12 @@
  */
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { pickServer, LSP_SERVERS } from "../src/graph/lsp/registry.js";
+import { writeFileSync } from "node:fs";
+import { delimiter, isAbsolute, join } from "node:path";
+import { pickServer, resetResolvedCommands, LSP_SERVERS } from "../src/graph/lsp/registry.js";
 import { enrichWithLsp } from "../src/graph/lsp/enrich.js";
 import type { GraphV1 } from "../src/graph/types.js";
+import { tmpRepo } from "./helpers.js";
 
 test("pickServer: no languages present → no server", () => {
   assert.equal(pickServer(new Set()), null);
@@ -23,6 +26,72 @@ test("registry rows are well-formed (languages, command, languageId)", () => {
     assert.ok(s.languages.length > 0 && s.command && s.languageId, `${s.command} row shape`);
     assert.ok(Array.isArray(s.args), `${s.command} args is an array`);
   }
+});
+
+// --- server resolution ---
+//
+// The lookup used to be `execSync("command -v <cmd>")`, a POSIX shell builtin. On
+// Windows `cmd.exe` answers "'command' is not recognized" and throws, so every
+// language resolved to null and `graft build --lsp` was a silent no-op across the
+// platform — indistinguishable, from the outside, from "no server installed", which
+// is all the tests above could tell you.
+
+/** Install a fake `rust-analyzer` on PATH, and point PATH at only that. */
+function stubServerDir(name: string): string {
+  const dir = tmpRepo("lsp-registry");
+  // Contents don't matter: resolution answers "where is it", and spawning it is
+  // `client.ts`'s business (and its own test's).
+  writeFileSync(join(dir, process.platform === "win32" ? `${name}.CMD` : name), "");
+  return dir;
+}
+
+function withPath(dir: string, fn: () => void): void {
+  const saved = process.env.PATH;
+  process.env.PATH = dir;
+  resetResolvedCommands();
+  try {
+    fn();
+  } finally {
+    process.env.PATH = saved;
+    resetResolvedCommands();
+  }
+}
+
+test("pickServer resolves a server on PATH to an absolute path (Windows: PATHEXT shims)", () => {
+  const dir = stubServerDir("rust-analyzer");
+  withPath(dir, () => {
+    const picked = pickServer(new Set(["rust"]));
+    assert.ok(picked, "rust-analyzer on PATH must be found");
+    // Absolute, because `spawn` resolves against PATH again and the two can
+    // disagree — resolving here is the point of the lookup.
+    assert.ok(isAbsolute(picked!.command));
+    assert.equal(picked!.languageId, "rust");
+  });
+});
+
+test("pickServer honours registry priority when several servers are installed", () => {
+  const dir = stubServerDir("clangd");
+  writeFileSync(join(dir, process.platform === "win32" ? "gopls.CMD" : "gopls"), "");
+  withPath(dir, () => {
+    // Both languages are present and both servers are installed; LSP_SERVERS order
+    // is the tiebreak, and clangd sits above gopls in it.
+    assert.match(pickServer(new Set(["c", "go"]))!.command, /clangd/);
+    // …but a language clangd doesn't cover still falls through to gopls.
+    assert.match(pickServer(new Set(["go"]))!.command, /gopls/);
+  });
+});
+
+test("pickServer returns null when the language is present but its server is not installed", () => {
+  withPath(tmpRepo("lsp-empty"), () => {
+    assert.equal(pickServer(new Set(["rust", "go", "python"])), null);
+  });
+});
+
+test("a quoted PATH entry still resolves (Windows writes them that way)", () => {
+  const dir = stubServerDir("gopls");
+  withPath(`"${dir}"${delimiter}`, () => {
+    assert.ok(pickServer(new Set(["go"])), "the surrounding quotes are not part of the directory name");
+  });
 });
 
 test("enrichWithLsp is a no-op when no server matches the repo's languages", async () => {

--- a/test/mcp-tools.test.ts
+++ b/test/mcp-tools.test.ts
@@ -1,10 +1,11 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { execFileSync } from 'node:child_process';
-import { TOOLS, callTool, canonicalToolName } from '../src/mcp/tools.js';
+import { TOOLS, callTool, canonicalToolName, parseDepth } from '../src/mcp/tools.js';
+import { rmDir } from "./helpers.js";
 
 function builtRepo(): string {
   const d = mkdtempSync(join(tmpdir(), 'graft-mcptools-'));
@@ -70,6 +71,25 @@ function multiDirRepo(): string {
   }
   execFileSync(process.execPath, ['--import', 'tsx', 'src/cli.ts', 'build', d], { stdio: 'pipe' });
   return d;
+}
+
+/** A WORKSPACE root (two git children, no .git of its own), so `callTool`
+ * takes the federated path. repoA carries the compute -> sub -> add chain the
+ * depth assertions need; both children carry a NEEDLE so a federated grep has
+ * something from each. */
+function workspaceChainFx(): string {
+  const p = mkdtempSync(join(tmpdir(), 'graft-mcptools-ws-'));
+  mkdirSync(join(p, 'repoA', '.git'), { recursive: true });
+  mkdirSync(join(p, 'repoB', '.git'), { recursive: true });
+  writeFileSync(
+    join(p, 'repoA', 'a.ts'),
+    'export function add(a: number, b: number): number {\n  return a + b; // NEEDLE\n}\n' +
+      'export function sub(a: number, b: number): number {\n  return add(a, -b);\n}\n' +
+      'export function compute(a: number, b: number): number {\n  return sub(a, b);\n}\n',
+  );
+  writeFileSync(join(p, 'repoB', 'b.ts'), 'export function beta(): number {\n  return 2; // NEEDLE\n}\n');
+  execFileSync(process.execPath, ['--import', 'tsx', 'src/cli.ts', 'build', p], { stdio: 'pipe' });
+  return p;
 }
 
 test('TOOLS lists the six tools with schemas', async () => {
@@ -194,6 +214,61 @@ test('graft_trace_calls: depth param is honored (depth 2 reaches further than de
   assert.match(deeper.text, /\[depth 1\]/);
   assert.match(deeper.text, /← compute \(/);
   assert.match(deeper.text, /\[depth 2\]/);
+});
+
+test('parseDepth: "all"/"full" mean the whole closure, anything unusable means 1', () => {
+  assert.equal(parseDepth('all'), Number.POSITIVE_INFINITY);
+  assert.equal(parseDepth('full'), Number.POSITIVE_INFINITY);
+  assert.equal(parseDepth(3), 3);
+  assert.equal(parseDepth(2.7), 2);
+  // Below 1, non-finite, wrong type, absent -> the documented default.
+  for (const v of [0, -5, Number.NaN, Number.POSITIVE_INFINITY, '2', null, undefined, {}])
+    assert.equal(parseDepth(v), 1, `parseDepth(${String(v)})`);
+});
+
+test('graft_trace_calls: depth "all" walks the whole closure in a WORKSPACE, not silently depth 1', async () => {
+  const p = workspaceChainFx();
+  // Direct callers only — `sub` is reachable at depth 1, `compute` is not.
+  const shallow = await callTool(p, 'graft_trace_calls', { symbol: 'add' });
+  assert.equal(shallow.isError, false);
+  assert.match(shallow.text, /← sub \(/);
+  assert.doesNotMatch(shallow.text, /compute/);
+
+  // "all" is documented in the tool's own schema. The workspace path used to
+  // test `typeof depth === 'number'` first, so 'all' became undefined and the
+  // federated walk quietly ran at depth 1 — the blast radius came back short
+  // for exactly the monorepo user who most needs it complete.
+  const closure = await callTool(p, 'graft_trace_calls', { symbol: 'add', depth: 'all' });
+  assert.equal(closure.isError, false);
+  assert.match(closure.text, /← sub \(/);
+  assert.match(closure.text, /← compute \(/);
+  assert.match(closure.text, /\[depth 2\]/);
+  rmDir(p);
+});
+
+test('graft_find_all: `in` at a workspace root is applied, never silently ignored', async () => {
+  const p = workspaceChainFx();
+  // Without `in`, federation legitimately searches every child.
+  const all = await callTool(p, 'graft_find_all', { pattern: 'NEEDLE' });
+  assert.equal(all.isError, false);
+  assert.match(all.text, /repoA\//);
+  assert.match(all.text, /repoB\//);
+
+  // `federateGrep` can honor `in` now (it narrows to the named child, and past the
+  // first segment to a path prefix inside it), so this tool no longer has to refuse
+  // the arg its own schema advertises. What must never happen is the third
+  // outcome — accepting it, searching everything, and answering as if it had been
+  // applied — so the assertion is on repoB being ABSENT, not merely on success.
+  const scoped = await callTool(p, 'graft_find_all', { pattern: 'NEEDLE', in: 'repoA' });
+  assert.equal(scoped.isError, false, scoped.text);
+  assert.match(scoped.text, /repoA\//);
+  assert.doesNotMatch(scoped.text, /repoB\//);
+
+  // An unknown child is still a loud caller mistake rather than an empty answer.
+  const bogus = await callTool(p, 'graft_find_all', { pattern: 'NEEDLE', in: 'repoZ' });
+  assert.equal(bogus.isError, true);
+  assert.match(bogus.text, /no workspace repo "repoZ"/);
+  rmDir(p);
 });
 
 test('graft_trace_calls depth>1 on a file aggregates dependents that call into a symbol the file defines, not just file-level imports', async () => {

--- a/test/paths.test.ts
+++ b/test/paths.test.ts
@@ -18,9 +18,10 @@
  */
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { join, sep } from "node:path";
+import { isAbsolute, join, resolve, sep } from "node:path";
 import { normalizePathPrefix, relPosix, stripTrailingSlashes, toPosixPath } from "../src/util/paths.js";
 import { pathUnderPrefix } from "../src/graph/scopes.js";
+import { contextDirFor } from "../src/context/node-file.js";
 
 test("toPosixPath: identity on an already-posix path, and idempotent", () => {
   assert.equal(toPosixPath("src/graph/build.ts"), "src/graph/build.ts");
@@ -74,6 +75,24 @@ test("stripTrailingSlashes: linear-time, and leaves interior slashes alone", () 
   // The regex this replaces was a polynomial-ReDoS shape (js/polynomial-redos):
   // a long run of trailing slashes must stay cheap, not quadratic.
   assert.equal(stripTrailingSlashes("a" + "/".repeat(50_000)), "a");
+});
+
+test("contextDirFor: the --dir/GRAFT_DIR override is absolute, whatever was passed", () => {
+  const root = sep === "/" ? "/repo" : "C:\\repo";
+  // The default is absolute by construction; the override used to be returned
+  // verbatim, so `GRAFT_DIR=.context` (which `.env.example` suggests) produced a
+  // relative context dir. Every consumer treats this value as absolute:
+  // `listSourceFiles` skips the output dir with `f.startsWith(outDir)` against
+  // absolute paths, so a relative one matched nothing and graft indexed its own
+  // graph back into itself.
+  assert.ok(isAbsolute(contextDirFor(root)));
+  assert.ok(isAbsolute(contextDirFor(root, ".context")), "a relative override is resolved");
+  assert.ok(isAbsolute(contextDirFor(root, join("..", "shared", "graft"))));
+  // An absolute override still comes back untouched — the overwhelmingly common
+  // case, and what every existing caller passes.
+  const abs = join(root, "elsewhere");
+  assert.equal(contextDirFor(root, abs), abs);
+  assert.equal(contextDirFor(root, ".context"), resolve(".context"));
 });
 
 test("pathUnderPrefix: segment-aware, so a prefix is not a substring", () => {

--- a/test/regression-single-repo.test.ts
+++ b/test/regression-single-repo.test.ts
@@ -22,6 +22,7 @@ import { buildRepoMap, formatRepoMap } from "../src/graph/map.js";
 import { grepGraph } from "../src/search/grep.js";
 import { resolveSymbol, callersOf } from "../src/graph/traverse.js";
 import type { GraphV1 } from "../src/graph/types.js";
+import { rmDir } from "./helpers.js";
 
 /** Materialize a fixture repo from a path→content map. */
 function fx(layout: Record<string, string>): string {
@@ -128,7 +129,7 @@ for (const [name, layout] of Object.entries(FIXTURES)) {
       const callers = callersOf(graph, targets[0]);
       assert.ok(callers.length > 0, `${name}/callers: "${calleeName}" should have >=1 caller`);
     } finally {
-      rmSync(dir, { recursive: true, force: true });
+      rmDir(dir);
     }
   });
 }

--- a/test/savings.test.ts
+++ b/test/savings.test.ts
@@ -5,6 +5,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { savingsFor, savingsLine, withSavings, toTokens } from '../src/context/savings.js';
+import { formatCount } from '../src/util/num.js';
 import type { GraphV1, NodeV1 } from '../src/graph/types.js';
 
 function fileNode(path: string, chars?: number): NodeV1 {
@@ -48,7 +49,10 @@ test('savingsLine: reports saved tokens and percent when the output is smaller',
   assert.match(footer, /tokens saved ≈ [\d,]+ \(\d+%\)/);
   assert.match(footer, /2 file\(s\)/);
   const base = toTokens(8000);
-  assert.ok(footer.includes((base - toTokens(body.length)).toLocaleString()));
+  // Pinned en-US, not the machine locale: this line is parsed by an agent that is
+  // asked to sum it, and a pt-BR "1.990" would read as 1.99.
+  assert.ok(footer.includes(formatCount(base - toTokens(body.length))));
+  assert.equal(savingsLine('x'.repeat(4000), { files: 2, baselineChars: 8_000_000 }).includes('1,999,000'), true);
   // The nudge rides along so the agent reports the turn total without SKILL.md.
   assert.match(footer, /end of your reply/i);
   assert.match(footer, /graft saved ~N tokens this turn/);

--- a/test/scripts-ci-contract.test.ts
+++ b/test/scripts-ci-contract.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Contract tests for the things CI and the package manifest PROMISE but that no
+ * code path would otherwise contradict out loud:
+ *
+ *   - engines.node is a promise about the published package, so no runtime
+ *     dependency may demand a newer Node than it (commander@15 wanted >=22.12 in
+ *     a package declaring >=20 for a whole release, and `engine-strict=true`
+ *     turns that from a warning into a failed install);
+ *   - the CI matrix must actually exercise the declared range, not one pinned
+ *     version;
+ *   - test/ has to be reachable by a type-checker at all (tsx strips types
+ *     without checking them);
+ *   - package.json must not advertise a supply-chain control it does not have.
+ *
+ * These are file-shaped rather than behaviour-shaped, so they are asserted by
+ * reading the manifests. That is the point: nothing else fails when a manifest
+ * quietly stops matching reality.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { engineViolations, minVersion } from "../scripts/check-engines.mjs";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const read = (...p: string[]): string => readFileSync(join(repoRoot, ...p), "utf8");
+const readJson = (...p: string[]): any => JSON.parse(read(...p));
+
+test("no runtime dependency demands a newer Node than engines.node", () => {
+  const pkg = readJson("package.json");
+  const lock = readJson("package-lock.json");
+  const bad = engineViolations(lock.packages, pkg.engines.node);
+  assert.deepEqual(
+    bad.map((b: { package: string }) => b.package),
+    [],
+    `runtime deps above engines.node (${pkg.engines.node}): ${JSON.stringify(bad)}`,
+  );
+});
+
+test("the engine check catches the commander@15 regression it was written for", () => {
+  // Exactly the situation that shipped: a direct runtime dep with a higher floor.
+  const bad = engineViolations(
+    {
+      "": { name: "@nanonets/graft" },
+      "node_modules/commander": { version: "15.0.0", engines: { node: ">=22.12.0" } },
+      "node_modules/dotenv": { version: "17.4.2", engines: { node: ">=12" } },
+      // A devDependency is not a user-facing install problem, so it must be ignored.
+      "node_modules/typescript": { version: "6.0.3", dev: true, engines: { node: ">=24" } },
+    },
+    ">=20",
+  );
+  assert.deepEqual(bad.map((b) => b.package), ["commander"]);
+});
+
+test("minVersion takes the lowest floor across or-clauses", () => {
+  assert.deepEqual(minVersion(">=22.12.0"), [22, 12, 0]);
+  assert.deepEqual(minVersion(">=20"), [20, 0, 0]);
+  assert.deepEqual(minVersion("^18 || >=20"), [18, 0, 0]);
+  assert.equal(minVersion("*"), null);
+});
+
+test("the CI matrix exercises the declared Node range on both platforms", () => {
+  const ci = read(".github", "workflows", "ci.yml");
+  const declared = minVersion(readJson("package.json").engines.node)![0];
+  assert.match(ci, /os:\s*\[ubuntu-latest,\s*windows-latest\]/, "both OS legs must stay");
+  assert.match(ci, /fail-fast:\s*false/);
+  // The floor must be run (that is where an engines break surfaces) and at least
+  // one newer major, or the matrix is pinned again.
+  assert.ok(ci.includes(`"${declared}"`), `CI must run the declared floor (node ${declared})`);
+  const majors = [...ci.matchAll(/"(\d\d)"/g)].map((m) => Number(m[1]));
+  assert.ok(
+    majors.some((m) => m > declared),
+    `engines.node is open-ended (>=${declared}); CI must run a newer major too, saw ${majors}`,
+  );
+});
+
+test("CI runs the packaged artifact and the graph-quality gate", () => {
+  const ci = read(".github", "workflows", "ci.yml");
+  assert.match(ci, /npm run check:package/, "the tarball's runtime assets must be asserted");
+  assert.match(ci, /npm pack/, "the published artifact must be installed and smoked");
+  assert.match(ci, /graph-quality\.mjs \. --strict/, "graph-quality advertises itself as a CI gate");
+  assert.match(ci, /npm run check:engines/);
+});
+
+test("tsconfig.test.json type-checks test/ without inheriting the build's rootDir", () => {
+  // Comments are legal in tsconfig; strip them the same way tsc does.
+  const raw = read("tsconfig.test.json").replace(/^\s*\/\/.*$/gm, "");
+  const cfg = JSON.parse(raw);
+  assert.ok(cfg.include.includes("test/**/*"), "test/ must be in the program");
+  assert.equal(cfg.compilerOptions.noEmit, true);
+  // rootDir "./src" from the base config makes test/**/* a TS6059 error; the
+  // check-only config has to widen it.
+  assert.notEqual(cfg.compilerOptions.rootDir, "./src");
+  assert.equal(cfg.compilerOptions.declaration, false, "declaration + noEmit is a tsc error");
+  const pkg = readJson("package.json");
+  assert.equal(pkg.scripts["typecheck:tests"], "tsc -p tsconfig.test.json");
+});
+
+test("package.json does not advertise an allow-scripts gate it does not enforce", () => {
+  const pkg = readJson("package.json");
+  const hasTool =
+    Boolean(pkg.devDependencies?.["@lavamoat/allow-scripts"]) &&
+    /allow-scripts/.test(String(pkg.scripts?.preinstall ?? ""));
+  assert.ok(
+    !pkg.allowScripts || hasTool,
+    "allowScripts reads as a supply-chain control; without @lavamoat/allow-scripts installed and " +
+      "a preinstall hook it gates nothing and every install script still runs",
+  );
+});

--- a/test/scripts-packaging.test.ts
+++ b/test/scripts-packaging.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Guards the tarball's runtime assets — the ones tsc does not emit and whose
+ * absence is SILENT.
+ *
+ * src/graph/generic.ts looks for its tags.scm queries in dist/graph/queries and
+ * then falls back to src/graph/queries, so every test and every dev run finds
+ * them whether or not build-viewer.mjs copied anything. An installed user has no
+ * src/, gets `loadQuery() -> null`, and the grammar is skipped — generic.ts is
+ * explicit that this "degrades to a file node only (never throws)". A release
+ * could therefore lose the entire breadth tier without a single error line.
+ * These tests drive the checker's pure half with hand-built file lists so the
+ * failure mode is reproduced here instead of in someone's install.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  REQUIRED_FILES,
+  missingFromPack,
+  queryFileNames,
+} from "../scripts/check-package-contents.mjs";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+/** A file list standing in for a healthy `npm pack --json` result. */
+function completePack(queries: string[]): string[] {
+  return [...REQUIRED_FILES, ...queries.map((q) => `dist/graph/queries/${q}`), "package.json"];
+}
+
+test("queryFileNames sees every .scm the breadth tier ships", () => {
+  const onDisk = readdirSync(join(repoRoot, "src", "graph", "queries"))
+    .filter((f) => f.endsWith(".scm"))
+    .sort();
+  assert.ok(onDisk.length > 0, "the generic tier has no queries at all — wrong path?");
+  assert.deepEqual(queryFileNames(repoRoot), onDisk);
+});
+
+test("a complete tarball reports nothing missing", () => {
+  assert.deepEqual(missingFromPack(completePack(queryFileNames(repoRoot)), queryFileNames(repoRoot)), []);
+});
+
+test("a tarball missing the .scm queries is caught", () => {
+  // The exact regression: build-viewer.mjs's copy step stops running, tsc still
+  // succeeds, and the breadth tier disappears at runtime with no error.
+  const queries = queryFileNames(repoRoot);
+  const missing = missingFromPack(REQUIRED_FILES, queries);
+  assert.deepEqual(missing, queries.map((q) => `dist/graph/queries/${q}`));
+});
+
+test("a PARTIAL query copy is caught too", () => {
+  // Parity, not "at least one": a copy loop that dies halfway leaves some
+  // grammars working and the rest silently degraded, which is harder to notice
+  // than losing all of them.
+  const queries = queryFileNames(repoRoot);
+  const pack = completePack(queries).filter((f) => !f.endsWith(`/${queries[0]}`));
+  assert.deepEqual(missingFromPack(pack, queries), [`dist/graph/queries/${queries[0]}`]);
+});
+
+test("a tarball missing the viewer bundle is caught", () => {
+  const queries = queryFileNames(repoRoot);
+  const pack = completePack(queries).filter((f) => f !== "dist/viewer/app.js");
+  assert.deepEqual(missingFromPack(pack, queries), ["dist/viewer/app.js"]);
+});
+
+test("the required list covers the assets no tsc run produces", () => {
+  // dist/viewer/* and dist/graph/queries/* come from scripts/build-viewer.mjs;
+  // if someone trims this list, the check stops checking the only files at risk.
+  assert.ok(REQUIRED_FILES.includes("dist/cli.js"));
+  assert.ok(REQUIRED_FILES.includes("dist/viewer/app.js"));
+  assert.ok(REQUIRED_FILES.includes("dist/viewer/index.html"));
+});

--- a/test/scripts-run-tests.test.ts
+++ b/test/scripts-run-tests.test.ts
@@ -1,0 +1,70 @@
+/**
+ * The test runner's own argument handling. Before this, `npm test` ignored
+ * process.argv entirely: `npm test -- test/graph-map.test.ts` and
+ * `--test-name-pattern=…` both silently ran all ~50 files, several of which spawn
+ * the real CLI or the MCP server per case, so the cheapest possible edit-test loop
+ * cost the full suite. The regression to protect against is subtle in both
+ * directions — forgetting to forward node's flags, or mistaking a flag's value for
+ * a file name — so both are asserted here.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { basename, join } from "node:path";
+import { planRun } from "../scripts/run-tests.mjs";
+
+// A stand-in for readdirSync's output, so this test does not change meaning when
+// a test file is added or renamed.
+const ALL = ["claude-paths.test.ts", "graph-map.test.ts", "graph-posix-paths.test.ts", "paths.test.ts"].map(
+  (f) => join("test", f),
+);
+const names = (r: { files?: string[] }): string[] => (r.files ?? []).map((f) => basename(f));
+
+test("no arguments runs every file, unchanged", () => {
+  const plan = planRun([], ALL);
+  assert.deepEqual(plan.files, ALL);
+  assert.deepEqual(plan.nodeArgs, []);
+});
+
+test("a bare name selects exactly that file", () => {
+  // "paths" must not fan out to claude-paths/graph-posix-paths: an exact
+  // <name>.test.ts match wins over the substring pass.
+  assert.deepEqual(names(planRun(["paths"], ALL)), ["paths.test.ts"]);
+  assert.deepEqual(names(planRun(["graph-map"], ALL)), ["graph-map.test.ts"]);
+});
+
+test("a path or file name selects that file", () => {
+  assert.deepEqual(names(planRun(["graph-map.test.ts"], ALL)), ["graph-map.test.ts"]);
+  assert.deepEqual(names(planRun(["test/graph-map.test.ts"], ALL)), ["graph-map.test.ts"]);
+  // Backslashes, because on Windows tab-completion hands you `test\graph-map.test.ts`.
+  assert.deepEqual(names(planRun(["test\\graph-map.test.ts"], ALL)), ["graph-map.test.ts"]);
+});
+
+test("a loose fragment fans out, in the suite's own order", () => {
+  assert.deepEqual(names(planRun(["graph"], ALL)), ["graph-map.test.ts", "graph-posix-paths.test.ts"]);
+  // Order follows the sorted full run, not the order the selectors were typed.
+  assert.deepEqual(names(planRun(["paths", "graph-map"], ALL)), ["graph-map.test.ts", "paths.test.ts"]);
+});
+
+test("node flags are forwarded, not treated as selectors", () => {
+  const plan = planRun(["graph-map", "--test-name-pattern=posix", "--test-only"], ALL);
+  assert.deepEqual(names(plan), ["graph-map.test.ts"]);
+  assert.deepEqual(plan.nodeArgs, ["--test-name-pattern=posix", "--test-only"]);
+});
+
+test("a flag's separate value is not mistaken for a file name", () => {
+  // `--test-name-pattern posix` (space form): without the value-taking-flag list,
+  // "posix" would look like a selector and the run would abort.
+  const plan = planRun(["--test-name-pattern", "posix", "graph-map"], ALL);
+  assert.deepEqual(plan.nodeArgs, ["--test-name-pattern", "posix"]);
+  assert.deepEqual(names(plan), ["graph-map.test.ts"]);
+});
+
+test("npm's own `--` separator is ignored", () => {
+  assert.deepEqual(names(planRun(["--", "graph-map"], ALL)), ["graph-map.test.ts"]);
+});
+
+test("a selector that matches nothing is an error, not a full run", () => {
+  const plan = planRun(["nope"], ALL);
+  assert.match(String(plan.error), /no test file matches 'nope'/);
+  assert.equal(plan.files, undefined);
+});

--- a/test/search-grep.test.ts
+++ b/test/search-grep.test.ts
@@ -16,7 +16,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { grepGraph } from '../src/search/grep.js';
-import { zeroHitNote } from '../src/search/grep-cli.js';
+import { formatGrepResult, zeroHitNote } from '../src/search/grep-cli.js';
 import { WALK_RELATIONS } from '../src/graph/relations.js';
 import { readGraph, wiringPath } from '../src/graph/write.js';
 import type { GraphV1, NodeV1 } from '../src/graph/types.js';
@@ -260,6 +260,146 @@ test('grepGraph: unreadable file is skipped and counted into truncated.files, no
   assert.equal(r.filesSearched, 2);
   assert.equal(r.truncated.files, 1);
   assert.equal(r.totalHits, 1);
+});
+
+test('grepGraph: CRLF files match end-anchored patterns — the \\r is not left on the line', () => {
+  const d = mkdtempSync(join(tmpdir(), 'graft-grep-crlf-'));
+  // Exactly what a Windows checkout with git's default core.autocrlf=true holds.
+  writeFileSync(join(d, 'crlf.ts'), 'const foo = 1;\r\nconst bar = 2;\r\n');
+  writeFileSync(join(d, 'lf.ts'), 'const foo = 1;\nconst bar = 2;\n');
+  const graph = graphOf([fileNode('crlf.ts', 2), fileNode('lf.ts', 2)]);
+
+  // `;$` is the ordinary "line ends with a semicolon" pattern. Splitting on
+  // "\n" alone leaves "const foo = 1;\r", where `$` never matches — so the CRLF
+  // file silently contributed zero hits while the LF file contributed two.
+  const anchored = grepGraph(graph, d, ';$');
+  assert.equal(anchored.totalHits, 4, 'both CRLF lines and both LF lines must match an end-anchored pattern');
+  assert.deepEqual(
+    [...new Set(anchored.groups.map((g) => g.path))].sort(),
+    ['crlf.ts', 'lf.ts'],
+  );
+
+  // The stray \r must not survive into the reported hit text either.
+  const text = grepGraph(graph, d, 'foo').groups.flatMap((g) => g.hits).map((h) => h.text);
+  assert.equal(text.some((t) => t.includes('\r')), false, 'hit text must be free of the CRLF carriage return');
+});
+
+test('grepGraph: a catastrophically-backtracking pattern is bounded by the time budget, and says so', () => {
+  const d = mkdtempSync(join(tmpdir(), 'graft-grep-redos-'));
+  // `(a+)+b` against a line of a's with no b is the textbook exponential case:
+  // ~22 a's is a few ms of pure backtracking, and 300 such lines is minutes of
+  // a wedged event loop — on the MCP server that is every other tool call too.
+  const line = 'a'.repeat(22) + '!';
+  writeFileSync(join(d, 'evil.txt'), Array.from({ length: 300 }, () => line).join('\n') + '\n');
+  const graph = graphOf([fileNode('evil.txt', 300)]);
+
+  const t0 = Date.now();
+  const r = grepGraph(graph, d, '(a+)+b', { budgetMs: 300 });
+  const elapsed = Date.now() - t0;
+
+  assert.equal(r.truncated.timeout, true, 'giving up must be reported, never silent');
+  assert.equal(r.filesSearched, 1, 'only the files actually opened are reported as searched');
+  // Generous ceiling: the budget bounds the loop, one in-flight RegExp.test can
+  // still overshoot it. Unbounded, this run takes tens of seconds.
+  assert.ok(elapsed < 5_000, `expected the scan to be bounded, took ${elapsed}ms`);
+});
+
+/** `files` file nodes plus `symbols` symbol nodes spread evenly over them —
+ * the shape (not the content) of a large real graph, for the grouping-cost
+ * assertions below. */
+function wideGraph(files: number, symbols: number): GraphV1 {
+  const nodes: NodeV1[] = [];
+  for (let f = 0; f < files; f++) nodes.push(fileNode(`src/f${f}.ts`, 100));
+  for (let s = 0; s < symbols; s++) {
+    const f = s % files;
+    nodes.push({
+      ...fileNode(`src/f${f}.ts`, 100),
+      id: `src/f${f}.ts#sym${s}`,
+      name: `sym${s}`,
+      kind: 'function',
+      span: `L${(s % 90) + 1}-L${(s % 90) + 2}`,
+    });
+  }
+  return graphOf(nodes);
+}
+
+test('grepGraph: symbol grouping is indexed once per call, not re-scanned per file', () => {
+  // 1000 files x 100000 symbols — a few times this repo's own cited scale
+  // ("at 32k nodes"), deliberately symbol-heavy so the quadratic term is what
+  // the clock sees. The old per-file `symbolsOf` walked ALL 101000 nodes for
+  // every file (101M node visits) purely to bucket spans; the one-pass index
+  // makes it 101000 visits total. Kept few enough files that the ENOENT cost
+  // of the (deliberately absent) sources stays small next to the grouping.
+  const graph = wideGraph(1_000, 100_000);
+  const dir = mkdtempSync(join(tmpdir(), 'graft-grep-perf-'));
+
+  const t0 = Date.now();
+  const r = grepGraph(graph, dir, 'NEEDLE');
+  const elapsed = Date.now() - t0;
+
+  assert.equal(r.filesSearched, 1_000);
+  assert.ok(elapsed < 400, `grouping should be near-linear in nodes, took ${elapsed}ms`);
+});
+
+test('grepGraph: the per-file symbol buckets are complete and start-sorted (what the one-pass index must preserve)', () => {
+  const d = mkdtempSync(join(tmpdir(), 'graft-grep-buckets-'));
+  writeFileSync(join(d, 'a.ts'), 'NEEDLE\n'.repeat(6));
+  writeFileSync(join(d, 'b.ts'), 'NEEDLE\n'.repeat(6));
+  const sym = (path: string, name: string, span: string): NodeV1 => ({
+    ...fileNode(path, 6),
+    id: `${path}#${name}`,
+    name,
+    kind: 'function',
+    span,
+  });
+  // Deliberately out of span order in `graph.nodes`, and interleaved between
+  // files: `enclosingSymbol` stops at the first span that starts after the
+  // line, so a bucket that isn't sorted by start silently loses hits.
+  const graph = graphOf([
+    fileNode('a.ts', 6),
+    fileNode('b.ts', 6),
+    sym('a.ts', 'late', 'L5-L6'),
+    sym('b.ts', 'only', 'L1-L6'),
+    sym('a.ts', 'early', 'L1-L2'),
+  ]);
+
+  const r = grepGraph(graph, d, 'NEEDLE');
+  const named = new Map(r.groups.filter((g) => g.symbol).map((g) => [g.symbol!.name, g.hits.map((h) => h.line)]));
+  assert.deepEqual(named.get('early'), [1, 2]);
+  assert.deepEqual(named.get('late'), [5, 6]);
+  assert.deepEqual(named.get('only'), [1, 2, 3, 4, 5, 6]);
+  // a.ts lines 3-4 fall outside every span -> file-level group, and b.ts has none.
+  const fileLevel = r.groups.filter((g) => g.symbol === null);
+  assert.equal(fileLevel.length, 1);
+  assert.deepEqual(fileLevel[0], { symbol: null, path: 'a.ts', inDegree: 0, hits: [{ line: 3, text: 'NEEDLE' }, { line: 4, text: 'NEEDLE' }] });
+});
+
+test('grep-cli.ts: a timeout is surfaced by BOTH the CLI notes, and never as a complete search', () => {
+  const d = mkdtempSync(join(tmpdir(), 'graft-grep-cli-timeout-'));
+  const line = 'a'.repeat(22) + '!';
+  writeFileSync(join(d, 'evil.txt'), Array.from({ length: 300 }, () => line).join('\n') + '\n');
+  const graph = graphOf([fileNode('evil.txt', 300)]);
+
+  // The MCP side already said this (`grepTimeoutNote` in mcp/tools.ts); the CLI's
+  // own two notes never mentioned the flag, so `graft grep` printed a zero-hit
+  // result claiming "All indexed code was searched" over a scan that gave up.
+  const none = grepGraph(graph, d, '(a+)+b', { budgetMs: 300 });
+  assert.equal(none.truncated.timeout, true);
+  const zero = zeroHitNote(none);
+  assert.match(zero, /never searched/);
+  assert.doesNotMatch(zero, /All indexed code was searched/);
+
+  // …and with hits, the header note has to carry it too — the note rides under the
+  // header precisely so a `head -N` of the report cannot lose the one line saying
+  // the answer is partial. Hand-built, because a pattern that both matches AND
+  // backtracks catastrophically is not something to make deterministic.
+  const withHits = {
+    ...none,
+    totalHits: 1,
+    groups: [{ symbol: null, path: 'evil.txt', inDegree: 0, hits: [{ line: 1, text: line }] }],
+  };
+  const report = formatGrepResult(withHits);
+  assert.match(report.split('\n')[1], /truncated: search hit its time budget/);
 });
 
 test('zeroHitNote (grep-cli.ts): zero hits AND unreadable indexed files mentions the unreadable count, not just the zero-hit note', () => {

--- a/test/upkeep-hooks.test.ts
+++ b/test/upkeep-hooks.test.ts
@@ -5,7 +5,7 @@
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdirSync, writeFileSync, existsSync } from 'node:fs';
+import { mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { main } from '../src/claude/hooks.js';
 import { readStamp, runningVersion, updateCachePath } from '../src/upkeep.js';
@@ -73,6 +73,21 @@ test('session-start refreshes stale wiring and stamps it', async () => {
   assert.ok(existsSync(join(repo, '.claude', 'skills', 'graft', 'SKILL.md')));
   assert.equal(readStamp(repo)?.version, runningVersion());
   assert.deepEqual(readStamp(repo)?.hosts, ['claude']);
+});
+
+test('a settings.json the refresh cannot parse is kept, and the user is told', async () => {
+  // This path, not `graft init`, is how most repos get re-inited — so a warning
+  // only the CLI printed would never reach the one person who needs it. And the
+  // file itself: an unparseable settings.json used to be treated as an absent one
+  // and replaced outright, taking the user's model, env and permissions with it.
+  const repo = wiredRepo('hook-badsettings');
+  const settings = join(repo, '.claude', 'settings.json');
+  const original = '{\n  "model": "opus",\n  "permissions": { "allow": ["Bash(ls)"] },\n}\n'; // trailing comma
+  writeFileSync(settings, original);
+
+  const ctx = contextOf(await runHook('session-start', repo, homeWithCache('hook-badsettings-home', null)));
+  assert.match(ctx, /not valid JSON/);
+  assert.equal(readFileSync(settings, 'utf8'), original, 'and it is still their file');
 });
 
 test('session-start says nothing on a second run — the stamp now matches', async () => {

--- a/test/upkeep.test.ts
+++ b/test/upkeep.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import {
   DEFAULT_WIRING_OPTS,
@@ -11,16 +11,24 @@ import {
   isNewer,
   needsRefresh,
   readStamp,
+  readWiringMemo,
   reconcileWiring,
+  refreshOpts,
   runningVersion,
   stampPath,
   updateCachePath,
   wiredHostIds,
+  wiringMemoPath,
   wiringOpts,
   writeStamp,
   type WiringOpts,
 } from '../src/upkeep.js';
-import { tmpRepo } from './helpers.js';
+import { tmpRepo, rmDir } from './helpers.js';
+
+/** Scratch home for the machine-global half of the stamp, so no test writes the
+ * real `~/.graft/wiring/`. Shared: the memo is keyed by repo path, and every test
+ * below builds its own repo. */
+const HOME = tmpRepo('upkeep-home');
 
 test('compareVersions orders releases numerically, not lexically', () => {
   assert.equal(compareVersions('0.9.1', '0.10.0'), -1); // the lexical trap
@@ -75,7 +83,7 @@ test('runningVersion resolves this package, not the caller depth', () => {
 test('the stamp round-trips under graft/.cache/', () => {
   const repo = tmpRepo('upkeep-stamp');
   assert.equal(readStamp(repo), null);
-  writeStamp(repo, '1.2.3', ['cursor', 'claude'], {}, '2026-01-01T00:00:00.000Z');
+  writeStamp(repo, '1.2.3', ['cursor', 'claude'], {}, '2026-01-01T00:00:00.000Z', HOME);
   assert.equal(stampPath(repo), join(repo, 'graft', '.cache', 'wiring-stamp.json'));
   assert.deepEqual(readStamp(repo), {
     version: '1.2.3',
@@ -98,11 +106,12 @@ test('wiringOpts defaults an older stamp to what plain `graft init` does', () =>
 
 test('a refresh replays the flags init was given, including --no-global', () => {
   const repo = tmpRepo('upkeep-replay');
-  writeStamp(repo, '1.0.0', ['agents'], { global: false, hooks: false });
+  writeStamp(repo, '1.0.0', ['agents'], { global: false, hooks: false }, undefined, HOME);
   let seen: WiringOpts | null = null;
   const r = reconcileWiring(repo, '2.0.0', {
     wired: () => ['agents'],
     rewrite: (_repo, _hosts, opts) => { seen = opts; },
+    home: HOME,
   });
   // The user said "keep out of ~/.codex" — a later session must not overrule that.
   assert.deepEqual(seen, { global: false, mcp: true, hooks: false });
@@ -114,14 +123,77 @@ test('by default a refresh DOES reach ~/.codex — nothing else ever would', () 
   // No skill, rule file, or MCP instruction tells an agent to run `graft init`,
   // so skipping the out-of-repo writes means a Codex user never gets them.
   const repo = tmpRepo('upkeep-global');
-  writeStamp(repo, '1.0.0', ['agents']);
+  writeStamp(repo, '1.0.0', ['agents'], {}, undefined, HOME);
   let seen: WiringOpts | null = null;
   const r = reconcileWiring(repo, '2.0.0', {
     wired: () => ['agents'],
     rewrite: (_repo, _hosts, opts) => { seen = opts; },
+    home: HOME,
   });
   assert.deepEqual(seen, DEFAULT_WIRING_OPTS);
   assert.equal(r?.global, true);
+});
+
+test('the memo keeps the flags outside the repo, keyed per repo', () => {
+  const repo = tmpRepo('upkeep-memo-path');
+  const p = wiringMemoPath(repo, '/home/dev');
+  assert.ok(p.startsWith(join('/home/dev', '.graft', 'wiring')), `outside the repo: ${p}`);
+  assert.notEqual(p, wiringMemoPath(tmpRepo('upkeep-memo-path2'), '/home/dev'), 'one file per repo');
+  // Same repo, same file — a trailing separator is not a different project.
+  assert.equal(wiringMemoPath(`${repo}/`, '/home/dev'), p);
+});
+
+test('refreshOpts: a record means replay, no record means stay inside the repo', () => {
+  assert.deepEqual(refreshOpts({ version: '1', hosts: [], at: 'x', opts: { global: false } }, null),
+    { global: false, mcp: true, hooks: true });
+  // A stamp with no opts predates the flags: init did run here, wiring everything.
+  assert.deepEqual(refreshOpts({ version: '1', hosts: [], at: 'x' }, null), DEFAULT_WIRING_OPTS);
+  // No stamp, but the machine remembers the init: replay what it chose.
+  assert.deepEqual(refreshOpts(null, { repo: '/r', at: 'x', opts: { global: false, hooks: false } }),
+    { global: false, mcp: true, hooks: false });
+  // Nothing anywhere: repo-local, plus out-of-repo entries that ALREADY name graft.
+  // A flat `global: false` here also abandoned every install predating the stamp —
+  // those users did run `graft init`, and nothing else ever refreshes ~/.codex.
+  assert.deepEqual(refreshOpts(null, null), { global: 'if-present', mcp: true, hooks: true });
+});
+
+test('--no-global survives graft/ being deleted — every fresh clone is that case', () => {
+  const repo = tmpRepo('upkeep-memo');
+  writeStamp(repo, '1.0.0', ['agents'], { global: false }, undefined, HOME);
+  assert.deepEqual(readWiringMemo(repo, HOME)?.opts, { global: false, mcp: true, hooks: true });
+
+  // graft/ is git-ignored, so this is also what every colleague's clone looks like.
+  rmDir(join(repo, 'graft'));
+  assert.equal(readStamp(repo), null);
+
+  let seen: WiringOpts | null = null;
+  reconcileWiring(repo, '2.0.0', {
+    wired: () => ['agents'],
+    rewrite: (_repo, _hosts, opts) => { seen = opts; },
+    home: HOME,
+  });
+  assert.deepEqual(seen, { global: false, mcp: true, hooks: true }, 'the opt-out outlived the cache dir');
+});
+
+test('an unsolicited refresh never CREATES machine-wide config', () => {
+  // Committed wiring (`git add .claude`, says the epilogue) plus a git-ignored
+  // graft/ means the first session in a fresh clone looks unstamped. Refreshing the
+  // repo's own files there is maintenance; installing graft's hooks into
+  // ~/.codex/hooks.json — read by every Codex project on the machine — for someone
+  // who never ran `graft init` is not. 'if-present' is exactly that line: entries
+  // that already name graft are the user's own earlier yes and stay current
+  // (installCodexHooks/registerMcpConfigs enforce it); nothing new is created.
+  const repo = tmpRepo('upkeep-unsolicited');
+  const home = tmpRepo('upkeep-unsolicited-home');
+  let seen: WiringOpts | null = null;
+  const r = reconcileWiring(repo, '2.0.0', {
+    wired: () => ['agents', 'claude'],
+    rewrite: (_repo, _hosts, opts) => { seen = opts; },
+    home,
+  });
+  assert.deepEqual(seen, { global: 'if-present', mcp: true, hooks: true });
+  assert.equal(r?.global, 'if-present');
+  assert.deepEqual(r?.hosts, ['agents', 'claude'], 'the repo-local wiring is still brought up to date');
 });
 
 test('wiredHostIds reads what init actually wrote, not what the machine has', () => {
@@ -149,19 +221,22 @@ test('reconcileWiring rewrites once on a version mismatch, then no-ops', () => {
   const calls: string[][] = [];
   const rewrite = (_r: string, hosts: string[]) => { calls.push(hosts); };
   const wired = () => ['claude', 'cursor'];
+  const deps = { wired, rewrite, home: HOME };
 
-  // No stamp (fresh clone, or wired by a pre-stamp graft) → refresh.
-  const first = reconcileWiring(repo, '2.0.0', { wired, rewrite });
-  assert.deepEqual(first, { from: 'unwired', to: '2.0.0', hosts: ['claude', 'cursor'], global: true });
+  // No stamp and no memo (a fresh clone of a repo whose wiring was committed) →
+  // refresh the repo, and out-of-repo only where graft is already registered:
+  // nobody asked this machine to install anything new.
+  const first = reconcileWiring(repo, '2.0.0', deps);
+  assert.deepEqual(first, { from: 'unwired', to: '2.0.0', hosts: ['claude', 'cursor'], global: 'if-present' });
   assert.deepEqual(calls, [['claude', 'cursor']]);
 
   // Stamp now matches the running binary → nothing happens on every later session.
-  assert.equal(reconcileWiring(repo, '2.0.0', { wired, rewrite }), null);
+  assert.equal(reconcileWiring(repo, '2.0.0', deps), null);
   assert.equal(calls.length, 1, 'idempotent: no rewrite per session');
 
   // A newer binary → one more refresh, reported with the version it came from.
-  const upgraded = reconcileWiring(repo, '2.1.0', { wired, rewrite });
-  assert.deepEqual(upgraded, { from: '2.0.0', to: '2.1.0', hosts: ['claude', 'cursor'], global: true });
+  const upgraded = reconcileWiring(repo, '2.1.0', deps);
+  assert.deepEqual(upgraded, { from: '2.0.0', to: '2.1.0', hosts: ['claude', 'cursor'], global: 'if-present' });
   assert.equal(calls.length, 2);
   assert.equal(readStamp(repo)?.version, '2.1.0');
 });
@@ -170,11 +245,12 @@ test('reconcileWiring restores a host whose file went missing', () => {
   // The whole point of a refresh is putting the wiring back. Detecting hosts from
   // disk alone would drop the one host whose file is gone — the one that needs it.
   const repo = tmpRepo('upkeep-restore');
-  writeStamp(repo, '1.0.0', ['claude', 'cursor']);
+  writeStamp(repo, '1.0.0', ['claude', 'cursor'], {}, undefined, HOME);
   const calls: string[][] = [];
   const r = reconcileWiring(repo, '2.0.0', {
     wired: () => ['claude'], // cursor's graft.mdc is no longer on disk
     rewrite: (_repo, hosts) => { calls.push(hosts); },
+    home: HOME,
   });
   assert.deepEqual(r?.hosts, ['claude', 'cursor']);
   assert.deepEqual(calls, [['claude', 'cursor']]);
@@ -183,15 +259,15 @@ test('reconcileWiring restores a host whose file went missing', () => {
 
 test('reconcileWiring adopts a host added since the stamp was written', () => {
   const repo = tmpRepo('upkeep-adopt');
-  writeStamp(repo, '1.0.0', ['claude']);
-  const r = reconcileWiring(repo, '2.0.0', { wired: () => ['claude', 'windsurf'], rewrite: () => {} });
+  writeStamp(repo, '1.0.0', ['claude'], {}, undefined, HOME);
+  const r = reconcileWiring(repo, '2.0.0', { wired: () => ['claude', 'windsurf'], rewrite: () => {}, home: HOME });
   assert.deepEqual(r?.hosts, ['claude', 'windsurf']);
 });
 
 test('reconcileWiring leaves a repo that graft never wired alone', () => {
   const repo = tmpRepo('upkeep-unwired');
   let rewrote = false;
-  const r = reconcileWiring(repo, '2.0.0', { wired: () => [], rewrite: () => { rewrote = true; } });
+  const r = reconcileWiring(repo, '2.0.0', { wired: () => [], rewrite: () => { rewrote = true; }, home: HOME });
   assert.equal(r, null);
   assert.equal(rewrote, false);
   assert.equal(existsSync(stampPath(repo)), false, 'no stamp written for a repo we do not manage');
@@ -202,6 +278,7 @@ test('reconcileWiring never throws out into a hook', () => {
   const r = reconcileWiring(repo, '2.0.0', {
     wired: () => ['claude'],
     rewrite: () => { throw new Error('disk full'); },
+    home: HOME,
   });
   assert.equal(r, null, 'a failed refresh is silent, not a broken session');
 });

--- a/test/utf16-source.test.ts
+++ b/test/utf16-source.test.ts
@@ -57,6 +57,44 @@ test("readSourceFile: decodes a UTF-16LE BOM, returns null for UTF-16BE, and rea
   }
 });
 
+/** BOM + UTF-8 bytes — what Visual Studio writes for .cs by default and what
+ * PowerShell 5.1's `Out-File -Encoding utf8` writes for anything at all. */
+function utf8bom(text: string): Buffer {
+  return Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from(text, "utf8")]);
+}
+
+test("readSourceFile: strips a UTF-8 BOM instead of handing U+FEFF to the grammar", () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-utf8bom-unit-"));
+  try {
+    writeFileSync(join(dir, "bom.ts"), utf8bom("export const x = 1;\n"));
+    const got = readSourceFile(join(dir, "bom.ts"));
+    assert.equal(got, "export const x = 1;\n");
+    assert.ok(!got!.startsWith("﻿"), "U+FEFF is category Cf, not whitespace — it becomes an ERROR node at offset 0");
+  } finally {
+    rmDir(dir);
+  }
+});
+
+test("a BOM-prefixed source file is indexed like any other", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-utf8bom-build-"));
+  try {
+    // Go's grammar lists only /\s/ in its `extras`, so a leading U+FEFF is what
+    // actually breaks — it starts the parse in error recovery.
+    writeFileSync(join(dir, "main.go"), utf8bom("package main\n\nfunc FromBom() int {\n\treturn 1\n}\n"));
+    writeFileSync(join(dir, "app.ts"), utf8bom("export function fromBomTs(): void {}\n"));
+    const r = await buildGraph(dir, { reuse: false });
+    assert.deepEqual(r.errors, []);
+    const graph = readGraph(wiringPath(join(dir, "graft")))!;
+    assert.ok(graph.nodes.some((n) => n.id === "main.go#FromBom"), "the BOM'd Go function must be extracted");
+    assert.ok(graph.nodes.some((n) => n.id === "app.ts#fromBomTs"), "…and the BOM'd TS one");
+    // hash-what-you-parse: the stripped text is what is hashed, so check must agree.
+    const check = await checkGraph(dir);
+    assert.equal(check.ok, true, "build and check must decode the BOM the same way");
+  } finally {
+    rmDir(dir);
+  }
+});
+
 test("A1 graph/build.ts: a UTF-16LE .ts file is decoded at graph ingest, not mojibake-parsed", async () => {
   const dir = mkdtempSync(join(tmpdir(), "graft-utf16-build-"));
   try {

--- a/test/utf16-source.test.ts
+++ b/test/utf16-source.test.ts
@@ -29,7 +29,7 @@ import { grepGraph } from "../src/search/grep.js";
 import { ask } from "../src/ask/ask.js";
 import { readGraph, wiringPath } from "../src/graph/write.js";
 import { contextDirFor } from "../src/context/node-file.js";
-import { fakeProviders } from "./helpers.js";
+import { fakeProviders, rmDir } from "./helpers.js";
 
 /** BOM + UTF-16LE bytes — the shape Windows tooling in general actually writes. */
 function utf16le(text: string): Buffer {
@@ -53,7 +53,7 @@ test("readSourceFile: decodes a UTF-16LE BOM, returns null for UTF-16BE, and rea
     assert.equal(readSourceFile(join(dir, "be.ts")), null);
     assert.equal(readSourceFile(join(dir, "plain.ts")), "export const x = 1;\n");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -66,7 +66,7 @@ test("A1 graph/build.ts: a UTF-16LE .ts file is decoded at graph ingest, not moj
     const graph = readGraph(wiringPath(join(dir, "graft")))!;
     assert.ok(graph.nodes.some((n) => n.id === "legacy.ts#fromLegacy"), "the UTF-16LE file's function must be extracted");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -79,7 +79,7 @@ test("A1 graph/build.ts: a UTF-16BE file is an empty entry, not a build error (n
     const graph = readGraph(wiringPath(join(dir, "graft")))!;
     assert.ok(!graph.nodes.some((n) => n.path === "legacy.ts"), "no nodes minted for the undecodable file");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -98,7 +98,7 @@ test("A1 hash-what-you-parse consistency: build/check/fingerprint agree on a UTF
     const drift = probeDrift(join(dir), join(dir, "graft"));
     assert.deepEqual(drift, { changed: [], added: [], removed: [] }, "fingerprint's probe must agree too — no drift");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -128,7 +128,7 @@ test("A1 fingerprint reports drift when indexed UTF-16LE becomes unsupported UTF
   } finally {
     if (previousRefresh === undefined) delete process.env.GRAFT_REFRESH;
     else process.env.GRAFT_REFRESH = previousRefresh;
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -150,7 +150,7 @@ test("A1 context/build.ts + check.ts: a UTF-16LE file's summarizer input decodes
     assert.equal(check.ok, true, "content hash must agree between build and check for the same UTF-16LE file");
     assert.deepEqual(check.contentDrift, []);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -169,7 +169,7 @@ test("A1 search/grep.ts: finds a pattern inside a UTF-16LE file", async () => {
     assert.equal(r.totalHits, 1, "grep must find the pattern in the UTF-16LE file's decoded text");
     assert.match(r.groups[0]!.hits[0]!.text, /NEEDLE hit/);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 
@@ -189,6 +189,6 @@ test("A1 ask.ts --source: inlines clean (non-garbled) source sliced from a UTF-1
     assert.match(hit!.code!, /return 42/, "the sliced span must decode cleanly, not as mojibake");
     assert.ok(!hit!.code!.includes("\u0000"), "no stray NUL bytes from a mis-decoded UTF-16LE read");
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });

--- a/test/viz-assemble.test.ts
+++ b/test/viz-assemble.test.ts
@@ -8,6 +8,7 @@ import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { assembleContextGraph, normalizeRelation } from "../src/viz/assemble.js";
+import { rmDir } from "./helpers.js";
 
 function makeContextDir(): string {
   const dir = mkdtempSync(join(tmpdir(), "graftviz-"));
@@ -87,7 +88,7 @@ test("assembleContextGraph builds nodes and edges from frontmatter", () => {
     assert.equal(g.meta.droppedEdges, 1);
     assert.equal(g.meta.skippedFiles, 1);
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmDir(dir);
   }
 });
 

--- a/test/viz-serve.test.ts
+++ b/test/viz-serve.test.ts
@@ -9,6 +9,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createServer } from "node:http";
 import { startVizServer } from "../src/viz/serve.js";
+import { rmDir } from "./helpers.js";
 
 function makeDirs(): { contextDir: string; viewerDir: string; root: string } {
   const root = mkdtempSync(join(tmpdir(), "graftviz-srv-"));
@@ -54,7 +55,7 @@ test("viz server serves viewer, context graph, and gates code graph", async () =
     assert.equal(code.meta.version, 1);
   } finally {
     await srv.close();
-    rmSync(root, { recursive: true, force: true });
+    rmDir(root);
   }
 });
 
@@ -68,7 +69,7 @@ test("viz server falls back to the next free port", async () => {
   } finally {
     await srv.close();
     await new Promise((res) => blocker.close(res));
-    rmSync(root, { recursive: true, force: true });
+    rmDir(root);
   }
 });
 
@@ -95,6 +96,6 @@ test("viz server emits an SSE event when the context dir changes", async () => {
     assert.match(seen, /data: change/);
   } finally {
     await srv.close();
-    rmSync(root, { recursive: true, force: true });
+    rmDir(root);
   }
 });

--- a/test/viz-serve.test.ts
+++ b/test/viz-serve.test.ts
@@ -7,9 +7,35 @@ import assert from "node:assert/strict";
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { createServer } from "node:http";
+import { createServer, request } from "node:http";
 import { startVizServer } from "../src/viz/serve.js";
 import { rmDir } from "./helpers.js";
+import type { VizGraph } from "../src/viz/assemble.js";
+import type { GraphV1 } from "../src/graph/types.js";
+
+/** `Response.json()` is typed `unknown`, so every field read below would otherwise
+ * be unchecked. Naming each endpoint's payload with the type the server actually
+ * builds it from means a drifting response fails the type check instead of quietly
+ * asserting against `undefined`. */
+type ContextGraphBody = VizGraph & { meta: VizGraph["meta"] & { repoName: string } };
+type ErrorBody = { error: string };
+
+/** A raw request with an arbitrary `Host`. `fetch` can't do this — `Host` is a
+ * forbidden header name there and undici silently drops it — but a browser
+ * under DNS rebinding sends exactly this: the attacker's hostname, on a socket
+ * connected to 127.0.0.1. */
+function getWithHost(port: number, path: string, host: string): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = request({ host: "127.0.0.1", port, path, headers: { host } }, (res) => {
+      let body = "";
+      res.setEncoding("utf8");
+      res.on("data", (c) => (body += c));
+      res.on("end", () => resolve({ status: res.statusCode ?? 0, body }));
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
 
 function makeDirs(): { contextDir: string; viewerDir: string; root: string } {
   const root = mkdtempSync(join(tmpdir(), "graftviz-srv-"));
@@ -34,7 +60,7 @@ test("viz server serves viewer, context graph, and gates code graph", async () =
     const html = await fetch(`${srv.url}/`).then((r) => r.text());
     assert.match(html, /stub/);
 
-    const graph = await fetch(`${srv.url}/api/context-graph`).then((r) => r.json());
+    const graph = (await fetch(`${srv.url}/api/context-graph`).then((r) => r.json())) as ContextGraphBody;
     assert.equal(graph.meta.nodeCount, 1);
     assert.equal(graph.meta.repoName, "fixture");
     assert.equal(graph.nodes[0].id, "alpha");
@@ -42,7 +68,7 @@ test("viz server serves viewer, context graph, and gates code graph", async () =
     // no wiring graph yet → 404 with an explanatory error
     const missing = await fetch(`${srv.url}/api/code-graph`);
     assert.equal(missing.status, 404);
-    const body = await missing.json();
+    const body = (await missing.json()) as ErrorBody;
     assert.match(body.error, /graft build/);
 
     // valid wiring graph → passthrough
@@ -51,7 +77,7 @@ test("viz server serves viewer, context graph, and gates code graph", async () =
       join(contextDir, ".graph", "wiring.json"),
       JSON.stringify({ meta: { version: 1, nodeCount: 0, edgeCount: 0, languages: [] }, nodes: [], edges: [] }),
     );
-    const code = await fetch(`${srv.url}/api/code-graph`).then((r) => r.json());
+    const code = (await fetch(`${srv.url}/api/code-graph`).then((r) => r.json())) as GraphV1;
     assert.equal(code.meta.version, 1);
   } finally {
     await srv.close();
@@ -73,6 +99,40 @@ test("viz server falls back to the next free port", async () => {
   }
 });
 
+test("viz server rejects a foreign Host header (DNS rebinding) on every route", async () => {
+  const { contextDir, viewerDir, root } = makeDirs();
+  mkdirSync(join(contextDir, ".graph"), { recursive: true });
+  writeFileSync(
+    join(contextDir, ".graph", "wiring.json"),
+    JSON.stringify({ meta: { version: 1, nodeCount: 0, edgeCount: 0, languages: [] }, nodes: [], edges: [] }),
+  );
+  const srv = await startVizServer({ contextDir, viewerDir, port: 4861, repoName: "fixture" });
+  try {
+    // A page on attacker.example that rebinds its own hostname to 127.0.0.1
+    // reaches this port as same-origin — but the Host it sends is still its
+    // own, and script cannot forge that header. Everything reachable must
+    // refuse it, especially /api/code-graph (the entire private wiring graph).
+    for (const path of ["/", "/app.js", "/api/context-graph", "/api/code-graph", "/events"]) {
+      const res = await getWithHost(4861, path, "attacker.example");
+      assert.equal(res.status, 403, `${path} must refuse a foreign Host`);
+      assert.doesNotMatch(res.body, /nodeCount|wiring|stub/, `${path} must leak nothing in the refusal`);
+    }
+    // A right-hostname-wrong-port Host is still a rebind attempt, not a typo a
+    // browser would produce on its own.
+    assert.equal((await getWithHost(4861, "/api/code-graph", "127.0.0.1:9999")).status, 403);
+
+    // The two names a human can actually have typed still work.
+    for (const host of ["127.0.0.1:4861", "localhost:4861"]) {
+      const res = await getWithHost(4861, "/api/context-graph", host);
+      assert.equal(res.status, 200, `${host} must still be served`);
+      assert.match(res.body, /nodeCount/);
+    }
+  } finally {
+    await srv.close();
+    rmDir(root);
+  }
+});
+
 test("viz server emits an SSE event when the context dir changes", async () => {
   const { contextDir, viewerDir, root } = makeDirs();
   const srv = await startVizServer({ contextDir, viewerDir, port: 4851, repoName: "fixture" });
@@ -85,6 +145,45 @@ test("viz server emits an SSE event when the context dir changes", async () => {
     const reader = res.body!.getReader();
     // trigger a change after the stream is open
     setTimeout(() => writeFileSync(join(contextDir, "alpha.md"), "---\nname: Alpha2\nslug: alpha\n---\n"), 150);
+    const deadline = Date.now() + 5000;
+    let seen = "";
+    while (Date.now() < deadline && !seen.includes("data: change")) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      seen += new TextDecoder().decode(value);
+    }
+    controller.abort();
+    assert.match(seen, /data: change/);
+  } finally {
+    await srv.close();
+    rmDir(root);
+  }
+});
+
+test("viz server emits an SSE event when only .graph/wiring.json is rewritten", async () => {
+  const { contextDir, viewerDir, root } = makeDirs();
+  // Present BEFORE the server starts, which is the realistic case: `graft viz`
+  // is run on an already-built repo, and the rebuild that follows may touch
+  // nothing but the wiring graph.
+  const graphDir = join(contextDir, ".graph");
+  mkdirSync(graphDir, { recursive: true });
+  const wiring = join(graphDir, "wiring.json");
+  const payload = (n: number) =>
+    JSON.stringify({ meta: { version: 1, nodeCount: n, edgeCount: 0, languages: [] }, nodes: [], edges: [] });
+  writeFileSync(wiring, payload(0));
+
+  const srv = await startVizServer({ contextDir, viewerDir, port: 4871, repoName: "fixture" });
+  try {
+    const controller = new AbortController();
+    const res = await fetch(`${srv.url}/events`, {
+      headers: { accept: "text/event-stream" },
+      signal: controller.signal,
+    });
+    const reader = res.body!.getReader();
+    // A graph-only refresh (the `--graph-only` rebuild the query path triggers)
+    // writes here and nowhere else. A single non-recursive watch on contextDir
+    // never sees it, so the Code graph tab silently went stale until F5.
+    setTimeout(() => writeFileSync(wiring, payload(1)), 150);
     const deadline = Date.now() + 5000;
     let seen = "";
     while (Date.now() < deadline && !seen.includes("data: change")) {

--- a/test/viz-viewer-escape.test.ts
+++ b/test/viz-viewer-escape.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Tests for the viewer's HTML escaping (viewer/escape.ts).
+ *
+ * `detail.ts` and `tree.ts` build markup as template strings and drop graph
+ * values straight into double-quoted attributes. The escape they used to share
+ * (copy-pasted into both files) handled `&` and `<` only, which is enough for
+ * text and not for attributes: a `"` in a node id closes the attribute and
+ * everything after it is parsed as more attributes.
+ *
+ * The values are not trustworthy: `src/viz/assemble.ts` lifts `slug` and
+ * `relation` out of card frontmatter, i.e. LLM output written while summarizing
+ * whatever repo graft was pointed at.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { escapeHtml } from "../viewer/escape.js";
+
+test("escapeHtml: a quote in a node id cannot break out of an attribute", () => {
+  const hostile = 'x" onmouseover="alert(document.domain)" y="';
+  const attr = `<button class="lnk" data-go="${escapeHtml(hostile)}">go</button>`;
+
+  // The literal `"` must be gone — that is the whole exploit.
+  assert.doesNotMatch(attr, /data-go="x" onmouseover=/);
+  assert.match(attr, /data-go="x&quot; onmouseover=&quot;/);
+  // Exactly three quote characters survive: the two around class="lnk" and…
+  // the two around data-go. Four total, none of them from the payload.
+  assert.equal(attr.split('"').length - 1, 4);
+});
+
+test("escapeHtml: covers every character that can change parsing, in both contexts", () => {
+  assert.equal(escapeHtml(`&<>"'`), "&amp;&lt;&gt;&quot;&#39;");
+  // & first, so an already-escaped-looking input doesn't come out double-decoded.
+  assert.equal(escapeHtml("&lt;"), "&amp;lt;");
+  // A tag injected as text content stays inert too.
+  assert.equal(escapeHtml("<img src=x onerror=alert(1)>"), "&lt;img src=x onerror=alert(1)&gt;");
+  // Single-quoted attributes are safe for the same reason.
+  assert.doesNotMatch(`<span title='${escapeHtml("a' onclick='alert(1)")}'>`, /' onclick='/);
+});
+
+test("escapeHtml: leaves ordinary graph ids and relation verbs completely alone", () => {
+  for (const s of ["src/graph/build.ts#buildGraph", "Cache.get", "depends_on", "part of", "helper~2", ""])
+    assert.equal(escapeHtml(s), s, `${s} must round-trip unchanged`);
+});

--- a/test/workspace.test.ts
+++ b/test/workspace.test.ts
@@ -21,6 +21,7 @@ import {
 } from "../src/graph/workspace.js";
 import { formatAsk } from "../src/ask/ask.js";
 import type { GraphV1 } from "../src/graph/types.js";
+import { rmDir } from "./helpers.js";
 
 /** A parent dir with git children (each a `.git` dir + one source file). */
 function workspaceFx(children: Record<string, Record<string, string>>): string {
@@ -59,14 +60,14 @@ function pad(n: number): string {
 test("isWorkspaceBuildRoot: ≥2 git children, no own .git → workspace", () => {
   const p = workspaceFx(REPOS);
   assert.equal(isWorkspaceBuildRoot(p), true);
-  rmSync(p, { recursive: true, force: true });
+  rmDir(p);
 });
 
 test("isWorkspaceBuildRoot: own .git (submodules) → NOT a workspace", () => {
   const p = workspaceFx(REPOS);
   mkdirSync(join(p, ".git"), { recursive: true });
   assert.equal(isWorkspaceBuildRoot(p), false);
-  rmSync(p, { recursive: true, force: true });
+  rmDir(p);
 });
 
 test("child built via parent is byte-identical to building it standalone", async () => {
@@ -76,12 +77,12 @@ test("child built via parent is byte-identical to building it standalone", async
   const viaParent = readFileSync(wiringPath(childGraft), "utf8");
 
   // Rebuild the same child standalone — deterministic writer, same source.
-  rmSync(childGraft, { recursive: true, force: true });
+  rmDir(childGraft);
   await buildGraph(join(p, "repoA"));
   const standalone = readFileSync(wiringPath(childGraft), "utf8");
 
   assert.equal(viaParent, standalone);
-  rmSync(p, { recursive: true, force: true });
+  rmDir(p);
 });
 
 test("workspace.json lists both children; parent holds no mega-graph", async () => {
@@ -92,7 +93,7 @@ test("workspace.json lists both children; parent holds no mega-graph", async () 
   // Parent graft holds ONLY workspace.json — no .graph/wiring.json.
   assert.equal(existsSync(wiringPath(contextDirFor(p))), false);
   assert.equal(existsSync(join(contextDirFor(p), "workspace.json")), true);
-  rmSync(p, { recursive: true, force: true });
+  rmDir(p);
 });
 
 test("ask at the parent federates hits from both children, labeled <child>/", async () => {
@@ -105,7 +106,7 @@ test("ask at the parent federates hits from both children, labeled <child>/", as
   // Pointers are child-prefixed so they open from the parent.
   assert.ok(r.hits.some((h) => h.pointer.startsWith("repoA/")));
   assert.ok(r.hits.some((h) => h.pointer.startsWith("repoB/")));
-  rmSync(p, { recursive: true, force: true });
+  rmDir(p);
 });
 
 test("ask inside a single child = standalone (no federation scopes)", async () => {
@@ -116,7 +117,7 @@ test("ask inside a single child = standalone (no federation scopes)", async () =
   assert.equal(r.scopes, undefined); // single-scope repo → no scope labels
   assert.ok(r.hits.length > 0);
   assert.ok(!r.hits.some((h) => h.pointer.startsWith("repoA/"))); // paths are child-relative
-  rmSync(p, { recursive: true, force: true });
+  rmDir(p);
 });
 
 test("migration: mega-graph parent split → .graph removed, workspace.json written, exact note", async () => {
@@ -139,7 +140,7 @@ test("migration: mega-graph parent split → .graph removed, workspace.json writ
     migrationNote(["repoA", "repoB"]),
     "⚠ this folder contains 2 separate git repos — splitting: each repo now gets its own committable graft/ (repoA/graft/, repoB/graft/); the combined graph here is replaced by a workspace index. Queries from here now search all repos, fairly.",
   );
-  rmSync(p, { recursive: true, force: true });
+  rmDir(p);
 });
 
 test("check federation: OK when all in sync, STALE + not-ok when a child drifts", async () => {
@@ -156,7 +157,7 @@ test("check federation: OK when all in sync, STALE + not-ok when a child drifts"
   const drifted = await federateCheck(p);
   assert.equal(drifted.ok, false);
   assert.ok(drifted.text.includes("repoA/: STALE"));
-  rmSync(p, { recursive: true, force: true });
+  rmDir(p);
 });
 
 test("callers federation resolves a symbol per child, grouped", async () => {
@@ -165,7 +166,7 @@ test("callers federation resolves a symbol per child, grouped", async () => {
   const { text, found } = federateCallers(p, undefined, "helperThing", {});
   assert.equal(found, true);
   assert.ok(text.includes("## repoA/"));
-  rmSync(p, { recursive: true, force: true });
+  rmDir(p);
 });
 
 test("grep federation merges groups across children with child-prefixed paths", async () => {
@@ -176,7 +177,7 @@ test("grep federation merges groups across children with child-prefixed paths", 
   const paths = result.groups.map((g) => g.path);
   assert.ok(paths.some((p) => p.startsWith("repoA/")));
   assert.ok(paths.some((p) => p.startsWith("repoB/")));
-  rmSync(p, { recursive: true, force: true });
+  rmDir(p);
 });
 
 test("one unbuilt child is surfaced, not silently skipped", async () => {
@@ -186,7 +187,7 @@ test("one unbuilt child is surfaced, not silently skipped", async () => {
   });
   await buildWorkspace(p);
   // Simulate repoC never having been built.
-  rmSync(contextDirFor(join(p, "repoC")), { recursive: true, force: true });
+  rmDir(contextDirFor(join(p, "repoC")));
 
   const wg = loadWorkspaceGraphs(p);
   assert.deepEqual(wg.loaded.map((l) => l.child), ["repoA", "repoB"]);
@@ -195,7 +196,7 @@ test("one unbuilt child is surfaced, not silently skipped", async () => {
     coverageNote(wg),
     "2 of 3 workspace repos have graphs; run graft build to cover repoC",
   );
-  rmSync(p, { recursive: true, force: true });
+  rmDir(p);
 });
 
 const JUNK = {
@@ -214,7 +215,7 @@ test("federated ask: a junk-body-token child is gated out of the ranking, into a
   assert.ok(!titles.some((t) => t.startsWith("renderPanel")), `junk hit must NOT federate:\n${titles.join("\n")}`);
   assert.ok(r.hits.every((h) => h.scope!.startsWith("repoA")), "only repoA federates");
   assert.deepEqual(r.scopes?.alsoMatched.map((m) => m.scope), ["repoB"], "junk child reported in alsoMatched");
-  rmSync(p, { recursive: true, force: true });
+  rmDir(p);
 });
 
 test("federated ask: a genuinely-shared query still federates both children", async () => {
@@ -223,7 +224,7 @@ test("federated ask: a genuinely-shared query still federates both children", as
   const r = federateAsk(p, undefined, "handler", { limit: 8 });
   const scopeSet = new Set(r.hits.map((h) => h.scope!.split("/")[0]));
   assert.ok(scopeSet.has("repoA") && scopeSet.has("repoB"), "both children federate a shared term");
-  rmSync(p, { recursive: true, force: true });
+  rmDir(p);
 });
 
 test("federated ask: --in <child> narrows to that child; --in <unknown> errors listing repos", async () => {
@@ -238,7 +239,7 @@ test("federated ask: --in <child> narrows to that child; --in <unknown> errors l
     () => federateAsk(p, undefined, "handler", { in: "nope" }),
     /no workspace repo "nope".*repoA.*repoB/s,
   );
-  rmSync(p, { recursive: true, force: true });
+  rmDir(p);
 });
 
 test("federated ask: explicit --in <weak child> bypasses the cross-child gate (footer hint is reachable)", async () => {
@@ -258,7 +259,7 @@ test("federated ask: explicit --in <weak child> bypasses the cross-child gate (f
   const scoped = federateAsk(p, undefined, "scrollbar overlay position", { limit: 8, in: "repoJunk" });
   assert.ok(scoped.hits.length > 0, "explicit --in on a gate-weak child must not return empty");
   assert.ok(scoped.hits.every((h) => h.scope!.startsWith("repoJunk")), "--in repoJunk stays in repoJunk");
-  rmSync(p, { recursive: true, force: true });
+  rmDir(p);
 });
 
 for (const padN of [0, 200]) {
@@ -275,7 +276,7 @@ for (const padN of [0, 200]) {
     assert.ok(!titles.some((t) => t.startsWith("drawFrame")), `body-only junk must NOT federate:\n${titles.join("\n")}`);
     assert.ok(r.hits.every((h) => h.scope!.startsWith("repoStrong")), "only the strong child federates");
     assert.deepEqual(r.scopes?.alsoMatched.map((m) => m.scope), ["repoJunk"], "junk reported in alsoMatched");
-    rmSync(p, { recursive: true, force: true });
+    rmDir(p);
   });
 }
 
@@ -291,7 +292,7 @@ test("strength gate: 3-child payment/gateway/refund — strong + mid federate, i
   assert.ok(scopes.has("repoStrong") && scopes.has("repoMid"), "genuine name matches federate");
   assert.ok(!scopes.has("repoJunk"), "incidental-var junk excluded from the ranking");
   assert.ok(r.scopes?.alsoMatched.some((m) => m.scope === "repoJunk"), "junk reported in alsoMatched");
-  rmSync(p, { recursive: true, force: true });
+  rmDir(p);
 });
 
 test("strength gate: a legit COMMON-term (low-idf) name match is NOT overcorrected out", async () => {
@@ -304,7 +305,7 @@ test("strength gate: a legit COMMON-term (low-idf) name match is NOT overcorrect
   await buildWorkspace(p);
   const r = federateAsk(p, undefined, "config loader", { limit: 8 });
   assert.ok(r.hits.some((h) => h.scope!.startsWith("repoConfig")), "real partial-relevance (low-idf name hit) must still federate");
-  rmSync(p, { recursive: true, force: true });
+  rmDir(p);
 });
 
 for (const [kind, junkFiles] of [
@@ -321,7 +322,7 @@ for (const [kind, junkFiles] of [
     assert.ok(r.hits[0]?.title.startsWith("paymentGatewayRefund"), `strong repo's real hit must be #1, got: ${r.hits[0]?.title}`);
     assert.ok(!r.hits.some((h) => h.scope!.startsWith("repoJunk")), "coincidental path-name junk must NOT federate");
     assert.ok(r.scopes?.alsoMatched.some((m) => m.scope === "repoJunk"), "junk reported in alsoMatched");
-    rmSync(p, { recursive: true, force: true });
+    rmDir(p);
   });
 }
 
@@ -332,5 +333,5 @@ test("readWorkspace: rejects foreign/invalid json as not-a-workspace", () => {
   assert.equal(readWorkspace(p), null);
   writeWorkspace(p, { version: 1, children: ["x", "a"] });
   assert.deepEqual(readWorkspace(p), { version: 1, children: ["a", "x"] });
-  rmSync(p, { recursive: true, force: true });
+  rmDir(p);
 });

--- a/test/workspace.test.ts
+++ b/test/workspace.test.ts
@@ -19,6 +19,7 @@ import {
   federateGrep,
   isWorkspaceBuildRoot,
 } from "../src/graph/workspace.js";
+import { keepGoingOnChildFailure } from "../src/graph/workspace-cli.js";
 import { formatAsk } from "../src/ask/ask.js";
 import type { GraphV1 } from "../src/graph/types.js";
 import { rmDir } from "./helpers.js";
@@ -180,6 +181,53 @@ test("grep federation merges groups across children with child-prefixed paths", 
   rmDir(p);
 });
 
+test("grep federation applies --in: one child, and a path prefix inside it", async () => {
+  const p = workspaceFx({
+    repoA: {
+      "src/a.ts": "export function alphaHandler() { return 1; }\n",
+      "tests/a.test.ts": "export function alphaHandlerSpec() { return 1; }\n",
+    },
+    repoB: { "b.ts": "export function betaHandler() { return 2; }\n" },
+  });
+  await buildWorkspace(p);
+
+  // Federation forwarded ignoreCase/fixed only, so `--in repoA` searched repoB
+  // too — and every path came back child-prefixed, which made the wider answer
+  // look deliberate rather than wrong.
+  const scoped = federateGrep(p, undefined, "Handler", { ignoreCase: true, in: "repoA" });
+  const paths = scoped.result.groups.map((g) => g.path);
+  assert.ok(paths.length > 0, JSON.stringify(paths));
+  assert.ok(paths.every((x) => x.startsWith("repoA/")), JSON.stringify(paths));
+
+  // Past the first segment the rest is that child's own path prefix — the same
+  // spelling `federateAsk --in` takes.
+  const inner = federateGrep(p, undefined, "Handler", { ignoreCase: true, in: "repoA/src" });
+  assert.deepEqual(inner.result.groups.map((g) => g.path), ["repoA/src/a.ts"]);
+
+  // A first segment naming no child is a caller mistake, not an empty result.
+  assert.throws(() => federateGrep(p, undefined, "Handler", { in: "nope" }), /no workspace repo "nope"/);
+  rmDir(p);
+});
+
+test("grep federation spends ONE hit budget and one clock across the children", async () => {
+  const p = workspaceFx(REPOS);
+  await buildWorkspace(p);
+
+  // Each child used to be handed the full cap, so a workspace could return
+  // maxHits × children — from a cap whose whole job is bounding one answer.
+  const capped = federateGrep(p, undefined, "Handler", { ignoreCase: true, maxHits: 1 });
+  assert.equal(capped.result.totalHits, 1);
+  assert.ok(capped.result.truncated.hits >= 1, JSON.stringify(capped.result.truncated));
+
+  // And an exhausted wall clock is reported, not lost: `truncated` was rebuilt as
+  // `{files, hits}` on this path, so a federated scan that gave up looked exactly
+  // like one that had searched everything and found nothing.
+  const outOfTime = federateGrep(p, undefined, "Handler", { ignoreCase: true, budgetMs: 0 });
+  assert.equal(outOfTime.result.truncated.timeout, true);
+  assert.equal(outOfTime.result.totalHits, 0);
+  rmDir(p);
+});
+
 test("one unbuilt child is surfaced, not silently skipped", async () => {
   const p = workspaceFx({
     ...REPOS,
@@ -264,7 +312,9 @@ test("federated ask: explicit --in <weak child> bypasses the cross-child gate (f
 
 for (const padN of [0, 200]) {
   test(`strength gate: body-only junk (\`position\`) gated out at ${padN ? "~200" : "~30"}-node scale`, async () => {
-    const strongPad = padN ? { "pad.ts": pad(padN) } : {};
+    // Annotated: the inferred type of the branch is `{ "pad.ts"?: undefined }` on
+    // the 0 side, which is not a valid file map to spread into a child's fixture.
+    const strongPad: Record<string, string> = padN ? { "pad.ts": pad(padN) } : {};
     const p = workspaceFx({
       repoStrong: { "m.ts": "export function scrollbarOverlay() { return computeThumb(); }\nfunction computeThumb() { return 1; }\n", ...strongPad },
       repoJunk: { "m.ts": "export function drawFrame() { const position = 0; return position; }\nfunction helper() { return 1; }\n", ...strongPad },
@@ -325,6 +375,43 @@ for (const [kind, junkFiles] of [
     rmDir(p);
   });
 }
+
+// One child failing used to reject splitWorkspace's await chain, reach
+// parseAsync().catch → process.exit(1), and leave every LATER child unbuilt. The
+// failures that really happen here (expired key, 429) hit every child alike, so
+// that is the worst possible moment to abandon the queue.
+test("a failing child is reported and skipped — the rest of the workspace still builds", async () => {
+  const p = workspaceFx({
+    repoA: { "a.ts": "export const a = 1;\n" },
+    repoB: { "b.ts": "export const b = 2;\n" },
+    repoC: { "c.ts": "export const c = 3;\n" },
+  });
+  const built: string[] = [];
+  const failed: string[] = [];
+  const errs: string[] = [];
+  const realError = console.error;
+  console.error = (msg?: unknown) => void errs.push(String(msg));
+  try {
+    const { children } = await splitWorkspace(
+      p,
+      undefined,
+      keepGoingOnChildFailure(async (_childDir, name) => {
+        if (name === "repoB") throw new Error("429 rate limited");
+        built.push(name);
+      }, failed),
+    );
+    assert.deepEqual(children, ["repoA", "repoB", "repoC"]);
+    assert.deepEqual(built, ["repoA", "repoC"], "repoC is queued AFTER the failure and must still be built");
+    assert.deepEqual(failed, ["repoB"], "recorded, so the caller can still exit non-zero");
+    assert.ok(
+      errs.some((e) => e.includes("repoB") && e.includes("429")),
+      `the reason must reach the user, got ${JSON.stringify(errs)}`,
+    );
+  } finally {
+    console.error = realError;
+    rmDir(p);
+  }
+});
 
 test("readWorkspace: rejects foreign/invalid json as not-a-workspace", () => {
   const p = mkdtempSync(join(tmpdir(), "ws-"));

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,24 @@
+{
+  // Type-checks test/ together with src/, which the build config cannot do: it
+  // emits into dist/ with "rootDir": "./src", so adding test/**/* there fails with
+  // TS6059 ("not under rootDir"). The tests run through tsx, which only strips
+  // types — nothing ever checked that a fixture still matches NodeV1 or that a
+  // helper still matches the Summarizer signature it imports, so a stale fixture
+  // could keep "passing" against the wrong shape. Check-only: rootDir and every
+  // emit-shaped option from the base are dropped, since noEmit makes them
+  // meaningless (and declaration + noEmit is an error).
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    // Tests that cover the build/CI scripts import them straight from scripts/*.mjs;
+    // without allowJs every one of those imports is a "no declaration file" error
+    // that has nothing to do with the test's own types.
+    "allowJs": true,
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false
+  },
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["node_modules", "dist", "examples"]
+}

--- a/viewer/detail.ts
+++ b/viewer/detail.ts
@@ -4,10 +4,7 @@
  * (incoming), mirroring the focus-mode edge colors.
  */
 import { type VizGraph, colorToken, cvar } from "./data.js";
-
-function esc(s: string): string {
-  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;");
-}
+import { escapeHtml as esc } from "./escape.js";
 
 export function renderDetail(
   host: HTMLElement,

--- a/viewer/escape.ts
+++ b/viewer/escape.ts
@@ -1,0 +1,32 @@
+/**
+ * HTML escaping for the two views that still build markup as strings
+ * (`detail.ts`, `tree.ts`).
+ *
+ * The old per-file version escaped `&` and `<` only, which is enough for text
+ * nodes and NOT enough here: every value is interpolated inside a
+ * double-quoted attribute (`data-go="…"`, `data-id="…"`, `style="…"`). A single
+ * `"` in a node id closes the attribute early and the rest of the id is parsed
+ * as more attributes — `x" onmouseover="alert(1)` becomes a live event handler
+ * on a button the user is being invited to click.
+ *
+ * The ids were treated as trusted because they come from graft's own output,
+ * but that trust never held: `assemble.ts` reads `slug` and `relation` straight
+ * out of card frontmatter, which an LLM wrote while summarizing a repo that may
+ * be anyone's. A prompt-injected slug is a plausible delivery path, and the
+ * viewer serves the private graph of the repo it is pointed at.
+ *
+ * `'` and `>` are escaped too, so the same function is correct for
+ * single-quoted attributes and for text content, and nobody has to remember
+ * which context they are in.
+ */
+const HTML_ESCAPES: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+
+export function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => HTML_ESCAPES[c]);
+}

--- a/viewer/main.ts
+++ b/viewer/main.ts
@@ -3,6 +3,7 @@
  * SSE live reload, and the three views (Context graph / Code graph / Outline).
  */
 import { loadContextGraph, loadCodeGraph, onServerChange, chipKey, CHIP_HINT, colorToken, cvar, famOf, type VizGraph } from "./data.js";
+import { escapeHtml } from "./escape.js";
 import { GraphView } from "./graph.js";
 import { renderDetail } from "./detail.js";
 import { renderOutline } from "./tree.js";
@@ -47,7 +48,10 @@ function renderChips(): void {
     const btn = document.createElement("button");
     btn.type = "button";
     btn.className = "echip" + (view.hiddenRels[key] ? "" : " on");
-    btn.innerHTML = `${glyphFor(key)} ${key} <span style="opacity:.55">${counts.get(key)}</span>`;
+    // `key` is a relation verb copied out of card frontmatter, i.e. LLM output
+    // over a repo graft did not write — same untrusted origin as the ids in
+    // detail.ts/tree.ts, and the same reason it cannot go into innerHTML raw.
+    btn.innerHTML = `${glyphFor(key)} ${escapeHtml(key)} <span style="opacity:.55">${counts.get(key)}</span>`;
     btn.title = (CHIP_HINT[key] ?? `"${key}" edges`) + " — click to " + (view.hiddenRels[key] ? "show" : "hide");
     btn.addEventListener("click", () => {
       view.hiddenRels[key] = !view.hiddenRels[key];
@@ -82,7 +86,7 @@ function renderLegend(): void {
     const chip = document.createElement("button");
     chip.type = "button";
     chip.className = "lchip" + (view.hiddenTypes[type] ? " off" : "");
-    chip.innerHTML = `<span class="sw" style="background:${cvar(colorToken(graphTab(), type))}"></span>${type} <span style="color:var(--muted);font-weight:500">${count}</span>`;
+    chip.innerHTML = `<span class="sw" style="background:${cvar(colorToken(graphTab(), type))}"></span>${escapeHtml(type)} <span style="color:var(--muted);font-weight:500">${count}</span>`;
     chip.addEventListener("click", () => {
       view.hiddenTypes[type] = !view.hiddenTypes[type];
       renderLegend();

--- a/viewer/tree.ts
+++ b/viewer/tree.ts
@@ -3,10 +3,7 @@
  * as a collapsible tree with kind dots and per-file symbol counts.
  */
 import { type VizGraph, colorToken, cvar } from "./data.js";
-
-function esc(s: string): string {
-  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;");
-}
+import { escapeHtml as esc } from "./escape.js";
 
 export function renderOutline(
   host: HTMLElement,


### PR DESCRIPTION
Documentation for the config surface the preceding parts introduce. It lands last so it never describes a flag that is not merged yet.

- The subscription provider and its two per-call ceilings (`--max-budget-usd` / `GRAFT_CLAUDE_MAX_BUDGET_USD`, `GRAFT_CLAUDE_TIMEOUT_MS`), with the point spelled out that a `--deep` build makes one call per file, so both bound **one call**, not the run.
- `GRAFT_MAX_RETRIES` and `GRAFT_TIMEOUT_MS` across all providers, and why the right retry count belongs to the endpoint rather than to graft.
- The persisted `--extensions` / `--include-dir` narrowing and how to clear it.
- Why `GRAFT_DIR` must be absolute: a relative value resolves against the current working directory, so `graft build` at the root and `graft ask` from a subdirectory write and read two different graphs, and the second reports an empty repo rather than an error.

It also corrects `GRAFT_MODEL`. The example was `openai/gpt-4o-mini`, but `api.openai.com` answers that with a 404 `model_not_found` — the `vendor/slug` form is OpenRouter addressing scheme, and the two spellings are not interchangeable.

---

**Part of a stack.** This work started as an audit of `main` and is split by area so each piece is reviewable on its own. Order, each based on the one before it:

1. `feat/subscription-provider` — `--deep` without an API key, + the locale bug
2. `fix/graph-extraction` — Python imports, JSX edges, WASM leak
3. `fix/query-and-viz-security` — ReDoS, DNS rebinding, XSS, `--in`
4. `fix/hosts-settings-safety` — the `settings.json` wipe
5. `fix/llm-build-robustness` — the concept-layer wipe, usage accounting
6. `fix/windows-and-cli-ux` — the dead npm path on Windows
7. `chore/ci-and-packaging` — type-check the tests, run the packaged artifact
8. `docs/config-reference` — the config surface the above introduced

Cross-fork PRs can only target `main`, so GitHub shows the cumulative diff here. **This PR own diff:** https://github.com/NanoNets/Graft/compare/chore/ci-and-packaging...christian-jorge:Graft:docs/config-reference

Every link in the stack is green on its own: `tsc` clean and the full suite at 0 failures on Windows. Happy to reorder, rebase, drop any piece, or squash the lot back into one — just say which.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
