### PR TITLE
chore(deps): bump tree-sitter-wasm to 1.1.6 to fix PHP heredoc parse crashes (#139)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "tree-sitter-python": "^0.21.0",
         "tree-sitter-r": "npm:@davisvaughan/tree-sitter-r@^1.3.0",
         "tree-sitter-typescript": "^0.23.2",
-        "tree-sitter-wasm": "^1.1.4",
+        "tree-sitter-wasm": "^1.1.6",
         "vscode-jsonrpc": "^8.2.1",
         "vscode-languageserver-protocol": "^3.18.2",
         "web-tree-sitter": "^0.25.10"
@@ -1026,9 +1026,9 @@
       }
     },
     "node_modules/tree-sitter-wasm": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/tree-sitter-wasm/-/tree-sitter-wasm-1.1.4.tgz",
-      "integrity": "sha512-+vvWfbH1fPzB8BBhoqH9j2GSyyPyTa9Fgkh7qQOadxQM7O7h0PsGwnvVPLW86fb/DwWH1nNxW4naVbiVgRIeBw==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/tree-sitter-wasm/-/tree-sitter-wasm-1.1.6.tgz",
+      "integrity": "sha512-jn/q9cOBIcTOA8QqtrPXNbibislSDuVChO4ws//aFy+DKjrUs9wzE4R6QXFx6yunEAYaxaVvpMW4+yX/ijQ7BQ==",
       "license": "MIT"
     },
     "node_modules/ts-algebra": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "tree-sitter-python": "^0.21.0",
     "tree-sitter-r": "npm:@davisvaughan/tree-sitter-r@^1.3.0",
     "tree-sitter-typescript": "^0.23.2",
-    "tree-sitter-wasm": "^1.1.4",
+    "tree-sitter-wasm": "^1.1.6",
     "vscode-jsonrpc": "^8.2.1",
     "vscode-languageserver-protocol": "^3.18.2",
     "web-tree-sitter": "^0.25.10"

--- a/test/generic-extract.test.ts
+++ b/test/generic-extract.test.ts
@@ -9,7 +9,15 @@ import assert from "node:assert/strict";
 import { mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { warmGenericGrammars, extractGeneric, genericLangOf, isWarm } from "../src/graph/generic.js";
+import {
+  warmGenericGrammars,
+  extractGeneric,
+  genericLangOf,
+  isWarm,
+  loadWasmLanguage,
+  parseWasm,
+  type TsNode,
+} from "../src/graph/generic.js";
 import { resolveEdges } from "../src/graph/resolve.js";
 import { buildGraph } from "../src/graph/build.js";
 import { readGraph, wiringPath } from "../src/graph/write.js";
@@ -337,4 +345,70 @@ test("Dart file-level skeleton lists the API, not function-body locals (#134)", 
     !r.entries.some((e) => e.kind === "class" && e.name === "int"),
     "skeleton has no bogus class int",
   );
+});
+
+// #139: tree-sitter-wasm 1.1.4's PHP grammar throws `memory access out of bounds`
+// on heredoc/nowdoc, and extractGeneric swallows that into a file-only result.
+// PHP is depth-tier now (.php is not claimed by the breadth registry), so this
+// loads the wasm grammar directly — the same parse the breadth path used when
+// the issue landed.
+// v1.1.6 is the first release that parses these without crashing.
+const PHP_HEREDOC = `<?php
+namespace App;
+class WithHeredoc {
+    public function sql(): string {
+        return <<<SQL
+            SELECT 1
+            SQL;
+    }
+    public function other(): int { return 2; }
+}
+`;
+
+const PHP_NOWDOC = `<?php
+namespace App;
+class WithNowdoc {
+    public function sql(): string {
+        return <<<'SQL'
+            SELECT 1
+            SQL;
+    }
+    public function other(): int { return 2; }
+}
+`;
+
+function namedOfType(root: TsNode, type: string): string[] {
+  const names: string[] = [];
+  const visit = (n: TsNode): void => {
+    if (n.type === type) {
+      const name = n.childForFieldName?.("name")?.text;
+      if (name) names.push(name);
+    }
+    for (let i = 0; i < (n.namedChildCount ?? 0); i++) {
+      const c = n.namedChild?.(i);
+      if (c) visit(c);
+    }
+  };
+  visit(root);
+  return names;
+}
+
+async function assertPhpWasmExtractsClassAndMethods(source: string, className: string, label: string): Promise<void> {
+  const language = await loadWasmLanguage("php");
+  assert.ok(language, "tree-sitter-wasm must ship a php grammar");
+  const root = parseWasm(language, source);
+  assert.ok(root, `${label}: PHP wasm parse must not crash (1.1.4 threw on heredoc/nowdoc)`);
+  const classes = namedOfType(root, "class_declaration");
+  const methods = namedOfType(root, "method_declaration");
+  assert.ok(classes.includes(className), `${label}: expected class ${className}, got: ${classes.join(", ") || "(none)"}`);
+  assert.ok(methods.includes("sql"), `${label}: expected method sql, got: ${methods.join(", ") || "(none)"}`);
+  assert.ok(methods.includes("other"), `${label}: expected method other, got: ${methods.join(", ") || "(none)"}`);
+}
+
+test("PHP wasm grammar extracts class + methods from a heredoc file (#139)", async () => {
+  await assertPhpWasmExtractsClassAndMethods(PHP_HEREDOC, "WithHeredoc", "heredoc");
+});
+
+test("PHP wasm grammar extracts class + methods from a nowdoc file (#139)", async () => {
+  await assertPhpWasmExtractsClassAndMethods(PHP_NOWDOC, "WithNowdoc", "nowdoc");
 });

--- a/test/graph-php.test.ts
+++ b/test/graph-php.test.ts
@@ -577,3 +577,38 @@ $b = new class { public function two(): int { return 2; } };
   assert.ok(ids.includes("dup.php#{anonymous}"), `expected an {anonymous} node, got: ${ids.join(", ")}`);
   assert.ok(ids.includes("dup.php#{anonymous}~2"), `expected a deduplicated {anonymous}~2 node, got: ${ids.join(", ")}`);
 });
+
+// #139: a PHP class whose methods return a heredoc/nowdoc must still emit the
+// class and both methods — not collapse to a file node. Depth-tier extractFile
+// uses native tree-sitter-php; the wasm grammar crash is covered in
+// generic-extract.test.ts. This pins the user-visible graph shape.
+const HEREDOC_PHP = `<?php
+namespace App;
+class WithHeredoc {
+    public function sql(): string {
+        return <<<SQL
+            SELECT 1
+            SQL;
+    }
+    public function other(): int { return 2; }
+}
+`;
+
+test("PHP heredoc: extractFile emits class + both methods (#139)", () => {
+  const { nodes } = extractFile("h.php", HEREDOC_PHP, "php");
+  const ids = symbolIds(nodes);
+  assert.equal(nodes.find((n) => n.id === "h.php#WithHeredoc")?.kind, "class", `expected class:WithHeredoc, got: ${ids.join(", ")}`);
+  assert.equal(nodes.find((n) => n.id === "h.php#WithHeredoc.sql")?.kind, "method", `expected method:sql, got: ${ids.join(", ")}`);
+  assert.equal(nodes.find((n) => n.id === "h.php#WithHeredoc.other")?.kind, "method", `expected method:other, got: ${ids.join(", ")}`);
+  assert.ok(nodes.some((n) => n.kind === "file"), "file node is still present");
+  assert.ok(nodes.filter((n) => n.kind !== "file").length >= 3, `must not be file-only, got: ${ids.join(", ")}`);
+});
+
+test("PHP nowdoc: extractFile emits class + both methods (#139)", () => {
+  const src = HEREDOC_PHP.replace("WithHeredoc", "WithNowdoc").replace("<<<SQL", "<<<'SQL'");
+  const { nodes } = extractFile("n.php", src, "php");
+  const ids = symbolIds(nodes);
+  assert.equal(nodes.find((n) => n.id === "n.php#WithNowdoc")?.kind, "class", `got: ${ids.join(", ")}`);
+  assert.equal(nodes.find((n) => n.id === "n.php#WithNowdoc.sql")?.kind, "method", `got: ${ids.join(", ")}`);
+  assert.equal(nodes.find((n) => n.id === "n.php#WithNowdoc.other")?.kind, "method", `got: ${ids.join(", ")}`);
+});


### PR DESCRIPTION
## Summary
- Bump `tree-sitter-wasm` from 1.1.4 to 1.1.6. Upstream maintainer [Crysthamus](https://github.com/NanoNets/Graft/issues/139#issuecomment-3728476142) confirmed 1.1.6 fixes the PHP heredoc/nowdoc wasm crash in #139 (and the grammar side of #145).
- Add regressions so a future downgrade cannot silently return: the bundled PHP wasm grammar must parse the issue fixture into a **class + two methods**, and depth-tier `extractFile` must not collapse to a file node.

This PR fixes the **grammar crash**. [#140](https://github.com/NanoNets/Graft/pull/140) (still open) fixes the **error being swallowed** in `generic.ts`. They are complementary — this does not replace #140, and #140 does not replace this.

Closes #139.

## Test plan
- [x] `npm run build && npm test` (919 pass)
- [x] PHP heredoc/nowdoc wasm parse yields `WithHeredoc`/`WithNowdoc` + methods `sql` and `other`
- [x] `extractFile` on the same fixture yields class + two methods (not file-only)

Made with [Cursor](https://cursor.com)