### PR TITLE
fix(graph): cold builds disagree on reference edges (#116)

### DIFF
--- a/src/graph/extract.ts
+++ b/src/graph/extract.ts
@@ -471,6 +471,23 @@ function collectTsImportBindings(
 }
 
 /**
+ * Do these two wrappers stand for the same syntax node? `===` does not answer that:
+ * node-tree-sitter materializes `SyntaxNode` objects on demand and caches them
+ * weakly, so reaching one node twice can return two different JS objects. Comparing
+ * wrappers makes a purely syntactic question depend on collector timing — two cold
+ * builds of unchanged source then disagree on `references` edges (#116).
+ *
+ * `id` is the stable identity, unique within one tree, so the tree is compared too.
+ * A `Tree` is one object per parse (unlike its nodes), so `===` is right for it.
+ */
+function sameSyntaxNode(
+  a: Parser.SyntaxNode | null | undefined,
+  b: Parser.SyntaxNode | null | undefined,
+): boolean {
+  return !!a && !!b && a.tree === b.tree && a.id === b.id;
+}
+
+/**
  * A parameter or local declaration wins over an import inside that function.
  * Drop that imported binding for the whole function rather than create a false
  * dependency. Nested functions are separate scopes and filter themselves.
@@ -483,7 +500,7 @@ function withoutShadowedImports(
   const shadowed = new Set<string>();
   const definitionValue = definition.childForFieldName("value");
   const visit = (node: Parser.SyntaxNode): void => {
-    if (node !== definition && node !== definitionValue && isFunctionBoundary(node)) {
+    if (!sameSyntaxNode(node, definition) && !sameSyntaxNode(node, definitionValue) && isFunctionBoundary(node)) {
       const name = node.childForFieldName("name");
       if (name?.type === "identifier") shadowed.add(name.text);
       return;
@@ -521,13 +538,16 @@ function isFunctionBoundary(node: Parser.SyntaxNode): boolean {
 function isDirectCallee(node: Parser.SyntaxNode, callTypes: ReadonlySet<string>): boolean {
   const parent = node.parent;
   if (!parent || !callTypes.has(parent.type)) return false;
-  return parent.childForFieldName("function") === node || parent.childForFieldName("name") === node;
+  return (
+    sameSyntaxNode(parent.childForFieldName("function"), node) ||
+    sameSyntaxNode(parent.childForFieldName("name"), node)
+  );
 }
 
 /** Definition/declaration identifiers name a new binding; they do not use one. */
 function isDeclarationName(node: Parser.SyntaxNode): boolean {
   const parent = node.parent;
-  return parent?.childForFieldName("name") === node;
+  return sameSyntaxNode(parent?.childForFieldName("name"), node);
 }
 
 /** Recognize the definition shapes: mapped node types, Go's type/method forms, and

--- a/test/graph-references.test.ts
+++ b/test/graph-references.test.ts
@@ -2,11 +2,17 @@
  * Regression coverage for issue #34: imported functions used as values must
  * remain visible to `callers`, but as weaker `references` edges rather than
  * being mislabeled as direct calls.
+ *
+ * …and for issue #116, at the bottom: the same rules have to hold in a file
+ * big enough that tree-sitter stops handing back the same JS wrapper object
+ * for a node it already materialized.
  */
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { buildGraph } from "../src/graph/build.js";
 import { callersOf } from "../src/graph/traverse.js";
 import { readGraph, wiringPath } from "../src/graph/write.js";
@@ -82,6 +88,95 @@ test("aliased named imports resolve references to the exported symbol", async ()
         edge.target === "src/gate.ts#isActive" &&
         edge.relation === "references",
     ),
+  );
+});
+
+/**
+ * Regression for #116. node-tree-sitter may rematerialize SyntaxNode wrappers
+ * after GC, so wrapper identity cannot reliably classify direct callees.
+ *
+ * The probe constrains GC pressure and exercises enough call sites to make the
+ * failure reproducible while preserving the intended calls/references semantics.
+ */
+const CALL_SITES = 60;
+
+test("a direct call is not also recorded as a value reference, at scale (#116)", () => {
+  const root = tmpRepo("graft-reference-scale-");
+  mkdirSync(join(root, "src"), { recursive: true });
+  writeFileSync(
+    join(root, "src", "dep.ts"),
+    [
+      "export function target(): number { return 1; }",
+      "export function register(fn: () => number): unknown { return fn; }",
+      "",
+    ].join("\n"),
+  );
+  writeFileSync(
+    join(root, "src", "consumer.ts"),
+    [
+      'import { target, register } from "./dep.js";',
+      "",
+      // (b) handed over as a value — a `references` edge
+      "export function usesValue(): unknown { return register(target); }",
+      // (c) both, in one body — BOTH edges, from two distinct occurrences
+      "export function usesBoth(): number { register(target); return target(); }",
+      "",
+      // (d) a block-scoped declaration that happens to reuse the imported name.
+      // It DECLARES a binding, so it is not a use of the import. Module-level, so
+      // `withoutShadowedImports` (which only runs inside a function or method) is
+      // not what protects it — `isDeclarationName` is.
+      "{",
+      "  const target = 0;",
+      "}",
+      "",
+      // (a) the case #116 breaks: every one of these invokes `target` directly, so
+      // each must produce a `calls` edge and no `references` edge.
+      ...Array.from(
+        { length: CALL_SITES },
+        (_, i) => `export function callsTarget${i}(): number { return target(); }`,
+      ),
+      "",
+    ].join("\n"),
+  );
+
+  const probe = join(dirname(fileURLToPath(import.meta.url)), "reference-scale-probe.ts");
+  const run = spawnSync(
+    process.execPath,
+    ["--max-semi-space-size=1", "--import", "tsx", probe, root],
+    { encoding: "utf8" },
+  );
+  assert.equal(run.status, 0, `probe failed:\n${run.stderr}`);
+  const line = run.stdout.split("\n").find((l) => l.startsWith("__EDGES__"));
+  assert.ok(line, `probe printed no edges:\n${run.stdout}\n${run.stderr}`);
+  const edges: Array<{ source: string; relation: string }> = JSON.parse(line.slice("__EDGES__".length));
+  const linked = (from: string, relation: string): boolean =>
+    edges.some((e) => e.source === `src/consumer.ts#${from}` && e.relation === relation);
+
+  // (a) a direct invocation is a call, and ONLY a call — at every one of the sites.
+  const callSites = (relation: string): number =>
+    edges.filter((e) => /^src\/consumer\.ts#callsTarget\d+$/.test(e.source) && e.relation === relation).length;
+  assert.equal(callSites("calls"), CALL_SITES, "every direct call resolves to a calls edge");
+  assert.equal(
+    callSites("references"),
+    0,
+    "an identifier that is the direct callee must not also be booked as a value reference",
+  );
+
+  // (b) the recall #34/#49 bought must survive any fix to (a).
+  assert.equal(linked("usesValue", "references"), true, "a function passed as a value is still a reference");
+
+  // (c) `calls` and `references` may legitimately coexist between the same pair —
+  // here two different occurrences of `target` in one body. Whatever fixes (a)
+  // must not become a blanket "references and calls are mutually exclusive" rule.
+  assert.equal(linked("usesBoth", "calls"), true, "the invoked occurrence yields a calls edge");
+  assert.equal(linked("usesBoth", "references"), true, "the value occurrence yields a references edge");
+
+  // (d) the block-scoped redeclaration is attributed to the file node, since it sits
+  // outside any definition. It names a binding, so it must not reference the import.
+  assert.equal(
+    edges.some((e) => e.source === "src/consumer.ts" && e.relation === "references"),
+    false,
+    "a declaration that reuses an imported name is not a use of the import",
   );
 });
 

--- a/test/reference-scale-probe.ts
+++ b/test/reference-scale-probe.ts
@@ -1,0 +1,28 @@
+/**
+ * Child process for the #116 regression test in `graph-references.test.ts`.
+ *
+ * It exists only so that the build can be run under `--max-semi-space-size=1`.
+ * #116 is a garbage-collection race: `isDirectCallee`/`isDeclarationName` compare
+ * tree-sitter `SyntaxNode` objects with `===`, which only answers correctly while
+ * the node is still in node-tree-sitter's tree cache. Whether a scavenge has
+ * cleared that cache mid-walk is otherwise pure luck — measured over a sweep of
+ * fixture sizes, the same input flips between correct and misclassified from one
+ * process to the next. Shrinking the young generation makes scavenges frequent
+ * enough that the cache is reliably cold, which turns the race into a fixed
+ * outcome and the regression test into a deterministic one.
+ *
+ * Prints one JSON line: every edge pointing at `src/dep.ts#target`.
+ */
+import { buildGraph } from "../src/graph/build.js";
+import { readGraph, wiringPath } from "../src/graph/write.js";
+import { join } from "node:path";
+
+const root = process.argv[2];
+
+await buildGraph(root, { reuse: false });
+const graph = readGraph(wiringPath(join(root, "graft")));
+const edges = (graph?.edges ?? [])
+  .filter((edge) => edge.target === "src/dep.ts#target")
+  .map(({ source, relation }) => ({ source, relation }));
+
+console.log(`__EDGES__${JSON.stringify(edges)}`);


### PR DESCRIPTION
## Problem

Two cold builds of byte-identical source can produce different graphs. On graft's own tracked source, ten `graft build --no-reuse` runs gave four distinct canonical edge digests. The node set was stable — as were `calls`, `contains`, `imports` and `implements`. Only `references` moved, between 201 and 238 edges.

## Root cause

`isDirectCallee`, `isDeclarationName` and `withoutShadowedImports` ask whether an identifier *is* the callee (or the declared name) of its parent, and answered by comparing `SyntaxNode` objects with `===`.

node-tree-sitter materializes those wrappers on demand and caches them weakly, so reaching the same node twice can return two different JS objects depending on whether a scavenge ran in between. A purely syntactic question therefore depended on collector timing, and a direct callee was intermittently booked as a value reference as well.

#87's determinism gate does not catch this: its fixture is three small files, far too little allocation to recycle the cache.

## Fix

A `sameSyntaxNode()` helper compares the stable node id *within the same tree*. Ids are unique per tree but not across trees, so the tree is compared too; a `Tree` is one object per parse (unlike its nodes), so `===` is correct for it.

Applied at those three sites — an audit of `src/` found they are the only `SyntaxNode` identity comparisons in the codebase.

## Validation

| | pre-fix | fixed |
|---|---|---|
| regression test ×20, Node 20.20.2 (local, Windows) | 20/20 red | 0/20 |
| regression test ×20, Node 24.8.0 (local, Windows) | 20/20 red | 0/20 |
| 10 cold builds of graft's own source | 4 distinct canonical edge digests | 1 digest, identical across all 10 |
| CI — `ubuntu-latest`, Node 20.20.2 | — | 660 tests, **660 pass, 0 fail** |
| CI — `windows-latest`, Node 20.20.2 | — | 660 tests, **0 fail** (4 pre-existing platform skips) |

The #116 test executed on both CI platforms (not skipped).

The regression test runs the build in a child with a 1 MB young generation, so the cold cache the defect needs is reproducible instead of occasional, and its fixture is bulk direct call sites rather than padding — asking the question once is a coin flip (measured 12/20 on Node 20), asking it 60 times is not. It also pins the behaviour a fix must not break: a value use still yields a `references` edge, `calls` and `references` still coexist when one body does both, and a declaration that reuses an imported name is not a use.

**Validation limit worth stating:** the red/green contrast was measured locally on Windows (Node 20 and Node 24). CI confirms the fixed state is green on Ubuntu and Windows, but the *pre-fix red* state was not re-run on Ubuntu — so the test's detection power on Linux is inferred from the mechanism, not measured.

## Behavioral impact

`references` on graft's own corpus goes from a fluctuating 201–238 to a stable 22. That is a precision correction rather than lost recall:

- 216 `references` edges removed, **0 added**, every other relation unchanged.
- 215 of the 216 duplicated a `calls` edge with the same source→target — which is exactly what `isDirectCallee` exists to prevent.
- Classified against the AST (a classifier over each occurrence, not a ground-truth oracle): 214 were direct-callee occurrences; 2 moved from a file node to the enclosing symbol (`src/cli.ts` → `src/cli.ts#wireTarget`, `test/ask.test.ts` → `…#rankOf`), i.e. more precise attribution.
- One removal genuinely loses connectivity: `test/claude-init-workspace.test.ts → test/helpers.ts#runCli`. `runCli` is defined in four files, so the bare call drops as ambiguous and the (wrongly emitted) reference edge was the only thing linking them. That is a pre-existing call-resolution limit the bug was masking; not addressed here.

## Note on #40

PR #40 (tree-sitter 0.25 bump) independently changes two of these three sites to compare `.id`, as an incidental part of a runtime upgrade. Happy to rebase on top of it, or to drop this if you would rather take it there — though that PR does not cover `withoutShadowedImports` and carries no determinism test.

Fixes #116
