### PR TITLE
feat(graph): add OCaml tags.scm — call edges for the breadth tier

### DIFF
--- a/src/graph/generic.ts
+++ b/src/graph/generic.ts
@@ -47,7 +47,7 @@ export const GENERIC_LANGS: readonly GenericLang[] = [
   { name: "cpp", exts: [".cpp", ".cc", ".cxx", ".hpp", ".hh"], wasm: "cpp" },
   { name: "ruby", exts: [".rb"], wasm: "ruby" },
   { name: "c_sharp", exts: [".cs"], wasm: "c_sharp" },
-  // These ship a tags.scm (calls + symbols); ocaml/zig have none and use the
+  // These ship a tags.scm (calls + symbols); zig has none and uses the
   // node-kind walker fallback (symbols only) — still one row, zero query.
   { name: "scala", exts: [".scala", ".sc"], wasm: "scala" },
   { name: "elixir", exts: [".ex", ".exs"], wasm: "elixir" },

--- a/src/graph/queries/ocaml.scm
+++ b/src/graph/queries/ocaml.scm
@@ -1,0 +1,38 @@
+; OCaml — breadth-tier tags.scm
+;
+; Confirmed against the tree-sitter-wasm `ocaml` grammar AST (not ocaml_interface).
+; Without this query the node-kind walker fallback runs: `value_definition`
+; matches `(^|_)(val|…)` so `let helper x = …` is minted as kind `variable`,
+; and there are no call edges.
+;
+; Function lets are a `let_binding` with a `parameter` child (`let f x = …`,
+; including `let rec`) or a `fun_expression` / `function_expression` body
+; (`let f = fun x -> …`). Plain value lets (`let n = 1`) have neither and
+; are left untagged.
+;
+; Calls are `application_expression` with `function: (value_path …)`.
+; Infix operators are `infix_expression` and are not tagged.
+
+; `let f x = …` / `let rec f x = …` / `let f ~x = …` / `let f () = …`
+(let_binding
+  pattern: (value_name) @name
+  (parameter)) @definition.function
+
+; `let f = fun x -> …` / `let f = function y -> …`
+(let_binding
+  pattern: (value_name) @name
+  body: [(fun_expression) (function_expression)]) @definition.function
+
+(module_definition
+  (module_binding (module_name) @name)) @definition.module
+
+(type_definition
+  (type_binding
+    name: [
+      (type_constructor) @name
+      (type_constructor_path (type_constructor) @name)
+    ])) @definition.type
+
+; `helper 2`, `M.inner x` (bare name is the last `value_name`)
+(application_expression
+  function: (value_path (value_name) @name)) @reference.call

--- a/test/generic-extract.test.ts
+++ b/test/generic-extract.test.ts
@@ -471,3 +471,40 @@ test("a throwing grammar is a per-file build error, cached as a failure (#139)",
     swapGrammarForTest("rust", prev);
   }
 });
+
+// #197: OCaml is registered in GENERIC_LANGS but had no tags.scm, so the walker
+// minted `let helper x = …` as kind `variable` (`value_definition` matches
+// `(^|_)(val|…)`) and emitted no call edges.
+const OCAML = `let helper x = 1
+
+let rec go x = helper x
+
+let n = 1
+
+module M = struct
+  let wrap x = go x
+end
+
+type t = { n : int }
+`;
+
+test("genericLangOf routes .ml/.mli to the breadth tier", () => {
+  assert.equal(genericLangOf("lib/example.ml")?.name, "ocaml");
+  assert.equal(genericLangOf("lib/example.mli")?.name, "ocaml");
+});
+
+test("OCaml let/let rec/module/type become symbols; call edges resolve; bare lets stay out (#197)", async () => {
+  await warmGenericGrammars(["ocaml"]);
+  assert.ok(isWarm("ocaml"), "ocaml grammar should warm");
+  const { nodes, rawEdges } = extractGeneric("lib/example.ml", OCAML, "ocaml");
+  const symbols = nodes.filter((n) => n.kind !== "file");
+  const kinds = symbols.map((n) => `${n.kind}:${n.name}`).sort();
+  assert.deepEqual(kinds, ["function:go", "function:helper", "function:wrap", "module:M", "type:t"]);
+
+  const edges = resolveEdges(nodes, rawEdges);
+  const calls = edges
+    .filter((e) => e.relation === "calls")
+    .map((e) => `${e.source.split("#")[1]}→${e.target.split("#")[1]}`);
+  assert.ok(calls.includes("go→helper"), `go → helper (got ${calls.join(", ")})`);
+  assert.ok(calls.includes("wrap→go"), `M.wrap → go (got ${calls.join(", ")})`);
+});

--- a/test/generic-extract.test.ts
+++ b/test/generic-extract.test.ts
@@ -472,7 +472,7 @@ test("a throwing grammar is a per-file build error, cached as a failure (#139)",
   }
 });
 
-// #197: OCaml is registered in GENERIC_LANGS but had no tags.scm, so the walker
+// #198: OCaml is registered in GENERIC_LANGS but had no tags.scm, so the walker
 // minted `let helper x = …` as kind `variable` (`value_definition` matches
 // `(^|_)(val|…)`) and emitted no call edges.
 const OCAML = `let helper x = 1
@@ -493,7 +493,7 @@ test("genericLangOf routes .ml/.mli to the breadth tier", () => {
   assert.equal(genericLangOf("lib/example.mli")?.name, "ocaml");
 });
 
-test("OCaml let/let rec/module/type become symbols; call edges resolve; bare lets stay out (#197)", async () => {
+test("OCaml let/let rec/module/type become symbols; call edges resolve; bare lets stay out (#198)", async () => {
   await warmGenericGrammars(["ocaml"]);
   assert.ok(isWarm("ocaml"), "ocaml grammar should warm");
   const { nodes, rawEdges } = extractGeneric("lib/example.ml", OCAML, "ocaml");


### PR DESCRIPTION
## Summary
- OCaml is already on the breadth-tier registry, but had no `tags.scm`, so the node-kind walker minted `let helper x = …` as kind `variable` (`value_definition` matches `(^|_)(val|…)`) and emitted no call edges.
- Add an OCaml tags query for `let` / `let rec` functions (parameter or `fun`/`function` body), modules, types, and `application_expression` calls. Bare `let n = 1` values and infix/`|>`/`@@` are left untagged (drop-not-guess). Node types confirmed against the `tree-sitter-wasm` ocaml grammar AST.
- Same pattern as Dart in #153. Zig is unchanged (still walker fallback). Independent of #201.

Fixes #197.

## Test plan
- [x] `node --import tsx --test test/generic-extract.test.ts` — OCaml fixture: `go → helper`, `M.wrap → go`; `let n = 1` is not a symbol
- [x] `npm run build`
- [x] `npm test` (884/884)