### PR TITLE
fix(init): windsurf rule frontmatter, docs consistency, launcher fallback (#80)

### DIFF
--- a/src/claude/shim-template.ts
+++ b/src/claude/shim-template.ts
@@ -8,16 +8,21 @@
 //   2. repo node_modules — a local dev-dep install.
 //   3. `execDir/../lib`  — the cheap legacy guess (covers nvm / classic prefix layout).
 //   4. `npm root -g`     — authoritative global dir, layout-agnostic. Only shelled out to
-//                     when 1–3 all miss; queried on demand — no on-disk cache, which on a
-//                     shared machine would be a world-writable path an attacker could point
-//                     at their own code for us to import.
+//                     when 1–3 all miss or fail to load; queried on demand — no on-disk
+//                     cache, which on a shared machine would be a world-writable path an
+//                     attacker could point at their own code for us to import.
 //
-// Among the candidates that exist we take the HIGHEST VERSION, not the first hit. First-hit
-// silently pinned users to a stale graft forever: `bakedDir` points into one Node install's
-// global node_modules, so switching Node versions (nvm/volta) or moving the install leaves
-// the old directory on disk and still winning, and `npm i -g @nanonets/graft@latest`
-// upgrades a directory the shim never looks at. The upgrade appeared to work and changed
-// nothing — the shim kept loading the version from whenever `graft init` was last run.
+// Among the candidates that exist we try the HIGHEST VERSION first, not the first hit.
+// First-hit silently pinned users to a stale graft forever: `bakedDir` points into one
+// Node install's global node_modules, so switching Node versions (nvm/volta) or moving
+// the install leaves the old directory on disk and still winning, and
+// `npm i -g @nanonets/graft@latest` upgrades a directory the shim never looks at.
+//
+// Existence is not enough. A stale or half-installed candidate whose file is on disk
+// but fails to import used to disable every later one — the `.catch()` swallowed the
+// load error and the hook silently no-op'd. Walk remaining candidates on *load*
+// failure (import throw, or no `main`). Once `main()` has been reached it owns the
+// outcome: retrying after it ran would repeat side effects.
 function shim(entryFile: string, call: string, bakedDir: string): string {
   return `#!/usr/bin/env node
 const path = require('path');
@@ -63,29 +68,41 @@ function newer(a, b) {
   return false;
 }
 
-// The highest-versioned dir in \`dirs\` that actually contains \`name\`, or null.
-function best(dirs, name) {
-  let bestDir = null, bestVer = null;
-  for (const d of dirs) {
-    if (!d || !fs.existsSync(path.join(d, name))) continue;
-    const v = versionOf(d);
-    if (bestDir === null || newer(v, bestVer)) { bestDir = d; bestVer = v; }
-  }
-  return bestDir;
+// Dirs in \`dirs\` that contain \`name\`, highest version first. Equal versions keep
+// their original order (the comparator returns 0).
+function ranked(dirs, name) {
+  return dirs.filter((d) => d && fs.existsSync(path.join(d, name))).sort((a, b) => {
+    const va = versionOf(a), vb = versionOf(b);
+    if (newer(va, vb)) return -1;
+    if (newer(vb, va)) return 1;
+    return 0;
+  });
 }
 
-function entry(name) {
-  // Cheap candidates first, and only shell out to npm when every one of them misses.
-  const cheap = [BAKED, fromPkg(dir), fromPkg(path.join(path.dirname(process.execPath), '..', 'lib'))];
-  const hit = best(cheap, name);
-  if (hit) return path.join(hit, name);
+async function launch(name, call) {
+  const seen = new Set();
+  const tryDir = async (d) => {
+    if (!d || seen.has(d)) return false;
+    seen.add(d);
+    const f = path.join(d, name);
+    if (!fs.existsSync(f)) return false;
+    let mod;
+    try { mod = await import(pathToFileURL(f).href); } catch { return false; }
+    if (typeof mod.main !== 'function') return false;
+    try { await call(mod); } catch { /* failed — do not block the session */ }
+    return true; // main() was reached; do not try another candidate
+  };
+  // Cheap candidates first; only shell out to npm when every one of them misses *or* fails to load.
+  for (const d of ranked([BAKED, fromPkg(dir), fromPkg(path.join(path.dirname(process.execPath), '..', 'lib'))], name)) {
+    if (await tryDir(d)) return;
+  }
   const gr = globalRoot();
   const global = gr && path.join(gr, '@nanonets', 'graft', 'dist', 'claude');
-  if (global && fs.existsSync(path.join(global, name))) return path.join(global, name);
-  return path.join(dir, 'dist', 'claude', name); // last-ditch; import will no-op if absent
+  if (await tryDir(global)) return;
+  await tryDir(path.join(dir, 'dist', 'claude')); // last-ditch
 }
 
-import(pathToFileURL(entry(${JSON.stringify(entryFile)})).href).then((m) => ${call}).catch(() => { /* graft unavailable — no-op */ });
+launch(${JSON.stringify(entryFile)}, async (m) => ${call}).catch(() => { /* graft unavailable — no-op */ });
 `;
 }
 

--- a/src/hosts/instructions.ts
+++ b/src/hosts/instructions.ts
@@ -6,8 +6,10 @@
 export function instructionBody(): string {
   return `## Graft — repo context graph
 
-This repo is indexed in \`graft/\`: small linked markdown nodes that explain each
-system and carry exact file:line spans, kept in sync with the code through git.
+\`graft/\` is a local, regenerable cache: small linked markdown nodes that explain
+each system and carry exact file:line spans. It is gitignored, so a fresh clone
+does not have it — run \`graft build\` when it is absent or stale, before
+\`graft map\`, \`graft ask\`, \`graft grep\` or \`graft callers\`.
 
 For ANY task here — understanding how something works, finding where code lives,
 or scoping a change — get context from the graph before grepping or opening
@@ -63,6 +65,13 @@ ${instructionBody()}
 }
 
 export function windsurfRule(): string {
-  return `${instructionBody()}
+  // Windsurf workspace rules require YAML frontmatter with `trigger`
+  // (always_on | glob | model_decision | manual). Without it the file is
+  // inert — Cascade never applies the body. `always_on` matches the other
+  // hosts' "always apply" frontmatter.
+  return `---
+trigger: always_on
+---
+${instructionBody()}
 `;
 }

--- a/test/claude-shim-resolve.test.ts
+++ b/test/claude-shim-resolve.test.ts
@@ -6,7 +6,9 @@
  * the first candidate is the absolute path baked in at `graft init` time. So
  * `npm i -g @nanonets/graft@latest` upgraded a directory the shim never looked
  * at, and the user's hooks kept loading whatever version wired the repo. The
- * shim now takes the highest-versioned candidate instead.
+ * shim now tries the highest-versioned candidate first. A candidate that *exists*
+ * but fails to load (throw on import, or no `main`) falls through to the next;
+ * once `main()` has run, a throw is swallowed and no later candidate is tried.
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -80,4 +82,31 @@ test('no candidate at all exits quietly — a hook must never fail the session',
   const root = tmpRepo('shim-none');
   mkdirSync(join(root, 'project'), { recursive: true });
   assert.equal(runShim(root, join(root, 'nowhere'), join(root, 'project')), null);
+});
+
+test('a candidate that fails to load falls through to a working later one (#80)', () => {
+  const root = tmpRepo('shim-load-fail');
+  const broken = fakeInstall(root, 'old-node-install', '0.12.0');
+  writeFileSync(join(broken, 'hooks.js'), 'throw new Error("cannot load");\n');
+  fakeInstall(join(root, 'project', 'node_modules', '@nanonets'), 'graft', '0.11.0');
+  assert.equal(runShim(root, broken, join(root, 'project')), '0.11.0');
+});
+
+test('a candidate without main() falls through to the next (#80)', () => {
+  const root = tmpRepo('shim-no-main');
+  const newer = fakeInstall(root, 'current', '0.12.0');
+  writeFileSync(join(newer, 'hooks.js'), 'module.exports.other = () => {};\n');
+  fakeInstall(join(root, 'project', 'node_modules', '@nanonets'), 'graft', '0.11.0');
+  assert.equal(runShim(root, newer, join(root, 'project')), '0.11.0');
+});
+
+test('once main() runs, a throw does not retry the next candidate (#80)', () => {
+  const root = tmpRepo('shim-main-owns');
+  const newer = fakeInstall(root, 'current', '0.12.0');
+  writeFileSync(
+    join(newer, 'hooks.js'),
+    `module.exports.main = () => { require('node:fs').writeFileSync(process.env.MARKER, '0.12.0'); throw new Error('boom'); };\n`,
+  );
+  fakeInstall(join(root, 'project', 'node_modules', '@nanonets'), 'graft', '0.11.0');
+  assert.equal(runShim(root, newer, join(root, 'project')), '0.12.0');
 });

--- a/test/claude-shim-template.test.ts
+++ b/test/claude-shim-template.test.ts
@@ -21,14 +21,16 @@ for (const [name, src] of [['statusline', statuslineShim(BAKED)], ['hooks', hook
     assert.match(src, /execFileSync\('npm', \['root', '-g'\]/);
     assert.doesNotMatch(src, /tmpdir/); // no predictable temp cache path
 
-    // Highest version wins among the candidates, not first-hit — otherwise the
-    // baked path pins the user to whatever graft wired the repo, forever.
-    // Behaviour is exercised for real in claude-shim-resolve.test.ts.
-    assert.match(src, /function best\(dirs, name\)/);
+    // Highest version is tried first among the candidates, not first-hit — otherwise
+    // the baked path pins the user to whatever graft wired the repo, forever.
+    // Load failure then walks the rest. Behaviour is in claude-shim-resolve.test.ts.
+    assert.match(src, /function ranked\(dirs, name\)/);
     assert.match(src, /'package\.json'/); // versionOf reads each candidate's version
+    assert.match(src, /typeof mod\.main !== 'function'/);
+    assert.match(src, /return true; \/\/ main\(\) was reached/);
 
     // Windows-safe dynamic import + best-effort catch
-    assert.match(src, /pathToFileURL\(entry\(/);
+    assert.match(src, /pathToFileURL\(f\)/);
     assert.match(src, /\.catch\(\(\) => \{/);
   });
 }

--- a/test/hosts-init.test.ts
+++ b/test/hosts-init.test.ts
@@ -242,6 +242,16 @@ test('CLI: --no-global stays quiet when the selection has nothing out-of-repo', 
   assert.doesNotMatch(out, /skipped out-of-repo writes/);
 });
 
+test('windsurf rule is written with always_on frontmatter (#80)', () => {
+  const home = fresh(); const repo = fresh();
+  const r = runHostsInit(repo, { home, agents: ['windsurf'] });
+  assert.deepEqual(r.written.map((w) => w.id), ['windsurf']);
+  const text = readFileSync(join(repo, '.windsurf', 'rules', 'graft.md'), 'utf8');
+  assert.match(text, /^---\ntrigger: always_on\n---\n/);
+  assert.match(text, /gitignored/);
+  assert.doesNotMatch(text, /kept in sync with the code through git/);
+});
+
 test('CLI: --dry-run respects an explicit --agents list', () => {
   const home = fresh(); const repo = fresh();
   mkdirSync(join(home, '.codex'), { recursive: true });

--- a/test/hosts-instructions.test.ts
+++ b/test/hosts-instructions.test.ts
@@ -15,6 +15,9 @@ test('canonical body names the three essentials', () => {
   assert.match(b, /graft map/, 'tells the agent to orient with graft map before exploring');
   assert.match(b, /\[scope\/\]/, 'teaches the [scope/] label on multi-scope/monorepo hits');
   assert.match(b, /--in <scope>\//, 'teaches narrowing with ask --in <scope>/');
+  assert.match(b, /local, regenerable cache/, 'graft/ is a cache, not a committed artifact (#80)');
+  assert.match(b, /gitignored/, 'tells the agent the graph is not in git (#80)');
+  assert.doesNotMatch(b, /through git/, 'must not claim git carries the graph (#80)');
   assert.ok(!/\bhook|statusline\b/i.test(b), 'no host-specific machinery in the shared body');
 });
 
@@ -30,6 +33,8 @@ test('kiro steering has inclusion: always frontmatter and the body', () => {
   assert.ok(r.includes(instructionBody()));
 });
 
-test('windsurf rule is the plain body', () => {
-  assert.ok(windsurfRule().includes(instructionBody()));
+test('windsurf rule has trigger: always_on frontmatter and the body', () => {
+  const r = windsurfRule();
+  assert.match(r, /^---\ntrigger: always_on\n---\n/);
+  assert.ok(r.includes(instructionBody()));
 });


### PR DESCRIPTION
## Summary

Re-checked all four defects from [#80](https://github.com/NanoNets/Graft/issues/80) against current `main` (0.13.0). Three still reproduce; this PR fixes those. Defect 3 is the CLI-on-PATH / MCP `command: "graft"` prerequisite and is being handled with [#61](https://github.com/NanoNets/Graft/issues/61), not here.

### Recheck matrix (issue filed against 0.9.1)

| # | Defect | Status on `main` | This PR |
|---|---|---|---|
| 1 | `.windsurf/rules/graft.md` has no YAML frontmatter, so Cascade never applies it | **Still present.** `windsurfRule()` was the plain `instructionBody()`; the test even asserted “plain body”. Cursor/Kiro already ship frontmatter. | Adds `trigger: always_on` (Wave 8 activation mode; field name from the on-disk rules format). |
| 2 | Generated instructions say `graft/` is “kept in sync with the code through git” while `graft init` gitignores it | **Still present in generated files.** README was corrected by [#131](https://github.com/NanoNets/Graft/pull/131); [#106](https://github.com/NanoNets/Graft/pull/106) only root-anchored the gitignore entry; [#157](https://github.com/NanoNets/Graft/pull/157) is unrelated (PHP `GENERIC_LANGS`). `instructionBody()` still had the old sentence, so AGENTS.md / GEMINI.md / copilot / cursor / kiro / windsurf all contradicted `.gitignore`. | Wording matches the gitignore behaviour (local regenerable cache; `graft build` when absent/stale). |
| 3 | MCP configs assume a global `graft` with nothing saying so | Out of scope here — same class of problem as [#61](https://github.com/NanoNets/Graft/issues/61). | Skipped. |
| 4 | Claude launchers stop at the first candidate that *exists* | **Partially fixed.** [#99](https://github.com/NanoNets/Graft/pull/99) / 0.11.0 already pick the **highest version** among files that exist, instead of first-hit. A candidate that exists but **fails to import** still won: `import(entry).catch(() => {})` swallowed the error and never tried the rest, so a stale/half-installed graft earlier in the list silently disabled a working one. | Walk remaining candidates on *load* failure (import throw, or no `main`). Once `main()` has been reached it owns the outcome — a throw there is swallowed and does **not** retry, so side effects are not repeated. Highest-version order and the cheap-then-`npm root -g` latency split from #99 are kept. |

### Collision notes

- christian-jorge’s 8/13 draft stack ([#108](https://github.com/NanoNets/Graft/pull/108)–[#114](https://github.com/NanoNets/Graft/pull/114)) touched `src/hosts/init.ts` / shims in [#110](https://github.com/NanoNets/Graft/pull/110). All seven were **closed unmerged** on 2026-08-20, so nothing to dodge on `main`.
- [#61](https://github.com/NanoNets/Graft/issues/61) will likely also edit `instructionBody()` (npx / runner wording). This PR only replaces the opening “through git” paragraph; the rest of the body is untouched so the two should merge.

Windsurf: official Cascade docs describe Always On / glob / model-decision / manual activation via the GUI ([memories & rules](https://docs.devin.ai/windsurf/plugins/cascade/memories), [Wave 8](https://devin.ai/blog/windsurf-wave-8-cascade-customization-features/)). The on-disk field for Always On is `trigger: always_on`. `description` is for `model_decision`; not required here.

## Test plan

- [x] `test/hosts-instructions.test.ts` — windsurf frontmatter; body says gitignored cache, not “through git”
- [x] `test/hosts-init.test.ts` — `--agents windsurf` writes `.windsurf/rules/graft.md` with `trigger: always_on`
- [x] `test/claude-shim-resolve.test.ts` — load failure / missing `main` fall through; `main()` throw does not retry
- [x] `npm run build && npm test` — 914 pass; 5 failures under full parallel load (PageRank timing, MCP stdio timeout) pass when those files are re-run in isolation, except `viz --tabs` which needs a local `graft/` (gitignored in this worktree) and is unrelated

Addresses #80

Made with [Cursor](https://cursor.com)