### PR TITLE
fix(claude): read the hook budget from user-level settings too

### DIFF
--- a/src/claude/hooks.ts
+++ b/src/claude/hooks.ts
@@ -1,6 +1,7 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { execFileSync, spawn } from 'node:child_process';
 import { join, basename, isAbsolute } from 'node:path';
+import { homedir } from 'node:os';
 import { readWiring } from './stats.js';
 import { formatBlastRadius, relevantRetrieval, formatOrientation } from './format.js';
 import { indexFreshness, staleBanner } from '../context/check.js';
@@ -59,11 +60,26 @@ export function promptAskTimeout(dir: string): number {
   return Math.max(MIN_CHILD_TIMEOUT_MS, installed - HOOK_OVERHEAD_MS);
 }
 
-/** The timeout on this repo's graft hook entry for `event`, or null if it can't be
- * read (no settings file, hand-edited shape, unparseable JSON). */
-function installedHookTimeout(dir: string, event: string): number | null {
+/**
+ * Every settings file Claude Code merges hook definitions from, for a session
+ * rooted at `dir`. The per-repo file is not the only place graft's hooks can be
+ * installed: declaring them once at the user level wires every repo on the
+ * machine at once, and such a repo has no `.claude/settings.json` at all.
+ */
+function hookSettingsFiles(dir: string): string[] {
+  const user = process.env.CLAUDE_CONFIG_DIR ?? join(homedir(), '.claude');
+  return [
+    join(dir, '.claude', 'settings.json'),
+    join(dir, '.claude', 'settings.local.json'),
+    join(user, 'settings.json'),
+  ];
+}
+
+/** The timeout on one settings file's graft hook entry for `event`, or null if it
+ * can't be read (no settings file, hand-edited shape, unparseable JSON). */
+function hookTimeoutIn(file: string, event: string): number | null {
   try {
-    const settings = JSON.parse(readFileSync(join(dir, '.claude', 'settings.json'), 'utf8')) as any;
+    const settings = JSON.parse(readFileSync(file, 'utf8')) as any;
     const blocks = settings?.hooks?.[event];
     if (!Array.isArray(blocks)) return null;
     for (const block of blocks) {
@@ -77,6 +93,27 @@ function installedHookTimeout(dir: string, event: string): number | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * The budget this hook is actually running under, or null when no settings file
+ * declares one.
+ *
+ * The smallest declared timeout wins rather than the nearest, because when more
+ * than one file declares the hook Claude Code runs every matching entry and this
+ * process cannot tell which one launched it. Guessing high is the expensive
+ * mistake: an overrunning child gets the whole hook SIGKILLed, so `emit()` and
+ * `writeSession()` never run and the turn silently gets no retrieval at all.
+ * Guessing low only shortens one query.
+ */
+function installedHookTimeout(dir: string, event: string): number | null {
+  let smallest: number | null = null;
+  for (const file of hookSettingsFiles(dir)) {
+    const timeout = hookTimeoutIn(file, event);
+    if (timeout === null) continue;
+    if (smallest === null || timeout < smallest) smallest = timeout;
+  }
+  return smallest;
 }
 
 function graftJson(dir: string, args: string[], timeout: number = CHILD_TIMEOUT_MS): any | null {

--- a/test/claude-hooks.test.ts
+++ b/test/claude-hooks.test.ts
@@ -459,15 +459,63 @@ function withSettings(timeout: unknown): string {
 }
 
 test('promptAskTimeout is derived from the installed hook budget', () => {
-  // A repo wired before the budget was raised.
-  assert.equal(promptAskTimeout(withSettings(8000)), 6000);
-  // A repo wired after.
-  assert.equal(promptAskTimeout(withSettings(15000)), 13000);
-  // Never so small the child has no chance.
-  assert.equal(promptAskTimeout(withSettings(1000)), 4000);
+  // User-level settings are one of the sources now, so point them somewhere empty:
+  // otherwise these assertions read whatever the developer running the suite has
+  // wired on their own machine.
+  const previous = process.env.CLAUDE_CONFIG_DIR;
+  process.env.CLAUDE_CONFIG_DIR = mkdtempSync(join(tmpdir(), 'graft-nouser-'));
+  try {
+    // A repo wired before the budget was raised.
+    assert.equal(promptAskTimeout(withSettings(8000)), 6000);
+    // A repo wired after.
+    assert.equal(promptAskTimeout(withSettings(15000)), 13000);
+    // Never so small the child has no chance.
+    assert.equal(promptAskTimeout(withSettings(1000)), 4000);
 
-  // Nothing readable: assume the conservative 8s budget the other hooks carry.
-  assert.equal(promptAskTimeout(withSettings(undefined)), 6000);
-  assert.equal(promptAskTimeout(withSettings('nonsense')), 6000);
-  assert.equal(promptAskTimeout(mkdtempSync(join(tmpdir(), 'graft-nosettings-'))), 6000);
+    // Nothing readable: assume the conservative 8s budget the other hooks carry.
+    assert.equal(promptAskTimeout(withSettings(undefined)), 6000);
+    assert.equal(promptAskTimeout(withSettings('nonsense')), 6000);
+    assert.equal(promptAskTimeout(mkdtempSync(join(tmpdir(), 'graft-nosettings-'))), 6000);
+  } finally {
+    if (previous === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = previous;
+  }
+});
+
+/**
+ * Hooks can be declared once at the user level, wiring every repo on the machine.
+ * Such a repo has no `.claude/settings.json`, so a lookup that only reads the repo
+ * finds nothing and falls back to the conservative 8s — starving the query in any
+ * repo whose graph takes longer than that, with no error to say so.
+ */
+function withUserSettings(timeout: unknown): string {
+  const d = mkdtempSync(join(tmpdir(), 'graft-userhooks-'));
+  const hooks = timeout === undefined ? {} : {
+    UserPromptSubmit: [{ hooks: [{ type: 'command', command: 'node "$HOME/.claude/helpers/graft-hooks.cjs" prompt', timeout }] }],
+  };
+  writeFileSync(join(d, 'settings.json'), JSON.stringify({ hooks }));
+  return d;
+}
+
+test('promptAskTimeout reads a user-level hook when the repo declares none', () => {
+  const previous = process.env.CLAUDE_CONFIG_DIR;
+  try {
+    process.env.CLAUDE_CONFIG_DIR = withUserSettings(15000);
+    // A repo with no .claude/ of its own still gets the budget it truly runs under.
+    assert.equal(promptAskTimeout(mkdtempSync(join(tmpdir(), 'graft-nosettings-'))), 13000);
+
+    // Declared in both places: Claude Code fires both entries and this process
+    // cannot tell which launched it, so the smallest budget is the only safe one.
+    assert.equal(promptAskTimeout(withSettings(8000)), 6000);
+
+    process.env.CLAUDE_CONFIG_DIR = withUserSettings(8000);
+    assert.equal(promptAskTimeout(withSettings(15000)), 6000);
+
+    // Nothing anywhere still means the conservative default.
+    process.env.CLAUDE_CONFIG_DIR = withUserSettings(undefined);
+    assert.equal(promptAskTimeout(mkdtempSync(join(tmpdir(), 'graft-nosettings-'))), 6000);
+  } finally {
+    if (previous === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = previous;
+  }
 });


### PR DESCRIPTION
The prompt hook sizes its `graft ask` child against the timeout Claude Code will kill it at, read from the repo's `.claude/settings.json`.

But hooks can be declared once at the **user level** instead — one entry in `~/.claude/settings.json` wires every repo on the machine, and none of those repos has a settings file of its own. The lookup finds nothing, falls back to the conservative 8s default, and leaves the child 6s.

In a repo whose graph takes longer than that, the hook then runs, is killed mid-query, and emits nothing: no retrieval pack, no session write, and no error anywhere to say retrieval has stopped. It is indistinguishable from a prompt graft had nothing to say about. One repo here queried in 9.5–12.5s and lost retrieval on **every single prompt** this way — it took timing the hook by hand to notice.

This searches the repo's `settings.json`, its `settings.local.json`, and the user's `settings.json` (honouring `CLAUDE_CONFIG_DIR`).

**Where more than one declares the hook, the smallest budget wins.** Claude Code fires every matching entry and the child cannot tell which one launched it, so only the smallest is safe. The asymmetry justifies it: guessing high gets the whole hook SIGKILLed and loses the turn's retrieval entirely, while guessing low only shortens one query.

One existing test needed a change. `promptAskTimeout` asserting "nothing readable anywhere → 6s" is now also a statement about the machine's home directory — it fails on any developer who has graft's hooks installed at the user level, which is exactly the configuration this fixes. It now pins `CLAUDE_CONFIG_DIR` at an empty directory so the suite stays hermetic.

Verified against the reported repo: the budget goes from 6000ms to 13000ms, and the hook answers in 313ms. `tsc --noEmit` clean, suite green (29/29) including a new test for the fallback and for the smallest-wins rule.
