### PR TITLE
Astro (.astro) support via the container tier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@
 
 ### Added
 
+- **Astro (`.astro`) joins the container tier**, the second row after Vue and the
+  one its registry comment was holding open. The `---` frontmatter is the same
+  shape as a Vue SFC's `<script>` with a different fence: `tree-sitter-astro`
+  (already in the bundled `tree-sitter-wasms`) parses the file to a top-level
+  `frontmatter` node whose only named child, `frontmatter_js_block`, holds
+  TypeScript — so the row is `block: "frontmatter", body: "frontmatter_js_block",
+  inner: "typescript"` and no extraction code changes. The span arithmetic
+  carries over unchanged and was the thing verified rather than assumed:
+  `frontmatter_js_block` starts on the opening `---` row exactly as `raw_text`
+  starts on its tag row, so slice line N lands on file line N +
+  `startPosition.row`. A fixture whose fence is pushed down the file by a leading
+  HTML comment pins it, because the usual case — a fence on line 1 — has offset 0
+  and passes even when the shift is dropped.
+
+  Frontmatter is where an Astro page's imports and server-side code live, so
+  pages stop being invisible: a `lib` function's `callers` now names the pages
+  that import it, and `graft grep` reaches `.astro` at all. Client `<script>`
+  blocks are deliberately still out — they nest inside the markup, and `blocks()`
+  walks the root's named children only, so reaching them needs a recursive walk
+  and a `block` that can name two node types. A file with only a client script
+  degrades to a file node; it never reports a wrong line. Svelte stays out of the
+  registry for the reason Astro just left it: nobody has verified its `body` node
+  against a real repo.
+
 - **`graft init --no-statusline`** (and `GRAFT_NO_STATUSLINE=1`) skips writing
   Claude Code's `statusLine` / `subagentStatusLine`. A custom bar — in the
   project's `.claude/settings.json` or in `~/.claude/settings.json` — stays in

--- a/src/graph/container.ts
+++ b/src/graph/container.ts
@@ -7,6 +7,9 @@
  * shell (`<template>` / `<script>` / `<style>`) and hands back the script body as
  * one opaque `raw_text` node, so the cards would come out empty.
  *
+ * Astro's `---` frontmatter is the same shape with a different fence: the
+ * grammar hands back one `frontmatter_js_block` holding TypeScript.
+ *
  * So the container grammar is used only to answer "where does the embedded
  * language start and end", and the block itself goes to the DEPTH-tier extractor
  * (extract.ts). A `.vue` file therefore gets the same quality of extraction as a
@@ -33,20 +36,38 @@ export interface ContainerLang {
   exts: string[];
   /** wasm basename in tree-sitter-wasms/out/tree-sitter-<wasm>.wasm */
   wasm: string;
-  /** Wrapper node that represents one embedded block (e.g. Vue's script_element). */
+  /** Wrapper node that represents one embedded block, as a NAMED CHILD OF THE
+   * ROOT (Vue's `script_element`, Astro's `frontmatter`). Blocks nested deeper
+   * in the markup are not reached — see the Astro row below. */
   block: string;
-  /** Child of `block` holding the raw embedded source (e.g. Vue's raw_text). */
+  /** Child of `block` holding the raw embedded source (Vue's `raw_text`,
+   * Astro's `frontmatter_js_block`). */
   body: string;
   /** Depth-tier grammar for the embedded language. TypeScript is a superset of
    * JavaScript, so it parses both `<script>` and `<script lang="ts">`. */
   inner: Language;
 }
 
-/** The container registry. Svelte and Astro are the same shape and would be a
- * row each, but they are left out until someone has a repo to verify them
- * against — a wrong `body` node type would produce silently misplaced spans. */
+/** The container registry. Svelte is the same shape and would be a row too, but
+ * it is left out until someone has a repo to verify it against — a wrong `body`
+ * node type would produce silently misplaced spans.
+ *
+ * **Astro indexes its frontmatter, not its `<script>` tags**, and that is the
+ * whole file as far as the graph is concerned: the `---` fence holds the
+ * imports and the server-side code, so a page becomes a real graph root ("who
+ * renders this component"). Client `<script>` blocks are deliberately out of
+ * reach — `blocks()` walks the root's named children only, and an Astro
+ * `<script>` is usually nested inside the markup (depth 3 in a layout), so
+ * reaching them needs a recursive walk and a `block` that can name two node
+ * types. Indexing half a file beats indexing none of it, and nothing here
+ * reports a wrong line. */
 export const CONTAINER_LANGS: readonly ContainerLang[] = [
   { name: "vue", exts: [".vue"], wasm: "vue", block: "script_element", body: "raw_text", inner: "typescript" },
+  // `frontmatter_js_block` starts on the opening `---` row, exactly as Vue's
+  // `raw_text` starts on its tag row, so the existing shift arithmetic applies
+  // unchanged: slice line 1 is the tail of the fence line, and slice line N
+  // lands on file line N + startPosition.row. Pinned by the tests below.
+  { name: "astro", exts: [".astro"], wasm: "astro", block: "frontmatter", body: "frontmatter_js_block", inner: "typescript" },
 ];
 
 const byExt = new Map<string, ContainerLang>();

--- a/test/container-extract.test.ts
+++ b/test/container-extract.test.ts
@@ -30,6 +30,11 @@ import { checkGraph } from "../src/graph/check.js";
 import { readGraph, wiringPath } from "../src/graph/write.js";
 
 const VUE = containerLangOf("Any.vue")!;
+const ASTRO = containerLangOf("Any.astro")!;
+
+/** Same contract as `sfc`, named for the Astro fixtures so the two fixture
+ * shapes are not confused when a test fails. */
+const astro = sfc;
 
 /** Line N of the fixture is `lines[N - 1]` — that is the whole point. */
 function sfc(lines: string[]): string {
@@ -289,4 +294,127 @@ test("container: a clean build of a .vue file checks as in sync", async () => {
   assert.deepEqual(check.added, []);
   assert.deepEqual(check.changed, []);
   assert.equal(check.ok, true, "a clean build checks OK");
+});
+
+/* ---------------------------------------------------------------------------
+ * Astro. Same tier, different fence: the embedded block is the `---`
+ * frontmatter (`frontmatter` → `frontmatter_js_block`) rather than a
+ * `<script>` element, and it holds TypeScript.
+ *
+ * Frontmatter usually opens on line 1, which makes the offset 0 — the case a
+ * naive implementation passes. The tests below therefore lead with a fixture
+ * whose fence is pushed down the file, because that is the one that fails when
+ * the shift is dropped.
+ * ------------------------------------------------------------------------- */
+
+test("container: registry claims .astro and reports it as supported", () => {
+  assert.equal(containerLangOf("src/pages/index.astro")?.name, "astro");
+  assert.equal(containerLangOf("src/pages/Index.ASTRO")?.name, "astro", "extension match is case-insensitive");
+  assert.ok(containerExtensions().includes(".astro"));
+  assert.ok(supportedExtensions().includes(".astro"), ".astro must be in the -e supported set");
+});
+
+test("container: spans point at the .astro line, not the frontmatter line", async () => {
+  await warmContainerGrammars(["astro"]);
+  assert.ok(isContainerWarm("astro"), "astro grammar must be available in tree-sitter-wasms");
+
+  const lines = [
+    "<!-- a comment above the fence pushes it down the file -->", //  1
+    "---",                                                        //  2
+    'import Card from "../components/Card.astro";',               //  3
+    "",                                                           //  4
+    "const rows = await load();",                                 //  5
+    "",                                                           //  6
+    "export function shout(what: string) {",                      //  7
+    "  return what.toUpperCase();",                               //  8
+    "}",                                                          //  9
+    "---",                                                        // 10
+    "<main>",                                                     // 11
+    "  <Card rows={rows} />",                                     // 12
+    "</main>",                                                    // 13
+  ];
+
+  const { nodes } = extractContainer("pages/index.astro", astro(lines), ASTRO);
+
+  // Line 7 in the file; line 6 inside the frontmatter block. Getting 6 here
+  // would be the exact failure this tier exists to avoid.
+  assert.equal(spanOf(nodes, "shout"), "L7-L9");
+});
+
+test("container: a fence at the top of the file still lands right", async () => {
+  await warmContainerGrammars(["astro"]);
+
+  const lines = [
+    "---",                          // 1
+    "export function first() {}",   // 2
+    "---",                          // 3
+    "<b />",                        // 4
+  ];
+
+  // Offset 0 — the shape almost every real .astro file has, and the one a fix
+  // for the previous test could break.
+  assert.equal(spanOf(extractContainer("A.astro", astro(lines), ASTRO).nodes, "first"), "L2-L2");
+});
+
+test("container: multi-byte characters inside the frontmatter do not shift the spans", async () => {
+  await warmContainerGrammars(["astro"]);
+
+  // Cyrillic and an emoji above the symbol: if the slice were taken by byte
+  // offset against a UTF-16 string, the block would be cut in the wrong place
+  // and the symbol would move or vanish.
+  const lines = [
+    "---",                                        // 1
+    'const title = "Поход в горы 🥾";',           // 2
+    'const note = "Регламент участия";',          // 3
+    "export function label() {",                  // 4
+    "  return title;",                            // 5
+    "}",                                          // 6
+    "---",                                        // 7
+    "<h1>{title}</h1>",                           // 8
+  ];
+
+  assert.equal(spanOf(extractContainer("Ru.astro", astro(lines), ASTRO).nodes, "label"), "L4-L6");
+});
+
+test("container: the file node describes the .astro, not the frontmatter block", async () => {
+  await warmContainerGrammars(["astro"]);
+
+  const lines = [
+    "---",                            // 1
+    "const x = 1;",                   // 2
+    "---",                            // 3
+    "<main>",                         // 4
+    "  <p>{x}</p>",                   // 5
+    "</main>",                        // 6
+    "<style>.a{color:red}</style>",   // 7
+  ];
+  const source = astro(lines);
+
+  const { nodes } = extractContainer("Card.astro", source, ASTRO);
+  const file = nodes[0];
+
+  assert.equal(file.kind, "file");
+  assert.equal(file.id, "Card.astro");
+  assert.equal(file.span, "L1-L8", "spans the whole component, markup and style included");
+  assert.equal(file.chars, source.length);
+  assert.equal(file.origin, "ast");
+});
+
+test("container: an .astro with no usable frontmatter degrades to a file node", async () => {
+  await warmContainerGrammars(["astro"]);
+
+  for (const [label, lines] of [
+    ["no frontmatter at all", ["<main>", "  <p>static</p>", "</main>"]],
+    ["empty frontmatter", ["---", "---", "<p />"]],
+    // The known limit of this row: client `<script>` blocks are nested in the
+    // markup, and `blocks()` only walks the root's named children. Pinned so
+    // the behaviour is a decision rather than a surprise — note it degrades to
+    // "not indexed", never to a wrong line.
+    ["client script only", ["<main>", "  <script>", "    function boot() {}", "  </script>", "</main>"]],
+  ] as const) {
+    const { nodes, rawEdges } = extractContainer("Empty.astro", astro([...lines]), ASTRO);
+    assert.equal(nodes.length, 1, `${label}: file node only`);
+    assert.equal(nodes[0].kind, "file");
+    assert.equal(rawEdges.length, 0, `${label}: no edges`);
+  }
 });


### PR DESCRIPTION
## What

Adds Astro (`.astro`) to the container tier — the second row after Vue, and the one the registry comment was holding open:

> The container registry. Svelte and Astro are the same shape and would be a row each, but they are left out until someone has a repo to verify them against — a wrong `body` node type would produce silently misplaced spans.

I have that repo: a 122-file / ~50k-line Astro app, which is what this was verified against.

## The row

The `---` frontmatter is a Vue `<script>` with a different fence. `tree-sitter-astro` is **already in the bundled `tree-sitter-wasms`** (no new dependency), and it parses a file to a top-level `frontmatter` node whose only named child, `frontmatter_js_block`, holds TypeScript:

```js
{ name: "astro", exts: [".astro"], wasm: "astro", block: "frontmatter", body: "frontmatter_js_block", inner: "typescript" }
```

No extraction code changes — `blocks()`, the shift and `supportedExtensions()` all pick it up as-is.

## The span risk, verified rather than assumed

`frontmatter_js_block` starts on the opening `---` row, exactly as Vue's `raw_text` starts on its tag row, so the existing arithmetic holds unchanged: slice line N lands on file line N + `startPosition.row` (slice line 1 is the tail of the fence line, and is empty).

The lead fixture pushes the fence down the file with an HTML comment, because the usual case — a fence on line 1 — has **offset 0 and passes even when the shift is dropped**. Confirmed against the grammar: a leading comment gives `startRow=1`, two leading blank lines give `startRow=2`.

Six tests, mirroring the Vue set: registry + `-e` supported set, the shifted-fence span, the top-of-file span, multi-byte (Cyrillic + emoji) inside the frontmatter, the file node describing the whole component, and the degrade-to-file-node cases. `npm test`: **1164 tests, 0 failures.**

## What it buys

Frontmatter is where an Astro page's imports and server-side code live, so pages stop being invisible to the graph. On the repo above:

| | before | after |
|---|---|---|
| indexed files | 486 | 611 |
| edges | 5,824 | 6,561 |
| languages | `javascript, tsx, typescript` | `astro, javascript, tsx, typescript` |

Concretely, `callers` now reaches into pages:

```
getAllHikes · function · web/src/lib/sanity.ts:L259-L282
  calls ← my-hikes.astro   (web/src/pages/[lang]/account/my-hikes.astro:L1-L176)
  calls ← [category].astro (web/src/pages/[lang]/hikes/category/[category].astro:L1-L340)
  calls ← index.astro      (web/src/pages/[lang]/hikes/index.astro:L1-L2114)
  calls ← map.astro        (web/src/pages/[lang]/hikes/map.astro:L1-L664)
```

…and `graft grep` reaches `.astro` at all, where before it answered "no hits in 486 indexed files".

## What it deliberately does not do

Client `<script>` blocks are **not** indexed. They nest inside the markup — in my repo, 2 sit at depth 1 in one page but 4 sit at **depth 3** in a layout — and `blocks()` walks the root's named children only. Reaching them needs a recursive walk plus a `block` that can name two node types; happy to follow up with that if you want it, but it is a behaviour change to the shared container path rather than a registry row, so I kept it out of this PR.

The same goes for component usage in the markup (`<Card />`), which is not a call in the frontmatter and so does not produce an edge.

A file whose only JS is a client `<script>` degrades to a file node — never to a wrong line — and there is a test pinning that, so it reads as a decision rather than a surprise.

Svelte stays out for exactly the reason Astro just left: nobody has verified its `body` node against a real repo.
