### PR TITLE
fix(openai): negotiate the four 400s reasoning-default models return

### DIFF
--- a/src/ai/llm/openai.ts
+++ b/src/ai/llm/openai.ts
@@ -85,6 +85,51 @@ function isRejectedObjectToolChoice(err: unknown): boolean {
   );
 }
 
+/**
+ * Newer reasoning-family models (o1/o3/o4, the gpt-5.x line, …) reject the
+ * classic `max_tokens` param outright and require `max_completion_tokens`
+ * instead, even though both are still in wide use across OpenAI-compatible
+ * servers. Detect the specific 400 rather than guessing from the model name,
+ * so older endpoints that still expect `max_tokens` are untouched.
+ */
+function isRejectedMaxTokens(err: unknown): boolean {
+  return (
+    err instanceof OpenAI.APIError &&
+    err.status === 400 &&
+    /max_tokens.*not supported.*max_completion_tokens/i.test(String((err as { message?: string }).message ?? ""))
+  );
+}
+
+/** Same reasoning-family models: temperature is fixed at 1, not caller-settable. */
+function isRejectedTemperature(err: unknown): boolean {
+  return (
+    err instanceof OpenAI.APIError &&
+    err.status === 400 &&
+    /temperature.*does not support/i.test(String((err as { message?: string }).message ?? ""))
+  );
+}
+
+/**
+ * Same models again: function tools are rejected on /v1/chat/completions while
+ * the model's default reasoning effort is active. The API's own error message
+ * names the fix — `reasoning_effort: "none"` — so apply exactly that.
+ *
+ * DeepSeek's v4 line refuses the same combination ("Thinking mode does not
+ * support this tool_choice") for every tool_choice except "auto", and accepts
+ * the identical `reasoning_effort: "none"` remedy. Matching both phrasings here
+ * keeps a forced tool_choice working rather than degrading it to "auto", which
+ * would leave the model free not to call the tool the caller asked for.
+ */
+function isRejectedToolsWithReasoning(err: unknown): boolean {
+  const message = String((err as { message?: string }).message ?? "");
+  return (
+    err instanceof OpenAI.APIError &&
+    err.status === 400 &&
+    (/function tools with reasoning_effort/i.test(message) ||
+      /thinking mode does not support this tool_choice/i.test(message))
+  );
+}
+
 export class OpenAIChatModel implements ChatModel {
   readonly label: string;
   private client: OpenAI;
@@ -141,14 +186,37 @@ export class OpenAIChatModel implements ChatModel {
    * automatically.
    */
   private async createChatCompletion(params: ChatParams): Promise<OpenAI.Chat.Completions.ChatCompletion> {
-    try {
-      return await this.client.chat.completions.create(params);
-    } catch (err) {
-      if (isRejectedObjectToolChoice(err) && typeof params.tool_choice === "object" && params.tools?.length === 1) {
-        return this.client.chat.completions.create({ ...params, tool_choice: "required" });
+    let attempt = params;
+    // Bounded: one retry per known incompatibility below, never an open loop.
+    for (let i = 0; i < 4; i++) {
+      try {
+        return await this.client.chat.completions.create(attempt);
+      } catch (err) {
+        // Checked before the tool_choice fallback below: a reasoning refusal
+        // also names tool_choice, and turning reasoning off keeps the caller's
+        // chosen tool instead of loosening the choice to work around it.
+        if (isRejectedToolsWithReasoning(err) && attempt.reasoning_effort === undefined) {
+          attempt = { ...attempt, reasoning_effort: "none" } as ChatParams;
+          continue;
+        }
+        if (isRejectedObjectToolChoice(err) && typeof attempt.tool_choice === "object" && attempt.tools?.length === 1) {
+          attempt = { ...attempt, tool_choice: "required" };
+          continue;
+        }
+        if (isRejectedMaxTokens(err) && attempt.max_tokens !== undefined) {
+          const { max_tokens, ...rest } = attempt;
+          attempt = { ...rest, max_completion_tokens: max_tokens } as ChatParams;
+          continue;
+        }
+        if (isRejectedTemperature(err) && attempt.temperature !== undefined) {
+          const { temperature, ...rest } = attempt;
+          attempt = rest as ChatParams;
+          continue;
+        }
+        throw err;
       }
-      throw err;
     }
+    return this.client.chat.completions.create(attempt);
   }
 
   private fromResponse(


### PR DESCRIPTION
Fixes #183.

`graft build --deep` fails on the first LLM call against models that reason by default. Each of these is a request shape the server rejects with a 400, and each is detected by that 400 rather than guessed from a model name, so endpoints that still expect the older shape are untouched:

| rejected | remedy |
|---|---|
| `max_tokens` | retry as `max_completion_tokens` |
| a caller-set `temperature` | drop it (fixed at 1, not settable) |
| function tools while reasoning is on | `reasoning_effort: "none"` |
| DeepSeek's `Thinking mode does not support this tool_choice` | same `reasoning_effort` remedy |

The single try/catch becomes a bounded loop, because one response can surface a second incompatibility once the first is fixed.

**Ordering matters.** DeepSeek's message also names `tool_choice`, so the existing object-form fallback matched it first and rewrote the request to `tool_choice: "required"` — which thinking mode rejects too. The reasoning check therefore runs first. It is also the better remedy: loosening to `"auto"` returns 200 but lets the model decline to call the tool at all, and since `fmt.kind === "json"` uses a forced synthetic tool as the structured-output mechanism, a model that opts out returns prose and the node write fails downstream.

Every branch is gated on the parameter it removes still being present, and the reasoning branch on `reasoning_effort` being unset, so no branch can fire twice. The loop bound is one per known incompatibility; the trailing call exists only so a genuine error still surfaces rather than being swallowed by loop exhaustion.

The detectors match error text rather than model ids on purpose. That is brittle if a provider rewords a message, but a model-name allowlist goes stale every time a provider ships a model and silently sends the wrong shape to anything unrecognised. A wording change degrades to today's behaviour — a surfaced 400. A stale allowlist degrades to a broken build with no clue why.

**Verified end to end** on a repo that previously failed at the first LLM call: `build --deep` completes and writes concept nodes against both `gpt-5.6` and `deepseek-v4-flash`. `tsc --noEmit` clean, existing suite green.

The issue also notes a separate rate-limit problem (`-j 5` trips 429s on a 200k TPM key, and the consecutive-failure gate aborts the build rather than backing off). That is not touched here — happy to open it separately if you agree it is one.
