### PR TITLE
fix(mcp): complete the initialize handshake instead of exiting on stdio (#211)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -773,7 +773,9 @@ program
     const dir = noteQuery(queryRoot(dirArg));
     const { startMcpServer } = await import("./mcp/server.js");
     const globalOpts = program.opts<{ dir?: string }>();
-    startMcpServer(dir, globalOpts.dir, currentVersion);
+    // Awaited so commander does not finish the action (and let the process
+    // exit) before a client writes `initialize`.
+    await startMcpServer(dir, globalOpts.dir, currentVersion);
   });
 
 program

--- a/src/graph/extract.ts
+++ b/src/graph/extract.ts
@@ -6,15 +6,8 @@
  * arrow-function consts) plus unresolved edge intents. Edge *targets* are
  * resolved against the whole-repo node index later, in build.ts.
  */
-import Parser from "tree-sitter";
-import TypeScript from "tree-sitter-typescript";
-import Python from "tree-sitter-python";
-import Go from "tree-sitter-go";
-import R from "tree-sitter-r";
-import Java from "tree-sitter-java";
-import Kotlin from "tree-sitter-kotlin";
-import Swift from "tree-sitter-swift";
-import PHP from "tree-sitter-php";
+import { createRequire } from "node:module";
+import type Parser from "tree-sitter";
 import { basename } from "node:path";
 import { contentHash } from "../util/id.js";
 import { collectBindings, goReceiverVarOf, resolveRecvType, type FileBindings } from "./bindings.js";
@@ -310,18 +303,59 @@ const FUNCTION_VALUE_TYPES = new Set([
 
 const EMPTY_SET: ReadonlySet<string> = new Set();
 
-const parser = new Parser();
-const GRAMMARS: Record<Language, unknown> = {
-  typescript: TypeScript.typescript,
-  tsx: TypeScript.tsx,
-  python: Python,
-  go: Go,
-  r: R,
-  java: Java,
-  kotlin: Kotlin,
-  swift: Swift,
-  php: PHP.php,
-};
+/**
+ * Native grammars are loaded on first parse, not at import. `graft mcp` has to
+ * answer `initialize` before it ever looks at source, and pulling eight node-gyp
+ * addons (one of which, kotlin, has no prebuild on some platforms) was exiting
+ * the process — or stalling past the client's handshake timeout — on boot.
+ */
+const require = createRequire(import.meta.url);
+let parser: Parser | undefined;
+const grammarCache = new Map<Language, unknown>();
+
+type ParserCtor = new () => Parser;
+
+function treeSitter(): Parser {
+  if (!parser) parser = new (require("tree-sitter") as ParserCtor)();
+  return parser;
+}
+
+function grammarOf(lang: Language): unknown {
+  const hit = grammarCache.get(lang);
+  if (hit !== undefined) return hit;
+  let loaded: unknown;
+  switch (lang) {
+    case "typescript":
+      loaded = require("tree-sitter-typescript").typescript;
+      break;
+    case "tsx":
+      loaded = require("tree-sitter-typescript").tsx;
+      break;
+    case "python":
+      loaded = require("tree-sitter-python");
+      break;
+    case "go":
+      loaded = require("tree-sitter-go");
+      break;
+    case "r":
+      loaded = require("tree-sitter-r");
+      break;
+    case "java":
+      loaded = require("tree-sitter-java");
+      break;
+    case "kotlin":
+      loaded = require("tree-sitter-kotlin");
+      break;
+    case "swift":
+      loaded = require("tree-sitter-swift");
+      break;
+    case "php":
+      loaded = require("tree-sitter-php").php;
+      break;
+  }
+  grammarCache.set(lang, loaded);
+  return loaded;
+}
 
 export interface WalkCtx {
   rel: string;
@@ -381,11 +415,11 @@ interface DefDescriptor {
  * the source in <32 KB slices. Code-unit indexing matches `String.slice`. */
 const PARSE_CHUNK = 16384;
 function parseSource(source: string): Parser.SyntaxNode {
-  return parser.parse((index: number) => source.slice(index, index + PARSE_CHUNK)).rootNode;
+  return treeSitter().parse((index: number) => source.slice(index, index + PARSE_CHUNK)).rootNode;
 }
 
 export function extractFile(rel: string, source: string, lang: Language): ExtractResult {
-  parser.setLanguage(GRAMMARS[lang] as never);
+  treeSitter().setLanguage(grammarOf(lang) as never);
   const root = parseSource(source);
   const bindings = collectBindings(root, lang);
   const importedSymbols = collectImportedSymbols(root, lang);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,15 +1,26 @@
 /**
  * Minimal MCP stdio server: newline-delimited JSON-RPC 2.0.
  * stdout carries protocol messages ONLY; diagnostics go to stderr.
+ *
+ * Dual-era: answers legacy `initialize` (2025-11-25 and earlier) and modern
+ * `server/discover` (2026-07-28). The graph engine is loaded only on
+ * `tools/call` so the handshake cannot die behind a missing native grammar.
  */
 import { createInterface } from 'node:readline';
-import { TOOLS, callTool } from './tools.js';
+import { TOOLS } from './tool-defs.js';
 import { mcpInstructions } from './instructions.js';
-import { hasGraftIndex } from '../graph/root.js';
-import { mainWorktreeRoot } from '../graph/seed.js';
-import { runUpkeep } from '../upkeep-run.js';
-import { runningVersion } from '../upkeep.js';
 import { maybeFlushInBackground, track } from '../telemetry/index.js';
+
+/**
+ * Newest first. Handshake-era clients speak the 2025/2024 dates; 2026 is the
+ * per-request-metadata revision. A missing version lands on the newest
+ * handshake-era date the official SDK still speaks.
+ */
+export const SUPPORTED_PROTOCOL_VERSIONS = ['2026-07-28', '2025-11-25', '2025-03-26', '2024-11-05'] as const;
+export const DEFAULT_PROTOCOL_VERSION = '2025-11-25';
+const UNSUPPORTED_PROTOCOL_VERSION = -32022;
+const META_PROTOCOL_VERSION = 'io.modelcontextprotocol/protocolVersion';
+const META_SERVER_INFO = 'io.modelcontextprotocol/serverInfo';
 
 /**
  * MCP tool name → the command enum the telemetry contract knows. A tool absent
@@ -26,16 +37,158 @@ const TOOL_COMMAND: Record<string, string> = {
   graft_check_freshness: 'check',
 };
 
-function send(msg: object): void {
+export function negotiateProtocolVersion(requested: unknown): { ok: true; version: string } | { ok: false; requested: string } {
+  if (requested === undefined || requested === null || requested === '') {
+    return { ok: true, version: DEFAULT_PROTOCOL_VERSION };
+  }
+  const version = String(requested);
+  if ((SUPPORTED_PROTOCOL_VERSIONS as readonly string[]).includes(version)) {
+    return { ok: true, version };
+  }
+  return { ok: false, requested: version };
+}
+
+type JsonRpc = { id?: unknown; method?: string; params?: Record<string, unknown> };
+
+export interface McpSession {
+  root: string;
+  dirOverride?: string;
+  version: string;
+  upkeepLines: string[];
+  write: (msg: object) => void;
+}
+
+function send(write: (msg: object) => void, msg: object): void {
+  write(msg);
+}
+
+function reply(session: McpSession, id: unknown, result: object): void {
+  send(session.write, { jsonrpc: '2.0', id, result });
+}
+
+function replyError(session: McpSession, id: unknown, code: number, message: string, data?: unknown): void {
+  const error: { code: number; message: string; data?: unknown } = { code, message };
+  if (data !== undefined) error.data = data;
+  send(session.write, { jsonrpc: '2.0', id, error });
+}
+
+function initializeResult(session: McpSession, protocolVersion: string): object {
+  const extra = session.upkeepLines.length ? `${session.upkeepLines.join('\n')}\n\n` : '';
+  return {
+    protocolVersion,
+    capabilities: { tools: {} },
+    serverInfo: { name: 'graft', version: session.version },
+    instructions: `${extra}${mcpInstructions()}`,
+  };
+}
+
+function discoverResult(session: McpSession): object {
+  const extra = session.upkeepLines.length ? `${session.upkeepLines.join('\n')}\n\n` : '';
+  return {
+    resultType: 'complete',
+    ttlMs: 60_000,
+    cacheScope: 'public',
+    supportedVersions: [...SUPPORTED_PROTOCOL_VERSIONS],
+    capabilities: { tools: {} },
+    instructions: `${extra}${mcpInstructions()}`,
+    _meta: { [META_SERVER_INFO]: { name: 'graft', version: session.version } },
+  };
+}
+
+function metaProtocolVersion(params?: Record<string, unknown>): string | undefined {
+  const meta = params?._meta;
+  if (!meta || typeof meta !== 'object') return undefined;
+  const v = (meta as Record<string, unknown>)[META_PROTOCOL_VERSION];
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}
+
+/** Handle one newline-delimited JSON-RPC line. Notifications produce no write. */
+export function handleMcpLine(line: string, session: McpSession): void {
+  const text = line.trim();
+  if (!text) return;
+  let msg: JsonRpc;
+  try {
+    msg = JSON.parse(text) as JsonRpc;
+  } catch {
+    replyError(session, null, -32700, 'parse error');
+    return;
+  }
+  const { id, method, params } = msg;
+  const isNotification = id === undefined;
+
+  if (method !== 'initialize' && method !== 'server/discover' && !isNotification) {
+    const offered = metaProtocolVersion(params);
+    if (offered !== undefined && negotiateProtocolVersion(offered).ok === false) {
+      replyError(session, id, UNSUPPORTED_PROTOCOL_VERSION, 'Unsupported protocol version', {
+        supported: [...SUPPORTED_PROTOCOL_VERSIONS],
+        requested: offered,
+      });
+      return;
+    }
+  }
+
+  switch (method) {
+    case 'initialize': {
+      const negotiated = negotiateProtocolVersion(params?.protocolVersion);
+      if (!negotiated.ok) {
+        replyError(session, id ?? null, UNSUPPORTED_PROTOCOL_VERSION, 'Unsupported protocol version', {
+          supported: [...SUPPORTED_PROTOCOL_VERSIONS],
+          requested: negotiated.requested,
+        });
+        return;
+      }
+      reply(session, id ?? null, initializeResult(session, negotiated.version));
+      return;
+    }
+    case 'server/discover':
+      if (!isNotification) reply(session, id, discoverResult(session));
+      return;
+    case 'notifications/initialized':
+    case 'notifications/cancelled':
+      return;
+    case 'ping':
+      if (!isNotification) reply(session, id, {});
+      return;
+    case 'tools/list':
+      if (isNotification) return;
+      {
+        const listed = advertised(session.root, session.dirOverride);
+        const send = (tools: typeof TOOLS) =>
+          reply(session, id, {
+            tools: tools.map((t) => ({ name: t.name, description: t.description, inputSchema: t.inputSchema })),
+          });
+        if (listed instanceof Promise) {
+          listed.then(send, (err) => replyError(session, id, -32603, err instanceof Error ? err.message : String(err)));
+        } else {
+          send(listed);
+        }
+      }
+      return;
+    case 'tools/call': {
+      if (isNotification) return;
+      const name = String(params?.name ?? '');
+      const args = (params?.arguments ?? {}) as Record<string, unknown>;
+      // Loaded here, not at boot: callTool pulls the graph engine and, on first
+      // parse, native grammars. The handshake must not wait on that.
+      import('./tools.js').then(({ callTool }) =>
+        callTool(session.root, name, args, session.dirOverride).then(
+          (r) => {
+            const command = Object.hasOwn(TOOL_COMMAND, name) ? TOOL_COMMAND[name] : undefined;
+            track('query', { command, surface: 'mcp' }, { repo: session.root, host: 'mcp' });
+            reply(session, id, { content: [{ type: 'text', text: r.text }], isError: r.isError });
+          },
+          (err) => replyError(session, id, -32603, err instanceof Error ? err.message : String(err)),
+        ),
+      ).catch((err) => replyError(session, id, -32603, err instanceof Error ? err.message : String(err)));
+      return;
+    }
+    default:
+      if (!isNotification) replyError(session, id, -32601, `method not found: ${method}`);
+  }
+}
+
+function stdoutWrite(msg: object): void {
   process.stdout.write(`${JSON.stringify(msg)}\n`);
-}
-
-function reply(id: unknown, result: object): void {
-  send({ jsonrpc: '2.0', id, result });
-}
-
-function replyError(id: unknown, code: number, message: string): void {
-  send({ jsonrpc: '2.0', id, error: { code, message } });
 }
 
 /**
@@ -55,97 +208,71 @@ function replyError(id: unknown, code: number, message: string): void {
  *
  * A `--dir` override is an explicit "the graph is over there", so it always
  * advertises without a probe.
+ *
+ * The index probe is loaded on first `tools/list`, not at boot: `graph/root.js`
+ * pulls `workspace.ts` → `check.ts` → the extractor. Handshake must not wait on that.
  */
-function advertised(root: string, dirOverride?: string): typeof TOOLS {
+function advertised(root: string, dirOverride?: string): typeof TOOLS | Promise<typeof TOOLS> {
   if (dirOverride !== undefined) return TOOLS;
-  if (hasGraftIndex(root)) return TOOLS;
-  const main = mainWorktreeRoot(root);
-  return main && hasGraftIndex(main) ? TOOLS : [];
+  return import('../graph/root.js').then(async ({ hasGraftIndex }) => {
+    if (hasGraftIndex(root)) return TOOLS;
+    const { mainWorktreeRoot } = await import('../graph/seed.js');
+    const main = mainWorktreeRoot(root);
+    return main && hasGraftIndex(main) ? TOOLS : [];
+  });
 }
 
 /**
  * `version` is threaded in from the CLI rather than read here: `readCurrentVersion`
  * resolves package.json relative to the calling module, and from `dist/mcp/` that
  * lookup misses. The caller already knows it.
+ *
+ * Readline is attached synchronously so a client that writes `initialize` the
+ * moment the process starts is not racing a wiring refresh — and so a missing
+ * repo or a non-TTY stdin cannot exit(0) before the first request is read.
+ *
+ * Resolves when stdin ends, so the CLI action does not return and let the
+ * process drain while a client still expects a handshake.
  */
-export function startMcpServer(root: string, dirOverride?: string, version = '0'): void {
-  // The self-maintenance pass, run once at boot. This is the ONLY channel that
-  // reaches hosts with no hook support (Cursor, and any plain MCP client): it
-  // refreshes rule files an older `graft init` wrote, and kicks off the cached
-  // registry check. Both are fail-soft, and the resulting lines ride along in
-  // `instructions` below — stdout is protocol-only, so there is nowhere else to
-  // put them. Never blocks: the registry fetch happens in a detached child.
-  const upkeep = runUpkeep(root, runningVersion()).lines;
-  for (const line of upkeep) console.error(line);
-  // Same deal for the telemetry queue: flushed from a detached child at boot, so
-  // a Cursor user who never touches the CLI still gets their events out.
-  //
-  // Deliberately NOT the first-run notice. This server's stderr goes to an editor
-  // log nobody reads, so printing it here would mark the disclosure as shown
-  // without anyone having seen it. It stays pending for the next CLI command,
-  // and `graft init`'s picker is the channel that reached this user already.
-  maybeFlushInBackground();
+export function startMcpServer(root: string, dirOverride?: string, version = '0'): Promise<void> {
+  const session: McpSession = {
+    root,
+    dirOverride,
+    version,
+    upkeepLines: [],
+    write: stdoutWrite,
+  };
 
   const rl = createInterface({ input: process.stdin, crlfDelay: Infinity });
-  rl.on('line', (line) => {
-    const text = line.trim();
-    if (!text) return;
-    let msg: { id?: unknown; method?: string; params?: Record<string, any> };
-    try {
-      msg = JSON.parse(text);
-    } catch {
-      replyError(null, -32700, 'parse error');
-      return;
-    }
-    const { id, method, params } = msg;
-    const isNotification = id === undefined;
-    switch (method) {
-      case 'initialize':
-        reply(id, {
-          protocolVersion: params?.protocolVersion ?? '2024-11-05',
-          capabilities: { tools: {} },
-          serverInfo: { name: 'graft', version },
-          // The one channel that survives tool deferral — see ./instructions.ts.
-          instructions: upkeep.length ? `${upkeep.join('\n')}\n\n${mcpInstructions()}` : mcpInstructions(),
-        });
-        return;
-      case 'notifications/initialized':
-      case 'notifications/cancelled':
-        return; // notifications get no response
-      case 'ping':
-        if (!isNotification) reply(id, {});
-        return;
-      case 'tools/list': {
-        if (isNotification) return;
-        reply(id, { tools: advertised(root, dirOverride).map((t) => ({ name: t.name, description: t.description, inputSchema: t.inputSchema })) });
-        return;
-      }
-      case 'tools/call': {
-        if (isNotification) return;
-        const name = String(params?.name ?? '');
-        const args = (params?.arguments ?? {}) as Record<string, unknown>;
-        // Async because a tool call may rebuild the graph first (see
-        // graph/refresh.ts). `callTool` absorbs its own errors, so the only thing
-        // that can reject here is a bug — surface it as a JSON-RPC error rather
-        // than an unhandled rejection that kills the server.
-        callTool(root, name, args, dirOverride).then(
-          (r) => {
-            // No `hit`: `isError` means the tool failed, which is not the same
-            // question as "did the graph have an answer". Absent beats wrong.
-            // hasOwn for the same reason as track()'s: a client is free to send
-            // `{"name":"constructor"}`, and a plain lookup would hand `track` a
-            // function rather than undefined.
-            const command = Object.hasOwn(TOOL_COMMAND, name) ? TOOL_COMMAND[name] : undefined;
-            track('query', { command, surface: 'mcp' }, { repo: root, host: 'mcp' });
-            reply(id, { content: [{ type: 'text', text: r.text }], isError: r.isError });
-          },
-          (err) => replyError(id, -32603, err instanceof Error ? err.message : String(err)),
-        );
-        return;
-      }
-      default:
-        if (!isNotification) replyError(id, -32601, `method not found: ${method}`);
-    }
+  rl.on('line', (line) => handleMcpLine(line, session));
+
+  // Fail-soft, and never on the handshake path. Cursor's stderr log is unread,
+  // so the first-run telemetry notice stays pending for the next CLI command.
+  setImmediate(() => {
+    import('../upkeep-run.js').then(async ({ runUpkeep }) => {
+      const { runningVersion } = await import('../upkeep.js');
+      try {
+        const upkeep = runUpkeep(root, runningVersion()).lines;
+        session.upkeepLines = upkeep;
+        for (const line of upkeep) console.error(line);
+      } catch { /* upkeep must not take down the server */ }
+      try {
+        maybeFlushInBackground();
+      } catch { /* same */ }
+    }).catch(() => { /* same */ });
   });
-  process.stdin.on('end', () => process.exit(0));
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+    // 'close' fires after any pending `line` events, so an `echo '{}' | graft mcp`
+    // still answers initialize before the action resolves.
+    rl.on('close', finish);
+    process.stdin.on('end', () => rl.close());
+    process.stdin.on('close', () => rl.close());
+  });
 }

--- a/src/mcp/tool-defs.ts
+++ b/src/mcp/tool-defs.ts
@@ -1,0 +1,95 @@
+/**
+ * MCP tool roster, kept out of `tools.ts` so the stdio server can advertise
+ * `tools/list` (and finish `initialize`) without importing the graph engine.
+ */
+export interface ToolDef {
+  name: string;
+  description: string;
+  inputSchema: object;
+}
+
+export const TOOLS: ToolDef[] = [
+  {
+    name: 'graft_find_code',
+    description:
+      'Query the repo context graph in plain words. Returns ranked nodes with exact file:line spans and the relevant source inlined — usually the full answer, no file reads needed.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'what you want to understand, in plain words' },
+        limit: { type: 'number', description: 'max results (default 5)' },
+        full: {
+          type: 'boolean',
+          description: 'inline whole definition spans instead of the default ≤8-line crux excerpts',
+        },
+        in: {
+          type: 'string',
+          description: 'narrow to nodes under this path prefix, filtered before scoring (segment-aware, like scopeOf)',
+        },
+      },
+      required: ['query'],
+    },
+  },
+  {
+    name: 'graft_file_api',
+    description:
+      "Signatures-only view of one file — every definition's signature + line span, ~10× cheaper than reading the file ($0, no LLM).",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        file: { type: 'string', description: 'repo-relative path (or unique basename) of the file' },
+      },
+      required: ['file'],
+    },
+  },
+  {
+    name: 'graft_check_freshness',
+    description: 'Report whether the committed graph is in sync with the code (drift check).',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'graft_trace_calls',
+    description:
+      'Structural edges for a symbol, over call/reference/import/implements/extends ($0, no LLM). Defaults to direct callers (who depends on it). Set direction:"out" for callees (what it calls); set depth>1 (or depth:"all" for the full closure) to walk transitively for the full blast radius — every source that breaks if it changes. Run before a multi-file refactor to find ALL affected files.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        symbol: { type: 'string', description: 'bare name, qualified (Class.method), or package-qualified (pkg.Fn); a file path also works' },
+        direction: {
+          type: 'string',
+          enum: ['in', 'out'],
+          description: '"in" (default) = callers/dependents; "out" = callees/dependencies',
+        },
+        depth: { description: 'transitive walk depth for blast radius (default 1 = direct edges only); pass "all" for the full connected closure — every source that would be affected' },
+        in: { type: 'string', description: 'narrow matches to nodes at or under this repo-relative path prefix, e.g. server/src' },
+      },
+      required: ['symbol'],
+    },
+  },
+  {
+    name: 'graft_find_all',
+    description:
+      'Regex search over the graph\'s indexed files, hits grouped by innermost enclosing symbol and ranked by incoming-edge count (coupling) — which hit matters, not just where it is.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        pattern: { type: 'string', description: 'regex pattern (or literal string with fixed: true)' },
+        in: { type: 'string', description: 'narrow to files at or under this repo-relative path prefix, e.g. server/src' },
+        ignore_case: { type: 'boolean', description: 'case-insensitive match' },
+        fixed: { type: 'boolean', description: 'treat pattern as a literal string, not a regex' },
+      },
+      required: ['pattern'],
+    },
+  },
+  {
+    name: 'graft_repo_map',
+    description:
+      'Token-budgeted repo orientation — directory clusters, per-directory hubs, and global hotspots computed purely from the wiring graph ($0, no LLM). Use this to get oriented in an unfamiliar repo before diving into files.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        max_dirs: { type: 'number', description: 'max directory entries shown, rest counted into dropped (default 16)' },
+      },
+    },
+  },
+];

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -27,103 +27,14 @@ import {
 import type { NodeV1 } from '../graph/types.js';
 import { canonicalToolName } from './tool-names.js';
 
-export interface ToolDef {
-  name: string;
-  description: string;
-  inputSchema: object;
-}
+export type { ToolDef } from './tool-defs.js';
+export { TOOLS } from './tool-defs.js';
 
 const NO_GRAPH = 'no graph found — run `graft build` first';
 
 function unknownSymbolText(query: string): string {
   return `no symbol "${query}" in the graph — check spelling or run \`graft build\``;
 }
-
-export const TOOLS: ToolDef[] = [
-  {
-    name: 'graft_find_code',
-    description:
-      'Query the repo context graph in plain words. Returns ranked nodes with exact file:line spans and the relevant source inlined — usually the full answer, no file reads needed.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        query: { type: 'string', description: 'what you want to understand, in plain words' },
-        limit: { type: 'number', description: 'max results (default 5)' },
-        full: {
-          type: 'boolean',
-          description: 'inline whole definition spans instead of the default ≤8-line crux excerpts',
-        },
-        in: {
-          type: 'string',
-          description: 'narrow to nodes under this path prefix, filtered before scoring (segment-aware, like scopeOf)',
-        },
-      },
-      required: ['query'],
-    },
-  },
-  {
-    name: 'graft_file_api',
-    description:
-      "Signatures-only view of one file — every definition's signature + line span, ~10× cheaper than reading the file ($0, no LLM).",
-    inputSchema: {
-      type: 'object',
-      properties: {
-        file: { type: 'string', description: 'repo-relative path (or unique basename) of the file' },
-      },
-      required: ['file'],
-    },
-  },
-  {
-    name: 'graft_check_freshness',
-    description: 'Report whether the committed graph is in sync with the code (drift check).',
-    inputSchema: { type: 'object', properties: {} },
-  },
-  {
-    name: 'graft_trace_calls',
-    description:
-      'Structural edges for a symbol, over call/reference/import/implements/extends ($0, no LLM). Defaults to direct callers (who depends on it). Set direction:"out" for callees (what it calls); set depth>1 (or depth:"all" for the full closure) to walk transitively for the full blast radius — every source that breaks if it changes. Run before a multi-file refactor to find ALL affected files.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        symbol: { type: 'string', description: 'bare name, qualified (Class.method), or package-qualified (pkg.Fn); a file path also works' },
-        direction: {
-          type: 'string',
-          enum: ['in', 'out'],
-          description: '"in" (default) = callers/dependents; "out" = callees/dependencies',
-        },
-        depth: { description: 'transitive walk depth for blast radius (default 1 = direct edges only); pass "all" for the full connected closure — every source that would be affected' },
-        in: { type: 'string', description: 'narrow matches to nodes at or under this repo-relative path prefix, e.g. server/src' },
-      },
-      required: ['symbol'],
-    },
-  },
-  {
-    name: 'graft_find_all',
-    description:
-      'Regex search over the graph\'s indexed files, hits grouped by innermost enclosing symbol and ranked by incoming-edge count (coupling) — which hit matters, not just where it is.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        pattern: { type: 'string', description: 'regex pattern (or literal string with fixed: true)' },
-        in: { type: 'string', description: 'narrow to files at or under this repo-relative path prefix, e.g. server/src' },
-        ignore_case: { type: 'boolean', description: 'case-insensitive match' },
-        fixed: { type: 'boolean', description: 'treat pattern as a literal string, not a regex' },
-      },
-      required: ['pattern'],
-    },
-  },
-  {
-    name: 'graft_repo_map',
-    description:
-      'Token-budgeted repo orientation — directory clusters, per-directory hubs, and global hotspots computed purely from the wiring graph ($0, no LLM). Use this to get oriented in an unfamiliar repo before diving into files.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        max_dirs: { type: 'number', description: 'max directory entries shown, rest counted into dropped (default 16)' },
-      },
-    },
-  },
-];
 
 /** Render every resolved match's header + edge report (or the loud zero-edge
  * note), one block per match, joined with a blank line — the same grouping

--- a/test/mcp-server.test.ts
+++ b/test/mcp-server.test.ts
@@ -188,7 +188,7 @@ const ALL_TOOLS = [
 ];
 
 async function listTools(dir: string): Promise<string[]> {
-  const rs = await rpc(
+  const { responses: rs, stderr } = await rpc(
     [
       { jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 't', version: '0' } } },
       { jsonrpc: '2.0', id: 2, method: 'tools/list' },
@@ -196,7 +196,9 @@ async function listTools(dir: string): Promise<string[]> {
     dir,
     2,
   );
-  return rs.find((r) => r.id === 2).result.tools.map((t: any) => t.name);
+  const list = rs.find((r) => r.id === 2);
+  assert.ok(list, `tools/list reply missing. stderr:\n${stderr.slice(0, 1500)}`);
+  return list.result.tools.map((t: { name: string }) => t.name);
 }
 
 test('a built repo advertises every tool', async () => {

--- a/test/mcp-server.test.ts
+++ b/test/mcp-server.test.ts
@@ -6,31 +6,150 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { once } from 'node:events';
 import { buildGraph } from '../src/graph/build.js';
+import {
+  DEFAULT_PROTOCOL_VERSION,
+  handleMcpLine,
+  negotiateProtocolVersion,
+  SUPPORTED_PROTOCOL_VERSIONS,
+  type McpSession,
+} from '../src/mcp/server.js';
 
-async function rpc(messages: object[], dir: string, expected: number): Promise<any[]> {
-  const child = spawn(process.execPath, ['--import', 'tsx', 'src/cli.ts', 'mcp', dir], { stdio: ['pipe', 'pipe', 'pipe'] });
+function session(): { s: McpSession; out: any[] } {
+  const out: any[] = [];
+  const s: McpSession = {
+    root: '/tmp/graft-mcp-handshake',
+    version: '0.13.0',
+    upkeepLines: [],
+    write: (msg) => out.push(msg),
+  };
+  return { s, out };
+}
+
+function send(s: McpSession, msg: object): void {
+  handleMcpLine(JSON.stringify(msg), s);
+}
+
+test('negotiateProtocolVersion: missing → default; known → echo; unknown → refuse', () => {
+  assert.deepEqual(negotiateProtocolVersion(undefined), { ok: true, version: DEFAULT_PROTOCOL_VERSION });
+  assert.deepEqual(negotiateProtocolVersion(null), { ok: true, version: DEFAULT_PROTOCOL_VERSION });
+  assert.deepEqual(negotiateProtocolVersion(''), { ok: true, version: DEFAULT_PROTOCOL_VERSION });
+  assert.deepEqual(negotiateProtocolVersion('2025-11-25'), { ok: true, version: '2025-11-25' });
+  assert.deepEqual(negotiateProtocolVersion('2025-03-26'), { ok: true, version: '2025-03-26' });
+  assert.deepEqual(negotiateProtocolVersion('2026-07-28'), { ok: true, version: '2026-07-28' });
+  assert.deepEqual(negotiateProtocolVersion('1999-01-01'), { ok: false, requested: '1999-01-01' });
+});
+
+test('fake stdin: initialize returns a JSON-RPC result with protocolVersion', () => {
+  const { s, out } = session();
+  send(s, {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: { protocolVersion: '2025-11-25', capabilities: {}, clientInfo: { name: 't', version: '0' } },
+  });
+  assert.equal(out.length, 1);
+  assert.equal(out[0].jsonrpc, '2.0');
+  assert.equal(out[0].id, 1);
+  assert.equal(out[0].result.protocolVersion, '2025-11-25');
+  assert.ok(out[0].result.capabilities.tools);
+  assert.equal(out[0].result.serverInfo.name, 'graft');
+  assert.equal(out[0].result.serverInfo.version, '0.13.0');
+});
+
+test('fake stdin: version-less initialize is served on the default', () => {
+  const { s, out } = session();
+  send(s, { jsonrpc: '2.0', id: 1, method: 'initialize', params: { capabilities: {}, clientInfo: { name: 't', version: '0' } } });
+  assert.equal(out[0].result.protocolVersion, DEFAULT_PROTOCOL_VERSION);
+});
+
+test('fake stdin: initialize with no params at all still replies', () => {
+  const { s, out } = session();
+  send(s, { jsonrpc: '2.0', id: 1, method: 'initialize' });
+  assert.equal(out[0].id, 1);
+  assert.equal(out[0].result.protocolVersion, DEFAULT_PROTOCOL_VERSION);
+});
+
+test('fake stdin: unsupported version is refused with the supported list, not echoed', () => {
+  const { s, out } = session();
+  send(s, {
+    jsonrpc: '2.0',
+    id: 'mcp-spec-test-initialize',
+    method: 'initialize',
+    params: { protocolVersion: '1999-01-01', capabilities: {}, clientInfo: { name: 't', version: '0' } },
+  });
+  assert.equal(out.length, 1);
+  assert.equal(out[0].id, 'mcp-spec-test-initialize');
+  assert.equal(out[0].error.code, -32022);
+  assert.equal(out[0].error.message, 'Unsupported protocol version');
+  assert.equal(out[0].error.data.requested, '1999-01-01');
+  assert.deepEqual(out[0].error.data.supported, [...SUPPORTED_PROTOCOL_VERSIONS]);
+  assert.ok(!out[0].result, 'must not echo the unsupported version as a result');
+});
+
+test('fake stdin: initialize then tools/list', () => {
+  const { s, out } = session();
+  // `--dir` is an explicit "the graph is over there", so advertised() returns
+  // the full catalog without probing the fake session root.
+  s.dirOverride = '/tmp/graft-mcp-handshake';
+  send(s, { jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-11-25', capabilities: {} } });
+  send(s, { jsonrpc: '2.0', method: 'notifications/initialized' });
+  send(s, { jsonrpc: '2.0', id: 2, method: 'tools/list' });
+  assert.equal(out.length, 2);
+  assert.deepEqual(
+    out[1].result.tools.map((t: { name: string }) => t.name),
+    ['graft_find_code', 'graft_file_api', 'graft_check_freshness', 'graft_trace_calls', 'graft_find_all', 'graft_repo_map'],
+  );
+});
+
+test('fake stdin: server/discover answers without a handshake', () => {
+  const { s, out } = session();
+  send(s, { jsonrpc: '2.0', id: 1, method: 'server/discover' });
+  assert.equal(out.length, 1);
+  const result = out[0].result;
+  assert.ok(result.supportedVersions.includes('2025-11-25'));
+  assert.ok(result.supportedVersions.includes('2026-07-28'));
+  assert.equal(result.resultType, 'complete');
+  assert.equal(result.cacheScope, 'public');
+  assert.equal(typeof result.ttlMs, 'number');
+  assert.ok(result.capabilities.tools);
+  assert.equal(result._meta['io.modelcontextprotocol/serverInfo'].name, 'graft');
+});
+
+async function rpc(messages: object[], dir: string, expected: number, delayMs = 0): Promise<{ responses: any[]; exitCode: number | null; stderr: string }> {
+  const child = spawn(process.execPath, ['--import', 'tsx', 'src/cli.ts', 'mcp', dir], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: { ...process.env, DO_NOT_TRACK: '1' },
+  });
   const responses: any[] = [];
   let buf = '';
+  let stderr = '';
   child.stdout.on('data', (d) => {
     buf += d.toString();
     let i;
     while ((i = buf.indexOf('\n')) !== -1) {
       const line = buf.slice(0, i).trim();
       buf = buf.slice(i + 1);
-      if (line) responses.push(JSON.parse(line));
+      if (line) {
+        try { responses.push(JSON.parse(line)); } catch { /* ignore non-JSON stdout */ }
+      }
     }
   });
+  child.stderr.on('data', (d) => { stderr += d.toString(); });
+  if (delayMs) await new Promise((r) => setTimeout(r, delayMs));
   for (const m of messages) child.stdin.write(`${JSON.stringify(m)}\n`);
-  const deadline = Date.now() + 15000;
-  while (responses.length < expected && Date.now() < deadline) await new Promise((r) => setTimeout(r, 50));
+  const deadline = Date.now() + 45000;
+  while (responses.length < expected && Date.now() < deadline && child.exitCode === null) {
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  const stillRunning = child.exitCode === null && !child.killed;
   child.kill();
   await once(child, 'exit').catch(() => {});
-  return responses;
+  return { responses, exitCode: stillRunning ? null : child.exitCode, stderr };
 }
 
 test('initialize → tools/list → tools/call round-trip', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'graft-mcpsrv-'));
-  const rs = await rpc(
+  const { responses: rs, stderr } = await rpc(
     [
       { jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 't', version: '0' } } },
       { jsonrpc: '2.0', method: 'notifications/initialized' },
@@ -40,7 +159,7 @@ test('initialize → tools/list → tools/call round-trip', async () => {
     dir,
     3,
   );
-  assert.equal(rs.length, 3);
+  assert.equal(rs.length, 3, `expected 3 JSON-RPC replies, got ${rs.length}. stderr:\n${stderr.slice(0, 1500)}`);
   const init = rs.find((r) => r.id === 1);
   assert.equal(init.result.protocolVersion, '2025-03-26');
   assert.ok(init.result.capabilities.tools);
@@ -128,7 +247,7 @@ test('a fresh worktree advertises every tool, on the strength of its parent', as
 
 test('initialize carries instructions — the layer that survives tool deferral', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'graft-mcpsrv-instr-'));
-  const rs = await rpc(
+  const { responses: rs } = await rpc(
     [{ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 't', version: '0' } } }],
     dir,
     1,
@@ -150,6 +269,18 @@ test('initialize carries instructions — the layer that survives tool deferral'
 
 test('unknown method returns -32601', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'graft-mcpsrv2-'));
-  const rs = await rpc([{ jsonrpc: '2.0', id: 9, method: 'resources/list' }], dir, 1);
+  const { responses: rs } = await rpc([{ jsonrpc: '2.0', id: 9, method: 'resources/list' }], dir, 1);
   assert.equal(rs[0].error.code, -32601);
+});
+
+test('stdio process answers initialize and is still running (does not exit on a quiet pipe)', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'graft-mcpsrv-wait-'));
+  const { responses: rs, exitCode } = await rpc(
+    [{ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-11-25', capabilities: {}, clientInfo: { name: 't', version: '0' } } }],
+    dir,
+    1,
+    300,
+  );
+  assert.equal(exitCode, null, 'process must still be running when initialize is sent');
+  assert.equal(rs[0].result.protocolVersion, '2025-11-25');
 });


### PR DESCRIPTION
## Summary
- Same root cause on **#211** (spec 2026-07-28) and **#212** (spec 2025-11-25): `graft mcp` either exited before answering or never wrote an `initialize` result, so the official SDK saw `Connection closed` / timeout.
- Arm stdin **before** upkeep, keep the process alive until stdin ends, and answer `initialize` even when `protocolVersion` is missing (default `2025-11-25`) or unsupported (JSON-RPC `-32022` with `{ supported, requested }` — not an echo of `1999-01-01`).
- Do not load tree-sitter grammars or the graph engine until `tools/call`. `initialize` / `tools/list` / `server/discover` only need the tool roster.

Closes #211
Closes #212

## Follow-up (still not this PR)
Pagination, resources, prompts, result-envelope fields (`resultType`, cache hints on list results), and `subscriptions/listen` were **not verified** in those issues because the handshake never completed. They are out of scope here.

After this lands they may start running in `@hasmcp/mcp-spec-test` and fail for real capability gaps rather than “server exited”. Local run of `2026-07-28` against this branch already shows that: handshake / discover / SDK interop pass; 4 remaining failures are envelope fields on `tools/list` and `tools/call` (`resultType`, `cacheScope`, `ttlMs`, `_meta` serverInfo).

## Test plan
- [x] `npm run build && npm test` — 923/923
- [x] Fake-stdin unit tests: version-less `initialize`, unsupported version refused, `tools/list`, `server/discover` without a session
- [x] Spawned `graft mcp <tmpdir>`: initialize → initialized → tools/list → tools/call; process still running on a quiet stdin pipe
- [x] `@hasmcp/mcp-spec-test@0.1.1 -c "node dist/cli.js mcp <abs>" --spec-version 2025-11-25`: **14 passed, 0 failed** (handshake, version negotiation, official SDK initialize + `tools/list`)
- [x] same suite `--spec-version 2026-07-28`: handshake, `server/discover`, and official SDK interop **pass**; 4 envelope failures left as follow-up

Made with [Cursor](https://cursor.com)