### PR TITLE
chore(deps): bump transitive js-yaml to 3.15.1 (GHSA-5p4m-2wfm-xmqj)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -730,9 +730,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",


### PR DESCRIPTION
Small dependency bump, surfaced while running a scan over `main`. Three lines of lockfile.

## What it clears

[GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) — High, CVSS 7.5, no CVE assigned.

The `!!omap` resolver enforces key uniqueness with a linear scan, making parse time quadratic in the number of ordered-map entries. Because `!!omap` is registered in the default schema, it applies to any plain `yaml.load()`. The original fix landed in 5.2.1 and was never backported, leaving both maintained legacy lines exposed:

| | affected | patched |
|---|---|---|
| 3.x | `>= 3.0.0, < 3.15.1` | **3.15.1** |
| 4.x | `>= 4.0.0, < 4.3.1` | 4.3.1 |

Reached via `gray-matter@4.0.3 > js-yaml@3.15.0`.

## Why it is only the lockfile

`gray-matter` declares `js-yaml: ^3.13.1`, so `3.15.1` already satisfies its range. No manifest change, no new dependency, no version pin — `npm update js-yaml --package-lock-only` and nothing else moves.

## Honest note on exposure

I would rather state this than let a High severity badge imply more than it should: `gray-matter` here parses the frontmatter of graft's **own generated cards** (`src/context/node-file.ts`, `src/graph/cards.ts`, `src/ask/ask.ts` all read from the `graft/` output directory). The YAML is written by graft, not supplied by a caller, so reaching the quadratic path means already having write access to the tree.

This is dependency hygiene rather than a live vulnerability. It seemed worth taking anyway since the fix is a patch release that costs nothing and keeps a clean scan for anyone who runs one against the package.

## Verification

```
snyk test    1 vulnerable path  ->  no vulnerable paths found
npm audit    1 high             ->  found 0 vulnerabilities
build        clean
suite        713 passing
```

---

Unrelated to the diff, but worth saying: thank you for building this. The Java work has been a genuine pleasure to contribute to, and the review on #104 — laying out both design decisions up front rather than letting me guess — is the most useful issue response I have had in a while.
