### PR TITLE
fix: key allowScripts for R by its resolved name, not the alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **`allowScripts` now names R by the identity npm actually matches on.** The
+  entry was `tree-sitter-r@1.3.0`, the alias in `dependencies`, but npm derives
+  the identity from the resolved package in the lockfile —
+  `@davisvaughan/tree-sitter-r@1.3.0`. The old key matched nothing, so the
+  grammar's install script counted as unreviewed and was blocked;
+  `npm ci --strict-allow-scripts` failed on it. Harmless in practice only
+  because the package ships prebuilds for every supported platform. Note the
+  `overrides` key must stay the alias — the two fields key differently.
+
 ## 0.13.0
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -93,6 +93,6 @@
     "fsevents@2.3.3": true,
     "tree-sitter-kotlin@0.3.8": true,
     "tree-sitter-php@0.23.12": true,
-    "tree-sitter-r@1.3.0": true
+    "@davisvaughan/tree-sitter-r@1.3.0": true
   }
 }


### PR DESCRIPTION
`allowScripts` has `tree-sitter-r@1.3.0` — the alias from `dependencies` — but npm derives the trusted identity from the resolved package in the lockfile, which is `@davisvaughan/tree-sitter-r@1.3.0`. The key matches nothing, so the grammar's install script counts as unreviewed and gets blocked.

On `main` today:

```
$ npm ci --strict-allow-scripts
npm error code ESTRICTALLOWSCRIPTS
npm error   @davisvaughan/tree-sitter-r@1.3.0 (install: (install scripts present))
```

With the key corrected, `npm ci --strict-allow-scripts` exits 0.

Latent rather than breaking so far, because the package ships prebuilds for every supported platform — a blocked `node-gyp-build` still resolved a binary. It would bite on any platform without a prebuild, and it already makes the strict flag unusable.

Worth a comment for whoever touches this next, and the reason I didn't "fix" both to match: the `overrides` key must stay the alias `tree-sitter-r`. Overrides are keyed by the dependency name as it appears in the tree; `allowScripts` by the resolved package. Keying overrides on the scoped name instead makes npm ignore it and `ERESOLVE` fires. The two fields differ on purpose here.

Spotted while rebasing #40; unrelated to it, so it's on its own.