### PR TITLE
fix(check): extract the container tier, so a clean .vue build is not drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Fixed
+
+- **`graft check` no longer reports every container-tier node as `removed`.**
+  `checkGraph` branched on the depth and breadth tiers but never on the container
+  tier the build uses for `.vue`, so `genericLangOf` returned null, a `generic!`
+  assertion threw, and the catch swallowed it as a parse failure — every `.vue`
+  node fell through to `removed` on a clean build, and the `graft build` the
+  check told you to run had already written them. The check now mirrors the
+  build's three-way branch, warms the container grammars alongside the generic
+  ones, and treats "no tier claims this file" as an explicit case rather than a
+  non-null assertion, so the next tier added fails in the type checker instead of
+  silently reporting drift. ([#236](https://github.com/trailhq/Graft/issues/236))
+
 ### Added
 
 - **`graft blast` suggests who to tag.** The comment already named the areas a

--- a/src/graph/check.ts
+++ b/src/graph/check.ts
@@ -22,6 +22,7 @@ import { relPosix } from "../util/paths.js";
 import { contextDirFor } from "../context/node-file.js";
 import { extractFile, languageOf } from "./extract.js";
 import { extractGeneric, genericLangOf, warmGenericGrammars } from "./generic.js";
+import { containerLangOf, extractContainer, warmContainerGrammars } from "./container.js";
 import { listSourceFiles } from "./build.js";
 import { readGraph, wiringPath } from "./write.js";
 import { readSourceFile } from "../util/source.js";
@@ -83,10 +84,22 @@ export async function checkGraph(
   await warmGenericGrammars(
     new Set(sourceFiles.map((f) => genericLangOf(f)?.name).filter((n): n is string => !!n)),
   );
+  // Container-tier grammars need the same warmup as the generic ones, for the same
+  // reason: extraction below is synchronous. Missing this is what made `graft
+  // check` report every `.vue` node as `removed` right after a clean build (#236)
+  // — the tier extracted fine, and then the check had no branch that could see it.
+  await warmContainerGrammars(
+    new Set(sourceFiles.map((f) => containerLangOf(f)?.name).filter((n): n is string => !!n)),
+  );
   const current = new Map<string, string>(); // id → body_hash
   for (const file of sourceFiles) {
+    // The same three-way branch `buildGraph` uses, in the same order. The two must
+    // stay in step: a tier the build extracts and the check cannot see reports as
+    // `removed` forever, and the `graft build` the check tells you to run can never
+    // repair it.
     const lang = languageOf(file);
-    const generic = lang ? null : genericLangOf(file);
+    const container = lang ? null : containerLangOf(file);
+    const generic = lang || container ? null : genericLangOf(file);
     let source: string | null;
     try {
       source = readSourceFile(file);
@@ -94,11 +107,23 @@ export async function checkGraph(
       continue; // unreadable now → its nodes show up as `removed` below
     }
     if (source === null) continue; // unsupported encoding (e.g. UTF-16BE)
+    const rel = relPosix(root, file);
     try {
-      const { nodes } = lang
-        ? extractFile(relPosix(root, file), source, lang)
-        : extractGeneric(relPosix(root, file), source, generic!.name);
-      for (const n of nodes) current.set(n.id, n.body_hash);
+      const extracted = lang
+        ? extractFile(rel, source, lang)
+        : container
+          ? extractContainer(rel, source, container)
+          : generic
+            ? extractGeneric(rel, source, generic.name)
+            : null;
+      // No tier claims this file. Spelled out rather than asserted away: the
+      // `generic!` that used to stand in this position threw a TypeError on a
+      // container-tier file, the catch below swallowed it as a parse failure, and
+      // a missing branch became a silent permanent `removed` (#236). Returning
+      // null here means the next tier graft gains fails loudly in the type
+      // checker instead.
+      if (extracted === null) continue;
+      for (const n of extracted.nodes) current.set(n.id, n.body_hash);
     } catch {
       // parse failure → skip; the committed nodes for this file become `removed`.
     }

--- a/test/container-extract.test.ts
+++ b/test/container-extract.test.ts
@@ -26,6 +26,7 @@ import {
 } from "../src/graph/container.js";
 import { supportedExtensions } from "../src/graph/source-files.js";
 import { buildGraph } from "../src/graph/build.js";
+import { checkGraph } from "../src/graph/check.js";
 import { readGraph, wiringPath } from "../src/graph/write.js";
 
 const VUE = containerLangOf("Any.vue")!;
@@ -245,4 +246,47 @@ test("container: a .vue file goes through a real build end to end", async () => 
     graph.edges.some((e) => e.source === label.id && e.target === greet.id && e.relation === "calls"),
     "the SFC's call into the .ts helper resolved",
   );
+});
+
+/**
+ * The check has to see every tier the build writes (#236).
+ *
+ * `checkGraph` re-extracts and diffs against the committed graph, so a tier it
+ * cannot extract reads as `removed` — and because the remedy it prints is
+ * `graft build`, which wrote those very nodes, the drift can never be cleared.
+ * That made `graft check` exit non-zero forever on any repo holding a `.vue`
+ * file, which is fatal for the CI drift gate it exists to be.
+ *
+ * Asserted on a clean build with NOTHING changed in between: the only correct
+ * answer there is "in sync", so any drift at all is the bug.
+ */
+test("container: a clean build of a .vue file checks as in sync", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-container-check-"));
+  mkdirSync(join(dir, "src"), { recursive: true });
+  writeFileSync(
+    join(dir, "src", "Hello.vue"),
+    sfc([
+      "<template><div @click=\"greet\">{{ msg }}</div></template>",
+      '<script setup lang="ts">',
+      "const msg = 'hi';",
+      "function greet(): void {",
+      "  console.log(msg);",
+      "}",
+      "</script>",
+    ]),
+  );
+
+  const outDir = join(dir, "graft");
+  await buildGraph(dir, outDir, { reuse: false });
+  const built = readGraph(wiringPath(outDir));
+  assert.ok(
+    built.nodes.some((n) => n.path.endsWith("Hello.vue")),
+    "precondition: the build extracted the .vue file",
+  );
+
+  const check = await checkGraph(dir, { contextDir: outDir });
+  assert.deepEqual(check.removed, [], "a tier the build wrote must not read as removed");
+  assert.deepEqual(check.added, []);
+  assert.deepEqual(check.changed, []);
+  assert.equal(check.ok, true, "a clean build checks OK");
 });


### PR DESCRIPTION
Fixes #236.

`graft check` reported every `.vue` node as `removed` immediately after a clean `graft build`, and the `graft build` it told you to run had written those very nodes — so the drift could never be cleared. That makes the command unusable as the CI gate it exists to be on any repo containing a `.vue` file.

## Cause

`buildGraph` branches three ways — depth tier, container tier, breadth tier. `checkGraph` branched only two, with no reference to the container tier at all. For a `.vue` file both `languageOf()` and `genericLangOf()` return null, so `generic!.name` threw a `TypeError`, the `catch` swallowed it as a parse failure, and the committed nodes fell through to `removed`.

The comment already in `src/graph/check.ts` anticipated exactly this for the breadth tier; it just wasn't extended when `.vue` support landed.

## Fix

- Warm the container grammars alongside the generic ones — extraction below is synchronous, same reason the generic warmup exists.
- Mirror `buildGraph`'s three-way branch, in the same order.
- Replace the `generic!` non-null assertion with an explicit "no tier claims this file" case. This is the part worth reviewing: the assertion is what turned a missing branch into silent permanent drift, and returning `null` means the next tier graft gains fails in the type checker instead. TypeScript caught this while I was writing it — it refused to narrow `generic` across the ternary chain, which is the same gap the assertion had been papering over.

## Verification

Reproduced the issue's exact repro first (`removed (2)`), then confirmed `OK` and exit 0 after the fix.

The regression test builds a `.vue` file and checks it with **nothing changed in between**, where the only correct answer is "in sync". I verified it fails against the unfixed code rather than assuming it would:

```
--- with the fix reverted ---
not ok 10 - container: a clean build of a .vue file checks as in sync
```

Full suite: 967 pass.