### PR TITLE
ci: let blast-pages check out fork PRs again

### DIFF
--- a/.github/workflows/blast-pages.yml
+++ b/.github/workflows/blast-pages.yml
@@ -75,12 +75,19 @@ jobs:
         run: npm ci && npm run build
 
       # 2. The PR's code, as data only.
+      #
+      # actions/checkout refuses a fork's PR ref under `pull_request_target` unless
+      # the workflow opts in — the review that opt-in asks for is the header of this
+      # file: the checkout is credential-less, lands in its own directory, and
+      # nothing below executes anything from it (the CLI that reads it was built
+      # from the base commit above). Without the flag every fork PR fails here.
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: refs/pull/${{ steps.pr.outputs.number }}/merge
           path: pr
           fetch-depth: 0
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       # Same cache the comment job reads (see blast-cache.yml). Both jobs name the
       # same clusters, so sharing the cache is what keeps the page's bubbles worded


### PR DESCRIPTION
## What

`actions/checkout` now refuses `refs/pull/N/merge` from a fork inside a `pull_request_target` workflow unless the step opts in with `allow-unsafe-pr-checkout: true`. The **Blast viewer** job (`.github/workflows/blast-pages.yml`) does exactly that checkout at step 2, so it currently fails for every fork PR — e.g. #69 ([run 32594531130](https://github.com/NanoNets/Graft/actions/runs/32594531130)) and #70:

> Refusing to check out fork pull request code from a 'pull_request_target' workflow. … To opt in, review the risks at https://gh.io/securely-using-pull_request_target and set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.

## Why it's safe to opt in

The workflow was designed for this case and its header documents the review the flag asks for:

- the CLI is built from the **base** commit, before the PR's code is fetched;
- the PR checkout is credential-less (`persist-credentials: false`) and lands in its own `pr/` directory;
- nothing after it executes anything from the PR — no `npm ci` on the PR's `package.json`, no scripts; `node ../base/dist/cli.js build .` parses the PR's source text with tree-sitter as data.

This PR adds the flag with that reasoning next to it, so the next reader doesn't have to reconstruct it. One file, +7 lines.

## Note

Because `pull_request_target` runs the **base** branch's workflow, fork PRs stay red until this lands on `main` — which is why it's split out from #69/#70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YTpgLc3iwX7m3Fe1zTeuou