### PR TITLE
Python: constructor calls resolve to the class instead of dropping

### DIFF
--- a/src/graph/resolve.ts
+++ b/src/graph/resolve.ts
@@ -20,6 +20,12 @@ import type { RawEdge } from "./extract.js";
 const IMPORT_EXTS = [".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs", ".py"];
 /** C/C++ source + header extensions, for resolving `#include` targets. */
 const C_EXT = /\.(c|h|cc|cpp|cxx|hpp|hh|hxx|inl|ipp|c\+\+|h\+\+)$/i;
+/** Python source + stub extensions, for the constructor-call fallback below. */
+const PY_EXT = /\.pyi?$/i;
+/** What a bare Python call falls back to when no function of that name exists:
+ * construction. Only `class` — Python enums, dataclasses and NamedTuples are all
+ * classes, so no other kind is reachable this way. */
+const PY_CTOR_KINDS: Kind[] = ["class"];
 
 /** A Go module discovered in the repo: its `module` path from `go.mod` and the repo
  * directory that `go.mod` lives in (posix, `.` for the repo root). A monorepo may hold
@@ -199,7 +205,16 @@ export function resolveEdges(
           : e.file.endsWith(".java")
             ? ["class", "struct", "enum", "interface"]
             : ["function"];
-      const hit = resolveName(e.name!, e.file, callKinds, perFileName, globalName);
+      let hit = resolveName(e.name!, e.file, callKinds, perFileName, globalName);
+      // Python is the Java case without the `new` to mark it: `Widget()` is an
+      // ordinary call node, so a constructor edge dies against the function-only
+      // index. Java can widen to types outright; Python has free functions, so
+      // widening would trade real function edges for type ones. Hence a fallback,
+      // not a swap — types are tried only once functions have found nothing, and
+      // resolveName's same-file-then-unique-global rule still drops the ambiguous.
+      if (!hit && PY_EXT.test(e.file)) {
+        hit = resolveName(e.name!, e.file, PY_CTOR_KINDS, perFileName, globalName);
+      }
       if (hit) add(e.source, hit.id, "calls", hit.confidence); // drop unresolved calls (too noisy)
     }
   }

--- a/test/graph-python.test.ts
+++ b/test/graph-python.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for Python constructor call edges in the Tier-1 code graph.
+ *
+ * Python spells construction as an ordinary call — `Widget()`, with no `new` to
+ * mark it — so a constructor edge reaches the resolver indistinguishable from a
+ * function call. Resolved against the function-only index it vanishes, and
+ * `graft callers <SomeClass>` reports "no indexed callers" on a class every file
+ * in the repo instantiates. That is the same failure `graph-java.test.ts` pins
+ * for `new Foo()`, in the language where it is invisible.
+ *
+ * The fix is a fallback, not a swap: unlike Java, Python HAS free functions, so
+ * resolving bare calls against types outright would trade real function edges
+ * away. Functions are matched first and unchanged; types are tried only when
+ * that finds nothing.
+ *
+ * The last two tests pin that ordering and the drop rule, because a fallback
+ * that fires too eagerly is worse than the missing edge. Both are written as
+ * negative assertions — bare-call resolution does not read import bindings
+ * today, so pinning which target it picks would freeze that limitation into the
+ * suite. What must hold under any implementation is that the fallback stays
+ * silent while a function matches, and never guesses between two same-named
+ * classes.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { buildGraph } from "../src/graph/build.js";
+import { readGraph, wiringPath } from "../src/graph/write.js";
+import type { GraphV1 } from "../src/graph/types.js";
+
+const THING = `class Widget:
+    def run(self):
+        return 1
+
+
+def helper():
+    return 2
+`;
+
+const MAIN = `from pkg.thing import Widget, helper
+
+
+def build():
+    w = Widget()
+    return w.run() + helper()
+`;
+
+/** `Thing` is a function here and a class in `dup_class.py` — the function must win. */
+const DUAL_FN = `def Thing():
+    return 1
+`;
+
+const DUAL_CLASS = `class Thing:
+    pass
+`;
+
+/** `Dup` is a class in two files. `dup_a.py` is the copy `caller.py` does NOT
+ * import, and it sorts first — so an implementation that takes the first global
+ * candidate instead of requiring a unique one picks it, and test 4 catches that. */
+const DUP_A = `class Dup:
+    pass
+`;
+
+const DUP_B = `class Dup:
+    pass
+`;
+
+const CALLER = `from dual_fn import Thing
+from dup_z import Dup
+
+
+def use_thing():
+    return Thing()
+
+
+def use_dup():
+    return Dup()
+`;
+
+/** Construction in the file that declares the class — a same-file, `extracted` edge. */
+const LOCAL = `class Local:
+    pass
+
+
+def make():
+    return Local()
+`;
+
+function makeFixture(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graft-python-"));
+  mkdirSync(join(dir, "pkg"), { recursive: true });
+  writeFileSync(join(dir, "pkg", "__init__.py"), "");
+  writeFileSync(join(dir, "pkg", "thing.py"), THING);
+  writeFileSync(join(dir, "main.py"), MAIN);
+  writeFileSync(join(dir, "dual_fn.py"), DUAL_FN);
+  writeFileSync(join(dir, "dup_class.py"), DUAL_CLASS);
+  writeFileSync(join(dir, "dup_a.py"), DUP_A);
+  writeFileSync(join(dir, "dup_z.py"), DUP_B);
+  writeFileSync(join(dir, "caller.py"), CALLER);
+  writeFileSync(join(dir, "local.py"), LOCAL);
+  return dir;
+}
+
+async function buildFixture(dir: string): Promise<GraphV1> {
+  await buildGraph(dir); // $0, Tier-1 only
+  const graph = readGraph(wiringPath(join(dir, "graft")));
+  assert.ok(graph, "wiring graph should be written");
+  return graph!;
+}
+
+test("Python: `Widget()` produces a constructor edge to the class", async () => {
+  const dir = makeFixture();
+  try {
+    const graph = await buildFixture(dir);
+    const calls = graph.edges.filter((e) => e.relation === "calls");
+
+    assert.ok(
+      calls.some((e) => e.source === "main.py#build" && e.target === "pkg/thing.py#Widget"),
+      "build should have a constructor edge to Widget",
+    );
+
+    // The existing function path is untouched: a plain call still resolves.
+    assert.ok(
+      calls.some((e) => e.source === "main.py#build" && e.target === "pkg/thing.py#helper"),
+      "build should still call helper",
+    );
+
+    // And the receiver bound by `w = Widget()` still reaches the method.
+    assert.ok(
+      calls.some((e) => e.source === "main.py#build" && e.target === "pkg/thing.py#Widget.run"),
+      "build should call Widget.run through the constructor-assigned receiver",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("Python: same-file construction resolves as an extracted edge", async () => {
+  const dir = makeFixture();
+  try {
+    const graph = await buildFixture(dir);
+    const edge = graph.edges.find(
+      (e) => e.relation === "calls" && e.source === "local.py#make" && e.target === "local.py#Local",
+    );
+    assert.ok(edge, "make should have a constructor edge to Local");
+    assert.equal(edge!.confidence, "extracted", "a same-file target is certain, not inferred");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("Python: the fallback stays silent when a function of that name matches", async () => {
+  const dir = makeFixture();
+  try {
+    const graph = await buildFixture(dir);
+    const targets = graph.edges
+      .filter((e) => e.relation === "calls" && e.source === "caller.py#use_thing")
+      .map((e) => e.target);
+
+    // `caller.py` imports the FUNCTION `Thing`, and a function match means the
+    // fallback never runs — so the class of the same name must not be linked.
+    assert.ok(targets.includes("dual_fn.py#Thing"), "Thing() should resolve to the imported function");
+    assert.ok(
+      !targets.includes("dup_class.py#Thing"),
+      "the same-named class must not be linked — the fallback fires only when no function matches",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("Python: an ambiguous class name is never guessed at", async () => {
+  const dir = makeFixture();
+  try {
+    const graph = await buildFixture(dir);
+    const targets = graph.edges
+      .filter((e) => e.relation === "calls" && e.source === "caller.py#use_dup")
+      .map((e) => e.target);
+
+    // `Dup` is declared in two files. Today resolveName finds two global
+    // candidates and drops, which is correct-by-omission; an import-aware
+    // resolver would instead pick `dup_z`, the one `caller.py` imports. Both are
+    // acceptable — picking `dup_a`, the one it does not import, never is.
+    assert.ok(
+      !targets.includes("dup_a.py#Dup"),
+      "a class the caller never imported must never be guessed at",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Symptom

`graft callers <SomeClass>` reports **"no indexed callers"** for a Python class the repo instantiates everywhere.

On a 372-file Python/TS repo, `callers VideoSelector` returned nothing while 7 other files import and instantiate it. In `wiring.json` that class node had **zero incoming `calls` edges** — the only edge pointing at it was the `contains` from its own file.

## Minimal repro (2 files, 10 lines)

```python
# pkg/thing.py                 # main.py
class Widget:                  from pkg.thing import Widget, helper
    def run(self): return 1    def build():
def helper(): return 2             w = Widget()
                                   return w.run() + helper()
```

```
$ graft callers helper   →  calls ← build           ✅
$ graft callers Widget   →  no indexed callers      ❌
```

## By language

| Language | Construct | Before |
|---|---|---|
| TypeScript | `new Widget()` | ✅ `references ← build` — a `new_expression` isn't in `CALL_TYPES`, so it takes the identifier/reference path |
| Java | `new Widget()` | ✅ `calls ← build` — the explicit `.java` branch in `resolve.ts` |
| **Python** | `Widget()` | ❌ nothing |

## Root cause

`src/graph/resolve.ts`, the bare-call branch:

```ts
      const srcOrigin = byId.get(e.source)?.origin;
      const callKinds: Kind[] =
        srcOrigin === "generic"
          ? ["function", "method"]
          : e.file.endsWith(".java")
            ? ["class", "struct", "enum", "interface"]
            : ["function"];
```

The comment directly above already diagnoses this for Java:

> *"Java (depth tier): an implicit-`this` call is spelled as a member call in extract.ts, so the only bare call reaching here is `new Foo()`, whose target is a TYPE. Against the function index every constructor edge would drop."*

Python's constructor call is syntactically an ordinary `call` node, so it arrives in this branch indistinguishable from a function call and drops against the function-only index — exactly as that comment predicts, in the one language where nothing in the syntax marks it.

## The fix — a fallback, not a swap

Java can widen bare calls to types outright because Java has no free functions. Python does have them, so the same widening would trade real function edges for type ones. Instead: functions are matched first and **byte-for-byte unchanged**; types are tried **only on a miss**. `resolveName`'s existing same-file-then-unique-global rule keeps doing the dropping when the name is ambiguous, so drop-rather-than-guess is preserved.

## Evidence

- **Full suite green:** 840/840.
- **The new tests fail without the patch** — 2 of 4, verified by restoring the parent revision of `resolve.ts`. The other 2 are precision guards that must pass both ways; each was checked against a deliberately wrong implementation (widening to `["function","class"]` fails test 3; taking the first global candidate instead of requiring a unique one fails test 4).
- **Real repo, before → after:** 9,295 → 10,808 edges (**+1,513**). Every new edge is a `calls` edge targeting a `class`; **zero edges removed**; no confidence changed on any pre-existing edge. `scripts/graph-quality.mjs --strict` passes.
- **Precision, measured over all 1,513 new edges** (not sampled) by parsing each source file's real imports with Python's `ast`:

  | | count |
  |---|---|
  | import points straight at the target file | 1,248 |
  | same-file construction | 256 |
  | package re-export of the target | 7 |
  | **false — name imported from outside the repo** | **2** |

  The 2 are the honest weakness of this approach: `backlot/server.py` imports `StreamingResponse` from fastapi, and a same-named class defined inside a test function got linked. The import specifier saying "this name is external" is right there in the file and this path ignores it. Construction is where that bites hardest — repos routinely define their own `Config`, `Client`, `Session`, `Response` — so it is a **new** failure mode, not merely more of the existing `inferred` risk. Measured rate on this corpus: 2/1,513 = 0.13%, n=1 repo.
- Confidence split of the new edges: 256 `extracted` (same-file), 1,257 `inferred` (unique global name).

## Tests (`test/graph-python.test.ts`)

1. cross-file `Widget()` → constructor edge, with the existing function edge and the constructor-bound receiver edge asserted unchanged
2. same-file construction resolves as `extracted`, not `inferred`
3. guard: the fallback stays silent while a function of that name matches
4. guard: an ambiguous class name is never guessed at — the fixture makes the *unimported* duplicate sort first, so a first-candidate implementation picks the wrong one and fails

Guards 3 and 4 are written as negative assertions on purpose: bare-call resolution doesn't read import bindings today, so pinning *which* target it picks would freeze that limitation into the suite.

## Three things for maintainers

1. **`collectImportedSymbols` is the more correct long-term fix, and this isn't it.** It already exists and already feeds a specifier-scoped path that resolves inside the imported file only — it just returns empty for everything except TS/TSX (`extract.ts:482`). Extending it to Python and attaching a `specifier` to bare call edges would make these edges `extracted` rather than `inferred`, resolve the ambiguous case correctly instead of dropping it, and eliminate the external-import collision above outright. That's a much larger change; this mirrors the existing Java precedent at a fraction of the risk. Happy to attempt the bigger one instead if you'd prefer.
2. **Relation naming.** This emits `calls`, matching the Java constructor precedent, and Python construction genuinely is a call. TypeScript's `new Widget()` lands as `references`. The two constructor paths therefore disagree — that predates this PR, and I'm happy to switch Python to `references` if you'd rather converge there.
3. **Go has the same symptom, and this does not fix it.** `w := Widget{n: 1}` is a `composite_literal`, never reaching `CALL_TYPES` at all, and the reference path is TS/TSX-only — so Go produces no construction edge from either route. That needs an extractor change. Happy to open it separately.

Also happy to add a `CHANGELOG.md` entry under `### Fixed` if that's contributor-owned rather than release-time.
