### PR TITLE
feat(build): opt out of .gitignore and .ignore writes (#148)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,10 @@
 # Where the graph lives (default: <repo>/.context)
 # GRAFT_DIR=.context
 
+# --- Build side effects (opt-out) ---------------------------------------------
+# GRAFT_NO_GITIGNORE=1  — skip writing graft/ into .gitignore (e.g. you already ignore it globally)
+# GRAFT_NO_IGNORE=1     — skip writing .ignore (ripgrep re-admit); only if you manage search yourself
+
 # --- Benchmark (bench/) -------------------------------------------------------
 # Per-role model overrides for the benchmark harness.
 # BENCH_AGENT_MODEL=anthropic/claude-sonnet-5

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -318,6 +318,8 @@ program
     (val: string, prev: string[]) => [...prev, val],
     [] as string[],
   )
+  .option("--no-gitignore", "skip writing graft/ into .gitignore (same as GRAFT_NO_GITIGNORE=1)")
+  .option("--no-ignore", "skip writing .ignore for ripgrep re-admit (same as GRAFT_NO_IGNORE=1)")
   .action(async (
     dir: string,
     opts: {
@@ -329,10 +331,14 @@ program
       allowPartial?: boolean;
       includeDir?: string[];
       followSubmodules?: boolean;
+      gitignore?: boolean;
+      ignore?: boolean;
     },
     command: Command,
   ) => {
     const buildStartedAt = Date.now();
+    if (opts.gitignore === false) process.env.GRAFT_NO_GITIGNORE = "1";
+    if (opts.ignore === false) process.env.GRAFT_NO_IGNORE = "1";
     const concurrency = opts.concurrency ? Math.max(1, Number(opts.concurrency)) : undefined;
     if (opts.concurrency && !Number.isFinite(concurrency)) {
       console.error(`✗ --concurrency must be a number, got "${opts.concurrency}"`);
@@ -472,7 +478,11 @@ program
     for (const e of g.errors) console.error(`✗ ${e}`);
 
     const rel = relative(process.cwd(), g.contextDir) || "graft";
-    console.log(`  ${rel}/ is git-ignored (added automatically) — a local cache; teammates run \`graft build\` to get their own.`);
+    if (process.env.GRAFT_NO_GITIGNORE) {
+      console.log(`  ${rel}/ is a local cache — add it to your gitignore if you want it untracked.`);
+    } else {
+      console.log(`  ${rel}/ is git-ignored (added automatically) — a local cache; teammates run \`graft build\` to get their own.`);
+    }
 
     // #127: a --deep run whose LLM calls failed used to print the same success
     // footer and exit 0, so a quota-exhausted build looked identical to a clean

--- a/src/context/node-file.ts
+++ b/src/context/node-file.ts
@@ -80,6 +80,12 @@ const MANIFEST_FILE = "manifest.json";
 /** Gitignored cache dir (per-file summaries + extractions), never committed. */
 export const CACHE_DIR = ".cache";
 
+/** Env kill switch — same truthy parsing as `GRAFT_NO_REFRESH` in ../graph/refresh.ts. */
+function envTruthy(name: string): boolean {
+  const v = process.env[name];
+  return v !== undefined && v !== "" && v !== "0" && v !== "false";
+}
+
 /** Turn a display name into a stable, filesystem- and link-safe slug. */
 export function slugify(name: string): string {
   const base = normalizeName(name)
@@ -115,6 +121,7 @@ export function contextDirFor(root: string, override?: string): string {
  * must never abort a build, so write failures are swallowed.
  */
 export function ensureGitignored(root: string, contextDir: string): void {
+  if (envTruthy("GRAFT_NO_GITIGNORE")) return;
   const rel = relPosix(root, contextDir);
   if (rel === "" || rel.startsWith("..")) return; // dir is at/above the repo root — nothing sane to ignore
   const bare = stripTrailingSlashes(rel); // "graft" (or a `--dir` subpath like "tools/ctx")
@@ -159,6 +166,7 @@ export function ensureGitignored(root: string, contextDir: string): void {
  * must not fail over a convenience file.
  */
 export function ensureSearchable(root: string, contextDir: string): void {
+  if (envTruthy("GRAFT_NO_IGNORE")) return;
   const rel = relPosix(root, contextDir);
   if (rel === "" || rel.startsWith("..")) return; // outside the repo — nothing to re-admit
   const dir = stripTrailingSlashes(rel);

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -376,6 +376,46 @@ test("ensureGitignored: no-op when the graph dir is outside the repo root", () =
   }
 });
 
+test("ensureGitignored: GRAFT_NO_GITIGNORE=1 skips writing .gitignore", () => {
+  const dir = mkdtempSync(join(tmpdir(), "ctxgi-"));
+  process.env.GRAFT_NO_GITIGNORE = "1";
+  try {
+    ensureGitignored(dir, contextDirFor(dir));
+    assert.equal(existsSync(join(dir, ".gitignore")), false);
+  } finally {
+    delete process.env.GRAFT_NO_GITIGNORE;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("ensureSearchable: GRAFT_NO_IGNORE=1 skips writing .ignore", () => {
+  const dir = mkdtempSync(join(tmpdir(), "ctxsearch-"));
+  process.env.GRAFT_NO_IGNORE = "1";
+  try {
+    ensureSearchable(dir, contextDirFor(dir));
+    assert.equal(existsSync(join(dir, ".ignore")), false);
+  } finally {
+    delete process.env.GRAFT_NO_IGNORE;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("graft build with GRAFT_NO_GITIGNORE and GRAFT_NO_IGNORE does not touch ignore files", () => {
+  const dir = mkdtempSync(join(tmpdir(), "ctxgi-build-"));
+  try {
+    writeFileSync(join(dir, "main.ts"), "export function main(): number {\n  return 1;\n}\n");
+    execFileSync(process.execPath, ["--import", "tsx", "src/cli.ts", "build", dir], {
+      stdio: "pipe",
+      env: { ...process.env, GRAFT_NO_GITIGNORE: "1", GRAFT_NO_IGNORE: "1" },
+    });
+    assert.equal(existsSync(join(dir, ".gitignore")), false);
+    assert.equal(existsSync(join(dir, ".ignore")), false);
+    assert.equal(existsSync(join(dir, "graft")), true, "build still writes the graph");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 // ensureSearchable — gitignoring the graph must not also hide it from `grep`.
 // ripgrep honours .gitignore, so without this the cards are unreachable by the
 // one mechanism they were designed around.


### PR DESCRIPTION
## Summary

- Add `GRAFT_NO_GITIGNORE=1` to skip writing `/graft/` into the repo's `.gitignore` during `graft build` (including hook-triggered builds that inherit env).
- Add `GRAFT_NO_IGNORE=1` to skip writing `.ignore` (the ripgrep re-admit file). Default behavior is unchanged; both are opt-in disable switches using the same truthy parsing as `GRAFT_NO_REFRESH`.
- Add matching CLI flags: `graft build --no-gitignore` and `graft build --no-ignore`.
- Document the env vars in `.env.example`.

Closes #148

## Notes

- If you disable `.ignore` writes, ripgrep will honor `.gitignore` and **won't search `graft/` cards** unless you manage search exclusions yourself (e.g. keep a hand-written `.ignore`, or use `rg -uu`).
- Global `core.excludesfile` detection is intentionally out of scope here — a good follow-up if users want automatic skip without env vars.

## Test plan

- [x] `npm run build && npm test` — all green
- [x] `node --import tsx --test test/context.test.ts` — new unit + CLI integration tests pass
- [x] Existing `ensureGitignored` / `ensureSearchable` tests unchanged (default path)


Made with [Cursor](https://cursor.com)