### PR TITLE
fix(claude): statusline distinguishes an empty graph from a missing one (#185)

### DIFF
--- a/src/claude/format.ts
+++ b/src/claude/format.ts
@@ -26,7 +26,7 @@ export function renderStatusline(
   session: SessionState | null,
   ctx: { ctxPct: number | null },
 ): string[] {
-  if (!stats || stats.nodeCount === 0) {
+  if (!stats) {
     return [C.muted('◤ graft · not built · run ') + C.text('graft build')];
   }
   const top = [C.muted('◤ ') + C.indigo('graft'), C.text(`${stats.nodeCount} nodes / ${stats.edgeCount} edges`)];

--- a/src/claude/statusline.ts
+++ b/src/claude/statusline.ts
@@ -7,16 +7,18 @@ import { readWiring, computeStats } from './stats.js';
  * The statusline's fast path is the hook-maintained cache (graft/.cache/stats.json).
  * When it's absent — a fresh checkout, or a plain `graft build` that doesn't write the
  * cache — fall back to reading the graph itself (wiring.json) so the bar reflects reality
- * immediately instead of showing "not built". The graph carries no drift signal, so it
- * reads as synced until the next edit repopulates the cache. Still a pure read (no
- * subprocess): the cache is preferred because it carries live dirty/stale state.
+ * immediately instead of showing "not built". An empty wiring.json is still a graph
+ * (docs-only repos legitimately have 0 nodes); "not built" is only when the artifact
+ * is missing. The graph carries no drift signal, so it reads as synced until the next
+ * edit repopulates the cache. Still a pure read (no subprocess): the cache is preferred
+ * because it carries live dirty/stale state.
  */
 export function resolveStats(dir: string): Stats | null {
   const cached = readStats(dir);
   if (cached && cached.nodeCount > 0) return cached;
   const wiring = readWiring(dir);
   if (wiring) return { ...emptyStats(), ...computeStats(wiring) };
-  return cached;
+  return null;
 }
 
 export function main(): void {

--- a/test/claude-format.test.ts
+++ b/test/claude-format.test.ts
@@ -8,6 +8,18 @@ const strip = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '');
 test('not-built state', () => {
   const lines = renderStatusline(null, null, { ctxPct: null });
   assert.match(strip(lines[0]), /not built/);
+  assert.match(strip(lines[0]), /graft build/);
+});
+
+test('empty graph (0 nodes) is built, not "not built"', () => {
+  // A successful `graft build` on a docs-only repo writes a real graph with
+  // zero symbols. nodeCount === 0 must not be treated as "never built".
+  const stats = { ...emptyStats(), nodeCount: 0, edgeCount: 0 };
+  const line = strip(renderStatusline(stats, null, { ctxPct: null })[0]);
+  assert.doesNotMatch(line, /not built/);
+  assert.doesNotMatch(line, /graft build/);
+  assert.match(line, /0 nodes \/ 0 edges/);
+  assert.match(line, /✓ synced/);
 });
 
 test('two-line bar: size + freshness + ctx + last', () => {

--- a/test/claude-statusline.test.ts
+++ b/test/claude-statusline.test.ts
@@ -4,7 +4,10 @@ import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { resolveStats } from '../src/claude/statusline.js';
+import { renderStatusline } from '../src/claude/format.js';
 import { writeStats, emptyStats } from '../src/claude/state.js';
+
+const strip = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '');
 
 function repo(): string { return mkdtempSync(join(tmpdir(), 'graft-sl-')); }
 function writeWiring(dir: string, obj: unknown): void {
@@ -44,4 +47,25 @@ test('resolveStats prefers the cache over the graph even when both exist', () =>
 
 test('resolveStats returns null when neither cache nor graph exists', () => {
   assert.equal(resolveStats(repo()), null);
+});
+
+test('empty wiring.json is a built graph: statusline shows 0 nodes, not "not built"', () => {
+  const d = repo();
+  writeWiring(d, { meta: { nodeCount: 0, edgeCount: 0, languages: [] }, nodes: [], edges: [] });
+  const s = resolveStats(d)!;
+  assert.equal(s.nodeCount, 0);
+  assert.equal(s.edgeCount, 0);
+  const line = strip(renderStatusline(s, null, { ctxPct: null })[0]);
+  assert.doesNotMatch(line, /not built/);
+  assert.doesNotMatch(line, /graft build/);
+  assert.match(line, /0 nodes \/ 0 edges/);
+});
+
+test('a 0-node cache without wiring.json is still not built', () => {
+  const d = repo();
+  writeStats(d, { ...emptyStats(), nodeCount: 0, edgeCount: 0 });
+  assert.equal(resolveStats(d), null, 'no artifact → missing, not an empty graph');
+  const line = strip(renderStatusline(null, null, { ctxPct: null })[0]);
+  assert.match(line, /not built/);
+  assert.match(line, /graft build/);
 });


### PR DESCRIPTION
## Summary

- Statusline "not built" is now "no graph artifact", not "zero nodes".
- A successful `graft build` that produces an empty wiring.json (docs-only repos, skipped languages) renders as `◤ graft · 0 nodes / 0 edges · ✓ synced`.
- Repos with no `wiring.json` still render `◤ graft · not built · run graft build`.
- Non-empty graphs are unchanged.

## Cause

As analyzed in #185: `renderStatusline()` treated `nodeCount === 0` as never-built, and `resolveStats()` could not tell a legitimate empty graph from a missing one — both look like zero. `graft build` already succeeds (`✓ wiring: 0 nodes ...`); only the bar was lying.

Built is now artifact presence (`wiring.json` via `readWiring()`). `renderStatusline` only shows "not built" when stats are `null`. A 0-node cache without wiring is still missing, not empty-and-built.

## Test plan

- [x] `node --import tsx --test test/claude-format.test.ts test/claude-statusline.test.ts test/claude-stats.test.ts` (31/31)
- [x] `npm run build && npm test` (882/882)
- [x] Manual docs-only repo (`README.md` only, `git init` + commit, `graft build`):

```
# graft build
✓ wiring: 0 nodes (), 0 edges, 0 cards []

# statusline after that successful empty build
◤ graft · 0 nodes / 0 edges · ✓ synced

# control: same layout, never built (no wiring.json)
◤ graft · not built · run graft build

# control: this repo (non-empty graph, same bar style as before)
◤ graft · 1524 nodes / 4547 edges · ✓ synced
```

Closes #185

Made with [Cursor](https://cursor.com)