### PR TITLE
fix(generic): surface a throwing grammar as a build error instead of swallowing it

### DIFF
--- a/src/graph/generic.ts
+++ b/src/graph/generic.ts
@@ -85,7 +85,7 @@ const KIND: Record<string, Kind> = {
 
 // Loaded grammars + compiled tags queries, keyed by graft lang name. Populated by
 // warmGenericGrammars; read synchronously by extractGeneric.
-interface Loaded { language: unknown; query: unknown | null }
+export interface Loaded { language: unknown; query: unknown | null }
 const loaded = new Map<string, Loaded>();
 let tsMod: typeof import("web-tree-sitter") | null = null;
 let initPromise: Promise<void> | null = null;
@@ -153,6 +153,18 @@ export function isWarm(langName: string): boolean {
   return loaded.has(langName);
 }
 
+/** Test seam: swap in (or, with null, remove) a grammar entry, returning the
+ * previous one so the caller can restore it. The parse-failure path in
+ * extractGeneric needs a grammar that throws deterministically; the real crash
+ * that motivated it (tree-sitter-wasm PHP on heredocs, #139) is heap-state
+ * dependent, so tests inject a fake here instead of depending on it. */
+export function swapGrammarForTest(name: string, entry: Loaded | null): Loaded | null {
+  const prev = loaded.get(name) ?? null;
+  if (entry) loaded.set(name, entry);
+  else loaded.delete(name);
+  return prev;
+}
+
 /** Load one grammar from the tree-sitter-wasms bundle, initialising
  * web-tree-sitter on first call. Null when the wasm is missing or won't
  * instantiate — never throws, so a caller degrades instead of failing the build.
@@ -218,8 +230,13 @@ export function extractGeneric(rel: string, source: string, langName: string): E
     const parser = new tsMod.Parser();
     parser.setLanguage(entry.language as never);
     tree = parser.parse((i: number) => source.slice(i, i + PARSE_CHUNK));
-  } catch {
-    return { nodes, rawEdges };
+  } catch (err) {
+    // A grammar that throws (e.g. a WASM "memory access out of bounds" from an
+    // external scanner) is not a per-file syntax problem: swallowing it here left
+    // the file with only its file node and the build reporting success. Rethrow so
+    // build.ts records it in `errors`, the CLI prints it, and the extract cache
+    // remembers the failure instead of caching an empty result as clean.
+    throw new Error(`${langName} grammar threw: ${err instanceof Error ? err.message : String(err)}`);
   }
   if (!tree) return { nodes, rawEdges };
 

--- a/test/generic-extract.test.ts
+++ b/test/generic-extract.test.ts
@@ -16,6 +16,7 @@ import {
   isWarm,
   loadWasmLanguage,
   parseWasm,
+  swapGrammarForTest,
   type TsNode,
 } from "../src/graph/generic.js";
 import { resolveEdges } from "../src/graph/resolve.js";
@@ -411,4 +412,62 @@ test("PHP wasm grammar extracts class + methods from a heredoc file (#139)", asy
 
 test("PHP wasm grammar extracts class + methods from a nowdoc file (#139)", async () => {
   await assertPhpWasmExtractsClassAndMethods(PHP_NOWDOC, "WithNowdoc", "nowdoc");
+});
+
+/**
+ * A grammar whose parse throws (the tree-sitter-wasm PHP grammar did, on
+ * heredocs — #139) must surface as a per-file build error, not be swallowed
+ * into a silently symbol-less file that the extract cache then replays as a
+ * clean parse. The real crash is heap-state dependent, so a deterministically
+ * throwing fake grammar is swapped in via the test seam instead.
+ */
+const THROWING_GRAMMAR = {
+  // web-tree-sitter's setLanguage() inspects the language object, so any
+  // property access blowing up makes extractGeneric's try block throw exactly
+  // like a crashing wasm scanner does.
+  language: new Proxy({}, { get(): never { throw new Error("memory access out of bounds (fake)"); } }),
+  query: null,
+};
+
+test("extractGeneric rethrows a throwing grammar with the language named (#139)", async () => {
+  await warmGenericGrammars(["rust"]); // initialises web-tree-sitter
+  const prev = swapGrammarForTest("rust", THROWING_GRAMMAR);
+  try {
+    assert.throws(
+      () => extractGeneric("src/lib.rs", "pub fn f() {}\n", "rust"),
+      (err: unknown): boolean => {
+        assert.ok(err instanceof Error, "throws an Error");
+        assert.match(err.message, /^rust grammar threw: /, "names the language");
+        assert.match(err.message, /memory access out of bounds/, "keeps the original message");
+        return true;
+      },
+    );
+  } finally {
+    swapGrammarForTest("rust", prev);
+  }
+});
+
+test("a throwing grammar is a per-file build error, cached as a failure (#139)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-throwing-grammar-"));
+  writeFileSync(join(dir, "lib.rs"), "pub fn f() {}\n");
+  await warmGenericGrammars(["rust"]); // so buildGraph's own warm call is a no-op
+  const prev = swapGrammarForTest("rust", THROWING_GRAMMAR);
+  try {
+    const first = await buildGraph(dir, { reuse: false });
+    assert.equal(first.errors.length, 1, `one build error (got: ${first.errors.join("; ")})`);
+    assert.match(first.errors[0], /lib\.rs: parse failed/);
+    assert.match(first.errors[0], /rust grammar threw: memory access out of bounds/);
+    const g = readGraph(wiringPath(contextDirFor(dir)));
+    assert.ok(g, "graph built");
+    assert.ok(!g!.nodes.some((n) => n.path === "lib.rs"), "failed file has no file node");
+
+    // The extract cache must remember the failure, not an empty success: an
+    // incremental rebuild of the unchanged file replays the error.
+    const second = await buildGraph(dir, { reuse: true });
+    assert.equal(second.parsed, 0, "unchanged file is not re-parsed");
+    assert.equal(second.errors.length, 1, `error replayed (got: ${second.errors.join("; ")})`);
+    assert.match(second.errors[0], /rust grammar threw/);
+  } finally {
+    swapGrammarForTest("rust", prev);
+  }
 });


### PR DESCRIPTION
Refs #139.

## Problem
`extractGeneric` catches any exception thrown by `parser.parse` and returns `{ nodes, rawEdges }` containing only the file node. When a grammar actually throws, the file silently loses every symbol, `build` still reports it as parsed, and the extract cache stores the empty result as a successful parse and replays it on every incremental build until the file changes.

The concrete trigger was the tree-sitter-wasm 1.1.4 PHP grammar crashing on heredocs; PHP has since moved to the depth tier (#157), so this now stands as general hardening for any breadth grammar.

## Fix
Rethrow the exception with the language name in the message. Everything downstream already exists: `build.ts` records per-file failures in `errors`, the CLI prints them, and the cache stores an `error` entry for them. A file whose grammar throws now prints an error line, counts as a build error, and no longer gets a file node - the same behaviour depth-tier parse failures already have. `check.ts` wraps its own call to `extractGeneric`, so it is unaffected. A graph built before this change and checked after it will read as STALE for such files until it is rebuilt.

## Test
Reworked per review: the tests no longer depend on the real PHP crash (gone from the breadth tier since #157, and heap-state dependent anyway). A small test seam - `swapGrammarForTest` in `generic.ts`, returning the previous entry so tests restore it, in the same style as the existing seams in `load.ts` and `context/build.ts` - swaps a deterministically throwing fake grammar into the loaded-grammar map. Two tests, both red on main with only the seam applied:

- `extractGeneric` rethrows with the language named and the original message preserved
- through `buildGraph`, seeded under the real `rust` name so build's own warm call is a no-op: the file becomes a per-file entry in `errors`, gets no file node, and an incremental rebuild of the unchanged file replays the cached failure instead of a cached empty success

Suite: 917/917 on Node 24; 913 pass, 4 skipped, 0 fail on Node 20.
