### PR TITLE
fix(viz): judge --tabs before the repo, not after

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -615,6 +615,10 @@ program
   .option("--title <text>", "subtitle shown beside the repo name in an exported page (e.g. \"PR #151\")")
   .option("--tabs <list>", "tabs the exported page offers, comma separated: context,code,outline (default: all three)")
   .action(async (dirArg: string | undefined, opts: { port: string; open: boolean; export?: string; title?: string; tabs?: string }) => {
+    // Flags are checked before the repository is: a typo'd `--tabs` is a mistake
+    // in the command the caller just typed, and telling them to go build an index
+    // first sends them off to fix the wrong thing.
+    const tabs = parseTabs(opts.tabs);
     const dir = noteQuery(queryRoot(dirArg));
     const { existsSync } = await import("node:fs");
     const { resolve, basename } = await import("node:path");
@@ -640,7 +644,7 @@ program
         outDir: resolve(opts.export),
         repoName: basename(root),
         subtitle: opts.title,
-        tabs: parseTabs(opts.tabs),
+        tabs,
       });
       const kb = Math.round(out.bytes / 1024);
       console.log(

--- a/test/viz-export.test.ts
+++ b/test/viz-export.test.ts
@@ -193,8 +193,14 @@ test("viz --tabs: a bad tab name fails loudly rather than exporting a page missi
     }
   };
 
-  const bad = run(["viz", ".", "--export", out(), "--tabs", "context,graph"]);
+  // Deliberately run where there is NO graft index — CI is such a checkout, and
+  // the first version of this test only passed on a machine that happened to have
+  // one, so it broke main the day it merged.
+  const bare = out();
+  const bad = run(["viz", bare, "--export", out(), "--tabs", "context,graph"]);
   assert.equal(bad.status, 1);
   assert.match(bad.stderr, /--tabs takes a comma-separated subset of context, code, outline — got "graph"/);
-  assert.equal(run(["viz", ".", "--export", out(), "--tabs", ""]).status, 1, "an empty list is a mistake too");
+  assert.equal(run(["viz", bare, "--export", out(), "--tabs", ""]).status, 1, "an empty list is a mistake too");
+  // …and the flag is judged on its own: an unbuilt repo is a different complaint.
+  assert.match(run(["viz", bare, "--export", out()]).stderr, /no context graph/);
 });


### PR DESCRIPTION
main's CI has been red since #180 merged, and it's my regression.

`parseTabs` ran *after* the "is this repo indexed" check, so on a checkout with no `graft/` directory — which is every CI runner — a typo'd `--tabs` exited with `✗ no context graph … run graft build --deep first`. Wrong complaint: the mistake is in the command the caller just typed, and that message sends them off to fix something unrelated.

The test I wrote for it ran `viz .` against the repo itself, so it passed on my machine (which has an index) and failed everywhere else. It now runs against a directory with no index at all, plus an assertion that an unbuilt repo still gets its own distinct complaint.

915 tests pass.