### PR TITLE
fix(graph): a call cannot cross a language boundary

### DIFF
--- a/src/graph/resolve.ts
+++ b/src/graph/resolve.ts
@@ -15,7 +15,8 @@
 import { posix } from "node:path";
 import { toPosixPath } from "../util/paths.js";
 import type { EdgeV1, Kind, NodeV1, Relation } from "./types.js";
-import type { RawEdge } from "./extract.js";
+import { languageOf, type RawEdge } from "./extract.js";
+import { genericLangOf } from "./generic.js";
 
 const IMPORT_EXTS = [".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs", ".py"];
 /** C/C++ source + header extensions, for resolving `#include` targets. */
@@ -26,6 +27,54 @@ const PY_EXT = /\.pyi?$/i;
  * construction. Only `class` — Python enums, dataclasses and NamedTuples are all
  * classes, so no other kind is reachable this way. */
 const PY_CTOR_KINDS: Kind[] = ["class"];
+
+/**
+ * Languages whose symbols can genuinely reach each other. A call edge may not
+ * cross a family boundary.
+ *
+ * This exists because name resolution is repo-wide and used to be language-blind.
+ * A Go file calling the builtin `make(...)` has nothing in the repo to resolve
+ * against, so the unique-global fallback below matched a TypeScript helper named
+ * `make` in a frontend test file — and then every `make(map[...])` in the backend
+ * became an edge into that file. One symbol collected 1040 in-edges across 476
+ * files, and any pull request touching that test dragged the entire Go backend
+ * into its blast radius. Uniqueness is what made it fire: the rarer the collision,
+ * the more confident the old code was that it had found the right target.
+ *
+ * Only real interop is grouped here. TS/TSX/JS import each other freely; Kotlin,
+ * Scala and Clojure compile against Java on one classpath; C and C++ share
+ * headers. Everything else stands alone.
+ */
+const FAMILIES: ReadonlyArray<readonly string[]> = [
+  ["typescript", "tsx"],
+  ["java", "kotlin", "scala", "clojure"],
+  ["c", "cpp"],
+];
+const FAMILY_OF = new Map<string, string>();
+for (const group of FAMILIES) for (const lang of group) FAMILY_OF.set(lang, group[0]);
+
+/**
+ * The language family a path belongs to, or null when no tier claims the file.
+ * A language of its own is its own family, so the common case needs no entry above.
+ */
+function familyOf(path: string): string | null {
+  const lang = languageOf(path) ?? genericLangOf(path)?.name ?? null;
+  if (!lang) return null;
+  return FAMILY_OF.get(lang) ?? lang;
+}
+
+/**
+ * Could a reference in `file` reach a definition in `candidatePath`?
+ *
+ * An unknown family never filters: absence of data is not evidence of a mismatch,
+ * and refusing edges for every extension graft cannot name would lose real ones.
+ */
+function reachable(file: string, candidatePath: string): boolean {
+  const from = familyOf(file);
+  if (from === null) return true;
+  const to = familyOf(candidatePath);
+  return to === null || from === to;
+}
 
 /** A Go module discovered in the repo: its `module` path from `go.mod` and the repo
  * directory that `go.mod` lives in (posix, `.` for the repo root). A monorepo may hold
@@ -281,7 +330,12 @@ function resolveName(
   // first in document order — and labelled it `extracted`, i.e. certain. That is the
   // guess this module's header says it does not make.
   if (local.length === 1) return { id: local[0].id, confidence: "extracted" };
-  const global = (globalName.get(name) ?? []).filter((n) => kinds.includes(n.kind));
+  // Cross-file: also require a language that could actually reach this one.
+  // Without it a unique name match ANYWHERE in the repo wins, which is how a Go
+  // builtin ended up resolving into a TypeScript test — see FAMILIES above.
+  const global = (globalName.get(name) ?? []).filter(
+    (n) => kinds.includes(n.kind) && reachable(file, n.path),
+  );
   if (global.length === 1) return { id: global[0].id, confidence: "inferred" };
   return null;
 }
@@ -336,7 +390,7 @@ function resolveTypedMember(
   let frontier = [recvType];
   for (let depth = 0; depth <= MAX_DEPTH && frontier.length; depth++) {
     for (const type of frontier) {
-      const all = ownerMethod.get(`${type}.${name}`);
+      const all = ownerMethod.get(`${type}.${name}`)?.filter((c) => reachable(file, c.path));
       if (all && all.length > 0) {
         const candidates = narrowByArity(all, argCount);
         if (candidates.length === 1) {
@@ -377,7 +431,7 @@ function resolveTraitMember(
   if (!traits?.length) return null;
   const matches: NodeV1[] = [];
   for (const trait of traits) {
-    const all = ownerMethod.get(`${trait}.${name}`);
+    const all = ownerMethod.get(`${trait}.${name}`)?.filter((c) => reachable(file, c.path));
     if (!all?.length) continue;
     matches.push(...narrowByArity(all, argCount));
   }

--- a/test/graph-cross-language.test.ts
+++ b/test/graph-cross-language.test.ts
@@ -1,0 +1,128 @@
+/**
+ * A call never crosses a language boundary.
+ *
+ * Name resolution is repo-wide: when a bare call has nothing local to bind to,
+ * `resolveName` accepts a unique match anywhere in the repo. That fallback was
+ * language-blind, and the failure it produced was not subtle. In a real polyglot
+ * repository (Go backend + TypeScript frontend) a frontend test file defined a
+ * helper named `make`. Go's `make` is a builtin, so every `make(map[...])` and
+ * `make(chan ...)` in the backend had nothing to resolve against — and matched
+ * that helper, because it was the only symbol named `make` in the repo.
+ *
+ * The result: 1040 in-edges into one test file, spread across 476 files, and any
+ * pull request touching that file reported the whole backend as its blast radius.
+ *
+ * The uniqueness rule is what made it fire, so the guard cannot live there — a
+ * rarer collision was a *more* confident wrong answer. It has to be the language.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolveEdges } from "../src/graph/resolve.js";
+import type { NodeV1 } from "../src/graph/types.js";
+
+function n(id: string, kind: NodeV1["kind"]): NodeV1 {
+  const post = id.includes("#") ? id.split("#")[1] : id;
+  const segs = post.split(".");
+  const name = segs[segs.length - 1];
+  const owner = kind === "method" && segs.length >= 2 ? segs[segs.length - 2] : undefined;
+  return {
+    id, name, kind, owner, path: id.split("#")[0], span: "L1-L1", signature: null,
+    exported: true, origin: "ast", body_hash: "h", summary_state: "pending", summary: null, crux: null,
+  } as NodeV1;
+}
+
+const calls = (edges: ReturnType<typeof resolveEdges>): string[] =>
+  edges.filter((e) => e.relation === "calls").map((e) => e.target);
+
+test("cross-language: a Go builtin does not resolve to a TypeScript helper", () => {
+  // Exactly the shape found in the wild — `make` exists only in a frontend test.
+  const nodes = [
+    n("backend/internal/evals/artifact_renderer.go", "file"),
+    n("backend/internal/evals/artifact_renderer.go#renderXLSX", "function"),
+    n("frontend/src/hooks/queries/useDraftDiffFiles.test.ts", "file"),
+    n("frontend/src/hooks/queries/useDraftDiffFiles.test.ts#make", "function"),
+  ];
+
+  const edges = resolveEdges(nodes, [
+    {
+      source: "backend/internal/evals/artifact_renderer.go#renderXLSX",
+      relation: "calls",
+      name: "make",
+      file: "backend/internal/evals/artifact_renderer.go",
+    },
+  ]);
+
+  assert.deepEqual(calls(edges), [], "an unresolvable Go builtin drops rather than reaching into the frontend");
+});
+
+test("cross-language: the guard is the language, not the ambiguity", () => {
+  // Two definitions of `render` — one reachable, one not. The Python one being
+  // present must not turn this into an "ambiguous, therefore drop": the TS caller
+  // has exactly one candidate it could actually call.
+  const nodes = [
+    n("web/app.ts", "file"), n("web/app.ts#boot", "function"),
+    n("web/view.ts", "file"), n("web/view.ts#render", "function"),
+    n("api/report.py", "file"), n("api/report.py#render", "function"),
+  ];
+
+  const edges = resolveEdges(nodes, [
+    { source: "web/app.ts#boot", relation: "calls", name: "render", file: "web/app.ts" },
+  ]);
+
+  assert.deepEqual(calls(edges), ["web/view.ts#render"]);
+});
+
+test("cross-language: families that really do interoperate still resolve", () => {
+  // TS/TSX/JS import each other freely; C and C++ share headers. Grouping them is
+  // the whole reason this is a family test and not a grammar equality check.
+  const tsx = resolveEdges(
+    [
+      n("web/page.ts", "file"), n("web/page.ts#mount", "function"),
+      n("web/Button.tsx", "file"), n("web/Button.tsx#Button", "function"),
+    ],
+    [{ source: "web/page.ts#mount", relation: "calls", name: "Button", file: "web/page.ts" }],
+  );
+  assert.deepEqual(calls(tsx), ["web/Button.tsx#Button"], "a .ts file calls into a .tsx file");
+
+  const c = resolveEdges(
+    [
+      n("src/main.cpp", "file"), n("src/main.cpp#run", "function"),
+      n("src/util.h", "file"), n("src/util.h#checksum", "function"),
+    ],
+    [{ source: "src/main.cpp#run", relation: "calls", name: "checksum", file: "src/main.cpp" }],
+  );
+  assert.deepEqual(calls(c), ["src/util.h#checksum"], "C++ calls a function declared in a C header");
+});
+
+test("cross-language: an unclaimed extension never filters", () => {
+  // Absence of data is not evidence of a mismatch. If graft cannot name the
+  // language of a file, the old behaviour has to stand or the graph silently
+  // loses real edges for anything outside the extension tables.
+  const nodes = [
+    n("scripts/tool.zzz", "file"), n("scripts/tool.zzz#drive", "function"),
+    n("scripts/lib.zzz", "file"), n("scripts/lib.zzz#helper", "function"),
+  ];
+
+  const edges = resolveEdges(nodes, [
+    { source: "scripts/tool.zzz#drive", relation: "calls", name: "helper", file: "scripts/tool.zzz" },
+  ]);
+
+  assert.deepEqual(calls(edges), ["scripts/lib.zzz#helper"]);
+});
+
+test("cross-language: a typed member call cannot cross either", () => {
+  // The owner-qualified path is stricter than bare names, but `Widget.render`
+  // colliding between a Python class and a TypeScript one is ordinary in a
+  // full-stack repo, so it needs the same guard.
+  const nodes = [
+    n("web/app.ts", "file"), n("web/app.ts#boot", "function"),
+    n("api/widget.py", "file"), n("api/widget.py#Widget", "class"),
+    n("api/widget.py#Widget.render", "method"),
+  ];
+
+  const edges = resolveEdges(nodes, [
+    { source: "web/app.ts#boot", relation: "calls", name: "render", viaMember: true, recvType: "Widget", file: "web/app.ts" },
+  ]);
+
+  assert.deepEqual(calls(edges), [], "a TS receiver does not bind to a Python class's method");
+});


### PR DESCRIPTION
## The bug

Found while running `graft blast` on a real polyglot repo (Go backend + TypeScript frontend).

```
renderXLSX · backend/internal/evals/artifact_renderer.go
  calls → make (frontend/src/hooks/queries/useDraftDiffFiles.test.ts:L5-L10)
```

A Go function "calls" a TypeScript helper in a frontend test file.

`make` is a Go **builtin**, so `sig := make(chan os.Signal, 1)` has nothing in the repo to resolve against. `resolveName`'s cross-file fallback then accepted a unique match *anywhere*:

```ts
const global = (globalName.get(name) ?? []).filter((n) => kinds.includes(n.kind));
if (global.length === 1) return { id: global[0].id, confidence: "inferred" };
```

Exactly one symbol named `make` existed — a TS test helper — so every `make(...)` in the Go backend became an edge into that file. **1040 in-edges across 476 files on one node.**

Note the shape of the failure: *uniqueness* is what made it fire. The rarer the collision, the more confident the old code was. So the guard cannot live in the ambiguity check — it has to be the language.

## Impact on the product

Same PR (102 files), before and after:

| | before | after |
| --- | --: | --: |
| areas affected | 116 | **14** |
| dependent symbols | 1744 | **31** |

Before, it reported an XLSX renderer and a quarterly access-review query as impacted by an agent-versioning change. After, the areas are `Agent Configuration Panels`, `Task Table Filtering`, `Agent Versioning Hooks`.

Any repo with more than one language hits this, which is most repos the GitHub App will land on.

## The fix

A call may not cross a language family. Families group what genuinely interoperates — TS/TSX/JS import each other freely, Kotlin/Scala/Clojure compile against Java on one classpath, C and C++ share headers. Everything else stands alone.

Applied to the bare-name fallback and to owner-qualified member resolution.

**An unclaimed extension never filters.** If no tier can name a file's language, behaviour is unchanged — absence of data is not evidence of a mismatch, and the alternative silently drops real edges for anything outside the extension tables.

## Tests

`test/graph-cross-language.test.ts` — 5 cases. Verified 3 of them **fail** without the fix (the other 2 are the must-still-resolve guards, green either way):

- the exact Go-builtin-to-TS-helper shape from the wild
- the guard is the language, not the ambiguity: a Python `render` sitting beside a TS `render` must not make the TS caller "ambiguous"
- families that really interoperate still resolve (.ts→.tsx, .cpp→.h)
- an unclaimed extension still resolves
- typed member calls cannot cross either

Full suite: **920 pass, 0 fail**.