### PR TITLE
feat: add Hermes Agent host support

### DIFF
--- a/src/hosts/registry.ts
+++ b/src/hosts/registry.ts
@@ -63,6 +63,19 @@ export const HOSTS: HostTarget[] = [
     detect: (p) => p.dirExists(join(p.home, '.gemini')),
   },
   {
+    id: 'hermes',
+    name: 'Hermes Agent (Nous Research)',
+    kind: 'section',
+    relPath: 'AGENTS.md',
+    content: instructionBody,
+    // Hermes is repo-aware: it reads AGENTS.md at the repo root (and the
+    // Graft-for-Hermes plugin keeps the graph fresh on every session start).
+    detect: (p) =>
+      p.dirExists(join(p.home, '.hermes')) ||
+      p.dirExists(join(p.home, 'AppData', 'Local', 'hermes')) ||
+      p.dirExists(join(p.repo, '.hermes')),
+  },
+  {
     id: 'antigravity',
     name: 'Google Antigravity',
     kind: 'section',

--- a/test/hosts-init.test.ts
+++ b/test/hosts-init.test.ts
@@ -34,7 +34,7 @@ test('explicit agents list overrides detection and flags unknown ids', () => {
 test('all writes every host and re-run converges (idempotent)', () => {
   const home = fresh(); const repo = fresh();
   const first = runHostsInit(repo, { home, all: true });
-  assert.equal(first.written.length, 8);
+  assert.equal(first.written.length, 9);
   const second = runHostsInit(repo, { home, all: true });
   assert.ok(second.written.every((w) => w.action === 'unchanged'));
   // `agents` and `antigravity` share AGENTS.md, but the fenced section is written once

--- a/test/hosts-registry.test.ts
+++ b/test/hosts-registry.test.ts
@@ -15,7 +15,7 @@ function probeFor(home: string, repo: string): DetectProbe {
 function fresh(): string { return mkdtempSync(join(tmpdir(), 'graft-registry-')); }
 
 test('registry exposes the known hosts', () => {
-  assert.deepEqual(hostIds().sort(), ['adal', 'agents', 'antigravity', 'copilot', 'cursor', 'gemini', 'kiro', 'windsurf']);
+  assert.deepEqual(hostIds().sort(), ['adal', 'agents', 'antigravity', 'copilot', 'cursor', 'gemini', 'hermes', 'kiro', 'windsurf']);
   for (const h of HOSTS) {
     assert.ok(h.relPath.length > 0);
     assert.ok(h.content().length > 0);
@@ -55,4 +55,12 @@ test('repo-local .adal also lights up the adal host', () => {
   mkdirSync(join(repo, '.adal'));
   const ids = detectHosts(probeFor(home, repo)).map((h) => h.id).sort();
   assert.deepEqual(ids, ['adal']);
+});
+
+test('~/.hermes or AppData/Local/hermes lights up the hermes host', () => {
+  const home = fresh(); const repo = fresh();
+  mkdirSync(join(home, 'AppData', 'Local', 'hermes'), { recursive: true });
+  const ids = detectHosts(probeFor(home, repo)).map((h) => h.id).sort();
+  assert.deepEqual(ids, ['hermes']);
+  assert.ok(HOSTS.find((h) => h.id === 'hermes')?.relPath === 'AGENTS.md');
 });


### PR DESCRIPTION
## What

Adds **Hermes Agent** (Nous Research) as a supported host in the registry, so `graft init --agents hermes` wires the Graft instruction block into a repo's AGENTS.md.

Hermes is repo-aware: it reads AGENTS.md at the repo root, and the Graft-for-Hermes plugin (this fork, published as `graft-for-hermes` on npm) keeps the graph fresh on every session start via its `on_session_start` hook.

## Why

Hermes Agent is a coding agent that reads AGENTS.md at repo root (same convention as Codex/OpenCode). Adding it to the registry means users get the same repo context graph benefit as Claude Code / Cursor / Gemini users, with zero manual wiring.

## Changes

- `src/hosts/registry.ts`: new `hermes` host entry (kind `section`, targets `AGENTS.md`)
- Detection is **path-based** (checks for `~/.hermes`, `AppData/Local/hermes`, or repo-local `.hermes`) so it doesn't fire under test temp homes
- `test/hosts-registry.test.ts`: hermes added to expected host list + dedicated detect test
- `test/hosts-init.test.ts`: written-files count 8 -> 9

## Tests

743 pass, 0 fail (5 pre-existing skips).

## Follow-up (in the fork, not this PR)

The fork ships a full native Hermes plugin (lifecycle hooks + 6 native graft tools + `graft install-plugin` CLI command) published as `graft-for-hermes` on npm. Happy to open a follow-up discussion if upstream wants the plugin packaged here too.