### PR TITLE
fix(viz): an empty radius says why, and any PR's page can be republished

### DIFF
--- a/.github/workflows/blast-pages.yml
+++ b/.github/workflows/blast-pages.yml
@@ -11,16 +11,26 @@ name: Blast viewer
 # PR's files as data — never runs a script from the PR (no `npm ci` on the PR's
 # package.json, no postinstall). The graph is built from the PR's source text by a
 # tree-sitter parser, which executes none of it.
+#
+# A dispatch by PR number is the second entry point. It exists because a fork PR's
+# comment job cannot post the link itself (a `pull_request` job on a fork gets a
+# read-only token), so publishing that page has to be startable by hand.
 on:
   pull_request_target:
     branches: [main]
     types: [opened, synchronize, reopened, closed]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "Pull request number to publish the page for."
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 concurrency:
-  group: blast-pages-${{ github.event.pull_request.number }}
+  group: blast-pages-${{ github.event.pull_request.number || inputs.pr }}
   cancel-in-progress: true
 
 jobs:
@@ -31,6 +41,25 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      # 0. Which pull request. An event carries it; a dispatch names it by number,
+      # and everything below reads these outputs so the two entry points cannot
+      # drift apart.
+      - name: Resolve the pull request
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.pull_request.number || inputs.pr }}
+        run: |
+          set -euo pipefail
+          # This number becomes a path under pr/ and a git ref. Digits only, so a
+          # dispatch cannot write outside its own directory.
+          case "$NUMBER" in
+            "" | *[!0-9]*) echo "not a pull request number: $NUMBER" >&2; exit 1 ;;
+          esac
+          gh api "repos/$REPO/pulls/$NUMBER" --jq \
+            '"number=\(.number)", "base_ref=\(.base.ref)", "base_sha=\(.base.sha)"' >> "$GITHUB_OUTPUT"
+
       # 1. The tooling, from the base branch — never from the PR.
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
@@ -48,7 +77,7 @@ jobs:
       # 2. The PR's code, as data only.
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          ref: refs/pull/${{ steps.pr.outputs.number }}/merge
           path: pr
           fetch-depth: 0
           persist-credentials: false
@@ -60,15 +89,15 @@ jobs:
       - uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: pr/graft
-          key: graft-${{ github.event.pull_request.base.sha }}
+          key: graft-${{ steps.pr.outputs.base_sha }}
           restore-keys: |
             graft-
 
       - name: Build the graph and export the radius
         working-directory: pr
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          BASE_REF: ${{ steps.pr.outputs.base_ref }}
           # `--name` reads a key, so the page gets the same concept names the comment
           # shows instead of hub-symbol fallbacks. The PR's code is never executed
           # here (see the header) — naming only sends its source text to the model,
@@ -93,7 +122,7 @@ jobs:
       - name: Publish to gh-pages
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -133,7 +162,7 @@ jobs:
       - name: Remove this PR's page
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail

--- a/src/blast/viz.ts
+++ b/src/blast/viz.ts
@@ -56,6 +56,24 @@ function affectedNode(m: ImpactedModule): VizNode {
 }
 
 /**
+ * What an empty canvas means.
+ *
+ * A PR that only touches lockfiles, workflows or docs has no radius, and the page
+ * published for it used to be a blank canvas behind a link promising a graph — a
+ * reader cannot tell that from a broken export. Naming the reason (usually: no
+ * parser claims these files) turns it into an answer.
+ */
+function emptyNote(r: BlastReport): string {
+  if (r.changed.length === 0) return "This pull request changes no files.";
+  if (r.unindexed.length === r.changed.length) {
+    const shown = r.unindexed.slice(0, 3).join(", ");
+    const rest = r.unindexed.length > 3 ? `, +${r.unindexed.length - 3} more` : "";
+    return `Nothing to draw: no parser claims ${plural(r.unindexed.length, "changed file")} (${shown}${rest}), so this change has no symbols to trace.`;
+  }
+  return "Nothing to draw: the changed symbols have no resolved dependents at this depth.";
+}
+
+/**
  * Build the viewer graph for a report.
  *
  * Nothing is capped here. The caps in the markdown renderer exist because a Mermaid
@@ -94,6 +112,7 @@ export function blastVizGraph(r: BlastReport): VizGraph {
   return {
     meta: {
       nodeCount: nodes.length,
+      emptyNote: nodes.length === 0 ? emptyNote(r) : undefined,
       edgeCount: edges.length,
       // Changed files no parser claims: named here so a thin graph is explained
       // rather than read as "this PR is safe".

--- a/src/viz/assemble.ts
+++ b/src/viz/assemble.ts
@@ -36,6 +36,10 @@ export interface VizGraph {
     edgeCount: number;
     skippedFiles: number;
     droppedEdges: number;
+    /** Why there is nothing to draw, when there is nothing to draw. A published
+     * page cannot answer a question a reader asks of the console, so an empty
+     * canvas has to say what it means — see `blastVizGraph`. */
+    emptyNote?: string;
   };
   nodes: VizNode[];
   edges: VizEdge[];

--- a/test/blast-viz.test.ts
+++ b/test/blast-viz.test.ts
@@ -110,3 +110,32 @@ test("blast viz: the page is titled after the repository, not the checkout direc
   execFileSync("git", ["-C", dir, "remote", "set-url", "origin", "https://github.com/NanoNets/Graft"]);
   assert.equal(repoLabel(dir), "Graft", "and an https remote with no .git suffix reads the same");
 });
+
+test("blast viz: an empty radius says why, instead of publishing a blank canvas", () => {
+  // A lockfile- or workflow-only PR has no radius, and the page published for it
+  // was a blank canvas behind a link promising a diagram — indistinguishable from
+  // a broken export.
+  const r = report();
+  r.areas = [];
+  r.modules = [];
+  r.changed = [
+    { path: ".github/workflows/x.yml", status: "modified", ranges: [{ start: 1, end: 1 }] },
+    { path: "package-lock.json", status: "modified", ranges: [{ start: 1, end: 1 }] },
+  ];
+  r.unindexed = [".github/workflows/x.yml", "package-lock.json"];
+
+  const g = blastVizGraph(r);
+  assert.equal(g.nodes.length, 0);
+  assert.match(g.meta.emptyNote ?? "", /no parser claims 2 changed files/);
+  assert.match(g.meta.emptyNote ?? "", /\.github\/workflows\/x\.yml, package-lock\.json/);
+
+  // A radius that exists needs no excuse — the note must not appear on a real page.
+  assert.equal(blastVizGraph(report()).meta.emptyNote, undefined);
+
+  // Changed code with no dependents is a different answer from unparsed files.
+  const orphan = report();
+  orphan.areas = [];
+  orphan.modules = [];
+  orphan.unindexed = [];
+  assert.match(blastVizGraph(orphan).meta.emptyNote ?? "", /no resolved dependents/);
+});

--- a/viewer/data.ts
+++ b/viewer/data.ts
@@ -25,6 +25,8 @@ export interface VizGraph {
     /** Set by `graft viz --export`: the tab whose graph actually has content. */
     defaultTab?: "context" | "code";
     nodeCount: number; edgeCount: number; skippedFiles?: number; droppedEdges?: number;
+    /** Why the graph is empty, when it is — set by `blast --export-viz`. */
+    emptyNote?: string;
   };
   nodes: VizNode[];
   edges: VizEdge[];

--- a/viewer/main.ts
+++ b/viewer/main.ts
@@ -149,10 +149,16 @@ function setTab(tab: Tab): void {
     }
   } else {
     const graph = activeGraph();
-    if (!graph) {
-      showEmpty(tab === "code"
+    if (!graph || graph.nodes.length === 0) {
+      // A graph that exists but holds no nodes used to fall through to the canvas
+      // and render nothing at all — worst on an exported page, where the reader
+      // arrived from a link that promised a diagram.
+      // The note names changed FILES, and a path on a fork's branch is written by
+      // whoever opened the pull request — it reaches a published page, so it is
+      // escaped rather than trusted.
+      showEmpty(graph?.meta.emptyNote ? escapeText(graph.meta.emptyNote) : (tab === "code"
         ? "No code graph yet — run <code>graft graph</code> to generate <span class=\"mono\">graph.json</span>."
-        : "No context graph — run <code>graft init</code> first.");
+        : "No context graph — run <code>graft init</code> first."));
     } else {
       empty.hidden = true;
       view.resetView();
@@ -164,6 +170,10 @@ function setTab(tab: Tab): void {
   renderLegend();
   updateShownCount();
   updateCounts();
+}
+
+function escapeText(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;");
 }
 
 function showEmpty(html: string): void {


### PR DESCRIPTION
A PR that only touches lockfiles, workflows or docs has no blast radius, so the page published for it was a **blank canvas** behind a link promising a diagram — indistinguishable from a broken export. The graph now carries the reason and the viewer renders it:

> Nothing to draw: no parser claims 2 changed files (.github/workflows/blast-pages.yml, package-lock.json), so this change has no symbols to trace.

Changed code with no dependents gets a different sentence, because it is a different answer.

The note names changed files, and on a fork those paths are written by whoever opened the PR — it reaches a published page, so it is escaped rather than trusted.

`blast-pages.yml` also accepts a PR number via `workflow_dispatch`. A `pull_request` job on a fork gets a read-only token and cannot post the link itself, so publishing that page has to be startable by hand; the number is validated as digits so a dispatch cannot write outside its own directory.

This PR is also the first one whose own page is built with `--name`, so its Context tab should show concept names rather than hub symbols.

755 tests pass.