### PR TITLE
feat(graph): add Lua language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ compiler-grade layer — all `$0` and deterministic (no model, no key):
 - **Broad** — symbols (functions, classes, methods, types, …) plus name-resolved
   call edges via a generic tree-sitter extractor, one grammar per language:
   **Rust, C, C++, C#, Ruby, PHP, Kotlin, Scala, Swift, Elixir, Solidity,
-  OCaml, Zig, Dart, Clojure**.
+  OCaml, Zig, Dart, Clojure, Lua**.
 
 - **Compiler-grade edges (opt-in)** — `graft build --lsp` adds precise
   `lsp_resolved` call edges (member calls the static pass can't type) when a
@@ -205,7 +205,7 @@ compiler-grade layer — all `$0` and deterministic (no model, no key):
   **gopls** (Go), **pyright** (Python), **typescript-language-server** (TS/JS).
   It's best-effort — with no server installed the graph is unchanged.
 
-Twenty-one languages in total. A file whose language isn't listed is skipped, not
+Twenty-two languages in total. A file whose language isn't listed is skipped, not
 indexed. Adding a broad-tier language is a small contribution — see
 [CREDITS.md](CREDITS.md) for the folks who added the current set.
 

--- a/src/graph/generic.ts
+++ b/src/graph/generic.ts
@@ -59,6 +59,7 @@ export const GENERIC_LANGS: readonly GenericLang[] = [
   { name: "zig", exts: [".zig"], wasm: "zig" },
   { name: "dart", exts: [".dart"], wasm: "dart" }, // surfaced by PR #38 (@muneebshere)
   { name: "clojure", exts: [".clj", ".cljs", ".cljc", ".bb"], wasm: "clojure" },
+  { name: "lua", exts: [".lua"], wasm: "lua" },
 ];
 
 const byExt = new Map<string, GenericLang>();

--- a/src/graph/queries/lua.scm
+++ b/src/graph/queries/lua.scm
@@ -1,0 +1,36 @@
+(function_declaration
+  name: [
+    (identifier) @name
+    (dot_index_expression
+      field: (identifier) @name)
+  ]) @definition.function
+
+(function_declaration
+  name: (method_index_expression
+    method: (identifier) @name)) @definition.method
+
+(assignment_statement
+  (variable_list
+    .
+    name: [
+      (identifier) @name
+      (dot_index_expression
+        field: (identifier) @name)
+    ])
+  (expression_list
+    .
+    value: (function_definition))) @definition.function
+
+(table_constructor
+  (field
+    name: (identifier) @name
+    value: (function_definition))) @definition.function
+
+(function_call
+  name: [
+    (identifier) @name
+    (dot_index_expression
+      field: (identifier) @name)
+    (method_index_expression
+      method: (identifier) @name)
+  ]) @reference.call

--- a/test/generic-extract.test.ts
+++ b/test/generic-extract.test.ts
@@ -36,6 +36,7 @@ fn helper() -> String {
 
 test("genericLangOf routes .rs to the breadth tier (and not depth-tier extensions)", () => {
   assert.equal(genericLangOf("src/main.rs")?.name, "rust");
+  assert.equal(genericLangOf("src/init.lua")?.name, "lua");
   assert.equal(genericLangOf("src/app.ts"), null); // depth tier owns .ts
   assert.equal(genericLangOf("README.md"), null);
 });
@@ -105,6 +106,13 @@ const SNIPPETS: Array<{ lang: string; file: string; src: string; defs: string[];
     lang: "clojure", file: "a.clj",
     src: `(ns my.core)\n\n(defn helper [] 1)\n\n(defn run [] (helper))\n`,
     defs: ["function:helper", "function:run", "module:my.core"], call: ["run", "helper"],
+  },
+  {
+    // Lua functions can be declarations, assigned expressions, or table fields;
+    // colon syntax defines and calls methods.
+    lang: "lua", file: "a.lua",
+    src: `local function helper()\n  return 1\nend\n\nlocal assigned = function()\n  return helper()\nend\n\nlocal handlers = { draw = function() return helper() end }\n\nfunction Widget:run()\n  return helper()\nend\n\nlocal function launch()\n  return Widget:run()\nend\n`,
+    defs: ["function:assigned", "function:draw", "function:helper", "function:launch", "method:run"], call: ["launch", "run"],
   },
 ];
 


### PR DESCRIPTION
## Summary

- Add Lua (`.lua`) to the breadth-tier generic extractor using the existing `tree-sitter-wasm` Lua grammar
- Register Lua in `GENERIC_LANGS`
- Add `lua.scm` queries for function and method definitions and call references
- Cover local functions, assigned functions, function-valued table fields, and `:` method syntax
- Update the supported-language documentation

## Test results

`npm run build` passes.

`npm test`: 832 passed, 5 skipped, 0 failed.