### PR TITLE
feat(init): detect the package runner for generated MCP configs, add --runner (#60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **`graft init --runner <npx|bunx|pnpm|yarn>`**, and lockfile detection for the
+  same choice. Generated MCP configs (`.mcp.json`, `.cursor/mcp.json`,
+  `.gemini/settings.json`, `.kiro/settings/mcp.json`, `opencode.json`, Codex/Grok
+  TOML) used to hardcode `npx -y`. They now pick `bunx` / `pnpm dlx` / `yarn dlx`
+  / `npx -y` from `bun.lock`/`bun.lockb`, `pnpm-lock.yaml`, `yarn.lock`, or the
+  flag. Re-running `init` updates the existing graft entry. `--runner` is
+  recorded in the wiring stamp so a later refresh replays it.
+
 ## 0.18.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ With no TTY to prompt on — CI, a Dockerfile, a piped shell — `init` writes *
 | `--no-hooks` | skip hook installation |
 | `--no-statusline` | skip writing Claude Code `statusLine` (same as `GRAFT_NO_STATUSLINE=1`) |
 | `--no-global` | skip writes outside this repo (the `~/.codex/` entries below) |
+| `--runner <npx\|bunx\|pnpm\|yarn>` | package runner written into generated MCP configs. Default: detect from the lockfile (`bun.lock`/`bun.lockb` → `bunx`, `pnpm-lock.yaml` → `pnpm dlx`, `yarn.lock` → `yarn dlx`, otherwise `npx -y`) |
 
 #### Writes outside the repo
 
@@ -298,7 +299,7 @@ Both configs are user-level, so they apply to **every** repo you open with Codex
 
 ### MCP server
 
-`graft init` also registers Graft's MCP server with agents that support it, so these six tools appear natively, no shell required. Claude Code gets this too: `graft init` writes the server into the project's `.mcp.json` (restart Claude Code to load it). Skip with `--no-mcp`; run it manually with `graft mcp [dir]`.
+`graft init` also registers Graft's MCP server with agents that support it, so these six tools appear natively, no shell required. Claude Code gets this too: `graft init` writes the server into the project's `.mcp.json` (restart Claude Code to load it). The launch command is the repo's package runner — `bunx` / `pnpm dlx` / `yarn dlx` / `npx -y` — so a Bun-only machine does not inherit a hardcoded `npx`. Override with `--runner`. Skip with `--no-mcp`; run it manually with `graft mcp [dir]`.
 
 | Tool | Takes | What it's for |
 |---|---|---|
@@ -394,6 +395,7 @@ graft init --agents cursor kiro      # wire only these agents, no prompt (ids: a
 graft init --yes                     # no prompt; wire every detected agent
 graft init --no-global               # skip writes outside this repo (~/.codex/ config + hooks)
 graft init --no-statusline           # skip Claude Code statusLine (same as GRAFT_NO_STATUSLINE=1)
+graft init --runner bunx             # write bunx into generated MCP configs (also: npx, pnpm, yarn)
 graft init --no-build                # wire the files only; don't build the graph
 graft init --all-agents              # wire every known agent, detected or not
 graft init --list-agents             # list known agent ids and exit

--- a/src/claude/init.ts
+++ b/src/claude/init.ts
@@ -7,7 +7,7 @@ import { mergeGraftSettings } from './settings-merge.js';
 import { statuslineShim, hooksShim } from './shim-template.js';
 import { skillTemplate } from './skill-template.js';
 import { claudeDistDir } from './paths.js';
-import { mergeJsonKey, serverEntry, type McpWrite } from '../hosts/mcp-config.js';
+import { mergeJsonKey, serverEntry, type McpWrite, type PackageRunner } from '../hosts/mcp-config.js';
 import { hasGraftIndex } from '../graph/root.js';
 import type { PlannedWrite } from '../hosts/plan.js';
 
@@ -62,7 +62,7 @@ export interface InitResult {
 
 export function runInit(
   dir: string,
-  opts: { build?: boolean; cliPath?: string; statusline?: boolean; global?: boolean; home?: string } = {},
+  opts: { build?: boolean; cliPath?: string; statusline?: boolean; global?: boolean; home?: string; runner?: PackageRunner } = {},
 ): InitResult {
   // Same list `--dry-run` and the picker report, so the two can't drift apart.
   const [settings, statusline, hooks, skill, mcpTarget] = claudeTargets(dir).map((t) => t.path);
@@ -90,14 +90,14 @@ export function runInit(
   // Register the graft MCP server in the project's .mcp.json so Claude Code
   // exposes graft_find_code/graft_trace_calls/etc. as tools — the same keyed merge the
   // other hosts use (existing servers preserved; unparseable files skipped).
-  const mcp = mergeJsonKey('claude', mcpTarget, 'mcpServers', serverEntry());
+  const mcp = mergeJsonKey('claude', mcpTarget, 'mcpServers', serverEntry({ runner: opts.runner, cwd: dir }));
 
   // The same wiring again, one level up in `~/.claude`, because everything above
   // this line can be erased by a `.gitignore` and lost to `git worktree add`. See
   // hosts/claude-global.ts for the failure that motivates it. Gated on the same
   // flag `registerMcpConfigs` uses, so `--no-global` still means "nothing outside
   // this repo".
-  const global = opts.global === false ? [] : installClaudeGlobal(opts.home ?? homedir());
+  const global = opts.global === false ? [] : installClaudeGlobal(opts.home ?? homedir(), { runner: opts.runner });
 
   const built = buildGraphIfMissing(dir, opts);
   return { settingsPath, shims: [sl, hk], skill: skillPath, mcp, global, warnings, built };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,7 @@ import { rulesForPointers } from "./brain/attach.js";
 import { clearLink, type BrainLink } from "./brain/link.js";
 import { buildLocalDigest, fetchExpectedRepo, pushDigest, repoSlugFromGit, sameRepo } from "./brain/push.js";
 import { readLink } from "./brain/link.js";
+import { isPackageRunner, type PackageRunner } from "./hosts/mcp-config.js";
 import { contextDirFor } from "./context/node-file.js";
 import { loadGraphCached } from "./graph/load.js";
 import { ensureFreshChildren, ensureFreshGraph, refreshNote } from "./graph/refresh.js";
@@ -947,7 +948,8 @@ program
   .option("-y, --yes", "skip the picker and wire every detected agent (the pre-0.8 default)")
   .option("--no-global", "skip writes outside this repo (the ~/.codex/ config + hooks)")
   .option("--brain <handoff>", "attach a Trail brain: <brainId>:<token> (or a bare brain id with GRAFT_BRAIN_TOKEN set)")
-  .action(async (dir: string, opts: { build?: boolean; agents?: string[]; allAgents?: boolean; listAgents?: boolean; mcp?: boolean; hooks?: boolean; statusline?: boolean; dryRun?: boolean; yes?: boolean; global?: boolean; brain?: string }) => {
+  .option("--runner <npx|bunx|pnpm|yarn>", "package runner written into generated MCP configs (default: detect from the lockfile)")
+  .action(async (dir: string, opts: { build?: boolean; agents?: string[]; allAgents?: boolean; listAgents?: boolean; mcp?: boolean; hooks?: boolean; statusline?: boolean; dryRun?: boolean; yes?: boolean; global?: boolean; brain?: string; runner?: string }) => {
     if (opts.listAgents) {
       for (const id of [...hostIds(), "claude"]) console.log(id);
       return;
@@ -964,6 +966,11 @@ program
       }
       brainLink = parsed;
     }
+    if (opts.runner !== undefined && !isPackageRunner(opts.runner)) {
+      console.error(`✗ unknown --runner ${opts.runner} — valid: npx, bunx, pnpm, yarn`);
+      process.exit(1);
+    }
+    const runner: PackageRunner | undefined = opts.runner !== undefined && isPackageRunner(opts.runner) ? opts.runner : undefined;
     const repo = resolve(dir);
     const explicit = Array.isArray(opts.agents) ? opts.agents : undefined;
 
@@ -1047,7 +1054,7 @@ program
 
     for (const target of targets) {
       if (target !== repo) console.error(`\n— ${relative(repo, target)}/`);
-      wireTarget(target, ids, { home, cliPath, plan, opts, wantClaude });
+      wireTarget(target, ids, { home, cliPath, plan, opts: { ...opts, runner }, wantClaude });
     }
 
     // The brain comes last, after the graph exists: its rules are anchored to
@@ -1093,7 +1100,7 @@ function wireTarget(
     cliPath: string;
     plan: ReturnType<typeof planInit>;
     wantClaude: boolean;
-    opts: { build?: boolean; mcp?: boolean; hooks?: boolean; global?: boolean; statusline?: boolean };
+    opts: { build?: boolean; mcp?: boolean; hooks?: boolean; global?: boolean; statusline?: boolean; runner?: PackageRunner };
   },
 ): void {
     const { home, cliPath, plan, wantClaude, opts } = ctx;
@@ -1114,7 +1121,7 @@ function wireTarget(
       // `global`/`home` are threaded through alongside `statusline`: the claude layer
       // writes under `~/.claude` now (hosts/claude-global.ts), so --no-global has to
       // reach it or the flag would silently mean "no out-of-repo writes, except three".
-      const res = runInit(repo, { build: opts.build, cliPath, statusline: wantStatusline, global: opts.global, home });
+      const res = runInit(repo, { build: opts.build, cliPath, statusline: wantStatusline, global: opts.global, home, runner: opts.runner });
       console.error(`✓ wrote ${res.settingsPath}`);
       for (const s of res.shims) console.error(`✓ wrote ${s}`);
       console.error(`✓ wrote ${res.skill}`);
@@ -1139,6 +1146,7 @@ function wireTarget(
         mcp: opts.mcp,
         hooks: opts.hooks,
         global: opts.global,
+        runner: opts.runner,
       });
       for (const w of r.written) console.error(`✓ ${w.id}: ${w.path} (${w.action})`);
       for (const m of r.mcp) console.error(`✓ mcp ${m.id}: ${m.path} (${m.action})`);
@@ -1158,6 +1166,7 @@ function wireTarget(
       mcp: opts.mcp !== false,
       hooks: opts.hooks !== false,
       statusline: wantStatusline,
+      ...(opts.runner ? { runner: opts.runner } : {}),
     });
 
     // Every host's wiring points at graft/, so the graph is built whatever was

--- a/src/hosts/claude-global.ts
+++ b/src/hosts/claude-global.ts
@@ -32,7 +32,7 @@ import { claudeDistDir } from '../claude/paths.js';
 import { mergeGraftHooks } from '../claude/settings-merge.js';
 import { toPosixPath } from '../util/paths.js';
 import { readJsonObject, writeOwned, type ConfigWrite } from './config-write.js';
-import { mergeJsonKey, serverEntry } from './mcp-config.js';
+import { mergeJsonKey, serverEntry, type PackageRunner } from './mcp-config.js';
 import type { PlannedWrite } from './plan.js';
 
 /** Same `{ id, path, action }` contract every other writer in this layer reports. */
@@ -90,7 +90,7 @@ function upsertGlobalHooks(id: string, path: string, helpers: string): GlobalWri
  * Best-effort by contract, like every other writer here: a failure is reported as an
  * action, never raised, so a bad `~/.claude.json` can't fail a `graft init`.
  */
-export function installClaudeGlobal(home: string): GlobalWrite[] {
+export function installClaudeGlobal(home: string, opts: { runner?: PackageRunner } = {}): GlobalWrite[] {
   const [shim, settings, mcp] = claudeGlobalTargets(home);
   const out: GlobalWrite[] = [];
 
@@ -116,7 +116,7 @@ export function installClaudeGlobal(home: string): GlobalWrite[] {
   }
 
   try {
-    out.push(mergeJsonKey(mcp.id, mcp.path, 'mcpServers', serverEntry()));
+    out.push(mergeJsonKey(mcp.id, mcp.path, 'mcpServers', serverEntry({ runner: opts.runner })));
   } catch {
     out.push({ id: mcp.id, path: mcp.path, action: 'skipped-unparseable' });
   }

--- a/src/hosts/init.ts
+++ b/src/hosts/init.ts
@@ -8,7 +8,7 @@ import { dirname, join } from 'node:path';
 import { homedir } from 'node:os';
 import { HOSTS, detectHosts, type DetectProbe, type HostTarget } from './registry.js';
 import { upsertSection } from './sections.js';
-import { registerMcpConfigs, type McpWrite } from './mcp-config.js';
+import { registerMcpConfigs, type McpWrite, type PackageRunner } from './mcp-config.js';
 import { installCodexHooks } from './codex-hooks.js';
 import { installCursorHooks } from './cursor-hooks.js';
 import type { ConfigWrite } from './config-write.js';
@@ -47,6 +47,8 @@ export function runHostsInit(
     hooks?: boolean;
     /** false → skip every write outside the repo (the ~/.codex/ targets). */
     global?: boolean;
+    /** `--runner`: written into every generated MCP config. */
+    runner?: PackageRunner;
   } = {},
 ): HostsInitResult {
   const home = opts.home ?? homedir();
@@ -77,7 +79,7 @@ export function runHostsInit(
   const mcp =
     opts.mcp === false
       ? []
-      : registerMcpConfigs(repo, selected.map((h) => h.id), { home, global: opts.global });
+      : registerMcpConfigs(repo, selected.map((h) => h.id), { home, global: opts.global, runner: opts.runner });
   // The Codex hook targets are user-level (~/.codex), so --no-global suppresses them.
   const hooks =
     opts.hooks === false || opts.global === false || !selected.some((h) => h.id === 'agents')

--- a/src/hosts/mcp-config.ts
+++ b/src/hosts/mcp-config.ts
@@ -1,7 +1,9 @@
 /**
  * Register the graft MCP server in each host's config.
  * JSON hosts get a keyed merge (other servers preserved; unparseable files
- * are never rewritten). The TOML host gets an append-if-absent section.
+ * are never rewritten). TOML hosts get the same graft-entry merge: a missing
+ * `[mcp_servers.graft]` is appended, an existing one has its command/args
+ * updated when the runner changes.
  *
  * `mcpTargets()` is the pure "which files would this touch" half, so `graft
  * init --dry-run` and the picker can report paths without writing;
@@ -22,53 +24,103 @@ export interface McpTarget extends PlannedWrite {
   format: 'json' | 'toml';
   /** JSON only: the top-level key holding the server map. */
   topKey?: string;
-  /** JSON only: the server entry to merge in under `graft`. */
+  /** The server entry to merge in under `graft` (JSON object, or `{command,args}` for TOML). */
   entry?: object;
 }
 
 /**
  * How to launch the MCP server, decided once at init time.
  *
- * `npx -y` resolves the package before it can serve: measured at a 211 ms
- * spawn→`initialize` handshake against 80 ms for the installed binary, five runs
- * each. The harness registers a server's tools only once that handshake lands, and
- * a slow one can miss the first request entirely — in a traced session graft's
- * tools arrived 13.9 s in, four model turns too late to shape the approach. (That
- * 13.9 s is NOT explained by 130 ms; the gap's cause is still unknown. This is the
- * cheap half of the fix, not the whole of it.)
+ * These files get committed and shared, so the command is a bare name, never an
+ * absolute path — this repo already carries the scar of a checked-in hook shim
+ * with another machine's home directory baked into it.
  *
- * Deliberately a bare command name, never an absolute path: these files get
- * committed and shared, and this repo already carries the scar of the alternative —
- * a checked-in hook shim with another machine's home directory baked into it. A
- * bare `graft` works on any machine that has it installed; `npx` remains the
- * fallback for machines that don't.
+ * Priority:
+ *   1. `--runner` (explicit, always wins)
+ *   2. `GRAFT_MCP_NPX=1` (escape hatch / test pin → npx)
+ *   3. lockfile in the repo: bun.lock(b) → bunx, pnpm-lock.yaml → pnpm dlx,
+ *      yarn.lock → yarn dlx. A bun/pnpm/yarn repo's committed config should
+ *      spawn that runner, even if the person who ran `graft init` has `graft`
+ *      on PATH — otherwise teammates without a global install (or without npm)
+ *      inherit a command that cannot run.
+ *   4. `graft` on PATH (the installed binary is ~80 ms to handshake vs ~211 ms
+ *      for `npx -y`; the cheap half of a slow-handshake fix, not the whole of it)
+ *   5. `npx -y`
+ *
+ * bunx auto-installs (no `-y`). `pnpm dlx` / `yarn dlx` likewise fetch without
+ * a prompt. npx still needs `-y` so the MCP host isn't blocked on "Ok to proceed?".
+ * bunx is *not* passed `--bun`: graft's shebang is node and the tree-sitter
+ * addons expect it; bunx still fetches the package without npm.
  */
-const NPX_LAUNCH = { command: 'npx', args: ['-y', '@nanonets/graft', 'mcp'] };
-const BIN_LAUNCH = { command: 'graft', args: ['mcp'] };
+export type PackageRunner = 'npx' | 'bunx' | 'pnpm' | 'yarn';
+export const PACKAGE_RUNNERS: readonly PackageRunner[] = ['npx', 'bunx', 'pnpm', 'yarn'];
+
+export interface McpLaunch {
+  command: string;
+  args: string[];
+}
+
+const GRAFT_PKG = '@nanonets/graft';
+const NPX_LAUNCH: McpLaunch = { command: 'npx', args: ['-y', GRAFT_PKG, 'mcp'] };
+const BIN_LAUNCH: McpLaunch = { command: 'graft', args: ['mcp'] };
+
+const LOCKFILE_RUNNERS: { files: string[]; runner: PackageRunner }[] = [
+  { files: ['bun.lock', 'bun.lockb'], runner: 'bunx' },
+  { files: ['pnpm-lock.yaml'], runner: 'pnpm' },
+  { files: ['yarn.lock'], runner: 'yarn' },
+];
+
+export function isPackageRunner(value: string): value is PackageRunner {
+  return (PACKAGE_RUNNERS as readonly string[]).includes(value);
+}
+
+/** bun.lock(b) > pnpm-lock.yaml > yarn.lock > npx. package-lock.json is npx. */
+export function detectPackageRunner(dir: string): PackageRunner {
+  for (const { files, runner } of LOCKFILE_RUNNERS) {
+    if (files.some((f) => existsSync(join(dir, f)))) return runner;
+  }
+  return 'npx';
+}
+
+export function launchForRunner(runner: PackageRunner): McpLaunch {
+  switch (runner) {
+    case 'bunx': return { command: 'bunx', args: [GRAFT_PKG, 'mcp'] };
+    case 'pnpm': return { command: 'pnpm', args: ['dlx', GRAFT_PKG, 'mcp'] };
+    case 'yarn': return { command: 'yarn', args: ['dlx', GRAFT_PKG, 'mcp'] };
+    default: return NPX_LAUNCH;
+  }
+}
 
 function graftOnPath(): boolean {
   const r = spawnSync('graft', ['--version'], { stdio: 'ignore', timeout: 5000 });
   return r.status === 0;
 }
 
+function npxForced(): boolean {
+  const forced = process.env.GRAFT_MCP_NPX;
+  return forced !== undefined && forced !== '' && forced !== '0' && forced !== 'false';
+}
+
 /**
  * JSON hosts: `{ command, args }`.
  *
- * `GRAFT_MCP_NPX=1` forces the `npx` form — the escape hatch for a machine whose
- * global install is stale or shadowed, and what the tests set so their expectations
- * don't depend on whether the machine running them happens to have graft installed.
- * `opts.onPath` is the same override for direct unit tests of both branches.
+ * `opts.runner` is `--runner` — explicit, always wins. `GRAFT_MCP_NPX=1` forces
+ * the `npx` form when no runner was given: the escape hatch for a machine whose
+ * global install is stale or shadowed, and what the tests set so their
+ * expectations don't depend on whether the machine running them happens to have
+ * graft installed. `opts.onPath` is the same override for direct unit tests of
+ * the PATH vs fallback branches. `opts.cwd` is the repo whose lockfile is read.
  */
-export function serverEntry(opts: { onPath?: boolean } = {}): { command: string; args: string[] } {
-  const forced = process.env.GRAFT_MCP_NPX;
-  if (forced !== undefined && forced !== '' && forced !== '0' && forced !== 'false') return NPX_LAUNCH;
+export function serverEntry(opts: { onPath?: boolean; runner?: PackageRunner; cwd?: string } = {}): McpLaunch {
+  if (opts.runner) return launchForRunner(opts.runner);
+  if (npxForced()) return NPX_LAUNCH;
+  const detected = detectPackageRunner(opts.cwd ?? process.cwd());
+  if (detected !== 'npx') return launchForRunner(detected);
   return (opts.onPath ?? graftOnPath()) ? BIN_LAUNCH : NPX_LAUNCH;
 }
 
-
-function opencodeEntry(): object {
-  const { command, args } = serverEntry();
-  return { type: 'local', command: [command, ...args], enabled: true };
+function opencodeEntry(launch: McpLaunch): object {
+  return { type: 'local', command: [launch.command, ...launch.args], enabled: true };
 }
 
 function dirExists(p: string): boolean {
@@ -122,14 +174,15 @@ export function stripTomlSection(text: string): { rest: string; found: boolean }
  * launch command at whatever the first init wrote: a repo wired when graft wasn't
  * on PATH kept the slow `npx` form forever, and no upgrade could correct it. Strip
  * and re-append instead, so this converges like every other writer — foreign
- * tables are untouched either way.
+ * tables are untouched either way. `launch` is the command decided by `--runner`
+ * / lockfile / PATH, so a re-run can switch `npx` to `bunx` without rewriting the
+ * rest of the file.
  */
-function upsertCodexToml(id: string, path: string): McpWrite {
+function upsertCodexToml(id: string, path: string, launch: McpLaunch): McpWrite {
   const existed = existsSync(path);
   const text = existed ? readFileSync(path, 'utf8') : '';
-  const { command, args } = serverEntry();
-  const argList = args.map((a) => JSON.stringify(a)).join(", ");
-  const section = `${TOML_HEADER}\ncommand = \"${command}\"\nargs = [${argList}]\n`;
+  const argList = launch.args.map((a) => JSON.stringify(a)).join(", ");
+  const section = `${TOML_HEADER}\ncommand = "${launch.command}"\nargs = [${argList}]\n`;
 
   const { rest, found } = stripTomlSection(text);
   // Byte-identical already: don't rewrite the file just to reorder it.
@@ -166,10 +219,10 @@ function jsonTarget(
 export function mcpTargets(
   repo: string,
   ids: string[],
-  opts: { home?: string } = {},
+  opts: { home?: string; runner?: PackageRunner } = {},
 ): McpTarget[] {
   const home = opts.home ?? homedir();
-  const entry = serverEntry();
+  const entry = serverEntry({ runner: opts.runner, cwd: repo });
   const out: McpTarget[] = [];
   for (const id of ids) {
     switch (id) {
@@ -197,6 +250,7 @@ export function mcpTargets(
         out.push({
           hostId: id, id: 'grok', path: join(repo, '.grok', 'config.toml'),
           scope: 'repo', kind: 'mcp', what: '[mcp_servers.graft]', format: 'toml',
+          entry,
         });
         break;
       case 'agents':
@@ -206,10 +260,11 @@ export function mcpTargets(
           out.push({
             hostId: id, id: 'codex', path: join(home, '.codex', 'config.toml'),
             scope: 'global', kind: 'mcp', what: '[mcp_servers.graft]', format: 'toml',
+            entry,
           });
         }
         if (dirExists(join(home, '.config', 'opencode'))) {
-          out.push(jsonTarget(id, 'opencode', join(repo, 'opencode.json'), 'mcp', opencodeEntry()));
+          out.push(jsonTarget(id, 'opencode', join(repo, 'opencode.json'), 'mcp', opencodeEntry(entry)));
         }
         break;
       default:
@@ -222,13 +277,13 @@ export function mcpTargets(
 export function registerMcpConfigs(
   repo: string,
   ids: string[],
-  opts: { home?: string; global?: boolean } = {},
+  opts: { home?: string; global?: boolean; runner?: PackageRunner } = {},
 ): McpWrite[] {
   return mcpTargets(repo, ids, opts)
     .filter((t) => opts.global !== false || t.scope !== 'global')
     .map((t) =>
       t.format === 'toml'
-        ? upsertCodexToml(t.id, t.path)
+        ? upsertCodexToml(t.id, t.path, (t.entry as McpLaunch | undefined) ?? serverEntry({ runner: opts.runner, cwd: repo }))
         : mergeJsonKey(t.id, t.path, t.topKey!, t.entry!),
     );
 }

--- a/src/upkeep-run.ts
+++ b/src/upkeep-run.ts
@@ -44,10 +44,10 @@ function rewriteWiring(repo: string, hosts: string[], opts: WiringOpts): void {
   // its `~/.claude` writes (hosts/claude-global.ts) are out-of-repo, and a user who
   // declined those at init time must keep declining them on every replay.
   if (hosts.includes('claude'))
-    runInit(repo, { build: false, cliPath: graftCliPath(), statusline: opts.statusline, global: opts.global });
+    runInit(repo, { build: false, cliPath: graftCliPath(), statusline: opts.statusline, global: opts.global, runner: opts.runner });
   const others = hosts.filter((h) => h !== 'claude');
   if (others.length)
-    runHostsInit(repo, { agents: others, global: opts.global, mcp: opts.mcp, hooks: opts.hooks });
+    runHostsInit(repo, { agents: others, global: opts.global, mcp: opts.mcp, hooks: opts.hooks, runner: opts.runner });
 }
 
 /**

--- a/src/upkeep.ts
+++ b/src/upkeep.ts
@@ -34,6 +34,7 @@ import { START } from './hosts/sections.js';
 import { getNpmViewVersion, readCurrentVersion } from './cli-meta.js';
 import { cacheIsStale, markRulesChecked, readLink, readRulesCache } from './brain/link.js';
 import { graftCliPath } from './claude/paths.js';
+import type { PackageRunner } from './hosts/mcp-config.js';
 
 /**
  * The version of the graft package this code was loaded from.
@@ -209,6 +210,8 @@ export interface WiringOpts {
   hooks: boolean;
   /** false → skip Claude Code statusLine (`--no-statusline` / GRAFT_NO_STATUSLINE). */
   statusline: boolean;
+  /** Set when the user passed `--runner`; absent → re-detect from the lockfile. */
+  runner?: PackageRunner;
 }
 
 export const DEFAULT_WIRING_OPTS: WiringOpts = { global: true, mcp: true, hooks: true, statusline: true };

--- a/test/claude-init.test.ts
+++ b/test/claude-init.test.ts
@@ -196,3 +196,10 @@ test('buildGraphIfMissing: an existing graph is left alone', () => {
   // A bogus cliPath would throw if it were reached; the wiring check short-circuits.
   assert.equal(buildGraphIfMissing(dir, { build: true, cliPath: '/nonexistent/cli.js' }), false);
 });
+
+test('runInit --runner bunx writes bunx into .mcp.json', () => {
+  const d = fresh();
+  runInit(d, { build: false, runner: 'bunx' });
+  const mcp = JSON.parse(readFileSync(join(d, '.mcp.json'), 'utf8'));
+  assert.deepEqual(mcp.mcpServers.graft, { command: 'bunx', args: ['@nanonets/graft', 'mcp'] });
+});

--- a/test/hosts-init.test.ts
+++ b/test/hosts-init.test.ts
@@ -250,3 +250,22 @@ test('CLI: --dry-run respects an explicit --agents list', () => {
   assert.doesNotMatch(out, /AGENTS\.md/);
   assert.doesNotMatch(out, /affects ALL repos/);
 });
+
+test('CLI: --runner bunx writes bunx into every generated MCP config', () => {
+  const repo = fresh();
+  const home = fresh();
+  const r = runCli(['init', repo, '--no-build', '--agents', 'cursor', 'claude', '--runner', 'bunx'], { home });
+  assert.equal(r.status, 0, r.describe());
+  const cursor = JSON.parse(readFileSync(join(repo, '.cursor', 'mcp.json'), 'utf8'));
+  assert.deepEqual(cursor.mcpServers.graft, { command: 'bunx', args: ['@nanonets/graft', 'mcp'] });
+  const claude = JSON.parse(readFileSync(join(repo, '.mcp.json'), 'utf8'));
+  assert.deepEqual(claude.mcpServers.graft, { command: 'bunx', args: ['@nanonets/graft', 'mcp'] });
+});
+
+test('CLI: unknown --runner exits non-zero and writes nothing', () => {
+  const repo = fresh();
+  const r = runCli(['init', repo, '--no-build', '--agents', 'cursor', '--runner', 'foo']);
+  assert.notEqual(r.status, 0, r.describe());
+  assert.match(r.stderr ?? '', /unknown --runner foo/);
+  assert.ok(!existsSync(join(repo, '.cursor', 'mcp.json')));
+});

--- a/test/hosts-mcp-config.test.ts
+++ b/test/hosts-mcp-config.test.ts
@@ -7,7 +7,7 @@ process.env.GRAFT_MCP_NPX = '1';
 import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { registerMcpConfigs, serverEntry } from '../src/hosts/mcp-config.js';
+import { registerMcpConfigs, serverEntry, detectPackageRunner, launchForRunner } from '../src/hosts/mcp-config.js';
 
 function fresh(): string { return mkdtempSync(join(tmpdir(), 'graft-mcpcfg-')); }
 
@@ -109,4 +109,89 @@ test('serverEntry prefers the installed binary and falls back to npx', () => {
 test('GRAFT_MCP_NPX overrides an installed binary', () => {
   process.env.GRAFT_MCP_NPX = '1';
   assert.equal(serverEntry({ onPath: true }).command, 'npx', 'the escape hatch wins');
+});
+
+function withoutNpxPin(fn: () => void): void {
+  const saved = process.env.GRAFT_MCP_NPX;
+  delete process.env.GRAFT_MCP_NPX;
+  try { fn(); } finally {
+    if (saved !== undefined) process.env.GRAFT_MCP_NPX = saved;
+    else delete process.env.GRAFT_MCP_NPX;
+  }
+}
+
+function lockfileRepo(name: string): string {
+  const repo = fresh();
+  writeFileSync(join(repo, name), '');
+  return repo;
+}
+
+test('detectPackageRunner reads lockfiles in bun > pnpm > yarn > npx order', () => {
+  assert.equal(detectPackageRunner(lockfileRepo('bun.lock')), 'bunx');
+  assert.equal(detectPackageRunner(lockfileRepo('bun.lockb')), 'bunx');
+  assert.equal(detectPackageRunner(lockfileRepo('pnpm-lock.yaml')), 'pnpm');
+  assert.equal(detectPackageRunner(lockfileRepo('yarn.lock')), 'yarn');
+  assert.equal(detectPackageRunner(fresh()), 'npx', 'no lockfile');
+  assert.equal(detectPackageRunner(lockfileRepo('package-lock.json')), 'npx', 'npm lockfile is the default');
+  const both = fresh();
+  writeFileSync(join(both, 'bun.lock'), '');
+  writeFileSync(join(both, 'pnpm-lock.yaml'), '');
+  assert.equal(detectPackageRunner(both), 'bunx', 'bun wins when several lockfiles exist');
+});
+
+test('launchForRunner matches each package manager\'s documented dlx shape', () => {
+  assert.deepEqual(launchForRunner('npx'), { command: 'npx', args: ['-y', '@nanonets/graft', 'mcp'] });
+  assert.deepEqual(launchForRunner('bunx'), { command: 'bunx', args: ['@nanonets/graft', 'mcp'] });
+  assert.deepEqual(launchForRunner('pnpm'), { command: 'pnpm', args: ['dlx', '@nanonets/graft', 'mcp'] });
+  assert.deepEqual(launchForRunner('yarn'), { command: 'yarn', args: ['dlx', '@nanonets/graft', 'mcp'] });
+});
+
+test('serverEntry uses the lockfile runner when graft is not on PATH', () => {
+  withoutNpxPin(() => {
+    assert.deepEqual(serverEntry({ onPath: false, cwd: lockfileRepo('bun.lock') }), { command: 'bunx', args: ['@nanonets/graft', 'mcp'] });
+    assert.deepEqual(serverEntry({ onPath: false, cwd: lockfileRepo('pnpm-lock.yaml') }), { command: 'pnpm', args: ['dlx', '@nanonets/graft', 'mcp'] });
+    assert.deepEqual(serverEntry({ onPath: false, cwd: lockfileRepo('yarn.lock') }), { command: 'yarn', args: ['dlx', '@nanonets/graft', 'mcp'] });
+    assert.deepEqual(serverEntry({ onPath: false, cwd: fresh() }), { command: 'npx', args: ['-y', '@nanonets/graft', 'mcp'] });
+  });
+});
+
+test('a bun/pnpm/yarn lockfile wins over an installed binary so committed configs stay portable', () => {
+  withoutNpxPin(() => {
+    assert.equal(serverEntry({ onPath: true, cwd: lockfileRepo('bun.lock') }).command, 'bunx');
+    assert.equal(serverEntry({ onPath: true, cwd: lockfileRepo('pnpm-lock.yaml') }).command, 'pnpm');
+    assert.equal(serverEntry({ onPath: true, cwd: fresh() }).command, 'graft', 'no lockfile → still prefer PATH');
+  });
+});
+
+test('--runner wins over lockfile, PATH, and GRAFT_MCP_NPX', () => {
+  process.env.GRAFT_MCP_NPX = '1';
+  const bun = lockfileRepo('bun.lock');
+  assert.deepEqual(serverEntry({ runner: 'pnpm', onPath: true, cwd: bun }), { command: 'pnpm', args: ['dlx', '@nanonets/graft', 'mcp'] });
+  assert.deepEqual(serverEntry({ runner: 'bunx' }), { command: 'bunx', args: ['@nanonets/graft', 'mcp'] });
+  assert.deepEqual(serverEntry({ runner: 'yarn' }), { command: 'yarn', args: ['dlx', '@nanonets/graft', 'mcp'] });
+  assert.deepEqual(serverEntry({ runner: 'npx' }), { command: 'npx', args: ['-y', '@nanonets/graft', 'mcp'] });
+});
+
+test('re-running init updates an existing JSON graft entry to the new runner', () => {
+  const repo = fresh(); const home = fresh();
+  registerMcpConfigs(repo, ['cursor'], { home, runner: 'npx' });
+  const first = JSON.parse(readFileSync(join(repo, '.cursor', 'mcp.json'), 'utf8'));
+  assert.equal(first.mcpServers.graft.command, 'npx');
+  const w = registerMcpConfigs(repo, ['cursor'], { home, runner: 'bunx' });
+  assert.deepEqual(w.map((x) => x.action), ['updated']);
+  const cfg = JSON.parse(readFileSync(join(repo, '.cursor', 'mcp.json'), 'utf8'));
+  assert.deepEqual(cfg.mcpServers.graft, { command: 'bunx', args: ['@nanonets/graft', 'mcp'] });
+});
+
+test('re-running init updates an existing TOML graft section to the new runner', () => {
+  const repo = fresh(); const home = fresh();
+  const w1 = registerMcpConfigs(repo, ['grok'], { home, runner: 'npx' });
+  assert.deepEqual(w1.map((x) => x.action), ['created']);
+  const w2 = registerMcpConfigs(repo, ['grok'], { home, runner: 'pnpm' });
+  assert.deepEqual(w2.map((x) => x.action), ['updated']);
+  const toml = readFileSync(join(repo, '.grok', 'config.toml'), 'utf8');
+  assert.match(toml, /command = "pnpm"/);
+  assert.match(toml, /"dlx"/);
+  const w3 = registerMcpConfigs(repo, ['grok'], { home, runner: 'pnpm' });
+  assert.deepEqual(w3.map((x) => x.action), ['unchanged']);
 });

--- a/test/upkeep.test.ts
+++ b/test/upkeep.test.ts
@@ -122,6 +122,18 @@ test('a refresh replays --no-statusline so a later session cannot re-install the
   assert.deepEqual(readStamp(repo)?.opts, { global: true, mcp: true, hooks: true, statusline: false });
 });
 
+test('a refresh replays --runner so a bunx wiring is not rewritten as npx', () => {
+  const repo = tmpRepo('upkeep-runner');
+  writeStamp(repo, '1.0.0', ['cursor'], { runner: 'bunx' });
+  let seen: WiringOpts | null = null;
+  reconcileWiring(repo, '2.0.0', {
+    wired: () => ['cursor'],
+    rewrite: (_repo, _hosts, opts) => { seen = opts; },
+  });
+  assert.equal(seen?.runner, 'bunx');
+  assert.equal(readStamp(repo)?.opts?.runner, 'bunx');
+});
+
 test('by default a refresh DOES reach ~/.codex — nothing else ever would', () => {
   // No skill, rule file, or MCP instruction tells an agent to run `graft init`,
   // so skipping the out-of-repo writes means a Codex user never gets them.


### PR DESCRIPTION
## Summary
- Generated MCP configs (`.mcp.json`, `.cursor/mcp.json`, `.gemini/settings.json`, `.kiro/settings/mcp.json`, `opencode.json`, Codex/Grok TOML) no longer hardcode `npx -y`. One constructor (`serverEntry`) picks the launch command for every host.
- `graft init --runner <npx|bunx|pnpm|yarn>` writes that runner into every graft MCP entry. Re-running `init` updates an existing graft entry (JSON merge and TOML `[mcp_servers.graft]` alike). `--runner` is recorded in the wiring stamp so a later refresh replays it.
- Without the flag, the repo lockfile decides (bun/pnpm/yarn beat a local `graft` on PATH so committed configs stay portable for teammates). `GRAFT_MCP_NPX=1` remains the test pin / escape hatch, below `--runner`.

### Detection (first match wins)

| Lockfile | Launch |
|---|---|
| `bun.lock` or `bun.lockb` | `bunx @nanonets/graft mcp` |
| `pnpm-lock.yaml` | `pnpm dlx @nanonets/graft mcp` |
| `yarn.lock` | `yarn dlx @nanonets/graft mcp` |
| none / `package-lock.json` | `graft mcp` if `graft` is on PATH, else `npx -y @nanonets/graft mcp` |

`bunx` is not passed `--bun`: graft's shebang is node and the tree-sitter addons expect it. bunx still fetches the package without npm ([bunx docs](https://bun.sh/docs/pm/bunx)). `pnpm dlx` / `yarn dlx` match the [pnpm](https://pnpm.io/cli/dlx) and [yarn](https://yarnpkg.com/cli/dlx) docs; neither needs an npx-style `-y`.

```
graft init --runner bunx
graft init --runner pnpm
```

## Test plan
- [x] lockfile detection: bun.lock / bun.lockb / pnpm-lock.yaml / yarn.lock / no lockfile
- [x] `--runner` beats lockfile, PATH, and `GRAFT_MCP_NPX`
- [x] re-run updates JSON and TOML graft entries; same runner stays `unchanged`
- [x] CLI `--runner bunx` writes bunx into `.cursor/mcp.json` and `.mcp.json`
- [x] unknown `--runner` exits non-zero and writes nothing
- [x] wiring stamp replays `--runner` on refresh
- [x] `npm run build`
- [x] `npm test` (925 pass; one PageRank timing assertion flakes under load, passes in isolation)

Closes #60

Made with [Cursor](https://cursor.com)