### PR TITLE
docs: graft/ is a local cache, not a committed artifact (#125)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ Graft builds that understanding **once** and writes it into your repo as a folde
 
 - **Real explanations, not a list of symbols.** Each node says, in plain English, what a part of the system does and how it connects to the rest, the way a senior engineer would explain it. That is the part an agent actually needs so it can skip the exploration. It is not a dump of function names.
 - **A real graph you can read.** No embeddings, no similarity search, no index to keep warm. The graph is a set of linked files your agent opens, greps, and follows, exactly the way it reads any other file in the repo.
-- **Grafted into git.** The graph is just files in `graft/`. Commit it, and anyone who clones the repo has it. No database, no server, no setup. Git does the syncing, and a stale graph shows up as a diff in review instead of rotting in some external store.
-- **The diff lives with the code.** When a change moves things around, you see it in the graph diff in the same pull request, right next to the code that caused it.
+- **A local cache, not a committed artifact.** `graft build` writes `graft/` and adds it to `.gitignore` — it's a regenerable local cache, like `node_modules`. What you commit is the small wiring `graft init` drops in (`.claude/`, `AGENTS.md`, the MCP config); each teammate runs `graft build` to generate their own graph. No database, no server, no setup.
+- **Always fresh, automatically.** Every query rebuilds the graph against the working tree first — structural, `$0`, ~3ms when nothing moved — so `ask`/`grep`/`callers`/`skeleton`/`map` describe the code as it is right now, including uncommitted edits. `graft check` is a local freshness signal; there's no stale index to babysit.
 - **Your provider, your key, your model.** Summaries are written by any provider you choose — OpenAI, Anthropic (native), OpenRouter, Fireworks, Groq, a LiteLLM proxy, or a local model — under your own key. The structural code graph (`graft build`, `graft check`) is deterministic tree-sitter and never calls a model at all.
 
 <p align="center">

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nanonets/graft",
   "version": "0.11.0",
-  "description": "Build a repo's context graph as a folder of linked markdown files that live in the repo and stay in sync with the code through git.",
+  "description": "Build a repo's context graph as a folder of linked markdown files: a local, regenerable cache that every query keeps in sync with your code.",
   "keywords": [
     "ai",
     "agents",


### PR DESCRIPTION
Fixes #125.

Since v0.7.0 made `graft/` a gitignored, regenerable local cache, the README carried two contradictory ownership models 36 lines apart, and `package.json` kept the old framing.

- README **"Grafted into git"** and **"The diff lives with the code"** bullets told users to commit `graft/`, let git sync it, and review graph diffs in the PR — impossible for a gitignored graph. Rewritten to: `graft/` is a local cache (like `node_modules`); you commit the small wiring (`.claude/`, `AGENTS.md`, MCP config) and each teammate runs `graft build`; every query refreshes the graph against the working tree, so it's always fresh with no committed diff to review.
- **`package.json`** description updated from "live in the repo and stay in sync through git" to the cache framing.

Swept the rest of the README and docs for other commit-the-graph stragglers — none remain; the CHANGELOG already states the v0.7.0 cache model. No code change; full suite green. Thanks @rikiyanai for the precise report.