### PR TITLE
fix(blast): post the comment from the job that has a write token

### DIFF
--- a/.github/workflows/blast-pages.yml
+++ b/.github/workflows/blast-pages.yml
@@ -1,7 +1,7 @@
 name: Blast viewer
 
-# Publishes the interactive viewer for a pull request to GitHub Pages, and links it
-# from the blast-radius comment.
+# Publishes the interactive viewer for a pull request to GitHub Pages, and posts the
+# blast-radius comment that links to it.
 #
 # `pull_request_target`, not `pull_request`, because publishing needs write access to
 # the gh-pages branch and a `pull_request` job on a fork PR has none. That choice
@@ -12,9 +12,18 @@ name: Blast viewer
 # package.json, no postinstall). The graph is built from the PR's source text by a
 # tree-sitter parser, which executes none of it.
 #
-# A dispatch by PR number is the second entry point. It exists because a fork PR's
-# comment job cannot post the link itself (a `pull_request` job on a fork gets a
-# read-only token), so publishing that page has to be startable by hand.
+# It posts the comment as well as the page, because a `pull_request` job on a fork
+# gets a read-only token no matter what its `permissions:` block says: `blast.yml`
+# can compute the radius there and cannot post it, and most of this repo's open pull
+# requests come from forks. So `blast.yml` runs with `comment: false` and this is the
+# single writer — two jobs editing one marked comment would race and overwrite each
+# other. The cost of that choice is honest: graft's own PRs are now described by
+# main's graft rather than by the code in the PR. `blast.yml` still runs the PR's
+# build and writes the body to its step summary, so a renderer a PR breaks still
+# fails visibly; it just no longer speaks on the PR.
+#
+# A dispatch by PR number is the second entry point. It backfills a pull request that
+# was opened before any of this existed, without waiting for a new push.
 on:
   pull_request_target:
     branches: [main]
@@ -22,7 +31,7 @@ on:
   workflow_dispatch:
     inputs:
       pr:
-        description: "Pull request number to publish the page for."
+        description: "Pull request number to publish the page and comment for."
         required: true
         type: string
 
@@ -123,8 +132,13 @@ jobs:
           # every bubble falls back to its hub symbol, so the page reads `cli.ts` and
           # `exportViz` where the comment reads "CLI Entry Point" and "Visualization
           # Export". The point of the page is that a reviewer recognises the feature.
+          #
+          # `--format markdown`, not text: one run produces both the page and the
+          # comment body, so the two can never describe different radii or word the
+          # same area differently.
           node ../base/dist/cli.js blast . --base "origin/$BASE_REF" \
-            --name --title "PR #$PR_NUMBER" --export-viz ../site --format text > /dev/null
+            --name --title "PR #$PR_NUMBER" --export-viz ../site --format markdown > ../blast.md
+          cat ../blast.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Publish to gh-pages
         env:
@@ -157,6 +171,43 @@ jobs:
           git add .nojekyll "pr/$PR_NUMBER"
           git commit -m "viz: PR #$PR_NUMBER" || { echo "nothing changed"; exit 0; }
           git push origin gh-pages
+
+      # 3. The comment — posted here, and only here.
+      #
+      # `blast.yml` runs the PR's own code, so it can never hold a write token; on a
+      # fork its comment step would 403, and most of this repo's open pull requests
+      # are forks. Under `pull_request_target` the token belongs to the BASE repo,
+      # so a fork PR is ordinary work. It runs after the page is pushed, so the link
+      # it carries is live by the time anyone can click it.
+      - name: Post or update the blast-radius comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          REPO: ${{ github.repository }}
+          # Unset, the comment simply has no link rather than a link that 404s.
+          VIEWER_BASE: ${{ vars.BLAST_VIEWER_BASE }}
+        run: |
+          set -euo pipefail
+          # One comment per PR, edited in place: a new one per push turns a busy PR
+          # into a wall of stale diagrams. The marker is how it is found again and
+          # stays invisible in the rendered body — the same marker the action used,
+          # so a PR that already has a comment from that path is edited, not doubled.
+          marker='<!-- graft-blast-radius -->'
+          printf '%s\n' "$marker" > body.md
+          cat blast.md >> body.md
+          if [ -n "$VIEWER_BASE" ]; then
+            printf '\n[**Open the interactive graph →**](%s/pr/%s/) — click an area to see its dependent symbols at file:line.\n' \
+              "$VIEWER_BASE" "$PR_NUMBER" >> body.md
+          fi
+          # `--paginate` runs the filter once per page, so a match can print more
+          # than one line; the first is the comment we own.
+          existing=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq "map(select(.body | startswith(\"$marker\"))) | .[0].id // empty" | head -1)
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$existing" -F body=@body.md >/dev/null
+          else
+            gh api -X POST "repos/$REPO/issues/$PR_NUMBER/comments" -F body=@body.md >/dev/null
+          fi
 
   # A merged or closed PR's page is dead weight — and on a busy repo, thousands of
   # 1 MB files. Removed with the PR, not on a timer.

--- a/.github/workflows/blast.yml
+++ b/.github/workflows/blast.yml
@@ -3,6 +3,13 @@ name: Blast radius
 # graft's own PRs run the action graft ships, so the comment format is reviewed the
 # same way the code is. `pull_request` (not `_target`) on purpose: the job reads the
 # PR's code, so it must not carry write access to secrets a fork could reach.
+#
+# Which is exactly why it no longer posts. A `pull_request` job on a fork holds a
+# read-only token regardless of the `permissions:` block below, so this step's
+# comment 403s on most of the repo's open pull requests. `blast-pages.yml` posts it
+# instead, from a token that belongs to the base repo. What stays here is the part
+# only this workflow can do: run the PR's OWN build, and fail if the code in the PR
+# cannot produce a comment body at all — the rendered body lands in the step summary.
 on:
   pull_request:
     branches: [main]
@@ -13,9 +20,10 @@ permissions:
 jobs:
   blast:
     runs-on: ubuntu-latest
+    # Read-only now that it does not comment: least privilege, and it makes the
+    # split with blast-pages.yml legible from the permissions alone.
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
@@ -25,6 +33,9 @@ jobs:
       - uses: ./.github/actions/graft-blast
         with:
           depth: "2"
+          # Computed, not posted — see the header. `blast-pages.yml` owns the comment
+          # so that fork PRs get one, and so two jobs never edit the same body.
+          comment: "false"
           # graft reviews its own PRs with the code IN the PR, not with the last
           # release — a release cannot run a command the PR is adding.
           setup-cmd: npm ci && npm run build
@@ -32,10 +43,8 @@ jobs:
           # A fork's PR gets no secrets, so naming would fail anyway; every area then
           # carries its hub-symbol name, which is still reviewable.
           name-areas: ${{ github.event.pull_request.head.repo.fork == false }}
-          # Linked only once Pages is actually serving: set the repo variable
-          # BLAST_VIEWER_BASE (e.g. https://nanonets.github.io/Graft) after pointing
-          # Pages at the gh-pages branch that blast-pages.yml writes. Unset, the
-          # comment simply has no link rather than a link that 404s.
+          # Still set so the step summary shows the same body the comment will
+          # carry, link included.
           viewer-url: ${{ vars.BLAST_VIEWER_BASE != '' && format('{0}/pr/{1}/', vars.BLAST_VIEWER_BASE, github.event.pull_request.number) || '' }}
         env:
           GRAFT_API_KEY: ${{ secrets.GRAFT_API_KEY }}


### PR DESCRIPTION
## Why

33 of the 44 open pull requests here are from forks, and none of them get a blast-radius comment.

`blast.yml` is triggered by `pull_request`. On a fork, GitHub hands that job a **read-only** `GITHUB_TOKEN` regardless of the `permissions:` block — so it computes the radius fine and then 403s on the POST. (First-time contributors hit a second gate before that: the run sits at `action_required` until someone approves it.) Dependabot PRs are treated the same way, so 8 more in-repo PRs are silent too.

`blast-pages.yml` does not have either problem: it runs under `pull_request_target`, from **main's** copy of the workflow, with a token that belongs to the base repo. It already builds the graph and exports the page — it just never posted anything.

## What changed

- `blast-pages.yml` renders the comment from the run that already exists (`--format markdown` instead of `--format text > /dev/null`, same invocation, same `--name` call) and upserts it after the page is pushed, so the link it carries is live.
- `blast.yml` runs with `comment: false` and drops to `contents: read`. It still runs the PR's **own** build and writes the body to its step summary, so a PR that breaks the renderer still fails visibly — it just no longer posts.

One writer, one marker, no race between two jobs editing the same comment. The existing marker is reused, so a PR that already has a comment is edited rather than duplicated.

## The tradeoff, stated plainly

Under `pull_request_target` the comment is produced by **main's** graft, not by the code in the PR. graft's own PRs lose that dogfooding property; `blast.yml`'s step summary is what keeps it observable. The GitHub App (#209) is the version that gets both back, plus one-click install and no `gh-pages` for private repos — this is the fix that works today, for the PRs that are already open.

## Backfilling

`blast-pages.yml` already takes a PR number via `workflow_dispatch`, so every open PR can be given a comment without waiting for a push:

```
gh workflow run blast-pages.yml -f pr=<number>
```

## Security

Unchanged. The comment step runs the CLI built from the **base** commit and reads `blast.md` produced by it; nothing from the PR is executed, every workflow value reaches the shell through `env`, and the checkout of the PR's code is still credential-less and in its own directory.