### PR TITLE
feat(graph): index HTML files so templates are findable by name (#150)

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ compiler-grade layer — all `$0` and deterministic (no model, no key):
 - **Broad** — symbols (functions, classes, methods, types, …) plus name-resolved
   call edges via a generic tree-sitter extractor, one grammar per language:
   **Rust, C, C++, C#, Ruby, Scala, Elixir, Solidity,
-  OCaml, Zig, Dart, Clojure, Nix, Lua**.
+  OCaml, Zig, Dart, Clojure, Nix, Lua, HTML**.
 
 - **Compiler-grade edges (opt-in)** — `graft build --lsp` adds precise
   `lsp_resolved` call edges (member calls the static pass can't type) when a
@@ -219,8 +219,9 @@ compiler-grade layer — all `$0` and deterministic (no model, no key):
   **gopls** (Go), **pyright** (Python), **typescript-language-server** (TS/JS).
   It's best-effort — with no server installed the graph is unchanged.
 
-Twenty-three languages in total. A file whose language isn't listed is skipped, not
-indexed. Adding a broad-tier language is a small contribution — see
+Twenty-four languages in total. HTML is indexed as a file node (no HTML-structure
+extraction), so templates are findable by name. A file whose language isn't listed
+is skipped, not indexed. Adding a broad-tier language is a small contribution — see
 [CREDITS.md](CREDITS.md) for the folks who added the current set.
 
 ---

--- a/src/graph/generic.ts
+++ b/src/graph/generic.ts
@@ -47,8 +47,8 @@ export const GENERIC_LANGS: readonly GenericLang[] = [
   { name: "cpp", exts: [".cpp", ".cc", ".cxx", ".hpp", ".hh"], wasm: "cpp" },
   { name: "ruby", exts: [".rb"], wasm: "ruby" },
   { name: "c_sharp", exts: [".cs"], wasm: "c_sharp" },
-  // These ship a tags.scm (calls + symbols); ocaml/zig have none and use the
-  // node-kind walker fallback (symbols only) — still one row, zero query.
+  // These ship a tags.scm (calls + symbols); ocaml/zig/html have none and use
+  // the node-kind walker fallback (symbols only) — still one row, zero query.
   { name: "scala", exts: [".scala", ".sc"], wasm: "scala" },
   { name: "elixir", exts: [".ex", ".exs"], wasm: "elixir" },
   { name: "solidity", exts: [".sol"], wasm: "solidity" },
@@ -58,6 +58,9 @@ export const GENERIC_LANGS: readonly GenericLang[] = [
   { name: "clojure", exts: [".clj", ".cljs", ".cljc", ".bb"], wasm: "clojure" },
   { name: "nix", exts: [".nix"], wasm: "nix" },
   { name: "lua", exts: [".lua"], wasm: "lua" },
+  // HTML's grammar has no definition-shaped nodes, so the walker yields a file
+  // node only — enough for Django/etc. templates to be findable by name (#150).
+  { name: "html", exts: [".html", ".htm"], wasm: "html" },
 ];
 
 const byExt = new Map<string, GenericLang>();

--- a/test/generic-extract.test.ts
+++ b/test/generic-extract.test.ts
@@ -24,7 +24,9 @@ import { buildGraph } from "../src/graph/build.js";
 import { readGraph, wiringPath } from "../src/graph/write.js";
 import { checkGraph } from "../src/graph/check.js";
 import { contextDirFor } from "../src/context/node-file.js";
-import { skeleton } from "../src/ask/ask.js";
+import { ask, skeleton } from "../src/ask/ask.js";
+import { grepGraph } from "../src/search/grep.js";
+import { resolveSymbol } from "../src/graph/traverse.js";
 
 const RUST = `pub struct Config {
     name: String,
@@ -470,4 +472,72 @@ test("a throwing grammar is a per-file build error, cached as a failure (#139)",
   } finally {
     swapGrammarForTest("rust", prev);
   }
+});
+
+// #150: HTML templates enter the graph as file nodes so they are findable by
+// name (Django `template_name` without walking View → template). No tags.scm —
+// the walker finds no definition-shaped HTML nodes, which is the point.
+const HTML = `<!DOCTYPE html>
+<html>
+<head><title>Shop home</title></head>
+<body>
+  <h1 id="hero">Shop home</h1>
+  {% block content %}welcome-to-the-shop{% endblock %}
+</body>
+</html>
+`;
+
+test("genericLangOf routes .html and .htm to the breadth tier", () => {
+  assert.equal(genericLangOf("templates/index.html")?.name, "html");
+  assert.equal(genericLangOf("legacy/home.HTM")?.name, "html");
+});
+
+test("HTML extract is a file node only — no walker-invented symbols (#150)", async () => {
+  await warmGenericGrammars(["html"]);
+  assert.ok(isWarm("html"), "html grammar should warm");
+  const { nodes, rawEdges } = extractGeneric("templates/index.html", HTML, "html");
+  assert.equal(nodes.length, 1, `file node only (got ${nodes.map((n) => n.kind + ":" + n.name).join(", ")})`);
+  assert.equal(nodes[0].kind, "file");
+  assert.equal(nodes[0].id, "templates/index.html");
+  assert.equal(nodes[0].name, "index.html");
+  assert.equal(nodes[0].origin, "generic");
+  assert.equal(rawEdges.length, 0);
+});
+
+test("HTML templates are findable by name after build — grep content, ask/resolveSymbol filename (#150)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-html-"));
+  mkdirSync(join(dir, "templates"));
+  writeFileSync(join(dir, "templates", "index.html"), HTML);
+  writeFileSync(
+    join(dir, "views.py"),
+    "from django.views.generic import TemplateView\n\nclass Home(TemplateView):\n    template_name = \"index.html\"\n",
+  );
+
+  await buildGraph(dir, { reuse: false });
+  const g = readGraph(wiringPath(contextDirFor(dir)));
+  assert.ok(g, "graph built");
+  const file = g!.nodes.find((n) => n.path === "templates/index.html" && n.kind === "file");
+  assert.ok(file, "html file node is in the graph");
+  assert.equal(file!.name, "index.html");
+
+  const grep = grepGraph(g!, dir, "welcome-to-the-shop");
+  assert.ok(
+    grep.groups.some((gr) => gr.path === "templates/index.html"),
+    `grep hits the template (got ${grep.groups.map((gr) => gr.path).join(", ")})`,
+  );
+
+  const byName = resolveSymbol(g!, "index.html");
+  assert.ok(
+    byName.some((n) => n.kind === "file" && n.path === "templates/index.html"),
+    `resolveSymbol("index.html") finds the template (got ${byName.map((n) => n.id).join(", ")})`,
+  );
+
+  const asked = ask(dir, "index.html");
+  assert.ok(
+    asked.hits.some((h) => h.pointer === "templates/index.html" || h.pointer.startsWith("templates/index.html:")),
+    `ask("index.html") hits the template (got ${asked.hits.map((h) => h.pointer).join(", ")})`,
+  );
+
+  const chk = await checkGraph(dir);
+  assert.equal(chk.ok, true, `check OK on an html+py repo (added=${chk.added}, removed=${chk.removed})`);
 });

--- a/test/supported-extensions.test.ts
+++ b/test/supported-extensions.test.ts
@@ -18,7 +18,7 @@ test("supportedExtensions covers both tiers, sorted and de-duped", () => {
   // depth tier
   for (const e of [".ts", ".tsx", ".py", ".go", ".java", ".js", ".php", ".kt", ".kts", ".swift"]) assert.ok(exts.includes(e), `depth ${e}`);
   // breadth tier
-  for (const e of [".rs", ".rb", ".c", ".cpp"]) assert.ok(exts.includes(e), `breadth ${e}`);
+  for (const e of [".rs", ".rb", ".c", ".cpp", ".html", ".htm"]) assert.ok(exts.includes(e), `breadth ${e}`);
   // container tier
   assert.ok(exts.includes(".vue"), "container .vue");
   // de-duped (.java is in BOTH tiers but must appear once) and sorted


### PR DESCRIPTION
## Summary

- Register HTML (`.html` / `.htm`) on the breadth tier so template files get a `kind: "file"` graph node and show up in `ask` / `grep` by name — Django users no longer have to walk View class → `template_name` to find the template (#150).
- `tree-sitter-wasm` already ships `tree-sitter-html.wasm`, so this is one `GENERIC_LANGS` row (same path as Clojure/Dart). No `tags.scm`: HTML has no definition-shaped nodes, and the node-kind walker correctly yields a file node only (ocaml/zig precedent).
- Grammar load stays lazy — a repo with no HTML files does not warm the HTML wasm.

Closes #150

## Route tradeoff

| Option | Why / why not |
|---|---|
| **GENERIC_LANGS + html wasm** (this PR) | Grammar is already in the bundle. File collection, lazy warmup, `graft build -e`, and banner labeling all fall out of the existing registry. |
| File-only ingest in `fs.ts` / `build.ts` | Would work without a grammar, but would duplicate "is this a source file?" outside the three-tier extension tables. Unnecessary once the wasm is there. |
| Deep HTML parse (ids/classes as `@definition`) | Out of scope. Useful later; not needed to find a template by filename. |
| Python `render` / `template_name` → HTML file edges | Cross-language, larger. Follow-up below. |

## Test plan

- [x] `npm run build && npm test` — 868 pass, 0 fail
- [x] `test/generic-extract.test.ts` — `.html`/`.htm` routing; extract is file-node-only; Django-style `templates/index.html` + `views.py` build: grep hits template content, `resolveSymbol("index.html")` and `ask("index.html")` hit the file node
- [x] `test/supported-extensions.test.ts` — `.html` / `.htm` in the `-e` supported set
- [x] Manual fixture (`templates/index.html` + Django `TemplateView`):

```
✓ wiring: 3 nodes (2 file, 1 class), … [html, python]

graft ask — "index.html"
1. index.html · file  [symbol]
   templates/index.html
2. Home · class  [symbol]
   views.py:L3-L4

graft grep welcome-to-the-shop
templates/index.html (module level)
  L6: {% block content %}welcome-to-the-shop{% endblock %}
```

## Follow-up

- Cross-language edges: resolve Python `render("…")` / `template_name = "…"` string literals onto the matching HTML file node. That is the "go to the template from the View" direction; this PR is the "find the template by name" direction.


Made with [Cursor](https://cursor.com)