### PR TITLE
fix(init): generated instructions work without a global graft install (#61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **Generated agent instructions work without a global `graft` install.**
+  `graft init` never puts `graft` on PATH, but AGENTS.md / GEMINI.md / SKILL.md
+  told agents to run bare `graft ask`. They now say to use
+  `npx -y @nanonets/graft` (or `bunx` / `pnpm dlx` / `yarn dlx`) when the
+  binary is missing.
+
 ## 0.18.0
 
 ### Added

--- a/src/claude/skill-template.ts
+++ b/src/claude/skill-template.ts
@@ -1,3 +1,5 @@
+import { cliFallbackNote } from '../hosts/instructions.js';
+
 // The graft Claude Code skill, bundled as a string so `graft init` can write it into a
 // consumer repo's .claude/skills/graft/SKILL.md (no network fetch, version-locked to the
 // installed graft). This is the single source of truth for the skill text; graft's own
@@ -22,6 +24,8 @@ that understanding by reading source costs thousands, and misses the edges.
 Every command below is \`$0\`, needs no API key, and returns in under a second.
 There are six of them. **Pick the one that fits the task, run it, act on the
 answer; don't chain tools hoping for more. Most tasks need one call.**
+
+${cliFallbackNote()}
 
 ## The tools
 

--- a/src/hosts/instructions.ts
+++ b/src/hosts/instructions.ts
@@ -3,11 +3,18 @@
  * native format. Content changes happen HERE only; renderers just wrap it.
  */
 
+/** How to invoke graft when `graft init` has not put a binary on PATH. */
+export function cliFallbackNote(): string {
+  return `If \`graft\` is not on PATH (\`graft init\` does not install it), use \`npx -y @nanonets/graft\` in its place — e.g. \`npx -y @nanonets/graft ask "<question>" --source\`. \`bunx\`, \`pnpm dlx\`, and \`yarn dlx\` work the same way.`;
+}
+
 export function instructionBody(): string {
   return `## Graft — repo context graph
 
 This repo is indexed in \`graft/\`: small linked markdown nodes that explain each
 system and carry exact file:line spans, kept in sync with the code through git.
+
+${cliFallbackNote()}
 
 For ANY task here — understanding how something works, finding where code lives,
 or scoping a change — get context from the graph before grepping or opening

--- a/test/claude-skill-template.test.ts
+++ b/test/claude-skill-template.test.ts
@@ -21,4 +21,6 @@ test('skill template is a well-formed SKILL.md', () => {
   assert.match(body, /--in <scope>\//, 'body teaches narrowing with ask --in <scope>/');
   assert.match(body, /tokens saved/i, 'body references the tokens-saved footer');
   assert.match(body, /every turn/i, 'body tells the agent to report savings each turn');
+  assert.match(body, /npx -y @nanonets\/graft/, 'body tells the agent how to run without a global install');
+  assert.match(body, /does not install it/, 'body says graft init does not put the CLI on PATH');
 });

--- a/test/hosts-instructions.test.ts
+++ b/test/hosts-instructions.test.ts
@@ -15,6 +15,8 @@ test('canonical body names the three essentials', () => {
   assert.match(b, /graft map/, 'tells the agent to orient with graft map before exploring');
   assert.match(b, /\[scope\/\]/, 'teaches the [scope/] label on multi-scope/monorepo hits');
   assert.match(b, /--in <scope>\//, 'teaches narrowing with ask --in <scope>/');
+  assert.match(b, /npx -y @nanonets\/graft/, 'tells the agent how to run without a global install');
+  assert.match(b, /does not install it/, 'says graft init does not put the CLI on PATH');
   assert.ok(!/\bhook|statusline\b/i.test(b), 'no host-specific machinery in the shared body');
 });
 


### PR DESCRIPTION
## Summary
- `graft init` does not install a global `graft` binary, but AGENTS.md / GEMINI.md / SKILL.md (and the other host copies of the same body) told agents to run bare `graft ask`. The first command then failed with command-not-found.
- Chose **scheme 2** (a fallback note) over rewriting every example as `npx @nanonets/graft …`: smaller diff, and re-running `init` only replaces graft's fenced section / owned skill file rather than making every listed command noisier for repos that already have the CLI.
- One shared sentence, `cliFallbackNote()`, is interpolated into `instructionBody()` and `skillTemplate()`. Agents that hit a missing binary are told to use `npx -y @nanonets/graft` in its place (example included); `bunx` / `pnpm dlx` / `yarn dlx` are named as equivalents. Commands stay `graft ask` so a global install keeps working unchanged.

Independent of #60 / #208 — the note is a static npx fallback, not lockfile detection. Those can merge later if instructions should follow `--runner`.

## Test plan
- [x] `hosts-instructions` and `claude-skill-template` assert the fallback wording
- [x] `graft init --agents claude cursor agents --no-global` writes the note into AGENTS.md, `.cursor/rules/graft.mdc`, and SKILL.md
- [x] `graft init --dry-run` still only lists paths
- [x] `npm run build`
- [x] related init/instruction tests green; full `npm test` matches origin/main aside from an unrelated `viz --tabs` failure when this worktree has no `graft/` graph

Closes #61

Made with [Cursor](https://cursor.com)