### PR TITLE
feat: add Nix language support

### DIFF
--- a/src/graph/generic.ts
+++ b/src/graph/generic.ts
@@ -59,6 +59,7 @@ export const GENERIC_LANGS: readonly GenericLang[] = [
   { name: "zig", exts: [".zig"], wasm: "zig" },
   { name: "dart", exts: [".dart"], wasm: "dart" }, // surfaced by PR #38 (@muneebshere)
   { name: "clojure", exts: [".clj", ".cljs", ".cljc", ".bb"], wasm: "clojure" },
+  { name: "nix", exts: [".nix"], wasm: "nix" },
 ];
 
 const byExt = new Map<string, GenericLang>();

--- a/src/graph/queries/nix.scm
+++ b/src/graph/queries/nix.scm
@@ -1,0 +1,32 @@
+; Nix tags — standard tree-sitter tags convention (@definition.<kind> + @name + @reference.call).
+; Based on upstream tree-sitter-nix queries, extended for graft's breadth tier.
+;
+; Note: `binding` inside `let_expression` cannot have its children matched in
+; tree-sitter queries (parse error), so let-bound variables are NOT captured as
+; @definition. They are still searchable via the file node's residual body.
+
+; Function definitions: `name = args: body` or `name = body` (where body is a function)
+(binding
+  (attrpath (identifier) @name)
+  (function_expression) @definition.function)
+
+; Inherit statements: `inherit (source) name1 name2`
+(inherit
+  (inherited_attrs (identifier) @name @definition.constant))
+
+; Function calls: `function arg` or `function arg1 arg2` (nested apply_expression)
+; Matches e.g. `import ./path` when `import` is applied to arguments.
+(apply_expression
+  function: (apply_expression
+    function: (variable_expression
+      name: (identifier) @name))) @reference.call
+
+; Method/attribute calls: `builtins.map`, `pkgs.python3.withPackages`, etc.
+(apply_expression
+  function: (select_expression
+    attrpath: (attrpath attr: (identifier) @name))) @reference.call
+
+; Direct function application: `f arg`
+(apply_expression
+  function: (variable_expression
+    name: (identifier) @name)) @reference.call


### PR DESCRIPTION
## Summary
- Add Nix (`.nix`) to the breadth-tier generic extractor using the existing `tree-sitter-wasm` WASM grammar from [nix-community/tree-sitter-nix](https://github.com/nix-community/tree-sitter-nix)
- Register nix in `GENERIC_LANGS` with `.nix` extension mapping
- Add `nix.scm` tags query capturing function definitions, inherit statements, and function calls (import, builtins.*, etc.)

## Test results
Verified against a 15-file NixOS flake: **50 nodes** (24 function, 15 file, 11 constant), **5 edges**. All 713 existing tests pass.

## Limitation
Tree-sitter queries cannot match children of `binding` nodes inside `let_expression`, so let-bound variables are not captured as individual definitions. They remain searchable via file node residual bodies.