### PR TITLE
feat(php): mint anonymous classes as nodes with their implements edges (#144)

### DIFF
--- a/src/graph/bindings.ts
+++ b/src/graph/bindings.ts
@@ -71,6 +71,8 @@ export function defName(node: Parser.SyntaxNode, lang: Language): string | null 
     // Closures push a scope segment in extract.ts too — mirror it so a typed
     // parameter bound inside a closure is keyed under the same scope path.
     if (node.type === "anonymous_function" || node.type === "arrow_function") return phpClosureName(node);
+    // Anonymous classes likewise mint an `{anonymous}` scope segment (#144).
+    if (node.type === "anonymous_class") return "{anonymous}";
     return null;
   }
   const defTypes =

--- a/src/graph/extract.ts
+++ b/src/graph/extract.ts
@@ -608,6 +608,22 @@ function describe(node: Parser.SyntaxNode, ctx: WalkCtx): DefDescriptor | null {
     };
   }
 
+  // PHP anonymous classes (`new class implements I {…}`): minted as a class
+  // node named `{anonymous}` (mirroring `{closure}`, deduplicated per file by
+  // mintId). Without this the type vanished — no node, no heritage edge — and
+  // its methods mis-attributed to the enclosing function (issue #144). The
+  // class kind makes the walk emit heritageEdges (base_clause /
+  // class_interface_clause are direct children) and own the nested methods.
+  if (ctx.lang === "php" && node.type === "anonymous_class") {
+    const body = node.childForFieldName("body");
+    return {
+      name: "{anonymous}",
+      kind: "class",
+      headerEnd: body ? body.startIndex : node.endIndex,
+      hashNode: node,
+    };
+  }
+
   const mapped = ctx.kinds[node.type];
   if (mapped) {
     const name = node.childForFieldName("name")?.text;

--- a/test/graph-php.test.ts
+++ b/test/graph-php.test.ts
@@ -261,6 +261,105 @@ test("PHP closures: `graft check` stays fresh after build (no name drift)", asyn
   }
 });
 
+// Issue #144: an anonymous class (`new class implements I {…}`) previously
+// produced no node and no heritage edge — its methods were mis-attributed to
+// the enclosing function (`…#make.run`), so the type and its interface
+// contract were invisible. It now mints an `{anonymous}` class node
+// (mirroring the `{closure}` naming), carries its `implements`/`extends`
+// edges, and owns the methods declared in its body.
+const ANON_PHP = `<?php
+namespace Poc;
+
+interface Runnable {}
+
+class Base
+{
+    public function label(): string
+    {
+        return 'b';
+    }
+}
+
+function make(): Runnable
+{
+    return new class implements Runnable {
+        public function run(): int { return 1; }
+    };
+}
+
+function decorate(): Base
+{
+    return new class extends Base {
+        public function label(): string { return 'd'; }
+    };
+}
+`;
+
+function makeAnonFixture(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graft-php-anon-"));
+  writeFileSync(join(dir, "composer.json"), `{"name": "poc/anon"}\n`);
+  writeFileSync(join(dir, "poc.php"), ANON_PHP);
+  return dir;
+}
+
+test("PHP anonymous classes: mint a class node that owns its methods (#144)", () => {
+  const { nodes } = extractFile("poc.php", ANON_PHP, "php");
+  const ids = nodes.map((n) => n.id);
+
+  const anon = nodes.find((n) => n.id === "poc.php#make.{anonymous}");
+  assert.equal(anon?.kind, "class", `expected an {anonymous} class node, got: ${ids.join(", ")}`);
+
+  // the method nests under the anonymous class, not the enclosing function
+  const run = nodes.find((n) => n.id === "poc.php#make.{anonymous}.run");
+  assert.equal(run?.kind, "method");
+  assert.equal(run?.owner, "{anonymous}", "run's owner is the anonymous class");
+  assert.ok(!ids.includes("poc.php#make.run"), "run must not attach to the enclosing function");
+
+  // control: enclosing functions and named classes are unchanged
+  assert.equal(nodes.find((n) => n.id === "poc.php#make")?.kind, "function");
+  assert.equal(nodes.find((n) => n.id === "poc.php#Base.label")?.owner, "Base");
+});
+
+test("PHP anonymous classes: implements/extends edges resolve (#144)", async () => {
+  const dir = makeAnonFixture();
+  try {
+    await buildGraph(dir);
+    const graph = readGraph(wiringPath(join(dir, "graft")))!;
+
+    assert.ok(
+      graph.edges.some(
+        (e) =>
+          e.relation === "implements" &&
+          e.source === "poc.php#make.{anonymous}" &&
+          e.target === "poc.php#Runnable",
+      ),
+      "anonymous class should have a resolved implements edge to Runnable",
+    );
+    assert.ok(
+      graph.edges.some(
+        (e) =>
+          e.relation === "extends" &&
+          e.source === "poc.php#decorate.{anonymous}" &&
+          e.target === "poc.php#Base",
+      ),
+      "anonymous class should have a resolved extends edge to Base",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("PHP anonymous classes: siblings in one scope dedupe like {closure}", () => {
+  const src = `<?php
+$a = new class { public function one(): int { return 1; } };
+$b = new class { public function two(): int { return 2; } };
+`;
+  const { nodes } = extractFile("dup.php", src, "php");
+  const ids = nodes.map((n) => n.id);
+  assert.ok(ids.includes("dup.php#{anonymous}"), `expected an {anonymous} node, got: ${ids.join(", ")}`);
+  assert.ok(ids.includes("dup.php#{anonymous}~2"), `expected a deduplicated {anonymous}~2 node, got: ${ids.join(", ")}`);
+});
+
 test("PHP extraction: closures become nodes and own the calls inside them", async () => {
   const dir = makeFixture();
   try {


### PR DESCRIPTION
## Summary

Part 2 of #144 — attributes were wired as `references` edges in #155. Together with #155 they address #144 (external/framework attribute references still open).

An anonymous class (`new class implements I {…}`) previously produced no node and no heritage edge; its methods were mis-attributed to the enclosing function (`…#make.run`), so the type and its interface contract were invisible in the wiring graph.

- `describe()` now recognizes `anonymous_class` (a distinct node type in tree-sitter-php 0.23) and mints a `class` node named `{anonymous}`, mirroring the existing `{closure}` naming — deduplicated per file by `mintId` (`{anonymous}~2`, …).
- Because the descriptor's kind is `class`, the existing walk does the rest with no further changes: `heritageEdges` picks up `base_clause` / `class_interface_clause` (both are direct children of `anonymous_class`), so `implements` **and** `extends` edges are emitted; `enclosingClass` becomes `{anonymous}`, so nested methods get the right `owner` and nest under the class in the id path.
- `bindings.ts`'s `defName` mirrors the same scope segment (as it already does for closures), keeping the two scope stacks in sync for typed-parameter bindings inside anonymous-class methods.

Deliberately orthogonal to #155 (attribute `references` edges) and to trait resolution — this branch is based on `main` and only touches the anonymous-class path. Happy to rebase whichever lands second.

## Verification

`graft build` on the issue's exact repro now yields:

```
✓ wiring: 4 nodes (1 file, 1 function, 1 class, 1 method), 4 edges, 1 cards [php]
```

```json
{"id":"poc.php#make.{anonymous}","kind":"class","name":"{anonymous}","span":"L6-L8","signature":"class implements Runnable"}
{"id":"poc.php#make.{anonymous}.run","kind":"method","name":"run","span":"L7-L7","signature":"public function run(): int","owner":"{anonymous}"}

{"source":"poc.php#make","target":"poc.php#make.{anonymous}","relation":"contains","confidence":"extracted"}
{"source":"poc.php#make.{anonymous}","target":"poc.php#make.{anonymous}.run","relation":"contains","confidence":"extracted"}
{"source":"poc.php#make.{anonymous}","target":"Runnable","relation":"implements","confidence":"inferred"}
```

The stale `poc.php#make.run` id is gone; when the interface is defined in the project the `implements` edge resolves to its node (asserted in the tests).

## Test plan

- [x] New: anonymous class mints a `class` node; `run`'s owner is `{anonymous}`, and no `…#make.run` id exists
- [x] New: `implements` → `Runnable` and `extends` → `Base` edges resolve through `buildGraph`
- [x] New: two sibling anonymous classes in one scope dedupe to `{anonymous}` / `{anonymous}~2` (same rule as `{closure}`)
- [x] Control: named classes, variable-named closures, and bare `{closure}` callbacks unchanged
- [x] `npm run build && npm test` — 757/757 green

Part 2 of #144 (anonymous classes)

Made with [Cursor](https://cursor.com)
