### PR TITLE
fix(blast): a closed PR deleted every page, not its own

### DIFF
--- a/.github/workflows/blast-pages.yml
+++ b/.github/workflows/blast-pages.yml
@@ -250,14 +250,46 @@ jobs:
       - name: Remove this PR's page
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          # Read from the event, NOT from `steps.pr` — that step belongs to the
+          # publish job and `steps.*` does not cross jobs. It was empty here, which
+          # turned `git rm -r "pr/$PR_NUMBER"` into `git rm -r "pr/"`: one closed
+          # pull request deleted the page of every open one, and `[ -d "pr/" ]`
+          # waved it through. This job only ever runs on a `closed` event, so the
+          # event always carries the number.
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          git clone --depth 1 --branch gh-pages "https://x-access-token:$GH_TOKEN@github.com/$REPO.git" pages || exit 0
-          cd pages
-          [ -d "pr/$PR_NUMBER" ] || exit 0
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git rm -r --quiet "pr/$PR_NUMBER"
-          git commit -m "viz: drop PR #$PR_NUMBER" && git push origin gh-pages
+          # Digits, and never the empty string. A path this deletes recursively is
+          # not somewhere to find out at runtime that a variable was unset.
+          case "$PR_NUMBER" in
+            "" | *[!0-9]*)
+              echo "no pull request number in the event: refusing to touch pr/" >&2
+              exit 1
+              ;;
+          esac
+          deleted=""
+          for i in 1 2 3; do
+            rm -rf pages
+            git clone --depth 1 --branch gh-pages "https://x-access-token:$GH_TOKEN@github.com/$REPO.git" pages || exit 0
+            cd pages
+            # Already gone, or never published: nothing owed.
+            if [ ! -d "pr/$PR_NUMBER" ]; then
+              deleted=1; cd ..; break
+            fi
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git rm -r --quiet "pr/$PR_NUMBER"
+            git commit -m "viz: drop PR #$PR_NUMBER"
+            # Same race as publishing, same answer — see the publish job.
+            if git push origin gh-pages; then
+              deleted=1; cd ..; break
+            fi
+            cd ..
+            echo "gh-pages push lost a race, retry $i" >&2
+            sleep $((i * 5))
+          done
+          if [ -z "$deleted" ]; then
+            echo "could not drop pr/$PR_NUMBER after 3 attempts" >&2
+            exit 1
+          fi


### PR DESCRIPTION
## What happened

Closing a pull request deleted **every** viewer page on `gh-pages`, not just its own. The commit is on the branch, and its message shows the bug in full:

```
viz: drop PR #        ← no number, 45 files deleted
```

## Why

The `cleanup` job read `${{ steps.pr.outputs.number }}`. That step ("Resolve the pull request") belongs to the **publish** job, and `steps.*` does not cross jobs — so in `cleanup` it expands to the empty string:

```bash
[ -d "pr/" ] || exit 0      # passes: pr/ exists
git rm -r --quiet "pr/"     # every page, not one
```

Both halves failed together: the guard that was supposed to catch "nothing to delete" is what waved it through.

The bug predates #224 — it needed pages to exist and a PR to close on the same day to show itself, which is exactly what backfilling all 43 open PRs arranged.

## Fix

- Read the number from `github.event.pull_request.number`. This job only runs on a `closed` event, so the event always carries it.
- Refuse anything that is not digits, and refuse the empty string explicitly. A path being deleted recursively is not where you want to discover a variable was unset.
- Retry the push, same as the publish job — two closes at once race on the same branch.

## Restoring

The pages themselves are rebuildable: `gh workflow run blast-pages.yml -f pr=<n>` for each open PR, which is how they were published in the first place. Doing that once this is merged.

The comments were unaffected — they are still on the PRs, and their links start working again the moment the pages are back.