### PR TITLE
Checkpoint crux to disk during --deep, atomically (#128)

### DIFF
--- a/src/graph/build.ts
+++ b/src/graph/build.ts
@@ -283,22 +283,14 @@ export async function buildGraph(
 
   const edges = resolveEdges(nodes, rawEdges, { goModules: readGoModules(root, repoFiles) });
 
-  // graph.json is its own Tier-2 cache: fold in the prior meaning layer so an
-  // unchanged body is never re-summarized (and a Tier-1-only run never wipes it).
-  const prior = readGraph(wiringPath(outDir));
-  const priorById = new Map((prior?.nodes ?? []).map((n) => [n.id, n]));
-  const meaning = await enrichGraph(nodes, priorById, sources, {
-    summarizer: opts.summarizer,
-    concurrency: opts.concurrency,
-    onProgress: ({ index, total, node }) =>
-      opts.onProgress?.({ phase: "enrich", index, total, file: node }),
-  });
-  errors.push(...meaning.errors);
-
   // Guard 5 (minimum-substance): node counts aren't known until nodes are
   // assembled, so the merge-tiny-scopes-into-root guard runs here.
   const scopes = applyMinSubstanceGuard(discoveredScopes, nodes);
 
+  // Assemble the graph BEFORE the meaning pass, so the crux pass can checkpoint it to
+  // disk periodically (#128): crux/summary mutate node objects in place and never
+  // change the node/edge SET, so `meta` stays valid; the opt-in LSP pass below is the
+  // only thing that adds edges, and it runs before the final write.
   const graph: GraphV1 = {
     meta: {
       version: 1,
@@ -310,6 +302,22 @@ export async function buildGraph(
     nodes,
     edges,
   };
+
+  // graph.json is its own Tier-2 cache: fold in the prior meaning layer so an
+  // unchanged body is never re-summarized (and a Tier-1-only run never wipes it).
+  // Read BEFORE the first checkpoint can overwrite wiring.json.
+  const prior = readGraph(wiringPath(outDir));
+  const priorById = new Map((prior?.nodes ?? []).map((n) => [n.id, n]));
+  const meaning = await enrichGraph(nodes, priorById, sources, {
+    summarizer: opts.summarizer,
+    concurrency: opts.concurrency,
+    onProgress: ({ index, total, node }) =>
+      opts.onProgress?.({ phase: "enrich", index, total, file: node }),
+    // Periodic durability flush of partial crux; the next run folds it back in by
+    // body_hash, so an interrupted --deep run never repays the crux it computed.
+    checkpoint: () => writeGraph(graph, outDir),
+  });
+  errors.push(...meaning.errors);
 
   // Opt-in compiler-grade enrichment (adds lsp_resolved call edges in place).
   // Runs on the assembled graph so callee positions map back to nodes; never

--- a/src/graph/enrich.ts
+++ b/src/graph/enrich.ts
@@ -35,6 +35,21 @@ export interface EnrichOptions {
   concurrency?: number;
   /** Progress is reported per file (one LLM call each), as files finish — not per node. */
   onProgress?: (info: { index: number; total: number; node: string }) => void;
+  /**
+   * Durability flush of the (partially) enriched graph, called from the per-file
+   * completion handler at most once every {@link CHECKPOINT_MS}. Without it, crux
+   * only reached wiring.json at build end, so an interrupted --deep run discarded
+   * every crux it had already computed and paid for (#128). Single-threaded, so it
+   * never interleaves with a node mutation.
+   */
+  checkpoint?: () => void;
+}
+
+/** How often the crux pass flushes partial progress to disk. Read at call time (not
+ * module load) so a test seam `GRAFT_CRUX_CHECKPOINT_MS=0` (flush on every completed
+ * file) takes effect. */
+function checkpointMs(): number {
+  return Number(process.env.GRAFT_CRUX_CHECKPOINT_MS ?? 15000);
 }
 
 export interface EnrichStats {
@@ -100,6 +115,8 @@ export async function enrichGraph(
   const files = [...byFile.keys()];
   const limit = Math.max(1, opts.concurrency ?? DEFAULT_CONCURRENCY);
   let done = 0;
+  const flushEvery = checkpointMs();
+  let lastCheckpoint = Date.now();
 
   await mapWithConcurrency(files, limit, async (path) => {
     const fileNodes = byFile.get(path)!;
@@ -130,6 +147,14 @@ export async function enrichGraph(
 
     // Report on completion so the counter climbs monotonically under concurrency.
     opts.onProgress?.({ index: done++, total: files.length, node: path });
+
+    // Flush partial crux to disk periodically, so a killed --deep run keeps what it
+    // has already computed (#128). Throttled by wall-clock; the caller's checkpoint
+    // writes wiring.json atomically, and the next run folds it back in by body_hash.
+    if (opts.checkpoint && Date.now() - lastCheckpoint >= flushEvery) {
+      lastCheckpoint = Date.now();
+      opts.checkpoint();
+    }
   });
 
   return stats;

--- a/src/graph/write.ts
+++ b/src/graph/write.ts
@@ -8,7 +8,7 @@
  * timestamps, so rebuilding an unchanged repo produces a byte-identical file and
  * git diffs stay minimal.
  */
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync, renameSync } from "node:fs";
 import { dirname, join } from "node:path";
 import type { EdgeV1, GraphV1, NodeV1 } from "./types.js";
 
@@ -41,7 +41,13 @@ export function writeGraph(graph: GraphV1, outDir: string): string {
   };
   const path = wiringPath(outDir);
   mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, JSON.stringify(sorted, null, 2) + "\n");
+  // Atomic write (temp + rename): the crux pass now checkpoints wiring.json
+  // periodically (#128), and a --deep run is exactly what gets killed mid-flush
+  // (SIGTERM/CI timeout/laptop sleep). A partial writeFileSync would leave a
+  // truncated, unparseable graph; rename swaps it in atomically on the same fs.
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, JSON.stringify(sorted, null, 2) + "\n");
+  renameSync(tmp, path);
   return path;
 }
 

--- a/test/graph-enrich-checkpoint.test.ts
+++ b/test/graph-enrich-checkpoint.test.ts
@@ -1,0 +1,77 @@
+/**
+ * #128: the crux pass used to reach wiring.json only at build end, so an interrupted
+ * `--deep` run discarded every crux it had already computed and paid for. `enrichGraph`
+ * now flushes partial progress via a `checkpoint` callback, and (as it always has) folds
+ * a prior graph back in by `body_hash`. Together those mean a killed run keeps its crux
+ * and the next run replays it rather than re-issuing the LLM calls. These tests exercise
+ * that with a fake summarizer, no real model.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { enrichGraph } from "../src/graph/enrich.js";
+import type { CruxSummarizer, FileCruxInput, NodeCrux } from "../src/ai/crux.js";
+import type { NodeV1 } from "../src/graph/types.js";
+
+/** A CruxSummarizer that records which files it was asked to summarize (so a test can
+ * prove a file was, or was NOT, re-issued) and returns a trivial crux for each node. */
+class RecordingCrux implements CruxSummarizer {
+  calls: string[] = [];
+  async describeFile(input: FileCruxInput): Promise<NodeCrux[]> {
+    this.calls.push(input.path);
+    return input.nodes.map((n) => ({ id: n.id, summary: `crux ${n.id}`, crux_start: 0, crux_end: 0 }));
+  }
+}
+
+function methodNode(path: string, name: string, hash: string): NodeV1 {
+  return {
+    id: `${path}#${name}`, name, kind: "method", path, span: "L1-L3",
+    signature: `${name}()`, exported: true, origin: "ast", body_hash: hash,
+    summary_state: "pending", summary: null, crux: null,
+  };
+}
+
+const FILES = ["a.ts", "b.ts", "c.ts", "d.ts"];
+function fixture(): { nodes: NodeV1[]; sources: Map<string, string> } {
+  const nodes = FILES.map((f, i) => methodNode(f, "run", `h${i}`));
+  const sources = new Map(FILES.map((f) => [f, "class X {\n  run() { return 1; }\n}\n"]));
+  return { nodes, sources };
+}
+
+test("#128: the crux pass flushes partial progress mid-run (checkpoint), not only at the end", async () => {
+  const { nodes, sources } = fixture();
+  const prev = process.env.GRAFT_CRUX_CHECKPOINT_MS;
+  process.env.GRAFT_CRUX_CHECKPOINT_MS = "0"; // flush on every completed file
+  try {
+    const readyAtCheckpoint: number[] = [];
+    await enrichGraph(nodes, new Map(), sources, {
+      summarizer: new RecordingCrux(),
+      concurrency: 1, // deterministic completion order for the snapshot assertion
+      checkpoint: () => readyAtCheckpoint.push(nodes.filter((n) => n.summary_state === "ready").length),
+    });
+    // A checkpoint fired DURING the pass (before the build's final write), and the
+    // count of persisted-ready nodes climbed — i.e. an interruption would have kept them.
+    assert.ok(readyAtCheckpoint.length > 0, "checkpoint fired during the pass");
+    assert.ok(readyAtCheckpoint.some((n) => n > 0 && n < FILES.length), "partial progress was flushable");
+    assert.equal(nodes.filter((n) => n.summary_state === "ready").length, FILES.length, "all ended ready");
+  } finally {
+    if (prev === undefined) delete process.env.GRAFT_CRUX_CHECKPOINT_MS;
+    else process.env.GRAFT_CRUX_CHECKPOINT_MS = prev;
+  }
+});
+
+test("#128: a rerun replays checkpointed crux by body_hash instead of re-issuing it", async () => {
+  const { nodes, sources } = fixture();
+  // Simulate an interrupted run that checkpointed the first two files as ready.
+  const prior = new Map(
+    nodes.slice(0, 2).map((n) => [n.id, { ...n, summary: `crux ${n.id}`, crux: null, summary_state: "ready" as const }]),
+  );
+  // The next run starts from fresh (pending) nodes with the SAME body_hash.
+  const fresh = FILES.map((f, i) => methodNode(f, "run", `h${i}`));
+  const rec = new RecordingCrux();
+  const stats = await enrichGraph(fresh, prior, sources, { summarizer: rec });
+
+  assert.ok(!rec.calls.includes("a.ts") && !rec.calls.includes("b.ts"), "already-done files are NOT re-summarized");
+  assert.ok(rec.calls.includes("c.ts") && rec.calls.includes("d.ts"), "only the unfinished files run");
+  assert.equal(stats.cached, 2, "two crux carried over from the interrupted run");
+  assert.equal(stats.computed, 2, "two freshly computed");
+});

--- a/test/graph-refresh.test.ts
+++ b/test/graph-refresh.test.ts
@@ -181,11 +181,13 @@ test("a failed rebuild still answers from the graph on disk", async (t) => {
   writeFileSync(join(d, "src", "math.ts"), `${MATH}export const X = 1;\n`);
 
   // Make the graph write itself fail: the query must degrade to the old graph, not
-  // start erroring because a rebuild couldn't happen.
-  const graphFile = wiringPath(outOf(d));
-  chmodSync(graphFile, 0o400);
+  // start erroring because a rebuild couldn't happen. writeGraph is atomic (temp +
+  // rename), and a rename can replace a read-only FILE, so the unwritable target has
+  // to be the DIRECTORY — which is also the realistic "can't write here" case.
+  const graphDir = dirname(wiringPath(outOf(d)));
+  chmodSync(graphDir, 0o500); // r-x: the temp write fails, old wiring.json stays put
   const r = await ensureFreshGraph(d);
-  chmodSync(graphFile, 0o600);
+  chmodSync(graphDir, 0o700);
 
   assert.equal(r.refreshed, false);
   assert.match(r.note ?? "", /refresh skipped/);


### PR DESCRIPTION
Fixes #128.

## Problem
Per-file summaries checkpoint to the cache as they complete, but crux/meaning reached `wiring.json` only at build **end** (one `writeGraph`). A `--deep` run killed partway (SIGTERM / CI timeout / laptop sleep — realistically 1-3h on a large repo) discarded **every crux it had already computed and paid for**, and the next run re-issued all of them. Observed by @Rajahn: an 884-file run killed at ~606/879 lost the entire crux pass.

## Fix
Reuses the existing mechanism where `wiring.json` *is* the Tier-2 crux cache (folded back in on the next build, keyed by `body_hash`):
- **enrich.ts** — the crux pass calls an optional `checkpoint` from its per-file completion handler, throttled to ~15s (seam `GRAFT_CRUX_CHECKPOINT_MS`).
- **build.ts** — assemble the graph *before* the meaning pass and pass `checkpoint: () => writeGraph(graph, outDir)`. crux/summary mutate nodes in place and never change the node/edge set, so `meta` stays valid; the opt-in LSP pass still runs before the final write.
- **write.ts** — `writeGraph` is now **atomic** (temp + `rename`). A periodic flush is exactly what gets killed mid-write, and a partial `writeFileSync` would leave a truncated, unparseable graph.

Net: an interrupted `--deep` run keeps its crux; the next run replays it by `body_hash` instead of repaying it.

## Tests
**688 pass** (+2, via a fake summarizer, no real model): partial crux is flushed mid-pass (checkpoint), and a rerun replays the completed files instead of re-issuing them. Real-repo build sanity-checked (valid graph, no `.tmp` leak). `graph-refresh`'s read-only-graph case updated: an atomic rename can replace a read-only *file*, so the unwritable target is now the *directory* (the realistic case, and the atomicity is worth it).

This is the durability gap #111 does not cover; #127/#129 (retry/backoff, content-fallback parsing) are addressed there.