### PR TITLE
feat(graph): add Zig tags.scm — call edges for the breadth tier

### DIFF
--- a/src/graph/generic.ts
+++ b/src/graph/generic.ts
@@ -47,7 +47,7 @@ export const GENERIC_LANGS: readonly GenericLang[] = [
   { name: "cpp", exts: [".cpp", ".cc", ".cxx", ".hpp", ".hh"], wasm: "cpp" },
   { name: "ruby", exts: [".rb"], wasm: "ruby" },
   { name: "c_sharp", exts: [".cs"], wasm: "c_sharp" },
-  // These ship a tags.scm (calls + symbols); ocaml/zig have none and use the
+  // These ship a tags.scm (calls + symbols); ocaml has none and uses the
   // node-kind walker fallback (symbols only) — still one row, zero query.
   { name: "scala", exts: [".scala", ".sc"], wasm: "scala" },
   { name: "elixir", exts: [".ex", ".exs"], wasm: "elixir" },

--- a/src/graph/queries/zig.scm
+++ b/src/graph/queries/zig.scm
@@ -1,0 +1,34 @@
+; Zig — breadth-tier tags.scm
+;
+; Without this query the node-kind walker fallback runs, which:
+;   - mints `const Point = struct { … }` as a variable (`variable_declaration`
+;     matches `(^|_)(var|…)`)
+;   - skips `test_declaration` (no kind after the declaration suffix)
+;   - never emits call edges, so `graft callers` is empty
+;
+; Captures are the shapes confirmed against tree-sitter-wasm's zig grammar:
+;   - `fn helper(n: i32) i32 { … }` / `pub fn run` → function_declaration
+;   - `const Point = struct { … }` → variable_declaration + struct_declaration
+;   - `test "name" { … }` → test_declaration with a string (unnamed `test { }`
+;     has no name token and is left untagged)
+;   - `helper(n)` / `p.local()` → call_expression
+;
+; Not captured (drop-not-guess): `const p = Point{ … }` (struct_initializer,
+; not a type def), enum/union, unnamed tests.
+
+(function_declaration
+  name: (identifier) @name) @definition.function
+
+(variable_declaration
+  (identifier) @name
+  (struct_declaration)) @definition.struct
+
+(test_declaration
+  (string (string_content) @name)) @definition.function
+
+(call_expression
+  function: (identifier) @name) @reference.call
+
+(call_expression
+  function: (field_expression
+    member: (identifier) @name)) @reference.call

--- a/test/generic-extract.test.ts
+++ b/test/generic-extract.test.ts
@@ -472,7 +472,7 @@ test("a throwing grammar is a per-file build error, cached as a failure (#139)",
   }
 });
 
-// #197: Zig is registered in GENERIC_LANGS but had no tags.scm, so the walker
+// #198: Zig is registered in GENERIC_LANGS but had no tags.scm, so the walker
 // minted `const Point = struct` as a variable and emitted no call edges.
 const ZIG = `const Point = struct {
     x: i32,
@@ -499,7 +499,7 @@ test("genericLangOf routes .zig to the breadth tier", () => {
   assert.equal(genericLangOf("src/main.zig")?.name, "zig");
 });
 
-test("Zig fn/const struct/named test become symbols; call edges resolve; unnamed tests stay out (#197)", async () => {
+test("Zig fn/const struct/named test become symbols; call edges resolve; unnamed tests stay out (#198)", async () => {
   await warmGenericGrammars(["zig"]);
   assert.ok(isWarm("zig"), "zig grammar should warm");
   const { nodes, rawEdges } = extractGeneric("src/main.zig", ZIG, "zig");

--- a/test/generic-extract.test.ts
+++ b/test/generic-extract.test.ts
@@ -471,3 +471,46 @@ test("a throwing grammar is a per-file build error, cached as a failure (#139)",
     swapGrammarForTest("rust", prev);
   }
 });
+
+// #197: Zig is registered in GENERIC_LANGS but had no tags.scm, so the walker
+// minted `const Point = struct` as a variable and emitted no call edges.
+const ZIG = `const Point = struct {
+    x: i32,
+};
+
+fn helper(n: i32) i32 {
+    return n;
+}
+
+pub fn run(n: i32) i32 {
+    return helper(n);
+}
+
+test "calls helper" {
+    _ = helper(1);
+}
+
+test {
+    _ = helper(2);
+}
+`;
+
+test("genericLangOf routes .zig to the breadth tier", () => {
+  assert.equal(genericLangOf("src/main.zig")?.name, "zig");
+});
+
+test("Zig fn/const struct/named test become symbols; call edges resolve; unnamed tests stay out (#197)", async () => {
+  await warmGenericGrammars(["zig"]);
+  assert.ok(isWarm("zig"), "zig grammar should warm");
+  const { nodes, rawEdges } = extractGeneric("src/main.zig", ZIG, "zig");
+  const symbols = nodes.filter((n) => n.kind !== "file");
+  const kinds = symbols.map((n) => `${n.kind}:${n.name}`).sort();
+  assert.deepEqual(kinds, ["function:calls helper", "function:helper", "function:run", "struct:Point"]);
+
+  const edges = resolveEdges(nodes, rawEdges);
+  const calls = edges
+    .filter((e) => e.relation === "calls")
+    .map((e) => `${e.source.split("#")[1]}→${e.target.split("#")[1]}`);
+  assert.ok(calls.includes("run→helper"), `run → helper (got ${calls.join(", ")})`);
+  assert.ok(calls.includes("calls helper→helper"), `named test → helper (got ${calls.join(", ")})`);
+});


### PR DESCRIPTION
## Summary
- Zig (`.zig`) is already on the breadth-tier registry, but had no `tags.scm`, so the node-kind walker minted `const Point = struct { … }` as kind `variable` (`variable_declaration` matches `(^|_)(var|…)`) and emitted no call edges. Named `test "…" { }` decls were skipped entirely.
- Add `src/graph/queries/zig.scm` with shapes confirmed against the `tree-sitter-wasm` zig grammar AST:
  - `@definition.function` — `fn` / `pub fn` (`function_declaration`)
  - `@definition.struct` — `const Name = struct { … }`
  - `@definition.function` — named `test "…" { }` (`string_content`)
  - `@reference.call` — `call_expression` (`helper(n)` and `p.local()`)
- Left untagged (drop-not-guess): unnamed `test { }`, `const p = Point{ … }` (struct_initializer, not a type), enum/union.
- Independent of the OCaml PR — branched from `origin/main`, not stacked. Same pattern as Dart (#153). Will conflict with #200 on the one `generic.ts` comment line; after both merge that exception should go away.

Fixes #197.

## Test plan
- [x] `node --import tsx --test test/generic-extract.test.ts` — Zig fixture: `run → helper`, named test → helper; unnamed `test { }` is not a symbol
- [x] `npm run build`
- [x] `npm test` (884/884)