### PR TITLE
Resumable --deep builds (+ crux coverage fix, resizable viz panel)

### DIFF
--- a/src/ai/crux.ts
+++ b/src/ai/crux.ts
@@ -45,13 +45,13 @@ export interface CruxSummarizer {
 
 const SYSTEM_PROMPT = `You explain code definitions for a code graph that helps engineers navigate a codebase.
 
-You are given ONE source file with 1-based line numbers, and a list of TARGET definitions in it. For every target, record its purpose and the line range of its core logic via the record_symbols tool.
+You are given ONE source file with 1-based line numbers, and a list of TARGET definitions in it. Describe EVERY target via the record_symbols tool.
 
 Rules:
-- Emit exactly one entry per target id given, using that id verbatim.
-- summary: ONE sentence — what the symbol is FOR at the business-logic level. Say what problem it solves or rule it enforces, not what its signature already says.
-- crux_start / crux_end: FILE line numbers (as shown), inside that symbol's own line range. Pick the SINGLE most important contiguous span — the core branch, formula, guard, or state change. Keep it TIGHT: at most ~8 lines, and NEVER the whole function. If you can't narrow it below that, the symbol has no distinct crux — use 0/0.
-- Skip boilerplate, logging, and plumbing. If a symbol has no meaningful crux (trivial getter, data holder, one-line delegation, or logic spread evenly with no focal point), use "crux_start": 0 and "crux_end": 0.`;
+- Return EXACTLY ONE entry for EVERY target id, using that id verbatim. The number of entries you return MUST equal the number of targets. Never omit a target: a reply missing any id is invalid and will be re-requested.
+- A trivial symbol is NOT an exception. You still return it — with a one-sentence summary and crux 0/0 (see below). "Skip" means "give it no crux span", NEVER "leave it out".
+- summary: ONE sentence — what the symbol is FOR at the business-logic level (the problem it solves or the rule it enforces), not a restatement of its signature.
+- crux_start / crux_end: FILE line numbers (as shown), inside that symbol's own line range. Pick the SINGLE most important contiguous span — the core branch, formula, guard, or state change — at most ~8 lines, and NEVER the whole function. When there is no single focal span (a trivial getter, a plain data holder, a one-line delegation, or logic spread evenly), use crux_start: 0 and crux_end: 0. That 0/0 IS the answer — do not drop the entry.`;
 
 const RECORD_TOOL = "record_symbols";
 
@@ -95,7 +95,8 @@ function userContent(input: FileCruxInput): string {
         (n.signature ? ` | ${n.signature}` : ""),
     )
     .join("\n");
-  return `FILE: ${input.path}\n\n${numberLines(input.source)}\n\nTARGETS:\n${targets}`;
+  const n = input.nodes.length;
+  return `FILE: ${input.path}\n\n${numberLines(input.source)}\n\nTARGETS (${n} — return all ${n}, one entry per id):\n${targets}`;
 }
 
 /** Normalize the tool's parsed argument object into a {@link NodeCrux} list. */

--- a/src/context/build.ts
+++ b/src/context/build.ts
@@ -11,7 +11,7 @@
  *      source files so staleness stays exact.
  *   5. Write one markdown file per node (preserving human notes) + a manifest.
  */
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { readFileSync, writeFileSync, renameSync, mkdirSync, existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { walkDir } from "../ingest/fs.js";
 import { contentHash } from "../util/id.js";
@@ -63,6 +63,8 @@ export interface BuildOptions {
   model: string;
   summarizer: Summarizer;
   synthesizer: Synthesizer;
+  /** Files summarized in parallel during phase 1. Default 8. Raised via `graft build -j`. */
+  concurrency?: number;
   onProgress?: (info: BuildProgress) => void;
 }
 
@@ -112,6 +114,18 @@ export async function buildContext(dir: string, opts: BuildOptions): Promise<Bui
     .filter((f) => !f.startsWith(outDir));
 
   const cache = loadCache(outDir);
+  // Flush the summary cache to disk during phase 1 so a build interrupted
+  // partway (session/rate limit, crash, Ctrl-C) resumes without re-summarizing
+  // the files it already did. Throttled to keep disk churn negligible; on the
+  // next run every already-summarized file is a content-hash cache hit ($0).
+  let lastFlush = Date.now();
+  const flushEveryMs = summaryCheckpointMs();
+  const maybeFlush = (): void => {
+    const now = Date.now();
+    if (now - lastFlush < flushEveryMs) return;
+    lastFlush = now;
+    saveCache(outDir, cache);
+  };
   const result: BuildResult = {
     contextDir: outDir,
     files: 0,
@@ -124,7 +138,7 @@ export async function buildContext(dir: string, opts: BuildOptions): Promise<Bui
   };
 
   // Phase 1: summarize each file, concurrent, content-hash cached.
-  const work = await mapWithConcurrency(files, 8, async (file, i): Promise<FileWork | undefined> => {
+  const work = await mapWithConcurrency(files, Math.max(1, opts.concurrency ?? 8), async (file, i): Promise<FileWork | undefined> => {
     const rel = relPosix(root, file);
     opts.onProgress?.({ phase: "summarize", index: i, total: files.length, file: rel });
     let code: string;
@@ -146,12 +160,17 @@ export async function buildContext(dir: string, opts: BuildOptions): Promise<Bui
       const summary = await opts.summarizer.summarize(code, { path: rel });
       cache.summaries[rel] = { hash, summary };
       result.summarized++;
+      maybeFlush();
       return { rel, hash, summary };
     } catch (err) {
       result.errors.push(`${rel}: ${errMsg(err)}`);
       return { rel, hash }; // covered (counts against staleness) but not summarized
     }
   });
+
+  // Phase 1 done: persist every summary before the (also LLM-backed) synthesis
+  // phase, so an interruption there never discards phase-1 work.
+  saveCache(outDir, cache);
 
   const processed = work.filter((w): w is FileWork => w !== undefined);
   result.files = processed.length;
@@ -336,7 +355,17 @@ function loadCache(outDir: string): BuildCache {
 function saveCache(outDir: string, cache: BuildCache): void {
   const path = cachePath(outDir);
   mkdirSync(join(outDir, CACHE_DIR), { recursive: true });
-  writeFileSync(path, JSON.stringify(cache, null, 2));
+  // Atomic: a kill mid-write can't leave a truncated (unparseable) cache that
+  // would throw away every prior summary on the next load.
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, JSON.stringify(cache, null, 2));
+  renameSync(tmp, path);
+}
+
+/** Min interval between phase-1 cache flushes. Env seam for tests. */
+function summaryCheckpointMs(): number {
+  const raw = Number(process.env.GRAFT_SUMMARY_CHECKPOINT_MS);
+  return Number.isFinite(raw) && raw >= 0 ? raw : 15_000;
 }
 
 /** Run `fn` over `items` with at most `limit` in flight, preserving order. */

--- a/test/context-checkpoint.test.ts
+++ b/test/context-checkpoint.test.ts
@@ -1,0 +1,96 @@
+/**
+ * The concept phase must be resumable across runs: a build interrupted partway
+ * (session/rate limit, crash) has to pick up where it left off, not re-summarize
+ * files it already did. That rests on the phase-1 summary cache being flushed to
+ * disk *during* the pass, not only at the end.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { buildContext } from "../src/context/build.js";
+import { BracketSynthesizer, PassthroughSummarizer } from "./helpers.js";
+import type { Summarizer } from "../src/ai/summarize.js";
+
+const rmDir = (dir: string): void => rmSync(dir, { recursive: true, force: true });
+
+const cachePath = (dir: string): string => join(dir, "graft", ".cache", "summaries.json");
+
+function fixture(n: number): string {
+  const dir = mkdtempSync(join(tmpdir(), "ctxflush-"));
+  for (let i = 0; i < n; i++) {
+    writeFileSync(join(dir, `f${i}.ts`), `// [[Node ${i}]]\nexport const v${i} = ${i};\n`);
+  }
+  return dir;
+}
+
+function diskSummaryCount(dir: string): number {
+  const p = cachePath(dir);
+  if (!existsSync(p)) return 0;
+  const parsed = JSON.parse(readFileSync(p, "utf8")) as { summaries?: Record<string, unknown> };
+  return Object.keys(parsed.summaries ?? {}).length;
+}
+
+test("phase-1 summaries flush to disk mid-run, so an interrupted build resumes", async () => {
+  const dir = fixture(4);
+  const prev = process.env.GRAFT_SUMMARY_CHECKPOINT_MS;
+  process.env.GRAFT_SUMMARY_CHECKPOINT_MS = "0"; // flush after every file
+  let calls = 0;
+  let diskAtThird = -1;
+  const summarizer: Summarizer = {
+    async summarize(code: string): Promise<string> {
+      calls++;
+      // By the time the 3rd file is being summarized (concurrency 1, in order),
+      // the first two must already be persisted — that is what makes a kill here
+      // survivable.
+      if (calls === 3) diskAtThird = diskSummaryCount(dir);
+      return code;
+    },
+  };
+  try {
+    await buildContext(dir, {
+      model: "fake",
+      summarizer,
+      synthesizer: new BracketSynthesizer(),
+      concurrency: 1,
+    });
+    assert.equal(calls, 4);
+    assert.ok(diskAtThird >= 2, `expected ≥2 summaries flushed before the 3rd file, saw ${diskAtThird}`);
+  } finally {
+    if (prev === undefined) delete process.env.GRAFT_SUMMARY_CHECKPOINT_MS;
+    else process.env.GRAFT_SUMMARY_CHECKPOINT_MS = prev;
+    rmDir(dir);
+  }
+});
+
+test("a rerun re-summarizes nothing — resume is $0 for unchanged files", async () => {
+  const dir = fixture(4);
+  try {
+    const first = await buildContext(dir, {
+      model: "fake",
+      summarizer: new PassthroughSummarizer(),
+      synthesizer: new BracketSynthesizer(),
+    });
+    assert.equal(first.summarized, 4);
+    assert.equal(first.cached, 0);
+
+    let called = false;
+    const summarizer: Summarizer = {
+      async summarize(code: string): Promise<string> {
+        called = true;
+        return code;
+      },
+    };
+    const second = await buildContext(dir, {
+      model: "fake",
+      summarizer,
+      synthesizer: new BracketSynthesizer(),
+    });
+    assert.equal(called, false, "no file should be re-summarized on an unchanged rerun");
+    assert.equal(second.summarized, 0);
+    assert.equal(second.cached, 4);
+  } finally {
+    rmDir(dir);
+  }
+});

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -40,6 +40,7 @@
   <div class="outline" id="outlineView" hidden>
     <div class="tree" id="tree"></div>
   </div>
+  <div class="resizer" id="detailResizer" role="separator" aria-orientation="vertical" aria-label="Resize details panel" tabindex="0" title="Drag to resize"></div>
   <aside class="detail" id="detail"><div class="empty">Select a node to view details</div></aside>
 </main>
 

--- a/viewer/main.ts
+++ b/viewer/main.ts
@@ -212,6 +212,53 @@ $("themeBtn").addEventListener("click", () => {
   showDetail(view.selected);
 });
 
+/* ---------- resizable detail panel ---------- */
+const DETAIL_W_KEY = "graft-viz-detail-w";
+const MIN_DETAIL = 220;
+const rootEl = document.documentElement;
+const clampDetail = (px: number): number =>
+  Math.min(Math.max(MIN_DETAIL, Math.round(window.innerWidth * 0.6)), Math.max(MIN_DETAIL, Math.round(px)));
+function setDetailWidth(px: number, persist = true): void {
+  const w = clampDetail(px);
+  rootEl.style.setProperty("--detail-w", `${w}px`);
+  if (persist) localStorage.setItem(DETAIL_W_KEY, String(w));
+}
+const savedDetailW = Number(localStorage.getItem(DETAIL_W_KEY));
+if (Number.isFinite(savedDetailW) && savedDetailW >= MIN_DETAIL) setDetailWidth(savedDetailW, false);
+
+const resizer = $("detailResizer");
+let draggingDetail = false;
+resizer.addEventListener("pointerdown", (ev) => {
+  const pe = ev as PointerEvent;
+  draggingDetail = true;
+  resizer.setPointerCapture(pe.pointerId);
+  document.body.style.cursor = "col-resize";
+  ev.preventDefault();
+});
+resizer.addEventListener("pointermove", (ev) => {
+  if (!draggingDetail) return;
+  // panel is flush to the window's right edge: width = distance from cursor to that edge.
+  setDetailWidth(window.innerWidth - (ev as PointerEvent).clientX);
+});
+const endDetailDrag = (ev: Event): void => {
+  if (!draggingDetail) return;
+  draggingDetail = false;
+  document.body.style.cursor = "";
+  try { resizer.releasePointerCapture((ev as PointerEvent).pointerId); } catch { /* not captured */ }
+  view.reheat();
+};
+resizer.addEventListener("pointerup", endDetailDrag);
+resizer.addEventListener("pointercancel", endDetailDrag);
+resizer.addEventListener("keydown", (ev) => {
+  const ke = ev as KeyboardEvent;
+  if (ke.key !== "ArrowLeft" && ke.key !== "ArrowRight") return;
+  const step = ke.shiftKey ? 40 : 16;
+  const cur = $("detail").getBoundingClientRect().width;
+  setDetailWidth(cur + (ke.key === "ArrowLeft" ? step : -step));
+  view.reheat();
+  ev.preventDefault();
+});
+
 /* ---------- data loading + live reload ---------- */
 async function loadAll(): Promise<void> {
   const [context, code] = await Promise.all([loadContextGraph(), loadCodeGraph()]);

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -83,7 +83,11 @@ svg.graph:active{cursor:grabbing}
 .zoomctl{position:absolute;right:14px;bottom:14px;display:flex;flex-direction:column;gap:6px}
 .zoomctl .iconbtn{background:var(--panel)}
 
-.detail{width:300px;flex:none;border-left:1px solid var(--border);background:var(--panel);overflow-y:auto;padding:18px 18px 24px}
+.resizer{flex:none;width:9px;margin:0 -4px;z-index:6;cursor:col-resize;position:relative;touch-action:none}
+.resizer::before{content:"";position:absolute;top:0;bottom:0;left:4px;width:1px;background:var(--border)}
+.resizer:hover::before,.resizer:focus-visible::before{left:3px;width:3px;background:var(--accent)}
+.resizer:focus-visible{outline:none}
+.detail{width:var(--detail-w,300px);flex:none;border-left:1px solid var(--border);background:var(--panel);overflow-y:auto;padding:18px 18px 24px}
 .detail .empty{color:var(--muted);font-size:13.5px;text-align:center;margin-top:200px}
 .d-type{display:inline-flex;align-items:center;gap:6px;font-size:11px;letter-spacing:.1em;text-transform:uppercase;font-weight:700;padding:3px 10px;border-radius:20px;background:var(--chip)}
 .d-type .sw{width:8px;height:8px;border-radius:50%}
@@ -116,4 +120,4 @@ svg.graph:active{cursor:grabbing}
 .emptytab code{background:var(--chip);padding:2px 8px;border-radius:6px;font-family:ui-monospace,"SF Mono",Menlo,Consolas,monospace;font-size:.9em}
 
 @media (prefers-reduced-motion:reduce){ .tree-row .chev{transition:none} }
-@media (max-width:760px){ .detail{display:none} .searchbox input{width:120px} .counts{display:none} }
+@media (max-width:760px){ .detail,.resizer{display:none} .searchbox input{width:120px} .counts{display:none} }


### PR DESCRIPTION
Three independent changes; each is its own commit.

## 1. Resumable `--deep` concept phase (the main one)
The concept phase held every file summary in memory and flushed the cache **once, at the very end**. A build interrupted partway — a session/rate limit, a crash, Ctrl-C — lost everything and the next run restarted from zero. On a large repo (thousands of files) that made `--deep` effectively impossible to finish within one session's usage window.

The cache is already keyed by `path + content hash`, and a matching hash is already an instant skip. The only missing piece was flushing it *during* the pass:

- Throttled flush during phase 1 (`GRAFT_SUMMARY_CHECKPOINT_MS`, default 15s), plus one guaranteed flush after phase 1 so an interruption during synthesis can't lose work.
- `saveCache` is now **atomic** (temp + rename) — a kill mid-write can't truncate the cache and throw away every prior summary.

Result: re-run the same `graft build --deep` next session and every already-summarized file is a **$0 cache hit**; the build resumes where it stopped. Because the key is content-hashed, later edits only re-summarize the files that changed.

New `test/context-checkpoint.test.ts`: one case proves summaries reach disk mid-run, one proves a rerun re-summarizes nothing.

## 2. Crux coverage fix for smaller models
The prompt said "skip boilerplate/logging/plumbing", which smaller models read literally as *omit those entries*, leaving symbols un-summarized. Reworded to an unambiguous contract: one entry per target id; "skip" means crux `0/0` (no focal span), never leaving the entry out.

## 3. Resizable viz detail panel
Draggable divider between the graph and the detail panel; keyboard (←/→, Shift for bigger steps); clamped 220px .. 60% width; persisted to localStorage; graph re-centers on release.

## Testing
Full suite green: **688 passing**, plus the 2 new checkpoint cases. Viewer bundle rebuilt and verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)