### PR TITLE
chore(graph): remove stale .php entry from GENERIC_LANGS (#142)

### DIFF
--- a/src/graph/generic.ts
+++ b/src/graph/generic.ts
@@ -46,7 +46,6 @@ export const GENERIC_LANGS: readonly GenericLang[] = [
   { name: "c", exts: [".c", ".h"], wasm: "c" },
   { name: "cpp", exts: [".cpp", ".cc", ".cxx", ".hpp", ".hh"], wasm: "cpp" },
   { name: "ruby", exts: [".rb"], wasm: "ruby" },
-  { name: "php", exts: [".php"], wasm: "php" },
   { name: "c_sharp", exts: [".cs"], wasm: "c_sharp" },
   // These ship a tags.scm (calls + symbols); ocaml/zig have none and use the
   // node-kind walker fallback (symbols only) — still one row, zero query.

--- a/test/generic-extract.test.ts
+++ b/test/generic-extract.test.ts
@@ -235,43 +235,6 @@ test("breadth tier: Rust use crate::… resolves to the in-repo module (longest-
   assert.deepEqual(fromTest.map((e) => e.target), ["crate::error::Error"], "test-binary crate:: never resolves into the lib");
 });
 
-// PHP `use App\Models\User` → a file→class-file import, resolved to the in-repo class by
-// the longest namespace-tail suffix (PSR-4 root is unknown). Groups expand; `use function`
-// is skipped; a vendor/unknown class or an ambiguous tail stays a string, never guessed.
-test("breadth tier: PHP use resolves to the class file (namespace-suffix, groups, drop-rather-than-guess)", async () => {
-  await warmGenericGrammars(["php"]);
-  const files: Record<string, string> = {
-    "src/Models/User.php": "<?php\nnamespace App\\Models;\nclass User {}\n",
-    "src/Http/Request.php": "<?php\nnamespace App\\Http;\nclass Request {}\n",
-    "src/Http/Response.php": "<?php\nnamespace App\\Http;\nclass Response {}\n",
-    "a/Dup.php": "<?php\nclass Dup {}\n",
-    "b/Dup.php": "<?php\nclass Dup {}\n",
-    "src/App.php":
-      "<?php\nnamespace App;\n" +
-      "use App\\Models\\User;\n" +              // → src/Models/User.php
-      "use App\\Http\\{Request, Response};\n" +  // group → both Http files
-      "use App\\Support\\Str as S;\n" +          // in-namespace but no file → string
-      "use function App\\helpers\\tap;\n" +      // function import → skipped, no edge
-      "use Psr\\Log\\LoggerInterface;\n" +       // external vendor → string
-      "use Whatever\\Dup;\n" +                   // ambiguous basename → drop
-      "class App {}\n",
-  };
-  const nodes = [], raw = [];
-  for (const [rel, src] of Object.entries(files)) {
-    const r = extractGeneric(rel, src, "php");
-    nodes.push(...r.nodes); raw.push(...r.rawEdges);
-  }
-  const imports = resolveEdges(nodes, raw).filter((e) => e.relation === "imports" && e.source === "src/App.php");
-  const targets = imports.map((e) => e.target).sort();
-
-  assert.ok(targets.includes("src/Models/User.php"), "use App\\Models\\User → Models/User.php");
-  assert.ok(targets.includes("src/Http/Request.php") && targets.includes("src/Http/Response.php"), "group expands to both");
-  assert.ok(targets.includes("App\\Support\\Str"), "in-namespace but fileless → kept as string");
-  assert.ok(targets.includes("Psr\\Log\\LoggerInterface"), "external vendor class → kept as string");
-  assert.ok(targets.includes("Whatever\\Dup"), "ambiguous basename → kept as string, never guessed");
-  assert.ok(!targets.some((t) => /tap|helpers/.test(t)), "use function … is skipped (symbol import, not a class file)");
-});
-
 test("buildGraph + checkGraph handle a breadth-tier (.rs) repo end-to-end", async () => {
   const dir = mkdtempSync(join(tmpdir(), "graft-rust-"));
   mkdirSync(join(dir, "src"), { recursive: true });

--- a/test/supported-extensions.test.ts
+++ b/test/supported-extensions.test.ts
@@ -16,9 +16,9 @@ import { supportedExtensions, unsupportedExtensions } from "../src/graph/source-
 test("supportedExtensions covers both tiers, sorted and de-duped", () => {
   const exts = supportedExtensions();
   // depth tier
-  for (const e of [".ts", ".tsx", ".py", ".go", ".java", ".js"]) assert.ok(exts.includes(e), `depth ${e}`);
+  for (const e of [".ts", ".tsx", ".py", ".go", ".java", ".js", ".php"]) assert.ok(exts.includes(e), `depth ${e}`);
   // breadth tier
-  for (const e of [".rs", ".rb", ".php", ".c", ".cpp", ".kt", ".swift"]) assert.ok(exts.includes(e), `breadth ${e}`);
+  for (const e of [".rs", ".rb", ".c", ".cpp", ".kt", ".swift"]) assert.ok(exts.includes(e), `breadth ${e}`);
   // container tier
   assert.ok(exts.includes(".vue"), "container .vue");
   // de-duped (.java is in BOTH tiers but must appear once) and sorted


### PR DESCRIPTION
## Summary
- Remove the `.php` row from `GENERIC_LANGS` in `src/graph/generic.ts`.
- PHP is already a depth/Tier-1 language (`EXTENSIONS` in `extract.ts`); `build.ts` routes depth before generic, so this entry was never used at runtime.
- Restores consistency with the registry comment: breadth extensions must not collide with depth extensions.

## Test plan
- [x] `npm run build`
- [x] `npm test`
- [x] `test/graph-php.test.ts` — PHP depth extraction unchanged
- [x] `test/supported-extensions.test.ts` — .php still indexed

Closes #142