### PR TITLE
feat(blast): the panel shows the change, not a line number

### DIFF
--- a/.github/workflows/blast-pages.yml
+++ b/.github/workflows/blast-pages.yml
@@ -11,16 +11,26 @@ name: Blast viewer
 # PR's files as data — never runs a script from the PR (no `npm ci` on the PR's
 # package.json, no postinstall). The graph is built from the PR's source text by a
 # tree-sitter parser, which executes none of it.
+#
+# A dispatch by PR number is the second entry point. It exists because a fork PR's
+# comment job cannot post the link itself (a `pull_request` job on a fork gets a
+# read-only token), so publishing that page has to be startable by hand.
 on:
   pull_request_target:
     branches: [main]
     types: [opened, synchronize, reopened, closed]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "Pull request number to publish the page for."
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 concurrency:
-  group: blast-pages-${{ github.event.pull_request.number }}
+  group: blast-pages-${{ github.event.pull_request.number || inputs.pr }}
   cancel-in-progress: true
 
 jobs:
@@ -31,6 +41,25 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      # 0. Which pull request. An event carries it; a dispatch names it by number,
+      # and everything below reads these outputs so the two entry points cannot
+      # drift apart.
+      - name: Resolve the pull request
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.pull_request.number || inputs.pr }}
+        run: |
+          set -euo pipefail
+          # This number becomes a path under pr/ and a git ref. Digits only, so a
+          # dispatch cannot write outside its own directory.
+          case "$NUMBER" in
+            "" | *[!0-9]*) echo "not a pull request number: $NUMBER" >&2; exit 1 ;;
+          esac
+          gh api "repos/$REPO/pulls/$NUMBER" --jq \
+            '"number=\(.number)", "base_ref=\(.base.ref)", "base_sha=\(.base.sha)"' >> "$GITHUB_OUTPUT"
+
       # 1. The tooling, from the base branch — never from the PR.
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
@@ -48,7 +77,7 @@ jobs:
       # 2. The PR's code, as data only.
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          ref: refs/pull/${{ steps.pr.outputs.number }}/merge
           path: pr
           fetch-depth: 0
           persist-credentials: false
@@ -60,15 +89,15 @@ jobs:
       - uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: pr/graft
-          key: graft-${{ github.event.pull_request.base.sha }}
+          key: graft-${{ steps.pr.outputs.base_sha }}
           restore-keys: |
             graft-
 
       - name: Build the graph and export the radius
         working-directory: pr
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          BASE_REF: ${{ steps.pr.outputs.base_ref }}
           # `--name` reads a key, so the page gets the same concept names the comment
           # shows instead of hub-symbol fallbacks. The PR's code is never executed
           # here (see the header) — naming only sends its source text to the model,
@@ -93,7 +122,7 @@ jobs:
       - name: Publish to gh-pages
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -133,7 +162,7 @@ jobs:
       - name: Remove this PR's page
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail

--- a/src/blast/blast-cli.ts
+++ b/src/blast/blast-cli.ts
@@ -187,7 +187,10 @@ async function exportRadius(
     outDir: resolvePath(outDir),
     repoName: repoLabel(root),
     subtitle,
-    contextGraph: blastVizGraph(report),
+    contextGraph: blastVizGraph(report, { root }),
+    // Context alone: see VizExportOptions.tabs — the other two tabs are about the
+    // repository, and this page is about one pull request.
+    tabs: ["context"],
   });
   console.error(`• --export-viz: ${out.file} (${Math.round(out.bytes / 1024)} kB, ${out.contextNodes} areas, ${out.codeNodes} code nodes)`);
 }

--- a/src/blast/diff.ts
+++ b/src/blast/diff.ts
@@ -18,6 +18,25 @@ export interface LineRange {
   end: number;
 }
 
+/**
+ * One line git reported inside a hunk.
+ *
+ * `n` is the POST-image number, so it is the number a reviewer sees in the file
+ * on disk — a deleted line has none.
+ */
+export interface DiffLine {
+  n: number | null;
+  sign: "+" | "-";
+  text: string;
+}
+
+/** A hunk's range and the lines in it. `ranges` on the file mirrors these. */
+export interface Hunk extends LineRange {
+  lines: DiffLine[];
+  /** Lines dropped by the per-hunk cap — a generated file is not worth holding. */
+  dropped: number;
+}
+
 export interface ChangedFile {
   /** Repo-relative posix path, post-image (the new name for a rename). */
   path: string;
@@ -26,6 +45,9 @@ export interface ChangedFile {
   oldPath?: string;
   /** Post-image changed line ranges. Empty for a pure delete or a mode-only change. */
   ranges: LineRange[];
+  /** The same hunks, carrying their text: what a panel shows so a reader sees the
+   * change rather than a line number they have to go look up. One per range. */
+  hunks: Hunk[];
 }
 
 export interface DiffResult {
@@ -35,6 +57,12 @@ export interface DiffResult {
 }
 
 const HUNK_RE = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/;
+
+/** Text kept per hunk, and per file. A regenerated lockfile is one hunk of 40,000
+ * lines: the ranges still matter (they seed the graph), the text does not, and it
+ * would otherwise ride along in `--format json` and in every exported page. */
+const MAX_HUNK_LINES = 24;
+const MAX_FILE_LINES = 200;
 
 /** Run git in `root`, or return null when git fails (not a repo, unknown ref). */
 function git(root: string, args: string[]): string | null {
@@ -126,38 +154,80 @@ function parseNameStatus(out: string): ChangedFile[] {
       const oldPath = fields[i++];
       const path = fields[i++];
       if (path === undefined) break;
-      files.push({ path, status: "renamed", oldPath, ranges: [] });
+      files.push({ path, status: "renamed", oldPath, ranges: [], hunks: [] });
       continue;
     }
     const path = fields[i++];
     if (path === undefined) break;
-    if (code.startsWith("A")) files.push({ path, status: "added", ranges: [] });
-    else if (code.startsWith("D")) files.push({ path, status: "deleted", ranges: [] });
-    else files.push({ path, status: "modified", ranges: [] });
+    if (code.startsWith("A")) files.push({ path, status: "added", ranges: [], hunks: [] });
+    else if (code.startsWith("D")) files.push({ path, status: "deleted", ranges: [], hunks: [] });
+    else files.push({ path, status: "modified", ranges: [], hunks: [] });
   }
   return files;
 }
 
-/** Attach each hunk's post-image range to its file. */
+/** Attach each hunk's post-image range — and its text — to its file. */
 function applyHunks(files: ChangedFile[], patch: string): void {
   const byPath = new Map(files.map((f) => [f.path, f]));
   let current: ChangedFile | undefined;
+  let hunk: Hunk | undefined;
+  /** Post-image number for the next `+` line of the open hunk. */
+  let next = 0;
+  let kept = 0;
+
   for (const line of patch.split("\n")) {
+    // Every file starts with this, and a content line cannot: a deleted one begins
+    // with `-`. Closing the open hunk here is what stops the NEXT file's `--- a/x`
+    // header being absorbed as a deleted line of the previous hunk.
+    if (line.startsWith("diff --git ")) {
+      current = undefined;
+      hunk = undefined;
+      continue;
+    }
     if (line.startsWith("+++ ")) {
       const raw = line.slice(4);
       current = raw === "/dev/null" ? undefined : byPath.get(stripPrefix(raw));
+      hunk = undefined;
+      kept = 0;
       continue;
     }
-    if (!line.startsWith("@@") || !current) continue;
-    const m = HUNK_RE.exec(line);
-    if (!m) continue;
-    const start = Number(m[1]);
-    // `+N,0` is a pure deletion: nothing survives in the post-image, and git
-    // reports the line BEFORE the gap. Recording that single line is what keeps
-    // "the body of foo() lost 10 lines" attributable to foo() at all.
-    const count = m[2] === undefined ? 1 : Number(m[2]);
-    current.ranges.push(count === 0 ? { start, end: start } : { start, end: start + count - 1 });
+    if (line.startsWith("@@")) {
+      hunk = undefined;
+      if (!current) continue;
+      const m = HUNK_RE.exec(line);
+      if (!m) continue;
+      const start = Number(m[1]);
+      // `+N,0` is a pure deletion: nothing survives in the post-image, and git
+      // reports the line BEFORE the gap. Recording that single line is what keeps
+      // "the body of foo() lost 10 lines" attributable to foo() at all.
+      const count = m[2] === undefined ? 1 : Number(m[2]);
+      const range = count === 0 ? { start, end: start } : { start, end: start + count - 1 };
+      hunk = { ...range, lines: [], dropped: 0 };
+      current.ranges.push(range);
+      current.hunks.push(hunk);
+      next = start;
+      continue;
+    }
+    if (!hunk) continue;
+    // With `--unified=0` every line inside a hunk is an edit, so there is no
+    // context to skip. `+++`/`---` headers are already consumed above; a bare
+    // `--- a/x` for the next file arrives before its `+++`, and the `!hunk`
+    // guard on a fresh file keeps it out.
+    if (line.startsWith("+")) {
+      pushLine(hunk, { n: next, sign: "+", text: line.slice(1) }, kept++ < MAX_FILE_LINES);
+      next += 1;
+    } else if (line.startsWith("-")) {
+      pushLine(hunk, { n: null, sign: "-", text: line.slice(1) }, kept++ < MAX_FILE_LINES);
+    }
   }
+}
+
+function pushLine(hunk: Hunk, line: DiffLine, withinFile: boolean): void {
+  if (!withinFile || hunk.lines.length >= MAX_HUNK_LINES) {
+    hunk.dropped += 1;
+    return;
+  }
+  hunk.lines.push(line);
 }
 
 /** `b/src/x.ts` → `src/x.ts`, minus any trailing tab-separated timestamp. */

--- a/src/blast/viz.ts
+++ b/src/blast/viz.ts
@@ -3,19 +3,26 @@
  * comment.
  *
  * The comment can hold about five circles before it stops being readable, and it
- * can never answer the reviewer's next question: which symbols, at which lines.
- * `graft viz --export` already produces a self-contained page, but its Context tab
- * is assembled from the deep tier's concept files, which the PR path deliberately
- * no longer builds — so on a structural build that tab held a single INDEX dot.
+ * can never answer the reviewer's next question: which symbols, at which lines,
+ * and what did they actually become. `graft viz --export` already produces a
+ * self-contained page, but its Context tab is assembled from the deep tier's
+ * concept files, which the PR path deliberately no longer builds — so on a
+ * structural build that tab held a single INDEX dot.
  *
  * This closes that gap with no new data and no LLM pass: `blast` has already
  * clustered both sides of the diff and named them (cached, one call), so the same
  * report is emitted here as {@link VizGraph} — amber node per changed area, blue
- * node per affected area, one edge per attribution the walk actually recorded. The
- * comment becomes a summary of this page rather than a separate computation.
+ * node per affected area, one edge per attribution the walk actually recorded.
+ *
+ * Each node also carries {@link Evidence}: the changed side shows its hunks, the
+ * affected side shows the line that reaches the diff. Both come from data already
+ * on hand — git's patch, and the file on disk — so the panel costs nothing.
  */
-import type { VizEdge, VizGraph, VizNode } from "../viz/assemble.js";
-import type { BlastReport, ChangedArea, ImpactedModule, TestSignal } from "./blast.js";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { Evidence, EvidenceLine, VizEdge, VizGraph, VizNode } from "../viz/assemble.js";
+import type { BlastReport, ChangedArea, Impacted, ImpactedModule, Seed, TestSignal } from "./blast.js";
+import type { ChangedFile, DiffLine } from "./diff.js";
 
 const plural = (n: number, one: string, many = `${one}s`): string => `${n} ${n === 1 ? one : many}`;
 
@@ -23,35 +30,229 @@ const plural = (n: number, one: string, many = `${one}s`): string => `${n} ${n =
 const CHANGED = "changed";
 const AFFECTED = "affected";
 
-const TEST_NOTE: Record<TestSignal, string> = {
-  changed: "a test that reaches it changed too",
-  stale: "it has tests, and this diff did not touch them",
-  none: "no test reaches it",
-  na: "no function, method or class changed here",
-};
+/** Symbols given their own snippet per node. Past this the panel is a file listing
+ * rather than a summary — the rest are still counted in the headline. */
+const MAX_EVIDENCE = 4;
+/** Lines shown per snippet before it folds. A handful is a hunk you can read at a
+ * glance; a 30-line refactor is a diff view's job, not a panel's. */
+const MAX_LINES = 6;
 
-function changedNode(a: ChangedArea): VizNode {
-  const reach = a.behavioural > 0 ? ` ${a.reached} of ${a.behavioural} changed functions have a test that reaches them.` : "";
+/** Kinds that carry behaviour — what "did a test reach it" is asked of. */
+const BEHAVIOURAL = new Set(["function", "method", "class", "constructor"]);
+
+/** `L12-L34` → the numbers, so a label is something a reader can type. */
+function spanRange(span: string): { start: number; end: number } | null {
+  const m = /^L(\d+)(?:-L(\d+))?$/.exec(span);
+  if (!m) return null;
+  const start = Number(m[1]);
+  return { start, end: m[2] === undefined ? start : Number(m[2]) };
+}
+
+function labelFor(name: string, path: string, span: string): string {
+  const r = spanRange(span);
+  return r ? `${name} · ${path}:${r.start}-${r.end}` : `${name} · ${path}`;
+}
+
+/** Keep the first {@link MAX_LINES}, and say how many were left. */
+function fold(lines: EvidenceLine[]): { lines: EvidenceLine[]; more?: number } {
+  if (lines.length <= MAX_LINES) return { lines };
+  return { lines: lines.slice(0, MAX_LINES), more: lines.length - MAX_LINES };
+}
+
+const asEvidenceLines = (lines: DiffLine[]): EvidenceLine[] =>
+  lines.map((l) => ({ n: l.n, sign: l.sign, text: l.text }));
+
+/**
+ * The hunks of `file` that fall inside `span`.
+ *
+ * A file's diff is split by symbol rather than shown whole, because two unrelated
+ * edits in one file are two answers — a panel that merges them makes the reader do
+ * the separating.
+ */
+function hunksIn(
+  file: ChangedFile,
+  span: { start: number; end: number } | null,
+): { lines: EvidenceLine[]; dropped: number } {
+  const out: EvidenceLine[] = [];
+  let dropped = 0;
+  for (const h of file.hunks) {
+    if (span && (h.end < span.start || h.start > span.end)) continue;
+    out.push(...asEvidenceLines(h.lines));
+    dropped += h.dropped;
+  }
+  return { lines: out, dropped };
+}
+
+/** Evidence for one changed symbol: what this PR did to it. */
+function seedEvidence(seed: Seed, file: ChangedFile | undefined): Evidence | null {
+  if (!file) return null;
+  const span = seed.wholeFile ? null : spanRange(seed.span);
+  const { lines, dropped } = hunksIn(file, span);
+  if (lines.length === 0 && dropped === 0) return null;
+  const folded = fold(lines);
+  const more = (folded.more ?? 0) + dropped;
+  return {
+    label: seed.wholeFile ? seed.path : labelFor(seed.name, seed.path, seed.span),
+    note: file.status === "added" ? "new file" : seed.wholeFile ? "outside any symbol" : undefined,
+    lines: folded.lines,
+    more: more > 0 ? more : undefined,
+  };
+}
+
+const escapeRe = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+/**
+ * Evidence for one dependent symbol: the line that reaches the diff.
+ *
+ * Nothing changed here, so there is no hunk to show — the useful line is the one
+ * naming a changed symbol or module, which answers "why am I in this blast radius
+ * at all". Found by reading the symbol's span off disk.
+ *
+ * When no line names the diff, this returns nothing rather than quoting the span's
+ * first line: for a file-level dependent that first line is `/**`, and a panel that
+ * shows it has spent a code block to say nothing.
+ */
+function impactedEvidence(
+  sym: Impacted,
+  reach: ReachTerms,
+  read: (path: string) => string[] | null,
+): Evidence | null {
+  const span = spanRange(sym.span);
+  const lines = read(sym.path);
+  if (!span || !lines) return null;
+
+  const body = lines.slice(span.start - 1, span.end);
+  for (const [i, text] of body.entries()) {
+    const hit = reach.names.find((n) => new RegExp(`\\b${escapeRe(n)}\\b`).test(text));
+    if (hit !== undefined) {
+      return {
+        label: labelFor(sym.name, sym.path, sym.span),
+        note: `${sym.relation} ${hit}`,
+        lines: [{ n: span.start + i, sign: " ", text }],
+      };
+    }
+    // A file-level dependent usually reaches the diff through its import line, and
+    // that line names a MODULE, not one of the changed symbols.
+    const mod = reach.modules.find((re) => re.test(text));
+    if (mod !== undefined) {
+      return {
+        label: labelFor(sym.name, sym.path, sym.span),
+        note: sym.relation,
+        lines: [{ n: span.start + i, sign: " ", text }],
+      };
+    }
+  }
+
+  // No line names the diff — an indirect reach, or a symbol whose whole file is
+  // the span. Quoting its first line means quoting `/**`, which answers nothing;
+  // the path stays in `sources` and the panel simply says less.
+  return null;
+}
+
+/** What a line has to mention to be the line that reaches the diff. */
+interface ReachTerms {
+  /** Changed symbol names, longest first. */
+  names: string[];
+  /** `from "./data.js"` for each changed file, matched on the module specifier so
+   * a common stem like `data` cannot match a variable of the same name. */
+  modules: RegExp[];
+}
+
+function reachTerms(seeds: Seed[], changed: ChangedFile[]): ReachTerms {
+  const names = [...new Set(seeds.filter((s) => !s.wholeFile).map((s) => s.name))].sort((a, b) => b.length - a.length);
+  const stems = [...new Set(changed.map((f) => f.path.replace(/\.[^./]+$/, "").split("/").pop() ?? ""))].filter(Boolean);
+  return {
+    names,
+    modules: stems.map((stem) => new RegExp(`["'\`][^"'\`]*\\b${escapeRe(stem)}(\\.[a-z]+)?["'\`]`)),
+  };
+}
+
+/** One sentence about the tests, rather than the two that used to say it twice. */
+function testNote(a: ChangedArea): string {
+  const signals: Record<TestSignal, string> = {
+    changed: `A test that reaches it changed too — ${a.reached} of ${plural(a.behavioural, "function")} covered.`,
+    stale: `Tests reach it, and this diff left all ${plural(a.testFiles.length, "of them", "of them")} alone.`,
+    none: "No test reaches this code.",
+    na: "No function or class changed here — types, config or comments only.",
+  };
+  return signals[a.tests];
+}
+
+/** `a`, `a and b`, `a, b and c`, `a, b and 3 more` — never a bare `+N`, which
+ * reads as a version number when it sits next to a symbol name. */
+function list(names: string[]): string {
+  const shown = names.slice(0, 3);
+  const rest = names.length - shown.length;
+  const tail = rest > 0 ? `${rest} more` : shown.pop();
+  return shown.length === 0 ? String(tail) : `${shown.join(", ")} and ${tail}`;
+}
+
+/**
+ * What this PR did to an area, in the reviewer's words.
+ *
+ * The old copy counted ("2 files, 3 symbols") and then said the same thing about
+ * tests twice ("no test reaches it. 0 of 2 changed functions have a test that
+ * reaches them"), where `0 of 2` reads like a coverage score. Naming the symbols
+ * is shorter AND the thing a reviewer wanted to know.
+ */
+function changedSummary(a: ChangedArea, seeds: Seed[]): string {
+  const named = seeds.filter((s) => !s.wholeFile);
+  const behaviour = named.filter((s) => BEHAVIOURAL.has(s.kind)).map((s) => s.name);
+  const rest = named.filter((s) => !BEHAVIOURAL.has(s.kind)).map((s) => s.name);
+  const where = ` in ${plural(a.files.length, "file")}.`;
+
+  let what: string;
+  if (behaviour.length > 0) {
+    what = `Edits ${list(behaviour)}`;
+    if (rest.length > 0) what += `, plus ${list(rest)}`;
+  } else if (rest.length > 0) {
+    what = `Edits ${list(rest)}`;
+  } else {
+    // Whole-file seeds only: an added file, or edits outside every symbol.
+    what = `Changes ${plural(a.seeds, "region")} outside any symbol`;
+  }
+  return `${what}${where} ${testNote(a)}`;
+}
+
+function changedNode(a: ChangedArea, seeds: Seed[], byPath: Map<string, ChangedFile>): VizNode {
+  const files = new Set(a.files);
+  const mine = seeds.filter((s) => files.has(s.path));
+  const evidence = mine
+    .slice(0, MAX_EVIDENCE)
+    .map((s) => seedEvidence(s, byPath.get(s.path)))
+    .filter((e): e is Evidence => e !== null);
+
   return {
     id: `changed:${a.key}`,
     name: a.label,
     type: CHANGED,
-    summary: `Changed in this PR: ${plural(a.files.length, "file")}, ${plural(a.seeds, "symbol")}. ${TEST_NOTE[a.tests]}.${reach}`,
+    summary: changedSummary(a, mine),
     sources: a.files,
+    evidence: evidence.length > 0 ? evidence : undefined,
   };
 }
 
-function affectedNode(m: ImpactedModule): VizNode {
+function affectedNode(
+  m: ImpactedModule,
+  reach: ReachTerms,
+  read: (path: string) => string[] | null,
+): VizNode {
   const nearest = m.symbols[0];
-  const how = nearest ? ` Nearest hop: ${nearest.name} at depth ${nearest.depth} (${nearest.relation}).` : "";
+  const how = nearest ? ` — nearest is ${nearest.name}, ${plural(nearest.depth, "hop")} away.` : ".";
+  const evidence = m.symbols
+    .slice(0, MAX_EVIDENCE)
+    .map((s) => impactedEvidence(s, reach, read))
+    .filter((e): e is Evidence => e !== null);
+
   return {
     id: `affected:${m.key}`,
     name: m.label,
     type: AFFECTED,
-    summary: `Can be affected by this PR: ${plural(m.symbols.length, "dependent symbol")} in ${plural(m.files.length, "file")}.${how}`,
-    // `path · span` is the shape the viewer's detail panel already renders, so each
-    // line is the exact place to start reading.
+    // Leading with "not edited" is the fact a reviewer needs first: this area is
+    // collateral, not part of their diff.
+    summary: `Not edited by this PR. ${plural(m.symbols.length, "symbol")} here ${m.symbols.length === 1 ? "reaches" : "reach"} code it changed${how}`,
     sources: m.symbols.map((s) => `${s.path} · ${s.span}`),
+    evidence: evidence.length > 0 ? evidence : undefined,
   };
 }
 
@@ -76,12 +277,26 @@ function emptyNote(r: BlastReport): string {
 /**
  * Build the viewer graph for a report.
  *
- * Nothing is capped here. The caps in the markdown renderer exist because a Mermaid
- * diagram inside a comment cannot lay out more than a handful of circles; this page
- * is force-directed and pannable, which is the entire reason it exists.
+ * `root` is the repository the report was taken in; without it the affected side
+ * loses its snippets — there is nothing to read — but keeps everything else, which
+ * is what a unit test wants.
+ *
+ * Nothing is capped at the graph level. The caps in the markdown renderer exist
+ * because a Mermaid diagram inside a comment cannot lay out more than a handful of
+ * circles; this page is force-directed and pannable, which is why it exists.
  */
-export function blastVizGraph(r: BlastReport): VizGraph {
-  const nodes: VizNode[] = [...r.areas.map(changedNode), ...r.modules.map(affectedNode)];
+export function blastVizGraph(r: BlastReport, opts: { root?: string } = {}): VizGraph {
+  const byPath = new Map(r.changed.map((f) => [f.path, f]));
+  // Longest name first, so `export` cannot match ahead of `exportViz` on a line
+  // that contains both.
+  const reach = reachTerms(r.seeds, r.changed);
+  const read = fileReader(opts.root);
+
+  const nodes: VizNode[] = [
+    ...r.areas.map((a) => changedNode(a, r.seeds, byPath)),
+    ...r.modules.map((m) => affectedNode(m, reach, read)),
+  ];
+
   /** Changed path → the id of the area node standing for it. */
   const areaOf = new Map<string, string>();
   for (const a of r.areas) for (const f of a.files) areaOf.set(f, `changed:${a.key}`);
@@ -112,8 +327,8 @@ export function blastVizGraph(r: BlastReport): VizGraph {
   return {
     meta: {
       nodeCount: nodes.length,
-      emptyNote: nodes.length === 0 ? emptyNote(r) : undefined,
       edgeCount: edges.length,
+      emptyNote: nodes.length === 0 ? emptyNote(r) : undefined,
       // Changed files no parser claims: named here so a thin graph is explained
       // rather than read as "this PR is safe".
       skippedFiles: r.unindexed.length,
@@ -121,5 +336,25 @@ export function blastVizGraph(r: BlastReport): VizGraph {
     },
     nodes,
     edges,
+  };
+}
+
+/** Read each file once, and never fail: a snippet is a nicety, and a symbol whose
+ * file moved under us must not take the whole page down. */
+function fileReader(root: string | undefined): (path: string) => string[] | null {
+  const cache = new Map<string, string[] | null>();
+  return (path: string) => {
+    if (root === undefined) return null;
+    const hit = cache.get(path);
+    if (hit !== undefined) return hit;
+    let lines: string[] | null = null;
+    try {
+      lines = readFileSync(join(root, path), "utf8").split("\n");
+    } catch {
+      // Deleted, renamed under us, or unreadable: no snippet, no failure.
+      lines = null;
+    }
+    cache.set(path, lines);
+    return lines;
   };
 }

--- a/src/blast/viz.ts
+++ b/src/blast/viz.ts
@@ -56,6 +56,24 @@ function affectedNode(m: ImpactedModule): VizNode {
 }
 
 /**
+ * What an empty canvas means.
+ *
+ * A PR that only touches lockfiles, workflows or docs has no radius, and the page
+ * published for it used to be a blank canvas behind a link promising a graph — a
+ * reader cannot tell that from a broken export. Naming the reason (usually: no
+ * parser claims these files) turns it into an answer.
+ */
+function emptyNote(r: BlastReport): string {
+  if (r.changed.length === 0) return "This pull request changes no files.";
+  if (r.unindexed.length === r.changed.length) {
+    const shown = r.unindexed.slice(0, 3).join(", ");
+    const rest = r.unindexed.length > 3 ? `, +${r.unindexed.length - 3} more` : "";
+    return `Nothing to draw: no parser claims ${plural(r.unindexed.length, "changed file")} (${shown}${rest}), so this change has no symbols to trace.`;
+  }
+  return "Nothing to draw: the changed symbols have no resolved dependents at this depth.";
+}
+
+/**
  * Build the viewer graph for a report.
  *
  * Nothing is capped here. The caps in the markdown renderer exist because a Mermaid
@@ -94,6 +112,7 @@ export function blastVizGraph(r: BlastReport): VizGraph {
   return {
     meta: {
       nodeCount: nodes.length,
+      emptyNote: nodes.length === 0 ? emptyNote(r) : undefined,
       edgeCount: edges.length,
       // Changed files no parser claims: named here so a thin graph is explained
       // rather than read as "this PR is safe".

--- a/src/viz/assemble.ts
+++ b/src/viz/assemble.ts
@@ -21,6 +21,9 @@ export interface VizNode {
   type: string;
   summary: string;
   sources: string[];
+  /** Code to show under the node, in place of `sources`. Set by
+   * `blast --export-viz`, where every node stands for real changed lines. */
+  evidence?: Evidence[];
 }
 
 export interface VizEdge {
@@ -28,6 +31,34 @@ export interface VizEdge {
   target: string;
   relation: string;
   description?: string;
+}
+
+/**
+ * One line of code shown under a node, with the sign git gave it (` ` for an
+ * unchanged line quoted as context — the affected side has no diff to show).
+ */
+export interface EvidenceLine {
+  /** Post-image line number; a deleted line has none. */
+  n: number | null;
+  sign: "+" | "-" | " ";
+  text: string;
+}
+
+/**
+ * A snippet a panel shows instead of a bare path.
+ *
+ * A reviewer reading "src/blast/blast-cli.ts · L172-L193" has to go and open the
+ * file to learn anything; the same block with four lines of the actual change in
+ * it answers the question where they are standing.
+ */
+export interface Evidence {
+  /** `symbol · path:12-34` — grep-able, because a span alone is not. */
+  label: string;
+  /** Why these lines are here, e.g. `calls blastVizGraph` or `added`. */
+  note?: string;
+  lines: EvidenceLine[];
+  /** Lines the cap dropped, so a folded hunk says so rather than lying. */
+  more?: number;
 }
 
 export interface VizGraph {

--- a/src/viz/assemble.ts
+++ b/src/viz/assemble.ts
@@ -36,6 +36,10 @@ export interface VizGraph {
     edgeCount: number;
     skippedFiles: number;
     droppedEdges: number;
+    /** Why there is nothing to draw, when there is nothing to draw. A published
+     * page cannot answer a question a reader asks of the console, so an empty
+     * canvas has to say what it means — see `blastVizGraph`. */
+    emptyNote?: string;
   };
   nodes: VizNode[];
   edges: VizEdge[];

--- a/src/viz/export.ts
+++ b/src/viz/export.ts
@@ -33,6 +33,16 @@ export interface VizExportOptions {
    * PR gets a Context tab worth opening without a `--deep` build.
    */
   contextGraph?: VizGraph;
+  /**
+   * Tabs the page offers. Default: all three.
+   *
+   * A blast page passes `["context"]`. The Code tab there is the repo's whole
+   * wiring graph — 1,377 nodes on graft itself, a hairball that answers nothing
+   * about the pull request, and ~95% of the exported megabyte — and Outline is the
+   * repo's file tree. Dropping them makes the page a tenth of the size and removes
+   * two tabs a reviewer has no reason to open.
+   */
+  tabs?: Array<"context" | "code" | "outline">;
 }
 
 export interface VizExportResult {
@@ -42,6 +52,8 @@ export interface VizExportResult {
   codeNodes: number;
   /** Tab the exported page opens on — see the reasoning in {@link exportViz}. */
   defaultTab: "context" | "code";
+  /** Tabs written into the page. */
+  tabs: Array<"context" | "code" | "outline">;
 }
 
 /** The wiring graph as the viewer's endpoint would have served it, or null. */
@@ -90,7 +102,11 @@ export function exportViz(opts: VizExportOptions): VizExportResult {
   const js = readFileSync(join(opts.viewerDir, "app.js"), "utf8");
 
   const context = opts.contextGraph ?? assembleContextGraph(opts.contextDir);
-  const code = codeGraph(opts.contextDir);
+  const tabs = opts.tabs ?? ["context", "code", "outline"];
+  // Both remaining tabs read the wiring graph, so dropping them drops the payload
+  // as well — the point of the option, not a side effect of it.
+  const wanted = tabs.includes("code") || tabs.includes("outline");
+  const code = wanted ? codeGraph(opts.contextDir) : null;
 
   // Which tab to open on. The viewer starts on Context, which only a `--deep` build
   // fills: a structural build writes wiring cards (no frontmatter, so nothing to
@@ -102,7 +118,7 @@ export function exportViz(opts: VizExportOptions): VizExportResult {
   const defaultTab = opts.contextGraph || context.nodes.length > 1 || codeNodes === 0 ? "context" : "code";
   const contextGraph = {
     ...context,
-    meta: { ...context.meta, repoName: opts.repoName, subtitle: opts.subtitle, defaultTab },
+    meta: { ...context.meta, repoName: opts.repoName, subtitle: opts.subtitle, defaultTab, tabs },
   };
 
   const data = [
@@ -123,5 +139,5 @@ export function exportViz(opts: VizExportOptions): VizExportResult {
   mkdirSync(opts.outDir, { recursive: true });
   const file = join(opts.outDir, "index.html");
   writeFileSync(file, page);
-  return { file, bytes: Buffer.byteLength(page), contextNodes: contextGraph.nodes.length, codeNodes, defaultTab };
+  return { file, bytes: Buffer.byteLength(page), contextNodes: contextGraph.nodes.length, codeNodes, defaultTab, tabs };
 }

--- a/test/blast-viz.test.ts
+++ b/test/blast-viz.test.ts
@@ -8,13 +8,14 @@
  */
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { basename, join } from "node:path";
 import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 import { blastVizGraph } from "../src/blast/viz.js";
 import { repoLabel } from "../src/blast/blast-cli.js";
-import type { BlastReport, ChangedArea, ImpactedModule } from "../src/blast/blast.js";
+import type { BlastReport, ChangedArea, ImpactedModule, Seed } from "../src/blast/blast.js";
+import type { ChangedFile, DiffLine } from "../src/blast/diff.js";
 
 function mod(label: string, from: string[], symbols: number): ImpactedModule {
   return {
@@ -36,12 +37,30 @@ function area(label: string, files: string[]): ChangedArea {
   };
 }
 
+/** A changed function, and the hunk git reported inside its span. */
+function seed(name: string, path: string, span: string, kind = "function"): Seed {
+  return { id: `${path}#${name}`, name, kind, path, span, wholeFile: false };
+}
+
+function changedFile(path: string, lines: DiffLine[], start = 2): ChangedFile {
+  return {
+    path, status: "modified",
+    ranges: [{ start, end: start + lines.length - 1 }],
+    hunks: [{ start, end: start + lines.length - 1, lines, dropped: 0 }],
+  };
+}
+
 function report(): BlastReport {
   return {
     basis: "origin/main...HEAD", depth: 2,
-    changed: [{ path: "src/a.ts", status: "modified", ranges: [{ start: 1, end: 1 }] }],
+    changed: [changedFile("src/a.ts", [
+      { n: null, sign: "-", text: "  return 1;" },
+      { n: 2, sign: "+", text: "  return 2;" },
+    ])],
     unindexed: [".github/workflows/x.yml"],
-    deleted: [], seeds: [], impacted: [],
+    deleted: [],
+    seeds: [seed("doThing", "src/a.ts", "L1-L4"), seed("Options", "src/a.ts", "L9-L12", "interface")],
+    impacted: [],
     modules: [mod("Query Freshness Gate", ["src/a.ts", "test/a.test.ts"], 2), mod("MCP Tool Surface", ["src/a.ts"], 1)],
     testModules: [mod("Test Suites", ["src/a.ts"], 9)],
     areas: [area("LLM Failure Gate", ["src/a.ts"])],
@@ -75,16 +94,87 @@ test("blast viz: edges are the dependency, so the viewer's wording comes out rig
   assert.equal(g.edges.length, 2);
 });
 
-test("blast viz: a node carries where to look and whether its tests moved", () => {
+test("blast viz: a changed node names what it edited, and says it once about tests", () => {
   const g = blastVizGraph(report());
-  const [changed, affected] = g.nodes;
+  const [changed] = g.nodes;
 
-  assert.match(changed.summary, /Changed in this PR: 1 file, 1 symbol\. no test reaches it\. 0 of 2 changed functions/);
-  assert.deepEqual(changed.sources, ["src/a.ts"]);
+  // The old copy counted ("2 files, 3 symbols") and then said the same thing about
+  // tests twice, with `0 of 2` reading like a coverage score.
+  assert.equal(
+    changed.summary,
+    "Edits doThing, plus Options in 1 file. No test reaches this code.",
+    "the symbols it edited, then one sentence on tests",
+  );
+  assert.ok(!/0 of 2/.test(changed.summary), "no ratio that reads as coverage");
+});
 
-  assert.match(affected.summary, /2 dependent symbols in 1 file\. Nearest hop: s0 at depth 1 \(calls\)\./);
-  // `path · span` is what the detail panel renders as a jump target.
-  assert.deepEqual(affected.sources, ["Query Freshness Gatedep.ts · L1-L3", "Query Freshness Gatedep.ts · L2-L4"]);
+test("blast viz: a changed node shows its hunk, split by symbol", () => {
+  const g = blastVizGraph(report());
+  const [changed] = g.nodes;
+
+  assert.equal(changed.evidence?.length, 1, "only doThing's span holds the hunk");
+  const [ev] = changed.evidence!;
+  // Grep-able: a reader can type the symbol name, not a line span.
+  assert.equal(ev.label, "doThing · src/a.ts:1-4");
+  assert.deepEqual(ev.lines, [
+    { n: null, sign: "-", text: "  return 1;" },
+    { n: 2, sign: "+", text: "  return 2;" },
+  ]);
+});
+
+test("blast viz: an affected node quotes the line that reaches the diff", () => {
+  const root = mkdtempSync(join(tmpdir(), "graft-blast-ev-"));
+  mkdirSync(join(root, "src"), { recursive: true });
+  // s0's span is L1-L3, and line 2 is the call that put it in the radius.
+  writeFileSync(
+    join(root, "Query Freshness Gatedep.ts"),
+    "export function s0() {\n  return doThing(1);\n}\n",
+  );
+
+  const g = blastVizGraph(report(), { root });
+  const affected = g.nodes.find((n) => n.type === "affected");
+
+  assert.equal(
+    affected?.summary,
+    "Not edited by this PR. 2 symbols here reach code it changed — nearest is s0, 1 hop away.",
+    "leads with the fact that this area is collateral, not part of the diff",
+  );
+  const [ev] = affected!.evidence!;
+  assert.deepEqual(ev.lines, [{ n: 2, sign: " ", text: "  return doThing(1);" }]);
+  assert.equal(ev.note, "calls doThing", "says WHICH changed symbol this line reaches");
+});
+
+test("blast viz: a file-level dependent is quoted at its import, not at its doc comment", () => {
+  const root = mkdtempSync(join(tmpdir(), "graft-blast-imp-"));
+  // A whole-file node: nothing in it names a changed SYMBOL, and its first line is
+  // a doc comment — quoting that spent a code block to say nothing.
+  writeFileSync(
+    join(root, "Query Freshness Gatedep.ts"),
+    '/**\n * A module.\n */\nimport { thing } from "./a.js";\n',
+  );
+  const r = report();
+  r.modules = [{
+    ...r.modules[0],
+    symbols: [{ id: "x", name: "dep.ts", kind: "file", path: "Query Freshness Gatedep.ts", span: "L1-L4", relation: "imports", depth: 1 }],
+  }];
+
+  const [ev] = blastVizGraph(r, { root }).nodes.find((n) => n.type === "affected")!.evidence!;
+  assert.deepEqual(ev.lines, [{ n: 4, sign: " ", text: 'import { thing } from "./a.js";' }], "the import line, matched on the changed module");
+  assert.equal(ev.note, "imports");
+
+  // And with nothing to point at, no block at all rather than a `/**`.
+  writeFileSync(join(root, "Query Freshness Gatedep.ts"), "/**\n * A module.\n */\nconst x = 1;\n");
+  const quiet = blastVizGraph(r, { root: mkdtempSync(join(tmpdir(), "graft-empty-")) });
+  assert.equal(quiet.nodes.find((n) => n.type === "affected")?.evidence, undefined);
+});
+
+test("blast viz: an unreadable file costs the snippet, not the page", () => {
+  // No root: nothing to read. The nodes, names and edges must all survive.
+  const g = blastVizGraph(report());
+  const affected = g.nodes.find((n) => n.type === "affected");
+  assert.equal(affected?.evidence, undefined);
+  assert.equal(affected?.sources.length, 2, "the paths are still listed");
+  assert.equal(g.edges.length, 2);
 });
 
 test("blast viz: nothing is capped, unlike the comment's diagram", () => {

--- a/test/blast-viz.test.ts
+++ b/test/blast-viz.test.ts
@@ -110,3 +110,32 @@ test("blast viz: the page is titled after the repository, not the checkout direc
   execFileSync("git", ["-C", dir, "remote", "set-url", "origin", "https://github.com/NanoNets/Graft"]);
   assert.equal(repoLabel(dir), "Graft", "and an https remote with no .git suffix reads the same");
 });
+
+test("blast viz: an empty radius says why, instead of publishing a blank canvas", () => {
+  // A lockfile- or workflow-only PR has no radius, and the page published for it
+  // was a blank canvas behind a link promising a diagram — indistinguishable from
+  // a broken export.
+  const r = report();
+  r.areas = [];
+  r.modules = [];
+  r.changed = [
+    { path: ".github/workflows/x.yml", status: "modified", ranges: [{ start: 1, end: 1 }] },
+    { path: "package-lock.json", status: "modified", ranges: [{ start: 1, end: 1 }] },
+  ];
+  r.unindexed = [".github/workflows/x.yml", "package-lock.json"];
+
+  const g = blastVizGraph(r);
+  assert.equal(g.nodes.length, 0);
+  assert.match(g.meta.emptyNote ?? "", /no parser claims 2 changed files/);
+  assert.match(g.meta.emptyNote ?? "", /\.github\/workflows\/x\.yml, package-lock\.json/);
+
+  // A radius that exists needs no excuse — the note must not appear on a real page.
+  assert.equal(blastVizGraph(report()).meta.emptyNote, undefined);
+
+  // Changed code with no dependents is a different answer from unparsed files.
+  const orphan = report();
+  orphan.areas = [];
+  orphan.modules = [];
+  orphan.unindexed = [];
+  assert.match(blastVizGraph(orphan).meta.emptyNote ?? "", /no resolved dependents/);
+});

--- a/test/blast.test.ts
+++ b/test/blast.test.ts
@@ -17,6 +17,7 @@ import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { join } from "node:path";
 import { runCli, tmpRepo } from "./helpers.js";
+import { changedFiles } from "../src/blast/diff.js";
 
 const MATH = `export function add(a: number, b: number): number {
   return a + b;
@@ -228,4 +229,31 @@ test("blast: a clean tree reports the last commit rather than nothing at all", (
   const report = blastJson([d]);
   assert.equal(report.basis, "HEAD~1...HEAD");
   assert.ok(report.impacted.some((i) => i.name === "total"));
+});
+
+test("diff: hunks carry their text, and the next file's header is not read as a deleted line", () => {
+  const d = builtRepo();
+  // A `--` line of SQL is the trap: `--- a/x.sql` is a header, `-- comment` is
+  // content, and both start with a dash in the patch.
+  writeFileSync(join(d, "src", "math.ts"), MATH_EDITED);
+  writeFileSync(join(d, "query.sql"), "-- report\n");
+  git(d, "add", "-A");
+  git(d, "commit", "-m", "edit");
+
+  const res = changedFiles(d, "HEAD~1");
+  assert.ok(res);
+  const math = res.files.find((f) => f.path === "src/math.ts");
+  assert.ok(math);
+  assert.deepEqual(math.hunks.map((h) => h.lines), [[
+    { n: null, sign: "-", text: "  return a + b;" },
+    { n: 2, sign: "+", text: "  return b + a;" },
+  ]], "both sides of the edit, with post-image numbering");
+  assert.deepEqual(math.ranges, math.hunks.map((h) => ({ start: h.start, end: h.end })), "ranges mirror hunks");
+  assert.ok(
+    !math.hunks.some((h) => h.lines.some((l) => l.text.includes("query.sql"))),
+    "the next file's --- header stayed out of this file's hunk",
+  );
+
+  const sql = res.files.find((f) => f.path === "query.sql");
+  assert.deepEqual(sql?.hunks[0].lines, [{ n: 1, sign: "+", text: "-- report" }], "a real -- line survives");
 });

--- a/test/viz-export.test.ts
+++ b/test/viz-export.test.ts
@@ -166,3 +166,17 @@ test("viz export: asset-path text inside the assets does not fail a correct expo
   assert.match(page, /replaces <link rel="stylesheet" href="\/style\.css">/, "the comment survives inlining");
   assert.match(page, /window\.__GRAFT_DATA__/, "and the export still happened");
 });
+
+test("viz export: tabs can be trimmed, and the payload goes with them", () => {
+  const ctx = contextDir();
+  const all = exportViz({ contextDir: ctx, viewerDir: viewerDir(), outDir: out(), repoName: "demo" });
+  const one = exportViz({ contextDir: ctx, viewerDir: viewerDir(), outDir: out(), repoName: "demo", tabs: ["context"] });
+
+  assert.deepEqual(one.tabs, ["context"]);
+  assert.match(readFileSync(one.file, "utf8"), /"tabs":\["context"\]/, "the viewer is told which tabs to show");
+  // The dropped tabs are the only readers of the wiring graph, so it must not be
+  // embedded at all — that payload is most of a blast page's size.
+  assert.equal(one.codeNodes, 0, "no code graph is read");
+  assert.match(readFileSync(one.file, "utf8"), /codeGraph: null/);
+  assert.ok(all.codeNodes > 0 && readFileSync(all.file, "utf8").length > readFileSync(one.file, "utf8").length);
+});

--- a/viewer/data.ts
+++ b/viewer/data.ts
@@ -25,6 +25,8 @@ export interface VizGraph {
     /** Set by `graft viz --export`: the tab whose graph actually has content. */
     defaultTab?: "context" | "code";
     nodeCount: number; edgeCount: number; skippedFiles?: number; droppedEdges?: number;
+    /** Why the graph is empty, when it is — set by `blast --export-viz`. */
+    emptyNote?: string;
   };
   nodes: VizNode[];
   edges: VizEdge[];

--- a/viewer/data.ts
+++ b/viewer/data.ts
@@ -9,6 +9,7 @@ export interface VizNode {
   type: string;
   summary: string;
   sources: string[];
+  evidence?: Evidence[];
 }
 
 export interface VizEdge {
@@ -19,11 +20,27 @@ export interface VizEdge {
   confidence?: "extracted" | "inferred";
 }
 
+export interface EvidenceLine {
+  n: number | null;
+  sign: "+" | "-" | " ";
+  text: string;
+}
+
+/** A code snippet shown under a node — see `Evidence` in src/viz/assemble.ts. */
+export interface Evidence {
+  label: string;
+  note?: string;
+  lines: EvidenceLine[];
+  more?: number;
+}
+
 export interface VizGraph {
   meta: {
     repoName?: string; subtitle?: string;
     /** Set by `graft viz --export`: the tab whose graph actually has content. */
     defaultTab?: "context" | "code";
+    /** Tabs this page offers. A blast export ships Context alone. */
+    tabs?: Array<"context" | "code" | "outline">;
     nodeCount: number; edgeCount: number; skippedFiles?: number; droppedEdges?: number;
     /** Why the graph is empty, when it is — set by `blast --export-viz`. */
     emptyNote?: string;

--- a/viewer/detail.ts
+++ b/viewer/detail.ts
@@ -3,10 +3,32 @@
  * both directions — amber "Depends on" (outgoing) and teal "Depended on by"
  * (incoming), mirroring the focus-mode edge colors.
  */
-import { type VizGraph, colorToken, cvar } from "./data.js";
+import { type Evidence, type VizGraph, colorToken, cvar } from "./data.js";
 
 function esc(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;");
+}
+
+/**
+ * One snippet: its label, why it is here, and the lines themselves.
+ *
+ * Line text is repo content — on a fork PR, written by whoever opened it — so
+ * every part of this is escaped.
+ */
+function evidenceBlock(e: Evidence): string {
+  const rows = e.lines
+    .map((l) => {
+      const cls = l.sign === "+" ? "add" : l.sign === "-" ? "del" : "ctx";
+      return `<div class="ev-l ${cls}"><span class="ev-n">${l.n ?? ""}</span>` +
+        `<span class="ev-s">${l.sign === " " ? "" : l.sign}</span>` +
+        `<span class="ev-t">${esc(l.text)}</span></div>`;
+    })
+    .join("");
+  return `<div class="ev">` +
+    `<div class="ev-h mono">${esc(e.label)}${e.note ? ` <span class="ev-note">${esc(e.note)}</span>` : ""}</div>` +
+    `<div class="ev-b mono">${rows}</div>` +
+    (e.more ? `<div class="ev-more">+ ${e.more} more lines</div>` : "") +
+    `</div>`;
 }
 
 export function renderDetail(
@@ -33,7 +55,14 @@ export function renderDetail(
   let html = `<span class="d-type"><span class="sw" style="background:${color}"></span>${esc(node.type)}</span>`;
   html += `<h3>${esc(node.name)}</h3>`;
   if (node.summary) html += `<p class="summary">${esc(node.summary)}</p>`;
-  if (node.sources.length) {
+  // Evidence replaces the plain path list wherever it exists: a reader wants the
+  // lines, and showing both would say the same thing twice.
+  if (node.evidence?.length) {
+    html += `<div class="d-label">Code · ${node.evidence.length}</div>`;
+    for (const e of node.evidence) html += evidenceBlock(e);
+    const extra = node.sources.length - node.evidence.length;
+    if (extra > 0) html += `<div class="src mono">+ ${extra} more, not shown</div>`;
+  } else if (node.sources.length) {
     html += `<div class="d-label">Sources · ${node.sources.length}</div>`;
     for (const s of node.sources) html += `<div class="src mono">${esc(s)}</div>`;
   }

--- a/viewer/main.ts
+++ b/viewer/main.ts
@@ -280,6 +280,14 @@ async function loadAll(): Promise<void> {
   const where = [context.meta.repoName, context.meta.subtitle].filter(Boolean).join(" · ");
   $("repoName").textContent = where;
   document.title = `graft viz — ${where}`;
+  // A blast export ships one tab: its Code tab would be the repo's whole wiring
+  // graph, which answers nothing about the pull request the page is about.
+  const tabs = context.meta.tabs;
+  if (tabs) {
+    document.querySelectorAll<HTMLButtonElement>(".tab").forEach((b) => {
+      b.hidden = !tabs.includes(b.dataset.tab as Tab);
+    });
+  }
   // An exported page says which tab holds its content: a structural build has no
   // concept nodes, so the default Context tab would open on an empty canvas.
   const wanted = context.meta.defaultTab;

--- a/viewer/main.ts
+++ b/viewer/main.ts
@@ -149,10 +149,16 @@ function setTab(tab: Tab): void {
     }
   } else {
     const graph = activeGraph();
-    if (!graph) {
-      showEmpty(tab === "code"
+    if (!graph || graph.nodes.length === 0) {
+      // A graph that exists but holds no nodes used to fall through to the canvas
+      // and render nothing at all — worst on an exported page, where the reader
+      // arrived from a link that promised a diagram.
+      // The note names changed FILES, and a path on a fork's branch is written by
+      // whoever opened the pull request — it reaches a published page, so it is
+      // escaped rather than trusted.
+      showEmpty(graph?.meta.emptyNote ? escapeText(graph.meta.emptyNote) : (tab === "code"
         ? "No code graph yet — run <code>graft graph</code> to generate <span class=\"mono\">graph.json</span>."
-        : "No context graph — run <code>graft init</code> first.");
+        : "No context graph — run <code>graft init</code> first."));
     } else {
       empty.hidden = true;
       view.resetView();
@@ -164,6 +170,10 @@ function setTab(tab: Tab): void {
   renderLegend();
   updateShownCount();
   updateCounts();
+}
+
+function escapeText(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;");
 }
 
 function showEmpty(html: string): void {

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -121,3 +121,20 @@ svg.graph:active{cursor:grabbing}
 
 @media (prefers-reduced-motion:reduce){ .tree-row .chev{transition:none} }
 @media (max-width:760px){ .detail,.resizer{display:none} .searchbox input{width:120px} .counts{display:none} }
+/* Evidence blocks: a snippet under a node, so a panel shows the change rather
+   than a line number the reader has to go and look up. */
+.ev{margin:7px 0 11px;border:1px solid var(--line);border-radius:7px;overflow:hidden}
+.ev-h{font-size:11px;padding:5px 8px;background:var(--chip);color:var(--fg);border-bottom:1px solid var(--line);overflow-wrap:anywhere}
+.ev-note{color:var(--muted);font-style:italic}
+.ev-b{font-size:11.5px;padding:4px 0;overflow-x:auto}
+.ev-l{display:flex;gap:8px;padding:1px 8px}
+.ev-n{color:var(--muted);opacity:.65;min-width:2.6em;text-align:right;user-select:none;flex:none}
+.ev-s{width:.7em;user-select:none;flex:none}
+/* Wrapped, not scrolled: the panel is ~280px and a diff line is longer than
+   that, so a horizontal scrollbar per hunk would hide the half that matters. */
+.ev-t{flex:1;white-space:pre-wrap;overflow-wrap:anywhere}
+.ev-l.add{background:color-mix(in srgb,var(--ok,#2E9E6B) 11%,transparent)}
+.ev-l.del{background:color-mix(in srgb,var(--warn,#D9534F) 10%,transparent)}
+.ev-l.add .ev-s{color:var(--ok,#2E9E6B)}
+.ev-l.del .ev-s{color:var(--warn,#D9534F)}
+.ev-more{font-size:11px;color:var(--muted);padding:3px 9px 5px}


### PR DESCRIPTION
The detail panel used to make a reviewer go and look things up:

```
Blast CLI
Can be affected by this PR: 2 dependent symbols in 1 file. Nearest hop: exportRadius at depth 1 (calls).
Sources · 2
  src/blast/blast-cli.ts · L172-L193
  src/blast/blast-cli.ts · L58-L104
```

Now it carries the code, and each block says why it is there:

```
Blast CLI
Not edited by this PR. 2 symbols here reach code it changed — nearest is exportRadius, 1 hop away.
Code · 2
  exportRadius · src/blast/blast-cli.ts:172-193   calls blastVizGraph
   186     contextGraph: blastVizGraph(report, { root }),
```

A changed area shows its **hunks, split by symbol** — two unrelated edits in one file are two answers — and names what it edited instead of counting: "Edits setTab and escapeText in 2 files. No test reaches this code." The old copy said the test thing twice, and `0 of 2 changed functions` read like a coverage score.

`diff.ts` already parsed hunk ranges and threw the text away; it now keeps both, capped at 24 lines per hunk and 200 per file so a regenerated lockfile cannot ride along in `--format json` or in every exported page.

For an affected node there is no diff to show, so the useful line is the one that reaches the change — matched on a changed symbol name, or on the module specifier of a changed file for a file-level dependent. When nothing in the span names the diff, the block is omitted rather than quoting the file's opening `/**`.

**Blast pages now ship the Context tab alone.** The Code tab there was the repository's whole wiring graph — 1,377 nodes that answer nothing about one pull request, and ~95% of the exported megabyte. **1,051 kB → 51 kB.**

Also folded in from #174 (closed): the empty-radius note, and the `workflow_dispatch` PR-number input that is the only way to publish a page for a fork PR.

Line text is repo content — on a fork PR, written by whoever opened it — so every part of a block is escaped before it reaches the page.

761 tests pass, including the trap that `--- a/x.sql` is a header while `-- comment` is content.