### PR TITLE
fix(ingest): skip _build, the underscore spelling of a build tree

### DIFF
--- a/src/ingest/fs.ts
+++ b/src/ingest/fs.ts
@@ -10,6 +10,12 @@ export const SKIP_DIRS = new Set([
   "node_modules",
   "dist",
   "build",
+  // The underscore spelling that Sphinx, CMake, Jekyll and the OCaml tools all
+  // emit. Left out, a materialized build tree lands in the graph as ordinary
+  // source: one repo here indexed 4,484 files of vendored WordPress against 121
+  // hand-written ones, and queries slowed enough that the prompt hook's budget
+  // could no longer fit them. `--include-dir _build` remains the way back in.
+  "_build",
   "out",
   "target",
   "vendor",


### PR DESCRIPTION
`SKIP_DIRS` covers `build/` but not `_build/` — the name Sphinx, CMake, Jekyll and the OCaml tools all emit. A repo that materializes its build tree under that name indexes it as ordinary source.

Concretely, on one repo here: **4,484 files of vendored WordPress against 121 hand-written ones**, or 97% of the graph.

The cost was not only noise. `graft ask` went from sub-second to **9.5–12.5s**, which no longer fit the prompt hook's child budget — so the hook ran, was killed mid-query, and emitted nothing. No retrieval pack, no session write, no error: it looked exactly like a prompt graft had nothing to say about. Retrieval had silently stopped happening on every prompt.

With `_build` skipped, the same repo indexes **121 files in 2s**, queries in **264ms**, and the hook answers again. Retrieval quality did not change — the same two questions return the same top hits, because nobody edits WordPress core.

Skipping is the same bet the list already makes for `build/`: a directory by that name is output far more often than it is source. `--include-dir _build` remains the documented way back in for a repo where it is not.

`tsc --noEmit` clean, existing suite green (29/29).
