### PR TITLE
fix(llm): recover bare arrays and truncated JSON from gateway content (#253)

### DIFF
--- a/src/ai/llm/recover-tool.ts
+++ b/src/ai/llm/recover-tool.ts
@@ -1,13 +1,16 @@
 /**
  * Recover a forced-tool payload from assistant `content` when a gateway ignored
- * `tool_choice` and wrote JSON text instead of `tool_calls` (#129).
+ * `tool_choice` and wrote JSON text instead of `tool_calls` (#129, #253).
  *
  * Conservative: only succeeds when `text` parses as JSON matching one of:
  *   - `[{ name, parameters|arguments|args }]`
  *   - `{ name, parameters|arguments|args }`
  *   - a fenced ```json block wrapping either
  *   - a bare object whose `payloadKey` is an array
- * Anything else (prose, truncated JSON, a guessed shape) returns undefined.
+ *   - a bare array of payload items (no tool envelope) — items may carry `name`
+ * Truncated JSON is repaired only by closing unmatched `[`/`{` after the last
+ * complete object (linear scan, bounded closers). Anything else (prose,
+ * unrepairable truncation, a guessed shape) returns undefined.
  * Callers MUST run the same schema validation they use for real tool calls.
  */
 
@@ -21,6 +24,99 @@ function unwrapMarkdownFence(raw: string): string {
   }
   if (s.endsWith("```")) s = s.slice(0, -3).trimEnd();
   return s.trim();
+}
+
+/** Walk back at most this many complete `}` when repairing a truncated prefix. */
+const MAX_REPAIR_CUTS = 64;
+/** Refuse to invent a deep wrapper — typical payloads need 1–3 closers. */
+const MAX_REPAIR_CLOSERS = 8;
+
+type PayloadFn = (value: unknown) => Record<string, unknown> | undefined;
+
+/**
+ * Closers that would finish `head` as JSON, or `undefined` if the prefix is
+ * already balanced, still inside a string, mismatched, or too deep to close.
+ * Linear in `head.length`; no regex.
+ */
+function closersFor(head: string): string | undefined {
+  const stack: Array<"}" | "]"> = [];
+  let inString = false;
+  let escape = false;
+  for (let i = 0; i < head.length; i++) {
+    const c = head[i]!;
+    if (inString) {
+      if (escape) {
+        escape = false;
+        continue;
+      }
+      if (c === "\\") {
+        escape = true;
+        continue;
+      }
+      if (c === '"') inString = false;
+      continue;
+    }
+    if (c === '"') {
+      inString = true;
+      continue;
+    }
+    if (c === "{") stack.push("}");
+    else if (c === "[") stack.push("]");
+    else if (c === "}" || c === "]") {
+      const want = stack.pop();
+      if (want !== c) return undefined;
+    }
+  }
+  if (inString) return undefined;
+  if (stack.length === 0 || stack.length > MAX_REPAIR_CLOSERS) return undefined;
+  let closers = "";
+  for (let i = stack.length - 1; i >= 0; i--) closers += stack[i];
+  return closers;
+}
+
+/**
+ * After `JSON.parse` of the whole string / `{…}` / `[…]` slices fail, keep
+ * complete objects by cutting at a `}` that is not inside a string and
+ * appending only `]` / `}`. Does not close dangling quotes (that would guess
+ * a truncated value). Linear scans; at most {@link MAX_REPAIR_CUTS} parses.
+ */
+function tryRepairedPayload(stripped: string, asPayload: PayloadFn): Record<string, unknown> | undefined {
+  const cuts: number[] = [];
+  let inString = false;
+  let escape = false;
+  for (let i = 0; i < stripped.length; i++) {
+    const c = stripped[i]!;
+    if (inString) {
+      if (escape) {
+        escape = false;
+        continue;
+      }
+      if (c === "\\") {
+        escape = true;
+        continue;
+      }
+      if (c === '"') inString = false;
+      continue;
+    }
+    if (c === '"') {
+      inString = true;
+      continue;
+    }
+    if (c === "}") cuts.push(i);
+  }
+  const from = Math.max(0, cuts.length - MAX_REPAIR_CUTS);
+  for (let k = cuts.length - 1; k >= from; k--) {
+    const head = stripped.slice(0, cuts[k]! + 1);
+    const closers = closersFor(head);
+    if (closers === undefined) continue;
+    try {
+      const hit = asPayload(JSON.parse(head + closers));
+      if (hit) return hit;
+    } catch {
+      /* earlier complete object */
+    }
+  }
+  return undefined;
 }
 
 export function recoverToolArgsFromContent(
@@ -38,6 +134,22 @@ export function recoverToolArgsFromContent(
       for (const item of value) {
         const hit = asPayload(item);
         if (hit) return hit;
+      }
+      // Bare item array: only parameters|arguments|args mark a tool wrapper —
+      // synth nodes legitimately carry `name` (#253).
+      if (
+        value.length > 0 &&
+        value.every(
+          (it) =>
+            it !== null &&
+            typeof it === "object" &&
+            !Array.isArray(it) &&
+            !("parameters" in it) &&
+            !("arguments" in it) &&
+            !("args" in it),
+        )
+      ) {
+        return { [opts.payloadKey]: value };
       }
       return undefined;
     }
@@ -85,12 +197,13 @@ export function recoverToolArgsFromContent(
   const arrEnd = stripped.lastIndexOf("]");
   if (arrStart >= 0 && arrEnd > arrStart) {
     try {
-      return asPayload(JSON.parse(stripped.slice(arrStart, arrEnd + 1)));
+      const hit = asPayload(JSON.parse(stripped.slice(arrStart, arrEnd + 1)));
+      if (hit) return hit;
     } catch {
-      return undefined;
+      /* truncated — repair below */
     }
   }
-  return undefined;
+  return tryRepairedPayload(stripped, asPayload);
 }
 
 /** One stderr line when a structured op got neither a tool call nor recoverable JSON. */

--- a/test/llm-ops.test.ts
+++ b/test/llm-ops.test.ts
@@ -156,6 +156,7 @@ test("#129: recoverToolArgsFromContent accepts the three issue shapes and refuse
   assert.deepEqual(recoverToolArgsFromContent(padded, RECOVER_OPTS)?.nodes, payload.nodes);
   assert.equal(recoverToolArgsFromContent("The architecture is a layered monolith.", RECOVER_OPTS), undefined);
   assert.equal(recoverToolArgsFromContent("", RECOVER_OPTS), undefined);
+  // Unrepairable truncation: no complete object, so do not guess (#253).
   assert.equal(
     recoverToolArgsFromContent('[{"name":"emit_json","parameters":{"nodes":[', RECOVER_OPTS),
     undefined,
@@ -164,6 +165,100 @@ test("#129: recoverToolArgsFromContent accepts the three issue shapes and refuse
     recoverToolArgsFromContent(JSON.stringify([{ name: "other_tool", parameters: payload }]), RECOVER_OPTS),
     undefined,
   );
+});
+
+const BARE_NODE = { name: "Auth", type: "system", summary: "s", sources: ["a.ts"] };
+const BARE_NODE_2 = { name: "Api", type: "system", summary: "billing", sources: ["b.ts"] };
+const CRUX_OPTS = { toolNames: ["record_symbols", "emit_json"] as const, payloadKey: "symbols" };
+const CRUX_ITEM = { id: "a.ts#create", summary: "creates a user", crux_start: 38, crux_end: 41 };
+
+test("#253: recoverToolArgsFromContent accepts a bare item array (no tool envelope)", () => {
+  const items = [BARE_NODE, BARE_NODE_2];
+  // Synth concept/system nodes carry `name`; that must not be treated as a tool wrapper.
+  assert.deepEqual(recoverToolArgsFromContent(JSON.stringify(items), RECOVER_OPTS)?.nodes, items);
+  assert.deepEqual(
+    recoverToolArgsFromContent("```json\n" + JSON.stringify(items) + "\n```", RECOVER_OPTS)?.nodes,
+    items,
+  );
+  const cruxItems = [CRUX_ITEM, { id: "a.ts#login", summary: "logs in", crux_start: 50, crux_end: 55 }];
+  assert.deepEqual(recoverToolArgsFromContent(JSON.stringify(cruxItems), CRUX_OPTS)?.symbols, cruxItems);
+});
+
+test("#253: recoverToolArgsFromContent repairs truncated JSON at a complete object", () => {
+  const truncatedBare = `[${JSON.stringify(BARE_NODE)},{"name":"Api","type":"system","summary":"par`;
+  assert.deepEqual(recoverToolArgsFromContent(truncatedBare, RECOVER_OPTS)?.nodes, [BARE_NODE]);
+
+  const truncatedEnvelope = `{"nodes":[${JSON.stringify(BARE_NODE)},{"name":"Api","type":`;
+  assert.deepEqual(recoverToolArgsFromContent(truncatedEnvelope, RECOVER_OPTS)?.nodes, [BARE_NODE]);
+
+  const truncatedCrux = `[${JSON.stringify(CRUX_ITEM)},{"id":"a.ts#login","summary":"par`;
+  assert.deepEqual(recoverToolArgsFromContent(truncatedCrux, CRUX_OPTS)?.symbols, [CRUX_ITEM]);
+
+  // Nested `}` then a cut: keep the complete item, do not invent the rest.
+  const nested = {
+    name: "Auth",
+    type: "system",
+    summary: "s",
+    sources: ["a.ts"],
+    extra: { x: 1 },
+  };
+  const truncatedNested = `[${JSON.stringify(nested)},{"name":"Api","summary":`;
+  assert.deepEqual(recoverToolArgsFromContent(truncatedNested, RECOVER_OPTS)?.nodes, [nested]);
+});
+
+test("#253: unrepairable truncation still fails without guessing", () => {
+  assert.equal(recoverToolArgsFromContent('{"nodes":[', RECOVER_OPTS), undefined);
+  assert.equal(recoverToolArgsFromContent('[{"id":"', CRUX_OPTS), undefined);
+  assert.equal(recoverToolArgsFromContent('{"nodes":[{"name":"Auth","summary":"has } in text', RECOVER_OPTS), undefined);
+});
+
+test("#253: long whitespace around a truncated prefix stays linear", () => {
+  const padded =
+    "[" + " ".repeat(8_000) + JSON.stringify(BARE_NODE) + ',{"name":"Api","type":"system","summary":"par';
+  assert.deepEqual(recoverToolArgsFromContent(padded, RECOVER_OPTS)?.nodes, [BARE_NODE]);
+});
+
+test("#253: ChatSynthesizer recovers a bare node array from content", async () => {
+  const m = new FakeChatModel({
+    text: JSON.stringify([AUTH_NODE, { name: "Api", type: "system", summary: "s", sources: ["b.ts"], links: [] }]),
+    toolCalls: [],
+  });
+  const { result: nodes, err } = await withCapturedError(() =>
+    new ChatSynthesizer(m).synthesize([{ path: "a.ts", summary: "x" }]),
+  );
+  assert.equal(nodes.length, 2);
+  assert.equal(nodes[0].name, "Auth");
+  assert.equal(nodes[1].name, "Api");
+  assert.equal(err.length, 0);
+});
+
+test("#253: ChatCruxSummarizer keeps complete items from truncated content", async () => {
+  const m = new FakeChatModel({
+    text: `[${JSON.stringify({ id: "sym1", summary: "does x", crux_start: 3, crux_end: 5 })},{"id":"sym2","summary":"par`,
+    toolCalls: [],
+  });
+  const { result: out, err } = await withCapturedError(() =>
+    new ChatCruxSummarizer(m).describeFile({
+      path: "a.ts",
+      source: "l1\nl2\nl3\nl4\nl5\n",
+      nodes: [
+        { id: "sym1", kind: "function", signature: null, startLine: 1, endLine: 5 },
+        { id: "sym2", kind: "function", signature: null, startLine: 6, endLine: 8 },
+      ],
+    }),
+  );
+  assert.deepEqual(out, [{ id: "sym1", summary: "does x", crux_start: 3, crux_end: 5 }]);
+  assert.equal(err.length, 0);
+});
+
+test("#253: a real toolCalls payload is still preferred over a bare content array", async () => {
+  const m = new FakeChatModel({
+    text: JSON.stringify([{ name: "WRONG", type: "system", summary: "s", sources: ["a.ts"], links: [] }]),
+    toolCalls: [{ id: "1", name: "record_graph", args: AUTH_PAYLOAD }],
+  });
+  const nodes = await new ChatSynthesizer(m).synthesize([{ path: "a.ts", summary: "x" }]);
+  assert.equal(nodes.length, 1);
+  assert.equal(nodes[0].name, "Auth");
 });
 
 /** Capture console.error so tests can assert the #129 warnings without leaking them. */


### PR DESCRIPTION
## Summary
- Follow-up to #129 / #216. `recoverToolArgsFromContent` still rejected two shapes that small local models (Ollama `qwen2.5-coder:7b`) emit routinely: a **bare item array** with no `{name, parameters}` envelope, and **truncated JSON** when `max_tokens` / `num_predict` cuts the last item. Meaning then failed on every file (`content is not parseable tool-call JSON`).
- **Bare array:** after trying wrapper items, an array of objects that do not carry `parameters|arguments|args` is the payload. Synth nodes legitimately have `name`; that is no longer treated as a tool wrapper.
- **Truncation:** after whole-string / `{…}` / `[…]` parse fail, a linear scan (no regex) cuts at the last `}` that is not inside a string and appends only unmatched `]` / `}` (cap: 64 cuts, 8 closers). Incomplete last items are dropped, not guessed. Unrepairable prefixes still return `undefined` and warn.
- **Not in this PR:** opt-in dump of unparsed content (`GRAFT_DUMP_UNPARSED_DIR` / `--debug-unparsed` in the issue). That is a separate diagnostic surface; leaving it out keeps this to the two recovery shapes.

## Overlap with #254
Does not share files with #254 (`src/ai/crux.ts`, `src/ai/failure.ts`, `src/graph/enrich.ts`). This PR only touches `src/ai/llm/recover-tool.ts` and `test/llm-ops.test.ts`, and does not change `LlmFailureGate`. Either PR can land first; no rebase needed unless #254 later expands into `recover-tool.ts`.

## Test plan
- [x] Bare item array (synth nodes with `name`, crux `{id,…}`, fenced) → payload
- [x] Truncated JSON at a complete object (bare array, `{nodes:[…]}` envelope, nested `}`) → complete items only
- [x] Unrepairable truncation (no complete object, `}` only inside an open string) → `undefined`, no guess
- [x] 8k spaces around a truncated prefix stays linear (CodeQL `js/polynomial-redos` regression; no new regex)
- [x] Real `toolCalls` still preferred over a bare content array
- [x] `ChatSynthesizer` / `ChatCruxSummarizer` recover through `clean()` / `parseResults()`
- [x] Existing #129 shapes still parse; wrong-tool wrapper still refused
- [x] `npm run build` and `npx tsc --noEmit` clean; `node --import tsx --test test/llm-ops.test.ts` — 16 pass

Addresses #253

Made with [Cursor](https://cursor.com)