### PR TITLE
fix(deep): recover crux payloads when the model echoes the source line (#259)

### DIFF
--- a/src/ai/crux.ts
+++ b/src/ai/crux.ts
@@ -134,15 +134,95 @@ function userContent(input: FileCruxInput): string {
   return `FILE: ${input.path}\n\n${numberLines(input.source)}\n\nTARGETS (${n} — return all ${n}, one entry per id):\n${targets}`;
 }
 
+/**
+ * Strip a TARGET-line echo from a crux `id` (#259).
+ *
+ * {@link userContent} renders each target as
+ * `id=${id} | ${kind} | lines L${start}-L${end} | ${signature}`. Some models
+ * (deepseek-chat) copy that whole line into the tool's `id`. Real node ids are
+ * `path#Name` and do not contain ` | `.
+ *
+ * Only rewrite when the suffix is that TARGET shape AND the peeled token is one
+ * of the ids this call asked for (or no expected list was given). A lone ` | `,
+ * a truncated line, or an id that peels to something we did not ask for is left
+ * unchanged so the caller can fail it with a specific reason instead of caching
+ * a guess (#177).
+ */
+export function peelEchoedCruxId(raw: string, expectedIds: readonly string[] = []): string {
+  const trimmed = stripIdWrapper(raw);
+  if (expectedIds.includes(trimmed)) return trimmed;
+
+  const peeled = peelTargetLineSuffix(trimmed);
+  if (peeled !== null && (expectedIds.length === 0 || expectedIds.includes(peeled))) {
+    return peeled;
+  }
+
+  if (expectedIds.length > 0) {
+    const hit = longestPrefixId(trimmed, expectedIds);
+    if (hit) return hit;
+  }
+  return trimmed;
+}
+
+/** True when `id` still looks like the TARGET line, not a node id. */
+export function looksLikeEchoedTargetLine(id: string): boolean {
+  return peelTargetLineSuffix(stripIdWrapper(id)) !== null;
+}
+
+function stripIdWrapper(raw: string): string {
+  let s = raw.trim();
+  if (
+    (s.startsWith('"') && s.endsWith('"') && s.length >= 2) ||
+    (s.startsWith("'") && s.endsWith("'") && s.length >= 2)
+  ) {
+    s = s.slice(1, -1).trim();
+  }
+  return s.startsWith("id=") ? s.slice(3) : s;
+}
+
+/**
+ * If `id` is `realId | kind | lines Lstart-Lend [| signature]`, return `realId`.
+ * Linear scan — the distinctive marker is ` | lines L`, which we emit and no
+ * node id contains. Kind must be a single token (the {@link Kind} vocabulary).
+ */
+function peelTargetLineSuffix(id: string): string | null {
+  const marker = " | lines L";
+  const linesAt = id.indexOf(marker);
+  if (linesAt < 0) return null;
+  const before = id.slice(0, linesAt);
+  const sep = before.lastIndexOf(" | ");
+  if (sep < 0) return null;
+  const kind = before.slice(sep + 3).trim();
+  if (!kind || /\s/.test(kind)) return null;
+  const after = id.slice(linesAt + marker.length);
+  if (!/^\d+-L\d+(?:\s+\|.*)?$/.test(after)) return null;
+  const peeled = before.slice(0, sep).trim();
+  return peeled || null;
+}
+
+/** Longest requested id that `raw` equals or continues as `id | …` (echoed rest). */
+function longestPrefixId(raw: string, expectedIds: readonly string[]): string | undefined {
+  let best: string | undefined;
+  for (const id of expectedIds) {
+    if (raw === id || raw.startsWith(`${id} | `)) {
+      if (!best || id.length > best.length) best = id;
+    }
+  }
+  return best;
+}
+
 /** Normalize the tool's parsed argument object into a {@link NodeCrux} list. */
-function parseResults(obj: { symbols?: unknown } | undefined): NodeCrux[] {
+function parseResults(
+  obj: { symbols?: unknown } | undefined,
+  expectedIds: readonly string[] = [],
+): NodeCrux[] {
   if (!obj || !Array.isArray(obj.symbols)) return [];
   const num = (v: unknown) => (typeof v === "number" && Number.isFinite(v) ? Math.trunc(v) : 0);
   return obj.symbols
     .map((s) => s as Record<string, unknown>)
     .filter((s) => typeof s.id === "string")
     .map((s) => ({
-      id: s.id as string,
+      id: peelEchoedCruxId(s.id as string, expectedIds),
       summary: typeof s.summary === "string" ? s.summary.trim() : "",
       crux_start: num(s.crux_start),
       crux_end: num(s.crux_end),
@@ -196,7 +276,10 @@ export class ChatCruxSummarizer implements CruxSummarizer {
         { role: "user", content: userContent(input) },
       ],
     });
-    const parsed = parseResults(argsFromResponse(res));
+    const parsed = parseResults(
+      argsFromResponse(res),
+      input.nodes.map((n) => n.id),
+    );
     this.lastMiss = classifyCruxMiss(res, parsed);
     return parsed;
   }

--- a/src/graph/enrich.ts
+++ b/src/graph/enrich.ts
@@ -19,7 +19,14 @@
  * once, to cut `crux.code` verbatim from the source. `crux.span` is a pointer
  * only and is never used to re-slice.
  */
-import { formatCruxMiss, type CruxMissKind, type CruxSummarizer, type NodeCrux, type NodeRef } from "../ai/crux.js";
+import {
+  formatCruxMiss,
+  looksLikeEchoedTargetLine,
+  type CruxMissKind,
+  type CruxSummarizer,
+  type NodeCrux,
+  type NodeRef,
+} from "../ai/crux.js";
 import { LlmFailureGate } from "../ai/failure.js";
 import type { Crux, NodeV1 } from "./types.js";
 
@@ -196,8 +203,11 @@ export async function enrichGraph(
 
     if (!fileError && refs.length > 0 && applied === 0) {
       // collectFileCrux already labels a total miss; this catches "got entries
-      // but every summary was blank" so the CLI's #127 degraded-exit path fires.
-      fileError = cruxMissMessage(summarizer, "empty-parsed");
+      // but none applied" so the CLI's #127 degraded-exit path fires. Name the
+      // miss (echoed TARGET line vs blank summaries vs unmatched ids) so a
+      // deepseek-chat echo (#259) is not the same string as a truncated payload.
+      // Blank summaries still go through #254's miss class + finish_reason.
+      fileError = unusableSymbolsReason(results, summarizer);
       stats.errors.push(`${path}: ${fileError}`);
       gate.record(fileError, { quality: true });
     } else if (!fileError) {
@@ -277,6 +287,21 @@ async function collectFileCrux(
     return { results, error: cruxMissMessage(summarizer, "empty-toolCalls"), quality: true };
   }
   return { results, error };
+}
+
+/**
+ * Why a non-empty reply still applied to zero nodes. Echoed TARGET-line ids
+ * (#259) must not share the blank-summary string; truncated JSON is the empty
+ * path above (the OpenAI adapter turns unparseable arguments into `{}`).
+ */
+function unusableSymbolsReason(results: Map<string, NodeCrux>, summarizer: CruxSummarizer): string {
+  if ([...results.keys()].some((id) => looksLikeEchoedTargetLine(id))) {
+    return "model echoed the target line into each symbol id";
+  }
+  if ([...results.values()].every((r) => !r.summary.trim())) {
+    return cruxMissMessage(summarizer, "empty-parsed");
+  }
+  return "model returned symbol ids that did not match any target";
 }
 
 /**

--- a/test/crux-echo.test.ts
+++ b/test/crux-echo.test.ts
@@ -1,0 +1,296 @@
+/**
+ * #259: deepseek-chat echoes the whole TARGET line into `record_symbols.id`.
+ * `summary` / crux ranges are fine; enrich then looks up `results.get(node.id)`,
+ * matches nothing, and every file dies as "no usable symbol summaries".
+ *
+ * These tests replay the captured payload against a fake ChatModel — no API key,
+ * no network. Rescue peels only the TARGET-line suffix onto a requested id;
+ * garbage and empty summaries still fail and stay uncached (#177).
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { ChatCruxSummarizer, peelEchoedCruxId, looksLikeEchoedTargetLine } from "../src/ai/crux.js";
+import { enrichGraph } from "../src/graph/enrich.js";
+import type { ChatModel, ChatRequest, ChatResponse, ToolCall } from "../src/ai/llm/types.js";
+import type { CruxSummarizer, FileCruxInput, NodeCrux, NodeRef } from "../src/ai/crux.js";
+import type { NodeV1 } from "../src/graph/types.js";
+
+/** Issue #259 captured tool-call `id` — the whole TARGET line, not the node id. */
+const ECHOED_CTOR =
+  "app/User.php#User.__construct | method | lines L40-L58 | public function __construct($object = null)";
+const ECHOED_CLASS = "app/User.php#User | class | lines L1-L80 | class User";
+const CTOR_ID = "app/User.php#User.__construct";
+const CLASS_ID = "app/User.php#User";
+const CTOR_SUMMARY =
+  "Builds an User from a source object, copying matching public properties and wrapping each Properties entry into an UserProperties instance.";
+const CLASS_SUMMARY = "A user entity hydrated from a source object.";
+
+class FakeChatModel implements ChatModel {
+  readonly label = "fake:model";
+  last?: ChatRequest;
+  constructor(private reply: { text?: string; toolCalls?: ToolCall[] }) {}
+  async create(req: ChatRequest): Promise<ChatResponse> {
+    this.last = req;
+    return {
+      text: this.reply.text ?? "",
+      toolCalls: this.reply.toolCalls ?? [],
+      usage: { input: 0, output: 0, cacheRead: 0, cacheCreate: 0 },
+      stopReason: "stop",
+      assistant: { role: "assistant", content: this.reply.text ?? "" },
+    };
+  }
+}
+
+const CTOR_REF: NodeRef = {
+  id: CTOR_ID,
+  kind: "method",
+  signature: "public function __construct($object = null)",
+  startLine: 40,
+  endLine: 58,
+};
+const CLASS_REF: NodeRef = {
+  id: CLASS_ID,
+  kind: "class",
+  signature: "class User",
+  startLine: 1,
+  endLine: 80,
+};
+
+function phpSource(): string {
+  return Array.from({ length: 80 }, (_, i) => {
+    const n = i + 1;
+    if (n === 1) return "class User";
+    if (n === 40) return "    public function __construct($object = null)";
+    if (n === 47) return "        $this->hydrate($object);";
+    return `        // line ${n}`;
+  }).join("\n");
+}
+
+function phpNode(id: string, name: string, kind: NodeV1["kind"], span: string, signature: string | null): NodeV1 {
+  return {
+    id,
+    name,
+    kind,
+    path: "app/User.php",
+    span,
+    signature,
+    exported: true,
+    origin: "ast",
+    body_hash: `h-${id}`,
+    summary_state: "pending",
+    summary: null,
+    crux: null,
+  };
+}
+
+function phpNodes(): NodeV1[] {
+  return [
+    phpNode(CLASS_ID, "User", "class", "L1-L80", "class User"),
+    phpNode(CTOR_ID, "__construct", "method", "L40-L58", "public function __construct($object = null)"),
+  ];
+}
+
+function issuePayload(overrides: Partial<{ id: string; summary: string }>[] = []): { symbols: unknown[] } {
+  const defaults = [
+    { id: ECHOED_CTOR, summary: CTOR_SUMMARY, crux_start: 47, crux_end: 57 },
+    { id: ECHOED_CLASS, summary: CLASS_SUMMARY, crux_start: 0, crux_end: 0 },
+  ];
+  return {
+    symbols: defaults.map((d, i) => ({ ...d, ...overrides[i] })),
+  };
+}
+
+test("#259: peelEchoedCruxId strips the captured TARGET-line suffix onto the node id", () => {
+  assert.equal(peelEchoedCruxId(ECHOED_CTOR, [CTOR_ID, CLASS_ID]), CTOR_ID);
+  assert.equal(peelEchoedCruxId(ECHOED_CLASS, [CTOR_ID, CLASS_ID]), CLASS_ID);
+  assert.equal(peelEchoedCruxId(`id=${ECHOED_CTOR}`, [CTOR_ID]), CTOR_ID);
+  assert.equal(peelEchoedCruxId(`"${ECHOED_CTOR}"`, [CTOR_ID]), CTOR_ID);
+  assert.ok(looksLikeEchoedTargetLine(ECHOED_CTOR));
+  assert.equal(looksLikeEchoedTargetLine(CTOR_ID), false);
+});
+
+test("#259: a lone pipe is not an echo — garbage ids are not rewritten", () => {
+  assert.equal(peelEchoedCruxId("hello | world", [CTOR_ID]), "hello | world");
+  assert.equal(
+    peelEchoedCruxId("totally-wrong | method | lines L1-L2 | function zzz()", [CTOR_ID]),
+    "totally-wrong | method | lines L1-L2 | function zzz()",
+  );
+  assert.equal(peelEchoedCruxId(CTOR_ID, [CTOR_ID]), CTOR_ID);
+});
+
+test("#259: prefix fallback picks the longest requested id when 'lines L' is missing", () => {
+  const short = "src/a.ts#Foo";
+  const long = "src/a.ts#Foo.bar";
+  assert.equal(peelEchoedCruxId(`${long} | method | L1-L2`, [short, long]), long);
+  assert.equal(peelEchoedCruxId(`${short} | method | L1-L2`, [short, long]), short);
+});
+
+test("#259: ChatCruxSummarizer recovers the issue sample without an API call", async () => {
+  const m = new FakeChatModel({
+    toolCalls: [{ id: "1", name: "record_symbols", args: issuePayload() }],
+  });
+  const out = await new ChatCruxSummarizer(m).describeFile({
+    path: "app/User.php",
+    source: phpSource(),
+    nodes: [CTOR_REF, CLASS_REF],
+  });
+  assert.equal(out.length, 2);
+  assert.deepEqual(
+    out.map((s) => s.id).sort(),
+    [CTOR_ID, CLASS_ID].sort(),
+  );
+  assert.equal(out.find((s) => s.id === CTOR_ID)?.summary, CTOR_SUMMARY);
+  assert.equal(out.find((s) => s.id === CTOR_ID)?.crux_start, 47);
+  assert.equal(out.find((s) => s.id === CTOR_ID)?.crux_end, 57);
+  assert.deepEqual(m.last?.responseFormat, { kind: "tool", name: "record_symbols" });
+});
+
+test("#259: a clean toolCalls payload is unchanged (regression)", async () => {
+  const m = new FakeChatModel({
+    toolCalls: [
+      {
+        id: "1",
+        name: "record_symbols",
+        args: { symbols: [{ id: "sym1", summary: "does x", crux_start: 3.9, crux_end: 5 }] },
+      },
+    ],
+  });
+  const out = await new ChatCruxSummarizer(m).describeFile({
+    path: "a.ts",
+    source: "l1\nl2\nl3\nl4\nl5\n",
+    nodes: [{ id: "sym1", kind: "function", signature: null, startLine: 1, endLine: 5 }],
+  });
+  assert.deepEqual(out, [{ id: "sym1", summary: "does x", crux_start: 3, crux_end: 5 }]);
+});
+
+test("#259: enrich applies echoed ids and does not leave the file pending", async () => {
+  const summarizer = new ChatCruxSummarizer(
+    new FakeChatModel({ toolCalls: [{ id: "1", name: "record_symbols", args: issuePayload() }] }),
+  );
+  const nodes = phpNodes();
+  const sources = new Map([["app/User.php", phpSource()]]);
+
+  const stats = await enrichGraph(nodes, new Map(), sources, { summarizer, concurrency: 1 });
+
+  assert.equal(stats.computed, 2);
+  assert.equal(stats.pending, 0);
+  assert.equal(stats.failedFiles, 0);
+  assert.equal(stats.errors.length, 0);
+  for (const n of nodes) {
+    assert.equal(n.summary_state, "ready");
+    assert.ok(n.summary && n.summary.trim().length > 0);
+  }
+  assert.equal(nodes.find((n) => n.id === CTOR_ID)?.summary, CTOR_SUMMARY);
+});
+
+test("#259: a rescued file is a cache hit on the next --deep, not a retry", async () => {
+  const summarizer = new ChatCruxSummarizer(
+    new FakeChatModel({ toolCalls: [{ id: "1", name: "record_symbols", args: issuePayload() }] }),
+  );
+  const nodes = phpNodes();
+  const sources = new Map([["app/User.php", phpSource()]]);
+  await enrichGraph(nodes, new Map(), sources, { summarizer, concurrency: 1 });
+
+  const prior = new Map(nodes.map((n) => [n.id, structuredClone(n)]));
+  let calls = 0;
+  const counting: CruxSummarizer = {
+    async describeFile(input: FileCruxInput): Promise<NodeCrux[]> {
+      calls++;
+      return input.nodes.map((n) => ({ id: n.id, summary: "should not run", crux_start: 0, crux_end: 0 }));
+    },
+  };
+  const again = phpNodes();
+  const second = await enrichGraph(again, prior, sources, { summarizer: counting, concurrency: 1 });
+  assert.equal(calls, 0);
+  assert.equal(second.cached, 2);
+  assert.equal(second.computed, 0);
+});
+
+test("#259: an echo that peels to an id we did not ask for is a named failure, not a cache hit", async () => {
+  const foreign =
+    "app/Other.php#Other.boot | method | lines L1-L2 | public function boot()";
+  const summarizer = new ChatCruxSummarizer(
+    new FakeChatModel({
+      toolCalls: [
+        {
+          id: "1",
+          name: "record_symbols",
+          args: { symbols: [{ id: foreign, summary: CLASS_SUMMARY, crux_start: 0, crux_end: 0 }] },
+        },
+      ],
+    }),
+  );
+  const nodes = phpNodes();
+  const sources = new Map([["app/User.php", phpSource()]]);
+  const stats = await enrichGraph(nodes, new Map(), sources, { summarizer, concurrency: 1 });
+
+  assert.equal(stats.computed, 0);
+  assert.equal(stats.pending, 2);
+  assert.equal(stats.failedFiles, 1);
+  assert.match(stats.errors[0] ?? "", /echoed the target line/i);
+  for (const n of nodes) {
+    assert.equal(n.summary_state, "pending");
+    assert.equal(n.summary, null);
+  }
+});
+
+test("#259: echoed ids with blank summaries stay pending — not cached as ready (#177)", async () => {
+  const summarizer = new ChatCruxSummarizer(
+    new FakeChatModel({
+      toolCalls: [{ id: "1", name: "record_symbols", args: issuePayload([{ summary: "  " }, { summary: "" }]) }],
+    }),
+  );
+  const nodes = phpNodes();
+  const sources = new Map([["app/User.php", phpSource()]]);
+  const stats = await enrichGraph(nodes, new Map(), sources, { summarizer, concurrency: 1 });
+
+  assert.equal(stats.computed, 0);
+  assert.equal(stats.pending, 2);
+  assert.match(stats.errors[0] ?? "", /no usable symbol summaries/i);
+  for (const n of nodes) {
+    assert.equal(n.summary_state, "pending", "blank summary must not flip the node to ready");
+    assert.equal(n.summary, null);
+  }
+});
+
+test("#259: unmatched ids that are not an echo say so, instead of the blank-summary string", async () => {
+  const summarizer = new ChatCruxSummarizer(
+    new FakeChatModel({
+      toolCalls: [
+        {
+          id: "1",
+          name: "record_symbols",
+          args: { symbols: [{ id: "not-a-node", summary: "something coherent", crux_start: 0, crux_end: 0 }] },
+        },
+      ],
+    }),
+  );
+  const nodes = phpNodes();
+  const sources = new Map([["app/User.php", phpSource()]]);
+  const stats = await enrichGraph(nodes, new Map(), sources, { summarizer, concurrency: 1 });
+
+  assert.equal(stats.computed, 0);
+  assert.equal(stats.failedFiles, 1);
+  assert.match(stats.errors[0] ?? "", /did not match any target/i);
+  assert.doesNotMatch(stats.errors[0] ?? "", /no usable symbol summaries/);
+});
+
+test("#259: empty tool args are a miss-class failure, not an echo", async () => {
+  const summarizer = new ChatCruxSummarizer(
+    new FakeChatModel({
+      // Same shape the OpenAI adapter yields when JSON.parse of arguments fails.
+      toolCalls: [{ id: "1", name: "record_symbols", args: {} }],
+    }),
+  );
+  const nodes = phpNodes();
+  const sources = new Map([["app/User.php", phpSource()]]);
+  const stats = await enrichGraph(nodes, new Map(), sources, { summarizer, concurrency: 1 });
+
+  assert.equal(stats.computed, 0);
+  assert.equal(stats.pending, 2);
+  assert.equal(stats.failedFiles, 1);
+  // #254 names this via miss class + finish_reason, not the old "empty or truncated" string.
+  assert.match(stats.errors[0] ?? "", /\[(unparseable|empty-toolCalls|truncated)/);
+  assert.doesNotMatch(stats.errors[0] ?? "", /echoed the target line/);
+  for (const n of nodes) assert.equal(n.summary_state, "pending");
+});


### PR DESCRIPTION
## Summary
- `deepseek-chat` copies the whole TARGET line into `record_symbols.id` (`id | kind | lines Lx-Ly | signature`). `summary` and crux ranges are fine; `enrichGraph` looks up `results.get(node.id)`, matches nothing, and every file dies as "no usable symbol summaries".
- `parseResults` now peels that TARGET-line suffix onto a **requested** id. A lone `|`, a truncated line, or an id that peels to something we did not ask for is left unchanged — rescue failure is still a failure, and blank summaries stay `pending` (#177). No prompt change (0 extra tokens); no #260 chunking.

Closes #259

## Payload shape (issue sample)

**Before** (what the model returned — `id` is the whole TARGET line):

```json
{
  "id": "app/User.php#User.__construct | method | lines L40-L58 | public function __construct($object = null)",
  "summary": "Builds an User from a source object, copying matching public properties and wrapping each Properties entry into an UserProperties instance.",
  "crux_start": 47,
  "crux_end": 57
}
```

**After peel** (what `parseResults` stores — lookup key matches `node.id`):

```json
{
  "id": "app/User.php#User.__construct",
  "summary": "Builds an User from a source object, copying matching public properties and wrapping each Properties entry into an UserProperties instance.",
  "crux_start": 47,
  "crux_end": 57
}
```

Misses are named, not lumped into "no usable":
- echo that does not map to a requested id → `model echoed the target line into each symbol id`
- empty/`{}` tool args (truncated JSON from the OpenAI adapter) → `empty or truncated tool response`
- blank summaries → `no usable symbol summaries` (unchanged, still not cached)

## Test plan
- [x] `node --import tsx --test test/crux-echo.test.ts` — issue sample rescue, garbage not rewritten, blank summaries stay pending, truncation vs echo, clean `toolCalls` regression
- [x] `node --import tsx --test test/llm-ops.test.ts test/graph-enrich-pending.test.ts test/graph-enrich-failures.test.ts` — normal toolCalls / #172 / #127 still green
- [x] `npm test` — 1070 passing locally


Made with [Cursor](https://cursor.com)