### PR TITLE
test: pin Node 24 WASM compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,24 @@ jobs:
 
       - name: Test
         run: npm test
+
+  node24-wasm:
+    name: Node 24 WASM regression
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Exercise every breadth grammar
+        run: node --import tsx --test test/generic-node24.test.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Fixed
 
+- **Node 24 no longer aborts breadth-tier builds with `Fatal process out of
+  memory: Zone`.** The broader `tree-sitter-wasm` grammar bundle avoids the V8
+  Turboshaft failure triggered by the previous bundle. CI now exercises every
+  breadth grammar under Node 24 to keep that runtime compatibility pinned
+  ([#122]).
 - **`npm install -g @nanonets/graft@latest` could silently do nothing.** The
   generated shims (`.claude/helpers/graft-*.cjs`, and Codex's
   `~/.codex/hooks/graft/`) locate the installed package at runtime from four

--- a/test/generic-node24-probe.ts
+++ b/test/generic-node24-probe.ts
@@ -1,0 +1,11 @@
+import { extractGeneric, GENERIC_LANGS, warmGenericGrammars } from "../src/graph/generic.js";
+
+const languages = GENERIC_LANGS.map((lang) => lang.name);
+const source = "pub fn run() -> usize { helper() }\nfn helper() -> usize { 1 }\n";
+
+await warmGenericGrammars(languages);
+for (let iteration = 0; iteration < 64; iteration++) {
+  for (const language of languages) {
+    extractGeneric(`src/probe-${iteration}.${language}`, source, language);
+  }
+}

--- a/test/generic-node24.test.ts
+++ b/test/generic-node24.test.ts
@@ -1,0 +1,22 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+test(
+  "Node 24 can exercise every breadth grammar without a V8 Zone OOM",
+  { skip: Number(process.versions.node.split(".")[0]) < 24 ? "V8 Turboshaft regression starts in Node 24" : false },
+  () => {
+    const probe = join(dirname(fileURLToPath(import.meta.url)), "generic-node24-probe.ts");
+    const run = spawnSync(process.execPath, ["--import", "tsx", probe], {
+      encoding: "utf8",
+      timeout: 60_000,
+    });
+    assert.equal(
+      run.status,
+      0,
+      `breadth grammar probe failed${run.signal ? ` with ${run.signal}` : ""}:\n${run.stdout}\n${run.stderr}`,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

- add an isolated Node 24 regression probe that warms and exercises every breadth-tier WASM grammar
- add a focused Node 24 CI job without duplicating the full OS test matrix
- document that the `tree-sitter-wasm` bundle now avoids the V8 Turboshaft `Zone` OOM

## Context

The published 0.10.1 grammar bundle aborts under Node 24 with `Fatal process out of memory: Zone`; `--max-old-space-size` cannot help because the failure is in V8's WASM optimizing compiler. The broader `tree-sitter-wasm` bundle already merged on `main` makes the minimized workload and a full 459-file cold build pass. This PR pins that runtime behavior so a dependency change cannot silently reintroduce the crash.

The probe runs in a child process because this failure aborts V8 rather than throwing a catchable JavaScript exception.

## Verification

- `node --import tsx --test test/generic-node24.test.ts` — 1 passed on Node 24.19.0
- `npm run build` — passed
- `npm test` — 687 passed
- full cold build of the original Rust/Swift/TypeScript repro — 459/459 files parsed

Fixes #122