### PR TITLE
feat: add Clojure support, on a broader WASM grammar bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ compiler-grade layer — all `$0` and deterministic (no model, no key):
 - **Broad** — symbols (functions, classes, methods, types, …) plus name-resolved
   call edges via a generic tree-sitter extractor, one grammar per language:
   **Rust, C, C++, C#, Ruby, PHP, Kotlin, Scala, Swift, Elixir, Solidity,
-  OCaml, Zig, Dart**.
+  OCaml, Zig, Dart, Clojure**.
 
 - **Compiler-grade edges (opt-in)** — `graft build --lsp` adds precise
   `lsp_resolved` call edges (member calls the static pass can't type) when a
@@ -205,7 +205,7 @@ compiler-grade layer — all `$0` and deterministic (no model, no key):
   **gopls** (Go), **pyright** (Python), **typescript-language-server** (TS/JS).
   It's best-effort — with no server installed the graph is unchanged.
 
-Twenty languages in total. A file whose language isn't listed is skipped, not
+Twenty-one languages in total. A file whose language isn't listed is skipped, not
 indexed. Adding a broad-tier language is a small contribution — see
 [CREDITS.md](CREDITS.md) for the folks who added the current set.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "tree-sitter-java": "^0.23.5",
         "tree-sitter-python": "^0.21.0",
         "tree-sitter-typescript": "^0.23.2",
-        "tree-sitter-wasms": "^0.1.13",
+        "tree-sitter-wasm": "^1.1.4",
         "vscode-jsonrpc": "^8.2.1",
         "vscode-languageserver-protocol": "^3.18.2",
         "web-tree-sitter": "^0.25.10"
@@ -958,14 +958,11 @@
         }
       }
     },
-    "node_modules/tree-sitter-wasms": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/tree-sitter-wasms/-/tree-sitter-wasms-0.1.13.tgz",
-      "integrity": "sha512-wT+cR6DwaIz80/vho3AvSF0N4txuNx/5bcRKoXouOfClpxh/qqrF4URNLQXbbt8MaAxeksZcZd1j8gcGjc+QxQ==",
-      "license": "Unlicense",
-      "dependencies": {
-        "tree-sitter-wasms": "^0.1.11"
-      }
+    "node_modules/tree-sitter-wasm": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/tree-sitter-wasm/-/tree-sitter-wasm-1.1.4.tgz",
+      "integrity": "sha512-+vvWfbH1fPzB8BBhoqH9j2GSyyPyTa9Fgkh7qQOadxQM7O7h0PsGwnvVPLW86fb/DwWH1nNxW4naVbiVgRIeBw==",
+      "license": "MIT"
     },
     "node_modules/ts-algebra": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "tree-sitter-java": "^0.23.5",
     "tree-sitter-python": "^0.21.0",
     "tree-sitter-typescript": "^0.23.2",
-    "tree-sitter-wasms": "^0.1.13",
+    "tree-sitter-wasm": "^1.1.4",
     "vscode-jsonrpc": "^8.2.1",
     "vscode-languageserver-protocol": "^3.18.2",
     "web-tree-sitter": "^0.25.10"

--- a/src/graph/generic.ts
+++ b/src/graph/generic.ts
@@ -4,7 +4,7 @@
  * graft covers the long tail of languages for ~one registry row each, instead of
  * a hand-written extractor per language (the depth tier in extract.ts).
  *
- * Grammars are WASM (`tree-sitter-wasms` bundle) loaded via `web-tree-sitter`, so
+ * Grammars are WASM (`tree-sitter-wasm` bundle) loaded via `web-tree-sitter`, so
  * a new language needs no native node-gyp build. Loading is async (WASM init), so
  * callers MUST `await warmGenericGrammars([...])` once before the synchronous
  * `extractGeneric()` is used in a build/check loop. If a grammar isn't warmed,
@@ -31,7 +31,7 @@ const require = createRequire(import.meta.url);
 const QUERY_DIRS = [join(HERE, "queries"), join(HERE, "..", "..", "src", "graph", "queries")];
 
 /** A breadth-tier language: graft name, file extensions, and the wasm basename
- * in tree-sitter-wasms/out/tree-sitter-<wasm>.wasm. One row per language. */
+ * in tree-sitter-wasm/<wasm>/tree-sitter-<wasm>.wasm. One row per language. */
 export interface GenericLang {
   name: string;
   exts: string[];
@@ -58,6 +58,7 @@ export const GENERIC_LANGS: readonly GenericLang[] = [
   { name: "ocaml", exts: [".ml", ".mli"], wasm: "ocaml" },
   { name: "zig", exts: [".zig"], wasm: "zig" },
   { name: "dart", exts: [".dart"], wasm: "dart" }, // surfaced by PR #38 (@muneebshere)
+  { name: "clojure", exts: [".clj", ".cljs", ".cljc", ".bb"], wasm: "clojure" },
 ];
 
 const byExt = new Map<string, GenericLang>();
@@ -91,9 +92,10 @@ let tsMod: typeof import("web-tree-sitter") | null = null;
 let initPromise: Promise<void> | null = null;
 
 function requireWasm(wasm: string): Buffer | null {
-  // Resolve the grammar wasm from the tree-sitter-wasms bundle.
+  // Resolve the grammar wasm from the tree-sitter-wasm bundle (its package.json
+  // `exports` maps the bare "<lang>/…" subpath to the actual "out/<lang>/…" file).
   try {
-    const p = require.resolve(`tree-sitter-wasms/out/tree-sitter-${wasm}.wasm`);
+    const p = require.resolve(`tree-sitter-wasm/${wasm}/tree-sitter-${wasm}.wasm`);
     return readFileSync(p);
   } catch {
     return null;

--- a/src/graph/queries/clojure.scm
+++ b/src/graph/queries/clojure.scm
@@ -1,0 +1,58 @@
+; Clojure's tree-sitter grammar has no dedicated node types for `defn`/`def`/etc
+; — every form, definition or call alike, is just a `list_lit` whose `value`
+; field lists its children positionally. So a "definition" here is a list whose
+; first symbol is a known defining macro, matched by name via `#any-of?`/`#eq?`,
+; with the second symbol captured as the defined name.
+
+; Definitions
+
+; * namespace
+(list_lit
+  .
+  value: (sym_lit name: (sym_name) @ignore)
+  .
+  value: (sym_lit name: (sym_name) @name)
+  (#eq? @ignore "ns")) @definition.module
+
+; * functions/macros/multimethods
+(list_lit
+  .
+  value: (sym_lit name: (sym_name) @ignore)
+  .
+  value: (sym_lit name: (sym_name) @name)
+  (#any-of? @ignore "defn" "defn-" "defmacro" "defmulti" "defmethod" "definline" "deftest")) @definition.function
+
+; * def / defonce — a Var binding, not necessarily a function
+(list_lit
+  .
+  value: (sym_lit name: (sym_name) @ignore)
+  .
+  value: (sym_lit name: (sym_name) @name)
+  (#any-of? @ignore "def" "defonce")) @definition.variable
+
+; * defprotocol / definterface
+(list_lit
+  .
+  value: (sym_lit name: (sym_name) @ignore)
+  .
+  value: (sym_lit name: (sym_name) @name)
+  (#any-of? @ignore "defprotocol" "definterface")) @definition.interface
+
+; * defrecord / deftype / defstruct — each mints a JVM class
+(list_lit
+  .
+  value: (sym_lit name: (sym_name) @ignore)
+  .
+  value: (sym_lit name: (sym_name) @name)
+  (#any-of? @ignore "defrecord" "deftype" "defstruct")) @definition.class
+
+; References
+
+; * function/macro call — any parenthesized list headed by a symbol. This also
+; matches the def-forms above on their own keyword (e.g. `(defn foo …)` reads
+; as a "call" to `defn`) and special forms (`let`, `if`, `fn`, …); those never
+; resolve to an in-repo definition, so the existing resolver drops them rather
+; than guessing — same trade-off the elixir/ruby queries make.
+(list_lit
+  .
+  value: (sym_lit name: (sym_name) @name)) @reference.call

--- a/test/generic-extract.test.ts
+++ b/test/generic-extract.test.ts
@@ -99,6 +99,13 @@ const SNIPPETS: Array<{ lang: string; file: string; src: string; defs: string[];
     src: `int helper() { return 1; }\nint run() { return helper(); }\n`,
     defs: ["function:helper", "function:run"], call: ["run", "helper"],
   },
+  {
+    // Lisp: every form is a bare list_lit, so definitions are matched by the
+    // head symbol's name (`defn`, `ns`, …), not a dedicated grammar node.
+    lang: "clojure", file: "a.clj",
+    src: `(ns my.core)\n\n(defn helper [] 1)\n\n(defn run [] (helper))\n`,
+    defs: ["function:helper", "function:run", "module:my.core"], call: ["run", "helper"],
+  },
 ];
 
 for (const s of SNIPPETS) {


### PR DESCRIPTION
No Lisp support existed, and the normal path (a GENERIC_LANGS row + a tags.scm) hit a wall: Clojure isn't in tree-sitter-wasms, the package the breadth tier pulls WASM grammars from. Swapped it for tree-sitter-wasm (112 grammars vs 36, no install script either way) and added Clojure's query. The grammar has no defn/def node types — every form is a bare list_lit — so definitions are matched positionally by head symbol, and @reference.call is anchored to the list's first symbol only, so passing a function as a value (map helper coll) doesn't misread helper/coll as calls.

Also fixes Scala and Solidity, silently broken today: their queries reference node types the currently-shipped grammars don't have, so the query fails to compile, is caught silently, and both tiers degrade to symbols-only extraction — zero call edges for every Scala/Solidity file graft has ever indexed. The newer grammars in tree-sitter-wasm match the existing queries as-is.

Ran every other breadth-tier language's query against both bundles on a def+call snippet and diffed extraction counts: rust, java, c, cpp, ruby, php, c_sharp, kotlin, swift, elixir all extract identically. ocaml/zig/ dart have no query in either bundle, so they're untouched.

660 tests (+1). Does not touch .vue support (#97, a container-extraction gap, not a missing grammar), the per-file Parser/Tree leak (#122, draft native depth-tier grammars, a different subsystem).