### PR TITLE
fix(check): mirror buildGraph's container tier so .vue never reads as removed

### DIFF
--- a/src/graph/check.ts
+++ b/src/graph/check.ts
@@ -22,6 +22,7 @@ import { relPosix } from "../util/paths.js";
 import { contextDirFor } from "../context/node-file.js";
 import { extractFile, languageOf } from "./extract.js";
 import { extractGeneric, genericLangOf, warmGenericGrammars } from "./generic.js";
+import { containerLangOf, extractContainer, warmContainerGrammars } from "./container.js";
 import { listSourceFiles } from "./build.js";
 import { readGraph, wiringPath } from "./write.js";
 import { readSourceFile } from "../util/source.js";
@@ -49,10 +50,11 @@ export interface GraphCheckOptions {
   contextDir?: string;
 }
 
-// async: the breadth tier's WASM grammars load asynchronously and must be warmed
-// before the (synchronous) re-extraction below, exactly as buildGraph does — else
-// breadth-tier files (.rs, …) would re-extract as empty here and read as `removed`
-// against a graph that built them, so `graft check` would never report OK.
+// async: the breadth and container tiers' WASM grammars load asynchronously and
+// must be warmed before the (synchronous) re-extraction below, exactly as
+// buildGraph does — else those files (.rs, .vue, …) would re-extract as empty
+// here and read as `removed` against a graph that built them, so `graft check`
+// would never report OK.
 export async function checkGraph(
   dir: string,
   opts: GraphCheckOptions = {},
@@ -83,10 +85,23 @@ export async function checkGraph(
   await warmGenericGrammars(
     new Set(sourceFiles.map((f) => genericLangOf(f)?.name).filter((n): n is string => !!n)),
   );
+  await warmContainerGrammars(
+    new Set(sourceFiles.map((f) => containerLangOf(f)?.name).filter((n): n is string => !!n)),
+  );
   const current = new Map<string, string>(); // id → body_hash
   for (const file of sourceFiles) {
     const lang = languageOf(file);
-    const generic = lang ? null : genericLangOf(file);
+    const container = lang ? null : containerLangOf(file);
+    const generic = lang || container ? null : genericLangOf(file);
+    // listSourceFiles only yields files one of the three tiers claims, so this is
+    // unreachable today. It is a throw rather than a `continue` because the silent
+    // path is precisely how #236 hid: a tier added to buildGraph and forgotten here
+    // re-extracts every one of its files as empty, and they read as `removed`
+    // against a graph that built them — forever, with `graft build` unable to
+    // repair it. Outside the try below, so the catch cannot swallow it.
+    if (!lang && !container && !generic) {
+      throw new Error(`graft check: no extractor tier claims ${relPosix(root, file)}`);
+    }
     let source: string | null;
     try {
       source = readSourceFile(file);
@@ -95,9 +110,12 @@ export async function checkGraph(
     }
     if (source === null) continue; // unsupported encoding (e.g. UTF-16BE)
     try {
+      const rel = relPosix(root, file);
       const { nodes } = lang
-        ? extractFile(relPosix(root, file), source, lang)
-        : extractGeneric(relPosix(root, file), source, generic!.name);
+        ? extractFile(rel, source, lang)
+        : container
+          ? extractContainer(rel, source, container)
+          : extractGeneric(rel, source, generic!.name);
       for (const n of nodes) current.set(n.id, n.body_hash);
     } catch {
       // parse failure → skip; the committed nodes for this file become `removed`.

--- a/test/container-extract.test.ts
+++ b/test/container-extract.test.ts
@@ -26,6 +26,7 @@ import {
 } from "../src/graph/container.js";
 import { supportedExtensions } from "../src/graph/source-files.js";
 import { buildGraph } from "../src/graph/build.js";
+import { checkGraph } from "../src/graph/check.js";
 import { readGraph, wiringPath } from "../src/graph/write.js";
 
 const VUE = containerLangOf("Any.vue")!;
@@ -245,4 +246,40 @@ test("container: a .vue file goes through a real build end to end", async () => 
     graph.edges.some((e) => e.source === label.id && e.target === greet.id && e.relation === "calls"),
     "the SFC's call into the .ts helper resolved",
   );
+});
+
+// #236: checkGraph mirrored buildGraph's depth and breadth tiers but not the
+// container tier, so `.vue` hit `generic!.name` on a null, the catch swallowed the
+// TypeError as a parse failure, and every committed .vue node read as `removed` —
+// permanently, since the `graft build` the report tells you to run rebuilt them
+// exactly as before. A false STALE that no rebuild can clear makes `graft check`
+// unusable as the CI drift gate it exists to be.
+test("container: check agrees with build on a .vue repo, so a fresh graph is not STALE", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-container-check-"));
+  mkdirSync(join(dir, "src"), { recursive: true });
+
+  writeFileSync(
+    join(dir, "src", "Hello.vue"),
+    sfc([
+      "<template><div @click=\"greet\">{{ msg }}</div></template>",
+      '<script setup lang="ts">',
+      "const msg = 'hi';",
+      "function greet(): void {",
+      "  console.log(msg);",
+      "}",
+      "</script>",
+    ]),
+  );
+
+  const outDir = join(dir, "graft");
+  await buildGraph(dir, outDir, { reuse: false });
+  const graph = readGraph(wiringPath(outDir));
+  const vue = graph.nodes.filter((n) => n.path.endsWith(".vue"));
+  assert.ok(vue.length >= 2, `the build indexed the .vue file (got ${vue.length} nodes)`);
+
+  // Nothing changed between the build and the check, so nothing may be drift.
+  const chk = await checkGraph(dir, { contextDir: outDir });
+  assert.deepEqual(chk.removed, [], "no .vue node may read as removed right after a build");
+  assert.deepEqual(chk.changed, [], "no .vue node may read as changed right after a build");
+  assert.equal(chk.ok, true, `check OK on a container-tier repo (added=${chk.added.length})`);
 });


### PR DESCRIPTION
Fixes #236.

`buildGraph` extracts in three tiers — depth (`languageOf`), container (`containerLangOf`, what claims `.vue`), breadth (`genericLangOf`). `checkGraph` only had two. For a `.vue` file both `languageOf` and `genericLangOf` return null, so the re-extraction hit `generic!.name` on a null, the surrounding `catch` swallowed the `TypeError` as a parse failure, and every committed `.vue` node fell through to `removed`.

That made it a false STALE no rebuild could clear: the `graft build` the report tells you to run rebuilds those nodes exactly as before, so `graft check` can never exit 0 on a repo containing a `.vue` file — unusable as the CI drift gate it exists to be.

## The change

- Import the container tier and warm its grammars alongside the generic ones, for the same reason the existing comment gives for the breadth tier.
- Add the `container` branch ahead of the breadth tier, matching `buildGraph`'s order.
- Replace the `generic!` non-null assertion with a real guard, placed **outside** the `try` so the catch cannot swallow it. It is unreachable today — `listSourceFiles` only yields files one of the three tiers claims — but the silent path is exactly how this hid, and a fourth tier added to `buildGraph` and forgotten here should be a loud error, not a permanent phantom `removed`.

## Verification

The issue's exact repro, before and after:

```
graph check: STALE          →   graph check: OK — the wiring graph is in sync with the code.

removed (2):
  - src/Hello.vue
  - src/Hello.vue#greet
```

New regression test in `test/container-extract.test.ts`, mirroring the breadth-tier one in `test/generic-extract.test.ts`: build a `.vue` repo, then assert `check` reports nothing removed or changed. Confirmed it fails without the `check.ts` change (`not ok 257`) and passes with it.

Full suite: **916 pass, 0 fail**.