### PR TITLE
fix(graph): index Dart top-level functions, consts, and call edges

### DIFF
--- a/src/graph/generic.ts
+++ b/src/graph/generic.ts
@@ -255,7 +255,7 @@ export function extractGeneric(rel: string, source: string, langName: string): E
   };
 
   if (entry.query) {
-    tagsExtract(entry.query, tree.rootNode as TsNode, rel, mkDef, defs, rawEdges);
+    tagsExtract(entry.query, tree.rootNode as TsNode, rel, mkDef, defs, rawEdges, langName);
   } else {
     walkExtract(tree.rootNode as TsNode, mkDef); // no tags.scm → symbols only
   }
@@ -366,6 +366,7 @@ function tagsExtract(
   mkDef: (name: string, kind: Kind, whole: TsNode) => void,
   defs: Def[],
   rawEdges: RawEdge[],
+  langName: string,
 ): void {
   const q = query as { matches(n: unknown): Array<{ captures: Array<{ name: string; node: TsNode }> }> };
   const matches = q.matches(root);
@@ -381,7 +382,7 @@ function tagsExtract(
     const defKey = Object.keys(cap).find((k) => k.startsWith("definition."));
     if (defKey && cap.name) {
       defNameAt.add(cap.name.startIndex);
-      mkDef(cap.name.text, KIND[defKey.slice("definition.".length)] ?? "function", defScope(cap[defKey]));
+      mkDef(cap.name.text, KIND[defKey.slice("definition.".length)] ?? "function", defScope(cap[defKey], langName));
     }
     if (("reference.call" in cap || "reference.send" in cap) && cap.name)
       calls.push({ name: cap.name.text, at: cap.name.startIndex });
@@ -488,8 +489,38 @@ export interface TsNode {
 // attributed to the function. Expand up to the outermost enclosing
 // declaration/definition node so a def's span covers its body.
 const DEF_CONTAINER = /(definition|declaration|specifier|_item)$/;
-function defScope(node: TsNode): TsNode {
+function nextNamedSibling(n: TsNode): TsNode | null {
+  const tagged = n as TsNode & { nextNamedSibling?: TsNode | null };
+  if ("nextNamedSibling" in tagged) return tagged.nextNamedSibling ?? null;
+  const p = n.parent;
+  if (!p?.namedChild) return null;
+  const count = p.namedChildCount ?? 0;
+  for (let i = 0; i < count - 1; i++) {
+    const c = p.namedChild(i);
+    if (c && c.startIndex === n.startIndex && c.endIndex === n.endIndex) return p.namedChild(i + 1);
+  }
+  return null;
+}
+function defScope(node: TsNode, langName?: string): TsNode {
   let n = node;
   while (n.parent && DEF_CONTAINER.test(n.parent.type)) n = n.parent;
+  // Dart's grammar leaves `function_signature` / `method_signature` as a sibling
+  // of `function_body` (no wrapping function_definition). Expand so a def's span
+  // covers its body and calls inside it attribute to the function, not the file
+  // or enclosing class. Gated on Dart so other breadth-tier languages are untouched.
+  if (langName === "dart") {
+    const body = nextNamedSibling(n);
+    if (body?.type === "function_body") {
+      return {
+        type: n.type,
+        text: n.text,
+        startIndex: n.startIndex,
+        endIndex: body.endIndex,
+        startPosition: n.startPosition,
+        endPosition: body.endPosition,
+        parent: n.parent,
+      };
+    }
+  }
   return n;
 }

--- a/src/graph/queries/dart.scm
+++ b/src/graph/queries/dart.scm
@@ -1,0 +1,42 @@
+; Dart — breadth-tier tags.scm
+;
+; The Dart grammar does not wrap a function's signature and body in one
+; definition node: `function_signature` / `method_signature` sit as siblings
+; of `function_body` under `program` / `class_body`. Graft's generic extractor
+; expands a captured signature to include a following `function_body` sibling
+; so calls inside the body are attributed to the function (see defScope).
+;
+; Without this query the node-kind walker fallback runs, which:
+;   - skips `function_signature` (type does not match the walker suffixes)
+;   - mints `class_body` as a class (type starts with "class") named after the
+;     first identifier in the body (`int`, `bool`, …)
+;   - mints function-body locals (`initialized_variable_definition`) as symbols
+;
+; Call sites are `identifier` + adjacent `selector`/`argument_part`, not a
+; `call_expression` node. Only that shape is tagged — assignment selectors and
+; bare identifier reads are left alone.
+
+; Top-level functions (direct children of program, not methods)
+(program
+  (function_signature
+    name: (identifier) @name) @definition.function)
+
+; Methods
+(method_signature
+  (function_signature
+    name: (identifier) @name)) @definition.method
+
+(class_definition
+  name: (identifier) @name) @definition.class
+
+; Top-level / static `const`/`final` (`const int kThreshold = 3`)
+(static_final_declaration
+  .
+  (identifier) @name) @definition.constant
+
+; identifier(args) — `isReady(count)`, `Counter.ready → isReady(value)`
+(
+  (identifier) @name
+  .
+  (selector
+    (argument_part))) @reference.call

--- a/test/generic-extract.test.ts
+++ b/test/generic-extract.test.ts
@@ -15,6 +15,7 @@ import { buildGraph } from "../src/graph/build.js";
 import { readGraph, wiringPath } from "../src/graph/write.js";
 import { checkGraph } from "../src/graph/check.js";
 import { contextDirFor } from "../src/context/node-file.js";
+import { skeleton } from "../src/ask/ask.js";
 
 const RUST = `pub struct Config {
     name: String,
@@ -289,4 +290,72 @@ test("buildGraph + checkGraph handle a breadth-tier (.rs) repo end-to-end", asyn
   // identically, so a fresh graph reads as in-sync, not perpetually stale.
   const chk = await checkGraph(dir);
   assert.equal(chk.ok, true, `check OK on a breadth-tier repo (added=${chk.added}, removed=${chk.removed})`);
+});
+
+// #134: Dart is a breadth-tier language with no vendored tags.scm, so the
+// node-kind walker minted class_body / locals and skipped top-level functions.
+// Issue fixture — top-level const + functions + a method that calls a top-level fn.
+const DART = `const int kThreshold = 3;
+
+bool isReady(int count) => count >= kThreshold;
+
+String describe(int count) {
+  final label = isReady(count) ? 'ready' : 'waiting';
+  return label;
+}
+
+class Counter {
+  int value = 0;
+
+  bool ready() => isReady(value);
+}
+`;
+
+test("genericLangOf routes .dart to the breadth tier", () => {
+  assert.equal(genericLangOf("lib/example.dart")?.name, "dart");
+});
+
+test("Dart top-level functions/consts become symbols; call edges resolve; body locals stay out (#134)", async () => {
+  await warmGenericGrammars(["dart"]);
+  assert.ok(isWarm("dart"), "dart grammar should warm");
+  const { nodes, rawEdges } = extractGeneric("lib/example.dart", DART, "dart");
+  const symbols = nodes.filter((n) => n.kind !== "file");
+  const byName = new Map(symbols.map((n) => [n.name, n]));
+
+  assert.equal(byName.get("isReady")?.kind, "function", "isReady is a top-level function");
+  assert.equal(byName.get("describe")?.kind, "function", "describe is a top-level function");
+  assert.equal(byName.get("kThreshold")?.kind, "constant", "kThreshold is a top-level const");
+  assert.equal(byName.get("Counter")?.kind, "class");
+  assert.equal(byName.get("ready")?.kind, "method", "Counter.ready is a method");
+
+  assert.ok(!symbols.some((n) => n.name === "label"), "function-body local `label` is not a symbol");
+  assert.ok(
+    !symbols.some((n) => n.kind === "class" && n.name === "int"),
+    `no bogus class int (got ${symbols.filter((n) => n.kind === "class").map((n) => n.name).join(", ")})`,
+  );
+
+  const edges = resolveEdges(nodes, rawEdges);
+  const calls = edges
+    .filter((e) => e.relation === "calls")
+    .map((e) => `${e.source.split("#")[1]}→${e.target.split("#")[1]}`);
+  assert.ok(calls.includes("describe→isReady"), `describe → isReady (got ${calls.join(", ")})`);
+  assert.ok(calls.includes("ready→isReady"), `Counter.ready → isReady (got ${calls.join(", ")})`);
+});
+
+test("Dart file-level skeleton lists the API, not function-body locals (#134)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-dart-"));
+  mkdirSync(join(dir, "lib"));
+  writeFileSync(join(dir, "lib", "example.dart"), DART);
+
+  await buildGraph(dir, { reuse: false });
+  const r = skeleton(dir, "lib/example.dart");
+  const names = r.entries.map((e) => e.name);
+  for (const want of ["isReady", "describe", "kThreshold", "Counter", "ready"]) {
+    assert.ok(names.includes(want), `skeleton includes ${want} (got ${names.join(", ")})`);
+  }
+  assert.ok(!names.includes("label"), "skeleton omits function-body local `label`");
+  assert.ok(
+    !r.entries.some((e) => e.kind === "class" && e.name === "int"),
+    "skeleton has no bogus class int",
+  );
 });


### PR DESCRIPTION
## Summary
- Dart is a breadth-tier language, but it had no `tags.scm`, so the node-kind walker skipped top-level `function_signature` nodes, minted `class_body` as `class int`, and listed function-body locals (`label`) as file-level API.
- Add a Dart tags query for top-level functions, methods, classes, `const`/`final`, and `identifier(args)` calls; expand signature spans over the sibling `function_body` so `describe → isReady` and `Counter.ready → isReady` resolve.
- Regression fixture from issue #134. Other breadth-tier languages are unchanged.

Fixes #134.

## Test plan
- [x] `node --import tsx --test test/generic-extract.test.ts test/graph-languages.test.ts` (20/20)
- [x] `npm run build`
- [x] `npm test` (716/716)
- [x] `graft build` on issue #134 repro: `graft callers isReady` finds `describe` + `Counter.ready`; `graft skeleton lib/example.dart` lists `kThreshold`, `isReady`, `describe`, `Counter.ready` (no body-local `label`); `graft grep "isReady"` finds all 3 occurrences