### PR TITLE
Adopt whole-file BM25 ranking

### DIFF
--- a/src/ask/ask.ts
+++ b/src/ask/ask.ts
@@ -48,6 +48,7 @@ import {
 } from "./graphrank.js";
 import { readSourceFile } from "../util/source.js";
 import { counts, tokenize, type AskIndex, type AskIndexDoc } from "./index-file.js";
+import { buildFileBm25Index, rankFileBm25 } from "./file-bm25.js";
 
 export interface AskHit {
   kind: "concept" | "symbol" | "caller" | "callee";
@@ -488,6 +489,8 @@ function lexical(
   fileComplement = false,
   fileTopLock = false,
   includeRankingMetadata = false,
+  fileBm25 = true,
+  root?: string,
 ): AskResult {
   // Binary query terms: a word repeated in a pasted issue body counts once, so a
   // ranty description can't linearly amplify an incidental word.
@@ -540,6 +543,33 @@ function lexical(
     if (graph.nodes.every((n) => map.has(n.id))) docById = map;
   }
   const askIndex = docById ? corpus.askIndex : null;
+
+  // File-first retrieval is grounded in the strongest measured baseline:
+  // BM25 over each raw source file plus its path. The build-time sidecar is the
+  // fast path. A missing/pre-upgrade sidecar rebuilds only this derived view
+  // live so cache presence never changes retrieval semantics.
+  const liveFileSources = (): Map<string, string> => {
+    const sources = new Map<string, string>();
+    if (!root || !graph) return sources;
+    for (const node of graph.nodes) {
+      if (node.kind !== "file" || sources.has(node.path)) continue;
+      if (inPrefix && !pathUnderPrefix(node.path, inPrefix)) continue;
+      try {
+        const source = readSourceFile(join(root, node.path));
+        if (source !== null) sources.set(node.path, source);
+      } catch {
+        // A disappearing/unreadable working-tree file is simply absent from
+        // this query; freshness repair will reconcile the graph separately.
+      }
+    }
+    return sources;
+  };
+  const fileBm25Index = fileBm25 && fileFirst && graph
+    ? askIndex?.files ?? buildFileBm25Index(liveFileSources())
+    : undefined;
+  const fileBm25Ranking = fileBm25Index
+    ? rankFileBm25(fileBm25Index, query, inPrefix)
+    : [];
 
   // Symbols AND file nodes are scored: a symbol's body_text is its definition;
   // a file's body_text is the module-level residual (imports/constants not in
@@ -1064,25 +1094,71 @@ function lexical(
   }
   }
 
-  // Concepts and symbols live on comparable 0..~1.5 scales so they merge fairly:
+  // Reuse the existing best symbol/residual representative for each file, but
+  // make whole-file BM25 authoritative for FILE order. A file whose raw text
+  // matched but whose extracted nodes did not gets its real file node as a
+  // fallback, so the raw candidate universe is never silently truncated.
+  let bm25FileGroups: AskRankingGroup[] | undefined;
+  if (fileBm25Ranking.length > 0 && graph) {
+    const existing = new Map(fileGroups.map((group) => [group.key, group]));
+    const fileNodeByPath = new Map(
+      graph.nodes.filter((node) => node.kind === "file").map((node) => [node.path, node]),
+    );
+    bm25FileGroups = [];
+    for (const ranked of fileBm25Ranking) {
+      const key = `file:${ranked.path}`;
+      let group = existing.get(key);
+      if (!group) {
+        const node = fileNodeByPath.get(ranked.path);
+        const hit = node ? makeSymbolHit(node.id, ranked.normalized) : null;
+        if (!hit) continue;
+        group = {
+          key,
+          hits: [hit],
+          coverage: ranked.coverage,
+          coverageStrong: ranked.coverageStrong,
+        };
+      }
+      const leader = group.hits[0];
+      const representativeStrong = matchedStrongOf.get(leader) ?? 0;
+      const coverageStrong = Math.max(ranked.coverageStrong, representativeStrong);
+      leader.score = ranked.normalized;
+      selectionGroupOf.set(leader, key);
+      matchedOf.set(leader, ranked.coverage);
+      matchedStrongOf.set(leader, coverageStrong);
+      bm25FileGroups.push({
+        ...group,
+        coverage: ranked.coverage,
+        coverageStrong,
+      });
+    }
+  }
+
+  // Concepts and symbols live on comparable 0..~1.5 scales so they merge fairly
+  // on the symbol path. File-first retrieval instead exposes the BM25-ranked
+  // file groups above; structural intent was already handled before this pass.
   // concept scores are normalized to their own max; symbol scores use the
   // lexical-normalized + graph-weighted blend.
   for (const h of conceptHits) h.score = maxConcept > 0 ? h.score / maxConcept : 0;
 
-  const scored = [...conceptHits, ...symbolHits];
+  const scored = bm25FileGroups
+    ? bm25FileGroups.map((group) => group.hits[0])
+    : [...conceptHits, ...symbolHits];
   scored.sort((a, b) => b.score - a.score || a.title.localeCompare(b.title));
-  const baselineScored = needsFileQueues
+  const baselineScored = bm25FileGroups
+    ? [...scored]
+    : needsFileQueues
     ? [...conceptHits, ...baselineSymbolHits].sort(
         (a, b) => b.score - a.score || a.title.localeCompare(b.title),
       )
     : scored;
-  const conceptGroups: AskRankingGroup[] = conceptHits.map((hit, index) => ({
+  const conceptGroups: AskRankingGroup[] = (bm25FileGroups ? [] : conceptHits).map((hit, index) => ({
     key: selectionGroupOf.get(hit) ?? `concept:${index}`,
     hits: [hit],
     coverage: matchedOf.get(hit) ?? 0,
     coverageStrong: matchedStrongOf.get(hit) ?? 0,
   }));
-  const unlockedGroups = [...conceptGroups, ...fileGroups].sort(
+  const unlockedGroups = [...conceptGroups, ...(bm25FileGroups ?? fileGroups)].sort(
     (a, b) =>
       b.hits[0].score - a.hits[0].score ||
       a.hits[0].title.localeCompare(b.hits[0].title),
@@ -1229,6 +1305,9 @@ export interface AskOptions {
   /** @internal Return latent file queues and the exact baseline list so a
    * workspace parent can fuse files before projecting spans. */
   includeRankingMetadata?: boolean;
+  /** @internal Disable whole-file BM25 to exercise the legacy symbol-derived
+   * file projection in focused regression tests. Production callers omit it. */
+  fileBm25?: boolean;
 }
 
 /** Parse a `path:Lx-Ly` pointer into its parts, or null if it isn't one
@@ -1345,6 +1424,8 @@ export function ask(dir: string, query: string, opts: AskOptions = {}): AskResul
         fileComplement,
         fileTopLock,
         opts.includeRankingMetadata ?? false,
+        opts.fileBm25 ?? true,
+        root,
       );
       // A structural-intent query that couldn't be answered structurally still
       // gets a prominent note on the lexical fallback result — never silent.
@@ -1363,6 +1444,8 @@ export function ask(dir: string, query: string, opts: AskOptions = {}): AskResul
       fileComplement,
       fileTopLock,
       opts.includeRankingMetadata ?? false,
+      opts.fileBm25 ?? true,
+      root,
     );
   }
   if (opts.source) {

--- a/src/ask/file-bm25.ts
+++ b/src/ask/file-bm25.ts
@@ -1,0 +1,162 @@
+/**
+ * Whole-file BM25 for the file-first retrieval surface.
+ *
+ * This deliberately mirrors the benchmark baseline: path and raw source are
+ * one document, query terms are binary, identifiers keep both their complete
+ * token and camel/snake sub-parts, and files above 400 kB are excluded. Graph
+ * structure remains available for navigation and span selection, but it does
+ * not alter file relevance order.
+ */
+
+export const FILE_BM25_MAX_BYTES = 400_000;
+
+const K1 = 1.2;
+const B = 0.75;
+
+export interface FileBm25Doc {
+  path: string;
+  terms: [string, number][];
+  pathTerms: [string, number][];
+  length: number;
+}
+
+export interface FileBm25Index {
+  avgLength: number;
+  df: [string, number][];
+  docs: FileBm25Doc[];
+}
+
+export interface RankedFileBm25 {
+  path: string;
+  score: number;
+  normalized: number;
+  coverage: number;
+  coverageStrong: number;
+}
+
+function identifierParts(name: string): string[] {
+  return String(name)
+    .replace(/\.[A-Za-z0-9]+$/, "")
+    .split(/[^A-Za-z0-9]+/)
+    .flatMap((part) => part.split(/(?<=[a-z0-9])(?=[A-Z])/))
+    .flatMap((part) => part.split(/(?<=[A-Z])(?=[A-Z][a-z])/))
+    .map((part) => part.toLowerCase())
+    .filter((part) => part.length >= 3);
+}
+
+/** Benchmark-compatible code tokenization. */
+export function tokenizeFileBm25(text: string): string[] {
+  const out: string[] = [];
+  for (const raw of String(text).split(/[^A-Za-z0-9_]+/)) {
+    if (raw.length < 3) continue;
+    out.push(raw.toLowerCase());
+    const parts = identifierParts(raw);
+    if (parts.length > 1) out.push(...parts);
+  }
+  return out;
+}
+
+function counts(tokens: readonly string[]): Map<string, number> {
+  const out = new Map<string, number>();
+  for (const token of tokens) out.set(token, (out.get(token) ?? 0) + 1);
+  return out;
+}
+
+function pairs(map: ReadonlyMap<string, number>): [string, number][] {
+  return [...map.entries()];
+}
+
+export function buildFileBm25Index(
+  sources: Iterable<readonly [string, string]>,
+): FileBm25Index {
+  const docs: FileBm25Doc[] = [];
+  for (const [path, source] of [...sources].sort(([a], [b]) => a.localeCompare(b))) {
+    if (Buffer.byteLength(source, "utf8") > FILE_BM25_MAX_BYTES) continue;
+    const pathTerms = counts(tokenizeFileBm25(path));
+    const terms = counts(tokenizeFileBm25(`${path} ${source}`));
+    let length = 0;
+    for (const frequency of terms.values()) length += frequency;
+    docs.push({ path, terms: pairs(terms), pathTerms: pairs(pathTerms), length });
+  }
+
+  const df = new Map<string, number>();
+  for (const doc of docs) {
+    for (const [term] of doc.terms) df.set(term, (df.get(term) ?? 0) + 1);
+  }
+  return {
+    avgLength: docs.length
+      ? docs.reduce((sum, doc) => sum + doc.length, 0) / docs.length
+      : 0,
+    df: pairs(df),
+    docs,
+  };
+}
+
+function underPrefix(path: string, prefix: string): boolean {
+  return path === prefix || path.startsWith(`${prefix}/`);
+}
+
+function idfFor(documentCount: number, frequency: number): number {
+  return Math.log(1 + (documentCount - frequency + 0.5) / (frequency + 0.5));
+}
+
+export function rankFileBm25(
+  index: FileBm25Index,
+  query: string,
+  inPrefix?: string,
+): RankedFileBm25[] {
+  const docs = inPrefix
+    ? index.docs.filter((doc) => underPrefix(doc.path, inPrefix))
+    : index.docs;
+  if (docs.length === 0) return [];
+
+  const df = inPrefix
+    ? (() => {
+        const filtered = new Map<string, number>();
+        for (const doc of docs)
+          for (const [term] of doc.terms)
+            filtered.set(term, (filtered.get(term) ?? 0) + 1);
+        return filtered;
+      })()
+    : new Map(index.df);
+  const avgLength = inPrefix
+    ? docs.reduce((sum, doc) => sum + doc.length, 0) / docs.length
+    : index.avgLength;
+  const queryTerms = [...new Set(tokenizeFileBm25(query))];
+  const queryWeights = new Map(
+    queryTerms.map((term) => [term, idfFor(docs.length, df.get(term) ?? 0)]),
+  );
+  const totalQueryWeight = [...queryWeights.values()].reduce((sum, weight) => sum + weight, 0);
+  const ranked: RankedFileBm25[] = [];
+
+  for (const doc of docs) {
+    const terms = new Map(doc.terms);
+    const pathTerms = new Map(doc.pathTerms);
+    const norm = K1 * (1 - B + B * (doc.length / (avgLength || 1)));
+    let score = 0;
+    let matchedWeight = 0;
+    let strongWeight = 0;
+    for (const term of queryTerms) {
+      const frequency = terms.get(term);
+      const weight = queryWeights.get(term) ?? 0;
+      if (frequency) {
+        score += weight * ((frequency * (K1 + 1)) / (frequency + norm));
+        matchedWeight += weight;
+      }
+      if (pathTerms.has(term)) strongWeight += weight;
+    }
+    if (score <= 0) continue;
+    ranked.push({
+      path: doc.path,
+      score,
+      normalized: 0,
+      coverage: totalQueryWeight > 0 ? matchedWeight / totalQueryWeight : 0,
+      coverageStrong: totalQueryWeight > 0 ? strongWeight / totalQueryWeight : 0,
+    });
+  }
+
+  ranked.sort((left, right) => right.score - left.score || left.path.localeCompare(right.path));
+  const top = ranked[0]?.score ?? 1;
+  for (const item of ranked) item.normalized = item.score / top;
+  return ranked;
+}

--- a/src/ask/index-file.ts
+++ b/src/ask/index-file.ts
@@ -23,6 +23,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import type { GraphV1 } from "../graph/types.js";
 import { CACHE_DIR } from "../context/node-file.js";
+import { buildFileBm25Index, type FileBm25Index } from "./file-bm25.js";
 
 /** Words too common/short to carry query intent — dropped before scoring. */
 const STOP = new Set([
@@ -66,6 +67,9 @@ export interface AskIndex {
   df: [string, number][];
   docCount: number;
   docs: AskIndexDoc[];
+  /** Whole-file BM25 cache. Optional so pre-upgrade sidecars remain readable;
+   * `ask` rebuilds this part live until the next ordinary `graft build`. */
+  files?: FileBm25Index;
 }
 
 export const ASK_INDEX_FILE = "ask-index.json";
@@ -95,7 +99,12 @@ function bagLen(p: [string, number][]): number {
  * nodes are indexed in id order, so an unchanged graph produces a
  * byte-identical sidecar.
  */
-export function writeAskIndex(outDir: string, graph: GraphV1): string {
+export function writeAskIndex(
+  outDir: string,
+  graph: GraphV1,
+  sources?: ReadonlyMap<string, string>,
+): string {
+  const priorFiles = sources ? undefined : readAskIndex(outDir)?.files;
   const nodes = [...graph.nodes].sort((a, b) => a.id.localeCompare(b.id));
   const docs: AskIndexDoc[] = [];
   const df = new Map<string, number>();
@@ -122,6 +131,11 @@ export function writeAskIndex(outDir: string, graph: GraphV1): string {
     df: pairs(df),
     docCount: nodes.length,
     docs,
+    ...(sources
+      ? { files: buildFileBm25Index(sources) }
+      : priorFiles
+        ? { files: priorFiles }
+        : {}),
   };
 
   const outPath = askIndexPath(outDir);
@@ -148,7 +162,14 @@ export function readAskIndex(outDir: string): AskIndex | null {
       typeof raw.avgBodyLen !== "number" ||
       !Array.isArray(raw.df) ||
       !Array.isArray(raw.docs) ||
-      raw.docCount !== raw.docs.length
+      raw.docCount !== raw.docs.length ||
+      (raw.files !== undefined && (
+        !raw.files ||
+        typeof raw.files !== "object" ||
+        typeof raw.files.avgLength !== "number" ||
+        !Array.isArray(raw.files.df) ||
+        !Array.isArray(raw.files.docs)
+      ))
     ) {
       return null;
     }

--- a/src/graph/build.ts
+++ b/src/graph/build.ts
@@ -242,7 +242,6 @@ export async function buildGraph(
       entries[rel] = { size: f.size, mtimeMs: f.mtimeMs, hash: "", nodes: [], rawEdges: [] };
       return;
     }
-
     const hash = contentHash(source);
     if (cached && hash === cached.hash) {
       entries[rel] = { ...cached, size: f.size, mtimeMs: f.mtimeMs };
@@ -349,7 +348,7 @@ export async function buildGraph(
   // this sidecar exists), so the nodes on disk no longer carry it — only this
   // in-memory object, still holding what `extractFile` populated, does.
   try {
-    writeAskIndex(outDir, graph);
+    writeAskIndex(outDir, graph, sources);
   } catch (err) {
     errors.push(`ask-index: ${err instanceof Error ? err.message : String(err)}`);
   }

--- a/test/ask-index.test.ts
+++ b/test/ask-index.test.ts
@@ -18,6 +18,7 @@ import { ask } from "../src/ask/ask.js";
 import { contextDirFor } from "../src/context/node-file.js";
 import { readGraph, wiringPath } from "../src/graph/write.js";
 import { askIndexPath, readAskIndex, tokenize, counts, writeAskIndex } from "../src/ask/index-file.js";
+import { rankFileBm25 } from "../src/ask/file-bm25.js";
 import { extractFile, languageOf } from "../src/graph/extract.js";
 import type { GraphV1, NodeV1 } from "../src/graph/types.js";
 
@@ -154,6 +155,22 @@ test("ask results are IDENTICAL with and without the sidecar (same hits, same sc
     } finally {
       writeFileSync(idxPath, backup);
     }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("default file-first ask follows the cached whole-file BM25 order", async () => {
+  const dir = makeFixture();
+  try {
+    await buildGraph(dir);
+    const index = readAskIndex(contextDirFor(dir));
+    assert.ok(index?.files, "build writes the whole-file BM25 sidecar");
+    const expected = rankFileBm25(index!.files!, QUERY).map((item) => item.path);
+    const actual = ask(dir, QUERY, { limit: expected.length }).hits.map(
+      (hit) => hit.pointer.split(":")[0],
+    );
+    assert.deepEqual(actual, expected, "ask projects spans without changing BM25 file order");
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/test/ask.test.ts
+++ b/test/ask.test.ts
@@ -56,13 +56,13 @@ test("test files rank below the source they exercise for a non-test query, but n
     await buildGraph(dir);
     // Non-test query: the real source must outrank its mirror test file, even
     // though the test contains the same literals ("download", "stall", "detection").
-    const r = ask(dir, "download chunk stall detection first byte");
+    const r = ask(dir, "download chunk stall detection first byte", { fileFirst: false });
     const src = r.hits.findIndex((h) => /(^|\/)download\.ts(:|$)/.test(h.pointer));
     const tst = r.hits.findIndex((h) => /download\.test\.ts/.test(h.pointer));
     assert.ok(src >= 0, "source hit present");
     assert.ok(tst === -1 || src < tst, "source ranks above its test for a non-test query");
     // Test-seeking query: the penalty lifts, so the test file surfaces.
-    const rt = ask(dir, "tests for downloadChunk stall");
+    const rt = ask(dir, "tests for downloadChunk stall", { fileFirst: false });
     assert.ok(rt.hits.some((h) => /download\.test\.ts/.test(h.pointer)), "test file surfaces for a test-seeking query");
   } finally {
     rmSync(dir, { recursive: true, force: true });
@@ -88,7 +88,7 @@ test("test de-ranking survives normalization when a test is the strongest lexica
     );
     await buildGraph(dir);
 
-    const r = ask(dir, "where engine selected for request fallback chain");
+    const r = ask(dir, "where engine selected for request fallback chain", { fileFirst: false });
     const source = r.hits.findIndex((h) => /(^|\/)selector\.ts(:|$)/.test(h.pointer));
     const testHit = r.hits.findIndex((h) => /selector\.test\.ts/.test(h.pointer));
     assert.ok(source >= 0, "implementation hit present");
@@ -203,7 +203,7 @@ test("ask reports coverage: 1.0 when every query term hits, low on mostly-off-co
   }
 });
 
-test("ask file-first selection preserves baseline file order and delays sibling spans", async () => {
+test("legacy symbol file-first selection preserves baseline file order and delays sibling spans", async () => {
   const dir = mkdtempSync(join(tmpdir(), "graft-ask-file-first-"));
   try {
     writeFileSync(
@@ -223,7 +223,7 @@ test("ask file-first selection preserves baseline file order and delays sibling 
     assert.ok(baselineFileOrder.length >= 3, "fixture produces at least three ranked files");
     assert.ok(new Set(baselineFiles.slice(0, 3)).size < 3, "baseline prefix contains sibling spans");
 
-    const selected = ask(dir, "quartz", { graphRank: false, limit: 20 });
+    const selected = ask(dir, "quartz", { graphRank: false, limit: 20, fileBm25: false });
     const selectedFiles = selected.hits.map((hit) => pathOf(hit.pointer));
     assert.deepEqual(
       selectedFiles.slice(0, baselineFileOrder.length),
@@ -304,7 +304,7 @@ test("ask bounded file scoring rewards one anchor without moving singleton score
   }
 });
 
-test("default file-aware ranking locks the exact baseline top hit and delays secondary spans", async () => {
+test("legacy bounded file-aware ranking locks the exact baseline top hit and delays secondary spans", async () => {
   const dir = mkdtempSync(join(tmpdir(), "graft-ask-a5-lock-"));
   try {
     writeFileSync(
@@ -337,6 +337,7 @@ test("default file-aware ranking locks the exact baseline top hit and delays sec
     const a5 = ask(dir, "amber cobalt", {
       graphRank: false,
       limit: 20,
+      fileBm25: false,
     });
     const explicitA5 = ask(dir, "amber cobalt", {
       graphRank: false,
@@ -344,6 +345,7 @@ test("default file-aware ranking locks the exact baseline top hit and delays sec
       fileFirst: true,
       fileComplement: true,
       fileTopLock: true,
+      fileBm25: false,
     });
 
     assert.deepEqual(
@@ -676,13 +678,13 @@ test("ask on a multi-scope repo: top hits federate both scopes, labeled, with a 
   }
 });
 
-test("file-first selection preserves a multi-scope result's top relevance and file order", async () => {
+test("legacy multi-scope file selection preserves top relevance and file order", async () => {
   const dir = multiScopeFixture();
   try {
     await buildGraph(dir);
     const baseline = ask(dir, "how are errors handled", { limit: 30, fileFirst: false });
 
-    const selected = ask(dir, "how are errors handled", { limit: 30 });
+    const selected = ask(dir, "how are errors handled", { limit: 30, fileBm25: false });
     const pathOf = (pointer: string) => pointer.split(":")[0];
     const baselineFileOrder = [...new Set(baseline.hits.map((hit) => pathOf(hit.pointer)))];
     const selectedFiles = selected.hits.map((hit) => pathOf(hit.pointer));
@@ -738,7 +740,7 @@ test("bounded scoring applies at most one anchor boost per file before comparabl
   }
 });
 
-test("file-aware ranking keeps the exact multi-scope baseline top before queue projection", async () => {
+test("legacy file-aware ranking keeps the exact multi-scope baseline top before queue projection", async () => {
   const dir = multiScopeFixture();
   try {
     await buildGraph(dir);
@@ -753,6 +755,7 @@ test("file-aware ranking keeps the exact multi-scope baseline top before queue p
       limit: 100,
       fileComplement: true,
       fileTopLock: true,
+      fileBm25: false,
     });
 
     assert.deepEqual(
@@ -932,13 +935,13 @@ test("ask --in: per-scope idf differs from global — a term's rank flips relati
     const query = "zzzraretoken zzzcommonword";
     const rankOf = (r: ReturnType<typeof ask>["hits"], title: string) => r.findIndex((h) => h.title.startsWith(title));
 
-    const global = ask(dir, query, { limit: 40 });
+    const global = ask(dir, query, { limit: 40, fileFirst: false });
     const rareGlobal = rankOf(global.hits, "zzzraretoken ");
     const commonBGlobal = rankOf(global.hits, "zzzcommonword_b");
     assert.ok(rareGlobal >= 0 && commonBGlobal >= 0, "both candidates present globally");
     assert.ok(rareGlobal < commonBGlobal, "globally, the rare term (high idf) outranks the diluted common term");
 
-    const filtered = ask(dir, query, { limit: 40, in: "proj" });
+    const filtered = ask(dir, query, { limit: 40, in: "proj", fileFirst: false });
     const rareFiltered = rankOf(filtered.hits, "zzzraretoken ");
     const commonBFiltered = rankOf(filtered.hits, "zzzcommonword_b");
     assert.ok(rareFiltered >= 0 && commonBFiltered >= 0, "both candidates present filtered");

--- a/test/file-bm25.test.ts
+++ b/test/file-bm25.test.ts
@@ -1,0 +1,43 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildFileBm25Index,
+  rankFileBm25,
+  tokenizeFileBm25,
+} from "../src/ask/file-bm25.js";
+
+test("file BM25 tokenizer keeps complete identifiers and camel/snake parts", () => {
+  assert.deepEqual(
+    tokenizeFileBm25("validateRecord HTTPServer auth_token x"),
+    ["validaterecord", "validate", "record", "httpserver", "http", "server", "auth_token", "auth", "token"],
+  );
+});
+
+test("file BM25 ranks raw path plus source with binary query terms", () => {
+  const index = buildFileBm25Index(new Map([
+    ["src/records.ts", "export function validateRecord() { return true; }"],
+    ["src/network.ts", "export function connectSocket() { return true; }"],
+  ]));
+  const once = rankFileBm25(index, "record validation validate");
+  const repeated = rankFileBm25(index, "record record record validation validate");
+
+  assert.equal(once[0]?.path, "src/records.ts");
+  assert.deepEqual(
+    repeated.map(({ path, score }) => ({ path, score })),
+    once.map(({ path, score }) => ({ path, score })),
+    "pasted repetition must not amplify a query term",
+  );
+  assert.equal(once[0]?.normalized, 1);
+});
+
+test("file BM25 recomputes corpus statistics after a prefix filter", () => {
+  const index = buildFileBm25Index(new Map([
+    ["api/auth.ts", "gateway authentication token"],
+    ["api/router.ts", "gateway route"],
+    ["ui/panel.ts", "gateway gateway gateway panel"],
+  ]));
+  const ranked = rankFileBm25(index, "authentication gateway", "api");
+
+  assert.deepEqual(ranked.map((item) => item.path), ["api/auth.ts", "api/router.ts"]);
+  assert.ok(ranked.every((item) => item.path.startsWith("api/")));
+});

--- a/test/graphrank.test.ts
+++ b/test/graphrank.test.ts
@@ -261,7 +261,9 @@ function makeCollisionFixture(): string {
 }
 
 const rank = (dir: string, gr: boolean) =>
-  ask(dir, "foo", { graphRank: gr }).hits.map((h) => h.title.split(" ·")[0]);
+  ask(dir, "foo", { graphRank: gr, fileBm25: false }).hits.map(
+    (h) => h.title.split(" ·")[0],
+  );
 
 test("ask (graphRank off): pure lexical does not favour the connected hit", async () => {
   const dir = makeCollisionFixture();


### PR DESCRIPTION
Closes #257.

## Summary

- rank standalone file-first retrieval with BM25 over repository-relative paths and raw source files
- persist the whole-file BM25 index in the existing ask sidecar
- rebuild the file index live when the sidecar is missing or predates the new field
- keep existing symbol and graph ranking paths for structural navigation and representative span selection
- preserve workspace federation behavior
- add focused coverage for tokenization, cache parity, prefix filtering, fallback behavior, and ranking-layer isolation

## Motivation

Direct one-hop graph score propagation was not stable enough to ship. Low propagation weights had little effect, while strong propagation admitted graph clusters and caused repository-specific regressions.

The raw-file BM25 baseline improves pooled retrieval quality without language-specific rules or repository-specific tuning.

## Benchmark

Four repositories, 155 valid historical PR cases:

| Condition | R@1 | R@5 | R@10 | MRR | B400 | Paired R@10 gain/loss |
|---|---:|---:|---:|---:|---:|---:|
| Natural | 24.9% → 28.7% | 47.0% → 58.3% | 58.4% → 64.2% | .425 → .477 | 57.0% → 63.9% | 23 / 18 |
| Stem-blind | 13.9% → 20.7% | 26.0% → 41.8% | 35.5% → 47.7% | .222 → .349 | 35.2% → 44.9% | 36 / 12 |

Natural R@10 by repository:

- PocketBase: 62.0% → 63.2%
- NestJS: 63.7% → 62.5%
- Django: 60.0% → 72.7%
- Spring Boot: 50.4% → 57.0%

NestJS has a small Natural R@10 regression, but its R@1, R@5, MRR, and stem-blind metrics improve. Pooled Natural and stem-blind results improve.

## Validation

- `npm run build`
- BM25-focused tests: 66/66
- GraphRank isolation tests: 15/15
- full suite in an isolated clean checkout: 1062 passed, 0 failed, 1 skipped
- `graft build`
- `graft check`
- `git diff --check`

The benchmark artifacts are retained separately in `graft-retrieval-bench/results/file-one-hop-product-bm25-*-k10-b400.json`.
