### PR TITLE
feat(app): name areas and tag reviewers in App comments

### DIFF
--- a/src/app/review.ts
+++ b/src/app/review.ts
@@ -59,6 +59,18 @@ export async function reviewPullRequest(job: ReviewJob, deps: ReviewDeps): Promi
     if (!diff) throw new Error(`no diff against ${job.baseRef}`);
 
     const report = blastRadiusIn(graph, contextDir, diff.files, diff.basis, DEPTH);
+
+    // Same two passes `graft blast --name` runs, in the same order: a reviewer's
+    // reason cites area labels, and naming is what gives an area its final one.
+    // Both are best-effort — without GRAFT_API_KEY the areas keep their symbol
+    // names and the comment still goes out.
+    const { nameReport } = await import("../blast/name.js");
+    const { note } = await nameReport(graph, report, contextDir);
+    if (note) log(`${job.owner}/${job.repo}#${job.number}: ${note}`);
+
+    const { attachOwners, diffAuthors } = await import("../blast/owners.js");
+    attachOwners(checkout.dir, report, { exclude: diffAuthors(checkout.dir, checkout.base) });
+
     // NOTE: once #180 lands, pass `{ root: checkout.dir }` so the collapsed list
     // quotes the reaching line here too. It is additive, and the App works without it.
     let body = `${MARKER}\n${markdownReport(report)}`;

--- a/src/blast/blast-cli.ts
+++ b/src/blast/blast-cli.ts
@@ -126,37 +126,13 @@ export async function runBlastCommand(dir: string, opts: BlastCliOptions): Promi
 /**
  * Name the clusters left on their symbol backstop, then report what it cost.
  *
- * Everything here is best-effort by construction: no key, a spent quota or a
- * refused call leaves the backstop labels in place and the command still exits 0,
- * because a PR check must not fail over a cosmetic layer.
+ * The work lives in `name.ts` so the GitHub App runs the identical pass; all
+ * this adds is the `--name:` prefix a CLI note wants.
  */
 async function nameClusters(graph: GraphV1, report: BlastReport, contextDir: string): Promise<void> {
-  const { applyNames, ChatNamer } = await import("./name.js");
-  const { resolveConfig } = await import("../ai/providers.js");
-  const cfg = resolveConfig({ contextDir });
-
-  let namer;
-  if (cfg.chatModel) {
-    namer = new ChatNamer(cfg.chatModel);
-  } else if (cfg.apiKey) {
-    const { createChatModel } = await import("../ai/llm/factory.js");
-    namer = new ChatNamer(createChatModel({
-      provider: cfg.provider, apiKey: cfg.apiKey, model: cfg.model,
-      baseUrl: cfg.baseUrl, headers: cfg.headers,
-    }));
-  }
-
-  const stats = await applyNames(graph, report, { namer, contextDir });
-  if (!namer) {
-    console.error("• --name: no API key (GRAFT_API_KEY), so areas keep their symbol names");
-    return;
-  }
-  if (stats.error) console.error(`• --name: naming failed (${stats.error}) — areas keep their symbol names`);
-  else if (stats.named + stats.cached + stats.declined > 0) {
-    const bits = [`${stats.named} named`, `${stats.cached} cached`];
-    if (stats.declined > 0) bits.push(`${stats.declined} left as symbols (mixed)`);
-    console.error(`• --name: ${bits.join(", ")}`);
-  }
+  const { nameReport } = await import("./name.js");
+  const { note } = await nameReport(graph, report, contextDir);
+  if (note) console.error(`• --name: ${note}`);
 }
 
 /**

--- a/src/blast/name.ts
+++ b/src/blast/name.ts
@@ -261,3 +261,42 @@ export async function applyNames(
   if (stats.named > 0) saveNameCache(opts.contextDir, cache);
   return stats;
 }
+
+/**
+ * Name the clusters left on their symbol backstop, and say what it cost.
+ *
+ * Everything here is best-effort by construction: no key, a spent quota or a
+ * refused call leaves the backstop labels in place, because neither a PR check
+ * nor a review comment should fail over a cosmetic layer. The note comes back
+ * rather than going to a stream, so `graft blast --name` can prefix it and the
+ * App can log it against the pull request it belongs to.
+ */
+export async function nameReport(
+  graph: GraphV1,
+  report: BlastReport,
+  contextDir: string,
+): Promise<{ stats: NameStats; note: string | null }> {
+  const { resolveConfig } = await import("../ai/providers.js");
+  const cfg = resolveConfig({ contextDir });
+
+  let namer: Namer | undefined;
+  if (cfg.chatModel) {
+    namer = new ChatNamer(cfg.chatModel);
+  } else if (cfg.apiKey) {
+    const { createChatModel } = await import("../ai/llm/factory.js");
+    namer = new ChatNamer(createChatModel({
+      provider: cfg.provider, apiKey: cfg.apiKey, model: cfg.model,
+      baseUrl: cfg.baseUrl, headers: cfg.headers,
+    }));
+  }
+
+  const stats = await applyNames(graph, report, { namer, contextDir });
+  if (!namer) return { stats, note: "no API key (GRAFT_API_KEY), so areas keep their symbol names" };
+  if (stats.error) return { stats, note: `naming failed (${stats.error}) — areas keep their symbol names` };
+  if (stats.named + stats.cached + stats.declined > 0) {
+    const bits = [`${stats.named} named`, `${stats.cached} cached`];
+    if (stats.declined > 0) bits.push(`${stats.declined} left as symbols (mixed)`);
+    return { stats, note: bits.join(", ") };
+  }
+  return { stats, note: null };
+}


### PR DESCRIPTION
The App and the Actions workflow are two callers of the same blast-radius
library, and only one of them opted into the last two passes.

`graft blast --name` runs: radius → name the areas → attach owners → render.
`reviewPullRequest` ran: radius → render. So App comments came back with hub
symbols (`callS…`) and no `Tag:` line, while CI comments on the same repo had
concept names and a reviewer.

- Moves the CLI's private `nameClusters` wrapper into `nameReport` in
  `src/blast/name.ts`. It returns a note instead of writing to `console.error`,
  so the CLI can prefix it with `--name:` and the App can log it against the PR.
- `blast-cli.ts` delegates to it — same output, no behaviour change.
- `review.ts` calls `nameReport` then `attachOwners`, in that order: a
  reviewer's reason cites area labels, and naming is what gives an area its
  final label.

Both passes stay best-effort. Without `GRAFT_API_KEY` the areas keep their
symbol names and the comment still posts.

Known gap: `attachOwners` excludes `diffAuthors(...)` but not the PR author by
login — `ReviewJob` doesn't carry one. Commit-email matching covers most cases;
threading `pull_request.user.login` through is a follow-up.

Tests: 1058 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)