### PR TITLE
fix(windows): hide detached background processes

### DIFF
--- a/src/claude/hooks.ts
+++ b/src/claude/hooks.ts
@@ -296,7 +296,7 @@ function handleStop(input: any, dir: string): void {
   const stats = readStats(dir);
   if (stats?.dirty && acquireLock(dir)) {
     patchStats(dir, { syncing: true });
-    const child = spawn(process.execPath, [syncRun, dir], { detached: true, stdio: 'ignore' });
+    const child = spawn(process.execPath, [syncRun, dir], { detached: true, stdio: 'ignore', windowsHide: true });
     child.unref();
   }
 }

--- a/src/telemetry/flush.ts
+++ b/src/telemetry/flush.ts
@@ -43,6 +43,7 @@ export function maybeFlushInBackground(home?: string, now = Date.now()): boolean
     const child = spawn(process.execPath, [graftCliPath(), '_telemetry-flush'], {
       detached: true,
       stdio: 'ignore',
+      windowsHide: true,
     });
     child.unref();
     return true;

--- a/src/upkeep.ts
+++ b/src/upkeep.ts
@@ -134,6 +134,7 @@ export function maybeRefreshInBackground(home?: string, now = Date.now()): boole
     const child = spawn(process.execPath, [graftCliPath(), '_update-check'], {
       detached: true,
       stdio: 'ignore',
+      windowsHide: true,
     });
     child.unref();
     return true;


### PR DESCRIPTION
## Summary

On Windows, detached background Graft processes can open a visible, empty console window when `windowsHide` is omitted.

This is especially noticeable when Graft is invoked from Codex hooks: after an edit marks the index dirty, the Stop hook launches the background sync (`sync-run.js` -> `graft build .`), which can show a blank `node.exe` console.

## Changes

Add `windowsHide: true` to the three detached background spawns in:

- `src/claude/hooks.ts` — background index sync
- `src/telemetry/flush.ts` — telemetry flush
- `src/upkeep.ts` — daily update check

The explicit browser opener in `dist/cli.js` remains unchanged. `dist/` is generated and was not edited.

`windowsHide` is ignored on non-Windows platforms.

## Validation

- `npm run build` passes.
- Relevant hook/upkeep/telemetry tests: 53 passed; 1 existing failure in the savings-format assertion, unrelated to this change.
- Full `npm test`: 1,047 passed, 7 existing unrelated failures, 5 skipped.