### PR TITLE
Astro client <script> blocks: a container language can carry several embedded shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@
 
 ### Added
 
+- **Astro (`.astro`) joins the container tier**, the second row after Vue and the
+  one its registry comment was holding open. The `---` frontmatter is the same
+  shape as a Vue SFC's `<script>` with a different fence: `tree-sitter-astro`
+  (already in the bundled `tree-sitter-wasms`) parses the file to a top-level
+  `frontmatter` node whose only named child, `frontmatter_js_block`, holds
+  TypeScript — so the row is `block: "frontmatter", body: "frontmatter_js_block",
+  inner: "typescript"` and no extraction code changes. The span arithmetic
+  carries over unchanged and was the thing verified rather than assumed:
+  `frontmatter_js_block` starts on the opening `---` row exactly as `raw_text`
+  starts on its tag row, so slice line N lands on file line N +
+  `startPosition.row`. A fixture whose fence is pushed down the file by a leading
+  HTML comment pins it, because the usual case — a fence on line 1 — has offset 0
+  and passes even when the shift is dropped.
+
+  Frontmatter is where an Astro page's imports and server-side code live, so
+  pages stop being invisible: a `lib` function's `callers` now names the pages
+  that import it, and `graft grep` reaches `.astro` at all. Client `<script>`
+  blocks are deliberately still out — they nest inside the markup, and `blocks()`
+  walks the root's named children only, so reaching them needs a recursive walk
+  and a `block` that can name two node types. A file with only a client script
+  degrades to a file node; it never reports a wrong line. Svelte stays out of the
+  registry for the reason Astro just left it: nobody has verified its `body` node
+  against a real repo.
+
 - **`graft init --no-statusline`** (and `GRAFT_NO_STATUSLINE=1`) skips writing
   Claude Code's `statusLine` / `subagentStatusLine`. A custom bar — in the
   project's `.claude/settings.json` or in `~/.claude/settings.json` — stays in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@
 
 ### Added
 
+- **A container language can carry SEVERAL embedded shapes, and Astro's client
+  `<script>` is the second one.** `ContainerLang.block`/`body` become
+  `embeds: EmbeddedBlock[]`, each with its own `block`/`body` pair, an opt-in
+  `nested` flag and an optional `accept` predicate. Astro needs all three: its
+  client code is a `script_element` → `raw_text`, a different node pair from the
+  fence, sitting inside the markup rather than at the root — three levels down in
+  a real layout — and a page can hold one 900-line block that is the whole of its
+  behaviour.
+
+  `nested` is per-shape rather than a change to the walk, because Vue's
+  `<script>` is always top-level and descending for it would newly index a
+  `<script>` written inside a `<template>` — a behaviour change to `.vue`
+  smuggled in with the Astro work. A test pins that Vue still ignores it.
+
+  `accept` exists for a subtler reason: **not every `<script>` holds code.**
+  `<script type="application/ld+json">` is structured data, and its body parses
+  as a perfectly good TypeScript block, so without a check the graph mints nodes
+  out of a JSON-LD blob. `isJavaScriptScript` reads the `type` attribute —
+  absent or valueless means JavaScript per the HTML spec, `module` /
+  `text/javascript` / `text/typescript` and friends are code, everything else
+  (`ld+json`, `importmap`, `speculationrules`) is data. A `type={dynamic}` that
+  cannot be read statically is treated as data: one un-indexed block beats
+  guessing at content we cannot see.
+
+  Blocks are now returned in **document order** across all shapes rather than
+  registry order. That is not cosmetic — ids are minted in the order blocks
+  arrive, so a name defined in both the fence and a script would otherwise get
+  its `~2` suffix based on how the registry happens to be written.
+
+  On the same repo as the entry above: 6,561 → **7,262 edges**, 2,808 → **3,120
+  nodes**, and a 20-line function 826 lines into a page's inline script now has
+  an exact span where it previously did not exist.
+
 - **Astro (`.astro`) joins the container tier**, the second row after Vue and the
   one its registry comment was holding open. The `---` frontmatter is the same
   shape as a Vue SFC's `<script>` with a different fence: `tree-sitter-astro`
@@ -21,12 +54,9 @@
   Frontmatter is where an Astro page's imports and server-side code live, so
   pages stop being invisible: a `lib` function's `callers` now names the pages
   that import it, and `graft grep` reaches `.astro` at all. Client `<script>`
-  blocks are deliberately still out — they nest inside the markup, and `blocks()`
-  walks the root's named children only, so reaching them needs a recursive walk
-  and a `block` that can name two node types. A file with only a client script
-  degrades to a file node; it never reports a wrong line. Svelte stays out of the
-  registry for the reason Astro just left it: nobody has verified its `body` node
-  against a real repo.
+  blocks follow in the entry below. Svelte stays out of the registry for the
+  reason Astro just left it: nobody has verified its `body` node against a real
+  repo.
 
 - **`graft init --no-statusline`** (and `GRAFT_NO_STATUSLINE=1`) skips writing
   Claude Code's `statusLine` / `subagentStatusLine`. A custom bar — in the

--- a/src/graph/container.ts
+++ b/src/graph/container.ts
@@ -186,9 +186,11 @@ const JS_SCRIPT_TYPES = new Set([
   "text/babel",
 ]);
 
-/** Read one attribute's value off a `start_tag`, or null when it is absent or
- * not a literal. Quoted and bare values differ by one nesting level, so both
- * shapes are walked rather than assumed. */
+/** Read one attribute's value off a `start_tag`: the empty string when the
+ * attribute is absent or carries no value, and null only when it is present but
+ * NOT A LITERAL (`type={expr}`) — the two cases mean different things to the
+ * caller. Quoted and bare values differ by one nesting level, so both shapes
+ * are walked rather than assumed. */
 function attrValue(tag: TsNode, name: string): string | null {
   const kids = tag.namedChildCount ?? 0;
   for (let i = 0; i < kids; i++) {
@@ -213,7 +215,10 @@ function attrValue(tag: TsNode, name: string): string | null {
       // An interpolated value (`type={expr}`) — present but not readable.
       return null;
     }
-    if (matched) return null; // bare `type` with no value at all
+    // A bare `type` with no value at all. HTML reads that as the empty string,
+    // and an empty `type` is a classic script — so it is JavaScript, not an
+    // unreadable value.
+    if (matched) return "";
   }
   return "";
 }

--- a/src/graph/container.ts
+++ b/src/graph/container.ts
@@ -29,20 +29,37 @@ import { loadWasmLanguage, parseWasm, type TsNode } from "./generic.js";
 import { contentHash } from "../util/id.js";
 import type { NodeV1 } from "./types.js";
 
-/** A container language: the wrapper grammar, the node that holds the embedded
+/** One shape of embedded block inside a container file. A language may carry
+ * several: an Astro page keeps its server code in `---` frontmatter and its
+ * client code in `<script>`, which are different node types in the same tree. */
+export interface EmbeddedBlock {
+  /** Wrapper node that represents one embedded block (Vue's `script_element`,
+   * Astro's `frontmatter`). */
+  block: string;
+  /** Child of `block` holding the raw embedded source (Vue's `raw_text`,
+   * Astro's `frontmatter_js_block`). */
+  body: string;
+  /** Search the whole tree instead of the root's named children. Opt-in per
+   * shape, not a change to how every container is walked: Astro's client
+   * `<script>` sits inside the markup — three levels down in a layout — while
+   * a Vue SFC's is always top-level, and letting the Vue row descend would
+   * newly index a `<script>` written inside a `<template>`. */
+  nested?: boolean;
+  /** Last chance to reject a block by its wrapper node, before its body is
+   * handed to the depth-tier extractor. */
+  accept?: (block: TsNode) => boolean;
+}
+
+/** A container language: the wrapper grammar, the nodes that hold the embedded
  * source, and which depth-tier extractor to hand that source to. */
 export interface ContainerLang {
   name: string;
   exts: string[];
   /** wasm basename in tree-sitter-wasms/out/tree-sitter-<wasm>.wasm */
   wasm: string;
-  /** Wrapper node that represents one embedded block, as a NAMED CHILD OF THE
-   * ROOT (Vue's `script_element`, Astro's `frontmatter`). Blocks nested deeper
-   * in the markup are not reached — see the Astro row below. */
-  block: string;
-  /** Child of `block` holding the raw embedded source (Vue's `raw_text`,
-   * Astro's `frontmatter_js_block`). */
-  body: string;
+  /** Every embedded shape, in no particular order — the blocks themselves are
+   * returned in document order regardless of which shape found them. */
+  embeds: readonly EmbeddedBlock[];
   /** Depth-tier grammar for the embedded language. TypeScript is a superset of
    * JavaScript, so it parses both `<script>` and `<script lang="ts">`. */
   inner: Language;
@@ -52,22 +69,29 @@ export interface ContainerLang {
  * it is left out until someone has a repo to verify it against — a wrong `body`
  * node type would produce silently misplaced spans.
  *
- * **Astro indexes its frontmatter, not its `<script>` tags**, and that is the
- * whole file as far as the graph is concerned: the `---` fence holds the
- * imports and the server-side code, so a page becomes a real graph root ("who
- * renders this component"). Client `<script>` blocks are deliberately out of
- * reach — `blocks()` walks the root's named children only, and an Astro
- * `<script>` is usually nested inside the markup (depth 3 in a layout), so
- * reaching them needs a recursive walk and a `block` that can name two node
- * types. Indexing half a file beats indexing none of it, and nothing here
- * reports a wrong line. */
+ * **Astro carries two shapes.** The `---` fence holds the imports and the
+ * server-side code; the client code lives in `<script>` tags nested inside the
+ * markup, which is why that row is `nested` — in a real layout they sit three
+ * levels down, and a page can hold one 900-line block that is the whole of its
+ * behaviour. Both feed the same TypeScript extractor and are returned in
+ * document order, so a name defined in both gets two nodes rather than one
+ * shadowing the other. */
 export const CONTAINER_LANGS: readonly ContainerLang[] = [
-  { name: "vue", exts: [".vue"], wasm: "vue", block: "script_element", body: "raw_text", inner: "typescript" },
+  { name: "vue", exts: [".vue"], wasm: "vue", embeds: [{ block: "script_element", body: "raw_text" }], inner: "typescript" },
   // `frontmatter_js_block` starts on the opening `---` row, exactly as Vue's
   // `raw_text` starts on its tag row, so the existing shift arithmetic applies
   // unchanged: slice line 1 is the tail of the fence line, and slice line N
   // lands on file line N + startPosition.row. Pinned by the tests below.
-  { name: "astro", exts: [".astro"], wasm: "astro", block: "frontmatter", body: "frontmatter_js_block", inner: "typescript" },
+  {
+    name: "astro",
+    exts: [".astro"],
+    wasm: "astro",
+    embeds: [
+      { block: "frontmatter", body: "frontmatter_js_block" },
+      { block: "script_element", body: "raw_text", nested: true, accept: isJavaScriptScript },
+    ],
+    inner: "typescript",
+  },
 ];
 
 const byExt = new Map<string, ContainerLang>();
@@ -141,25 +165,121 @@ function containerFileNode(rel: string, source: string, residual: string): NodeV
   };
 }
 
-/** Every embedded block in document order, as [bodyNode] — an SFC may legally
- * carry two (`<script>` for options/exports plus `<script setup>`), and each
- * needs its own offset. */
-function blocks(root: TsNode, lang: ContainerLang): TsNode[] {
-  const out: TsNode[] = [];
-  const n = root.namedChildCount ?? 0;
-  for (let i = 0; i < n; i++) {
-    const child = root.namedChild?.(i);
-    if (!child || child.type !== lang.block) continue;
-    const kids = child.namedChildCount ?? 0;
-    for (let j = 0; j < kids; j++) {
-      const body = child.namedChild?.(j);
-      // An empty `<script></script>` has no body child at all — skipped here, so
-      // the file still gets its file node and nothing else, which is the same
-      // shape as a file whose grammar is missing.
-      if (body && body.type === lang.body) out.push(body);
+/** `<script>` types that mean JavaScript. A tag with no `type` is JS by the
+ * HTML spec; `application/ld+json`, `importmap` and `speculationrules` are DATA
+ * wearing a script tag. The depth-tier extractor would happily parse a JSON-LD
+ * body — `{"@type": "Organization"}` is a syntactically fine TypeScript block —
+ * and mint nodes out of a structured-data blob no reader thinks of as code.
+ *
+ * An unreadable type (`type={dynamic}`) is treated as not-JavaScript: the cost
+ * is one un-indexed block, and the alternative is guessing at content we cannot
+ * see. */
+const JS_SCRIPT_TYPES = new Set([
+  "module",
+  "text/javascript",
+  "application/javascript",
+  "text/ecmascript",
+  "application/ecmascript",
+  "text/typescript",
+  "application/typescript",
+  "text/jsx",
+  "text/babel",
+]);
+
+/** Read one attribute's value off a `start_tag`, or null when it is absent or
+ * not a literal. Quoted and bare values differ by one nesting level, so both
+ * shapes are walked rather than assumed. */
+function attrValue(tag: TsNode, name: string): string | null {
+  const kids = tag.namedChildCount ?? 0;
+  for (let i = 0; i < kids; i++) {
+    const attr = tag.namedChild?.(i);
+    if (!attr || attr.type !== "attribute") continue;
+    const parts = attr.namedChildCount ?? 0;
+    let matched = false;
+    for (let j = 0; j < parts; j++) {
+      const part = attr.namedChild?.(j);
+      if (!part) continue;
+      if (part.type === "attribute_name") {
+        matched = part.text.toLowerCase() === name;
+        if (!matched) break;
+        continue;
+      }
+      if (!matched) continue;
+      if (part.type === "attribute_value") return part.text;
+      if (part.type === "quoted_attribute_value") {
+        const inner = part.namedChild?.(0);
+        return inner?.type === "attribute_value" ? inner.text : "";
+      }
+      // An interpolated value (`type={expr}`) — present but not readable.
+      return null;
+    }
+    if (matched) return null; // bare `type` with no value at all
+  }
+  return "";
+}
+
+/** True when a `<script>` element holds JavaScript rather than embedded data. */
+export function isJavaScriptScript(script: TsNode): boolean {
+  const tag = script.namedChild?.(0);
+  if (!tag) return false;
+  const type = attrValue(tag, "type");
+  if (type === null) return false; // present but not a literal
+  if (type === "") return true; // absent, or valueless: JS by default
+  return JS_SCRIPT_TYPES.has(type.trim().toLowerCase());
+}
+
+/** Every node of `type` in the tree, pre-order. Used only for `nested` shapes;
+ * a top-level shape stays a single pass over the root's children so the walk
+ * cost is unchanged for `.vue`. */
+function descendants(root: TsNode, type: string): TsNode[] {
+  const found: TsNode[] = [];
+  const stack: TsNode[] = [root];
+  while (stack.length) {
+    const node = stack.pop()!;
+    if (node !== root && node.type === type) found.push(node);
+    const kids = node.namedChildCount ?? 0;
+    for (let i = kids - 1; i >= 0; i--) {
+      const child = node.namedChild?.(i);
+      if (child) stack.push(child);
     }
   }
-  return out;
+  return found;
+}
+
+/** Every embedded block in DOCUMENT ORDER, as [bodyNode] — an SFC may legally
+ * carry two (`<script>` for options/exports plus `<script setup>`), an Astro
+ * page carries a fence plus any number of `<script>` tags, and each needs its
+ * own offset.
+ *
+ * Document order is not cosmetic: `extractContainer` mints ids in the order it
+ * receives blocks, so a duplicate name's `~2` suffix would otherwise depend on
+ * the order the shapes happen to be listed in the registry. */
+function blocks(root: TsNode, lang: ContainerLang): TsNode[] {
+  const found: TsNode[] = [];
+  for (const embed of lang.embeds) {
+    const hosts: TsNode[] = [];
+    if (embed.nested) {
+      hosts.push(...descendants(root, embed.block));
+    } else {
+      const n = root.namedChildCount ?? 0;
+      for (let i = 0; i < n; i++) {
+        const child = root.namedChild?.(i);
+        if (child && child.type === embed.block) hosts.push(child);
+      }
+    }
+    for (const host of hosts) {
+      if (embed.accept && !embed.accept(host)) continue;
+      const kids = host.namedChildCount ?? 0;
+      for (let j = 0; j < kids; j++) {
+        const body = host.namedChild?.(j);
+        // An empty `<script></script>` has no body child at all — skipped here, so
+        // the file still gets its file node and nothing else, which is the same
+        // shape as a file whose grammar is missing.
+        if (body && body.type === embed.body) found.push(body);
+      }
+    }
+  }
+  return found.sort((a, b) => a.startIndex - b.startIndex);
 }
 
 /**

--- a/src/graph/container.ts
+++ b/src/graph/container.ts
@@ -7,6 +7,9 @@
  * shell (`<template>` / `<script>` / `<style>`) and hands back the script body as
  * one opaque `raw_text` node, so the cards would come out empty.
  *
+ * Astro's `---` frontmatter is the same shape with a different fence: the
+ * grammar hands back one `frontmatter_js_block` holding TypeScript.
+ *
  * So the container grammar is used only to answer "where does the embedded
  * language start and end", and the block itself goes to the DEPTH-tier extractor
  * (extract.ts). A `.vue` file therefore gets the same quality of extraction as a
@@ -33,20 +36,38 @@ export interface ContainerLang {
   exts: string[];
   /** wasm basename in tree-sitter-wasms/out/tree-sitter-<wasm>.wasm */
   wasm: string;
-  /** Wrapper node that represents one embedded block (e.g. Vue's script_element). */
+  /** Wrapper node that represents one embedded block, as a NAMED CHILD OF THE
+   * ROOT (Vue's `script_element`, Astro's `frontmatter`). Blocks nested deeper
+   * in the markup are not reached — see the Astro row below. */
   block: string;
-  /** Child of `block` holding the raw embedded source (e.g. Vue's raw_text). */
+  /** Child of `block` holding the raw embedded source (Vue's `raw_text`,
+   * Astro's `frontmatter_js_block`). */
   body: string;
   /** Depth-tier grammar for the embedded language. TypeScript is a superset of
    * JavaScript, so it parses both `<script>` and `<script lang="ts">`. */
   inner: Language;
 }
 
-/** The container registry. Svelte and Astro are the same shape and would be a
- * row each, but they are left out until someone has a repo to verify them
- * against — a wrong `body` node type would produce silently misplaced spans. */
+/** The container registry. Svelte is the same shape and would be a row too, but
+ * it is left out until someone has a repo to verify it against — a wrong `body`
+ * node type would produce silently misplaced spans.
+ *
+ * **Astro indexes its frontmatter, not its `<script>` tags**, and that is the
+ * whole file as far as the graph is concerned: the `---` fence holds the
+ * imports and the server-side code, so a page becomes a real graph root ("who
+ * renders this component"). Client `<script>` blocks are deliberately out of
+ * reach — `blocks()` walks the root's named children only, and an Astro
+ * `<script>` is usually nested inside the markup (depth 3 in a layout), so
+ * reaching them needs a recursive walk and a `block` that can name two node
+ * types. Indexing half a file beats indexing none of it, and nothing here
+ * reports a wrong line. */
 export const CONTAINER_LANGS: readonly ContainerLang[] = [
   { name: "vue", exts: [".vue"], wasm: "vue", block: "script_element", body: "raw_text", inner: "typescript" },
+  // `frontmatter_js_block` starts on the opening `---` row, exactly as Vue's
+  // `raw_text` starts on its tag row, so the existing shift arithmetic applies
+  // unchanged: slice line 1 is the tail of the fence line, and slice line N
+  // lands on file line N + startPosition.row. Pinned by the tests below.
+  { name: "astro", exts: [".astro"], wasm: "astro", block: "frontmatter", body: "frontmatter_js_block", inner: "typescript" },
 ];
 
 const byExt = new Map<string, ContainerLang>();

--- a/test/container-extract.test.ts
+++ b/test/container-extract.test.ts
@@ -23,7 +23,9 @@ import {
   containerLangOf,
   containerExtensions,
   isContainerWarm,
+  isJavaScriptScript,
 } from "../src/graph/container.js";
+import { loadWasmLanguage, parseWasm, type TsNode } from "../src/graph/generic.js";
 import { supportedExtensions } from "../src/graph/source-files.js";
 import { buildGraph } from "../src/graph/build.js";
 import { checkGraph } from "../src/graph/check.js";
@@ -562,4 +564,58 @@ test("container: Vue does not descend into the template — nesting is opt-in pe
   const { nodes } = extractContainer("Nested.vue", sfc(lines), VUE);
   assert.equal(nodes.length, 1, "file node only");
   assert.ok(!nodes.some((n) => n.name === "inTemplate"));
+});
+
+/** The first `script_element` in a parsed snippet. Only `isJavaScriptScript`
+ * needs one directly — every other test goes through `extractContainer`,
+ * because what matters there is which spans come back, not which node was
+ * handed to which helper. */
+async function firstScriptElement(markup: string): Promise<TsNode> {
+  const language = await loadWasmLanguage("astro");
+  assert.ok(language, "astro grammar must be available in tree-sitter-wasms");
+  const root = parseWasm(language, markup);
+  assert.ok(root, "snippet must parse");
+  const stack: TsNode[] = [root];
+  while (stack.length) {
+    const node = stack.pop()!;
+    if (node.type === "script_element") return node;
+    for (let i = (node.namedChildCount ?? 0) - 1; i >= 0; i--) {
+      const child = node.namedChild?.(i);
+      if (child) stack.push(child);
+    }
+  }
+  throw new Error(`no script_element in: ${markup}`);
+}
+
+test("container: isJavaScriptScript classifies a <script> by its type attribute", async () => {
+  // The predicate's own truth table, asserted directly. The extraction-level
+  // test above covers the same ground behaviourally; this one exists so the
+  // rule is legible as a rule, and so a future `type` value can be added here
+  // without reasoning about spans.
+  for (const [tag, isJs] of [
+    ["<script>", true],
+    ["<script is:inline>", true],
+    ["<script defer async>", true],
+    ['<script src="/boot.js">', true],
+    ["<script type>", true],
+    ['<script type="">', true],
+    ['<script type="module">', true],
+    ["<script type=module>", true],
+    ['<script type="MODULE">', true],
+    ['<script type=" text/javascript ">', true],
+    ['<script type="application/javascript">', true],
+    ['<script type="text/typescript">', true],
+    ['<script type="application/ld+json">', false],
+    ['<script type="application/json">', false],
+    ["<script type=application/json>", false],
+    ['<script type="importmap">', false],
+    ['<script type="speculationrules">', false],
+    ['<script type="text/plain">', false],
+    // Present but not readable without evaluating the expression. Treated as
+    // data: one un-indexed block beats guessing at content we cannot see.
+    ["<script type={contentType}>", false],
+  ] as const) {
+    const node = await firstScriptElement(`<div>${tag}const x = 1;</script></div>`);
+    assert.equal(isJavaScriptScript(node), isJs, `${tag} should be ${isJs ? "" : "not "}JavaScript`);
+  }
 });

--- a/test/container-extract.test.ts
+++ b/test/container-extract.test.ts
@@ -30,6 +30,11 @@ import { checkGraph } from "../src/graph/check.js";
 import { readGraph, wiringPath } from "../src/graph/write.js";
 
 const VUE = containerLangOf("Any.vue")!;
+const ASTRO = containerLangOf("Any.astro")!;
+
+/** Same contract as `sfc`, named for the Astro fixtures so the two fixture
+ * shapes are not confused when a test fails. */
+const astro = sfc;
 
 /** Line N of the fixture is `lines[N - 1]` — that is the whole point. */
 function sfc(lines: string[]): string {
@@ -289,4 +294,127 @@ test("container: a clean build of a .vue file checks as in sync", async () => {
   assert.deepEqual(check.added, []);
   assert.deepEqual(check.changed, []);
   assert.equal(check.ok, true, "a clean build checks OK");
+});
+
+/* ---------------------------------------------------------------------------
+ * Astro. Same tier, different fence: the embedded block is the `---`
+ * frontmatter (`frontmatter` → `frontmatter_js_block`) rather than a
+ * `<script>` element, and it holds TypeScript.
+ *
+ * Frontmatter usually opens on line 1, which makes the offset 0 — the case a
+ * naive implementation passes. The tests below therefore lead with a fixture
+ * whose fence is pushed down the file, because that is the one that fails when
+ * the shift is dropped.
+ * ------------------------------------------------------------------------- */
+
+test("container: registry claims .astro and reports it as supported", () => {
+  assert.equal(containerLangOf("src/pages/index.astro")?.name, "astro");
+  assert.equal(containerLangOf("src/pages/Index.ASTRO")?.name, "astro", "extension match is case-insensitive");
+  assert.ok(containerExtensions().includes(".astro"));
+  assert.ok(supportedExtensions().includes(".astro"), ".astro must be in the -e supported set");
+});
+
+test("container: spans point at the .astro line, not the frontmatter line", async () => {
+  await warmContainerGrammars(["astro"]);
+  assert.ok(isContainerWarm("astro"), "astro grammar must be available in tree-sitter-wasms");
+
+  const lines = [
+    "<!-- a comment above the fence pushes it down the file -->", //  1
+    "---",                                                        //  2
+    'import Card from "../components/Card.astro";',               //  3
+    "",                                                           //  4
+    "const rows = await load();",                                 //  5
+    "",                                                           //  6
+    "export function shout(what: string) {",                      //  7
+    "  return what.toUpperCase();",                               //  8
+    "}",                                                          //  9
+    "---",                                                        // 10
+    "<main>",                                                     // 11
+    "  <Card rows={rows} />",                                     // 12
+    "</main>",                                                    // 13
+  ];
+
+  const { nodes } = extractContainer("pages/index.astro", astro(lines), ASTRO);
+
+  // Line 7 in the file; line 6 inside the frontmatter block. Getting 6 here
+  // would be the exact failure this tier exists to avoid.
+  assert.equal(spanOf(nodes, "shout"), "L7-L9");
+});
+
+test("container: a fence at the top of the file still lands right", async () => {
+  await warmContainerGrammars(["astro"]);
+
+  const lines = [
+    "---",                          // 1
+    "export function first() {}",   // 2
+    "---",                          // 3
+    "<b />",                        // 4
+  ];
+
+  // Offset 0 — the shape almost every real .astro file has, and the one a fix
+  // for the previous test could break.
+  assert.equal(spanOf(extractContainer("A.astro", astro(lines), ASTRO).nodes, "first"), "L2-L2");
+});
+
+test("container: multi-byte characters inside the frontmatter do not shift the spans", async () => {
+  await warmContainerGrammars(["astro"]);
+
+  // Cyrillic and an emoji above the symbol: if the slice were taken by byte
+  // offset against a UTF-16 string, the block would be cut in the wrong place
+  // and the symbol would move or vanish.
+  const lines = [
+    "---",                                        // 1
+    'const title = "Поход в горы 🥾";',           // 2
+    'const note = "Регламент участия";',          // 3
+    "export function label() {",                  // 4
+    "  return title;",                            // 5
+    "}",                                          // 6
+    "---",                                        // 7
+    "<h1>{title}</h1>",                           // 8
+  ];
+
+  assert.equal(spanOf(extractContainer("Ru.astro", astro(lines), ASTRO).nodes, "label"), "L4-L6");
+});
+
+test("container: the file node describes the .astro, not the frontmatter block", async () => {
+  await warmContainerGrammars(["astro"]);
+
+  const lines = [
+    "---",                            // 1
+    "const x = 1;",                   // 2
+    "---",                            // 3
+    "<main>",                         // 4
+    "  <p>{x}</p>",                   // 5
+    "</main>",                        // 6
+    "<style>.a{color:red}</style>",   // 7
+  ];
+  const source = astro(lines);
+
+  const { nodes } = extractContainer("Card.astro", source, ASTRO);
+  const file = nodes[0];
+
+  assert.equal(file.kind, "file");
+  assert.equal(file.id, "Card.astro");
+  assert.equal(file.span, "L1-L8", "spans the whole component, markup and style included");
+  assert.equal(file.chars, source.length);
+  assert.equal(file.origin, "ast");
+});
+
+test("container: an .astro with no usable frontmatter degrades to a file node", async () => {
+  await warmContainerGrammars(["astro"]);
+
+  for (const [label, lines] of [
+    ["no frontmatter at all", ["<main>", "  <p>static</p>", "</main>"]],
+    ["empty frontmatter", ["---", "---", "<p />"]],
+    // The known limit of this row: client `<script>` blocks are nested in the
+    // markup, and `blocks()` only walks the root's named children. Pinned so
+    // the behaviour is a decision rather than a surprise — note it degrades to
+    // "not indexed", never to a wrong line.
+    ["client script only", ["<main>", "  <script>", "    function boot() {}", "  </script>", "</main>"]],
+  ] as const) {
+    const { nodes, rawEdges } = extractContainer("Empty.astro", astro([...lines]), ASTRO);
+    assert.equal(nodes.length, 1, `${label}: file node only`);
+    assert.equal(nodes[0].kind, "file");
+    assert.equal(rawEdges.length, 0, `${label}: no edges`);
+  }
 });

--- a/test/container-extract.test.ts
+++ b/test/container-extract.test.ts
@@ -406,15 +406,160 @@ test("container: an .astro with no usable frontmatter degrades to a file node", 
   for (const [label, lines] of [
     ["no frontmatter at all", ["<main>", "  <p>static</p>", "</main>"]],
     ["empty frontmatter", ["---", "---", "<p />"]],
-    // The known limit of this row: client `<script>` blocks are nested in the
-    // markup, and `blocks()` only walks the root's named children. Pinned so
-    // the behaviour is a decision rather than a surprise — note it degrades to
-    // "not indexed", never to a wrong line.
-    ["client script only", ["<main>", "  <script>", "    function boot() {}", "  </script>", "</main>"]],
+    // A `<script src>` has an empty `raw_text`, not a missing one: the block is
+    // found and handed over, and the inner extractor returns nothing from it.
+    ["external script only", ["<main>", '  <script src="/boot.js"></script>', "</main>"]],
   ] as const) {
     const { nodes, rawEdges } = extractContainer("Empty.astro", astro([...lines]), ASTRO);
     assert.equal(nodes.length, 1, `${label}: file node only`);
     assert.equal(nodes[0].kind, "file");
     assert.equal(rawEdges.length, 0, `${label}: no edges`);
   }
+});
+
+/* ---------------------------------------------------------------------------
+ * Astro client `<script>`: the second embedded shape. Nested in the markup
+ * rather than at the root, and living in the same tree as the frontmatter, so
+ * the risks are (a) the offset, again, now with a much larger shift, and
+ * (b) document order across two different node types.
+ * ------------------------------------------------------------------------- */
+
+test("container: a client <script> nested in the markup is extracted", async () => {
+  await warmContainerGrammars(["astro"]);
+
+  const lines = [
+    "---",                                    //  1
+    "const title = 'hi';",                    //  2
+    "---",                                    //  3
+    "<main>",                                 //  4
+    "  <section>",                            //  5
+    "    <p>{title}</p>",                     //  6
+    "    <script>",                           //  7
+    "      export function boot() {",         //  8
+    "        return 1;",                      //  9
+    "      }",                                // 10
+    "    </script>",                          // 11
+    "  </section>",                           // 12
+    "</main>",                                // 13
+  ];
+
+  // Three levels down, and 7 lines below the fence: the offset here is neither
+  // zero nor the frontmatter's.
+  assert.equal(spanOf(extractContainer("Deep.astro", astro(lines), ASTRO).nodes, "boot"), "L8-L10");
+});
+
+test("container: fence and scripts come back in document order, each with its own offset", async () => {
+  await warmContainerGrammars(["astro"]);
+
+  const lines = [
+    "---",                              //  1
+    "export function fromFence() {}",   //  2
+    "---",                              //  3
+    "<script>",                         //  4
+    "function firstScript() {}",        //  5
+    "</script>",                        //  6
+    "<p>between</p>",                   //  7
+    "<script>",                         //  8
+    "function secondScript() {}",       //  9
+    "</script>",                        // 10
+  ];
+
+  const { nodes } = extractContainer("Order.astro", astro(lines), ASTRO);
+  assert.equal(spanOf(nodes, "fromFence"), "L2-L2");
+  assert.equal(spanOf(nodes, "firstScript"), "L5-L5");
+  assert.equal(spanOf(nodes, "secondScript"), "L9-L9");
+  assert.equal(nodes.filter((n) => n.kind === "file").length, 1, "exactly one file node");
+});
+
+test("container: a name defined in both the fence and a script gets two nodes", async () => {
+  await warmContainerGrammars(["astro"]);
+
+  const lines = [
+    "---",                    // 1
+    "function dup() {}",      // 2
+    "---",                    // 3
+    "<script>",               // 4
+    "function dup() {}",      // 5
+    "</script>",              // 6
+  ];
+
+  const { nodes, rawEdges } = extractContainer("Dup.astro", astro(lines), ASTRO);
+  const dups = nodes.filter((n) => n.name === "dup");
+
+  assert.equal(dups.length, 2, "both definitions survive");
+  assert.equal(new Set(dups.map((n) => n.id)).size, 2, "ids are distinct");
+  assert.deepEqual(dups.map((n) => n.span).sort(), ["L2-L2", "L5-L5"]);
+
+  const ids = new Set(nodes.map((n) => n.id));
+  for (const e of rawEdges) {
+    assert.ok(ids.has(e.source), `edge source ${e.source} has no node`);
+    if (e.targetId) assert.ok(ids.has(e.targetId), `edge target ${e.targetId} has no node`);
+  }
+});
+
+test("container: a <script> holding data, not code, is left alone", async () => {
+  await warmContainerGrammars(["astro"]);
+
+  // JSON-LD parses fine as a TypeScript block, so nothing downstream would
+  // complain — it would just mint nodes out of a structured-data blob.
+  const lines = [
+    "<head>",                                             //  1
+    '  <script type="application/ld+json">',              //  2
+    '    {"@type": "Organization", "name": "Acme"}',      //  3
+    "  </script>",                                        //  4
+    "  <script type=application/json>",                   //  5
+    '    {"a": 1}',                                       //  6
+    "  </script>",                                        //  7
+    '  <script type="module">',                           //  8
+    "    export function real() {}",                      //  9
+    "  </script>",                                        // 10
+    "</head>",                                            // 11
+  ];
+
+  const { nodes } = extractContainer("Data.astro", astro(lines), ASTRO);
+  assert.equal(spanOf(nodes, "real"), "L9-L9", 'type="module" is JavaScript and is indexed');
+  assert.equal(nodes.length, 2, "the file node and `real` — the two data blocks contribute nothing");
+});
+
+test("container: isJavaScriptScript reads the type attribute, defaulting to JS", async () => {
+  await warmContainerGrammars(["astro"]);
+
+  // Exercised through extraction rather than by hand-building nodes, so the
+  // assertion is about behaviour and not about a helper's signature.
+  for (const [tag, indexed] of [
+    ["<script>", true],
+    ['<script is:inline>', true],
+    ['<script type="module">', true],
+    ["<script type=text/javascript>", true],
+    ['<script type="text/typescript">', true],
+    ['<script type="application/ld+json">', false],
+    ['<script type="importmap">', false],
+    ['<script type="speculationrules">', false],
+    ["<script type={dynamic}>", false],
+  ] as const) {
+    const { nodes } = extractContainer("T.astro", astro(["<div>", `  ${tag}`, "  function probe() {}", "  </script>", "</div>"]), ASTRO);
+    const hit = nodes.some((n) => n.name === "probe");
+    assert.equal(hit, indexed, `${tag} should ${indexed ? "" : "not "}be indexed`);
+  }
+});
+
+test("container: Vue does not descend into the template — nesting is opt-in per shape", async () => {
+  await warmContainerGrammars(["vue"]);
+
+  // Astro's row is `nested`; Vue's is not. A <script> written inside a Vue
+  // template is markup the framework never runs as a module, and indexing it
+  // would be a behaviour change to `.vue` smuggled in with the Astro work.
+  const lines = [
+    "<template>",                     // 1
+    "  <div>",                        // 2
+    "    <script>",                   // 3
+    "      function inTemplate() {}", // 4
+    "    </script>",                  // 5
+    "  </div>",                       // 6
+    "</template>",                    // 7
+  ];
+
+  const { nodes } = extractContainer("Nested.vue", sfc(lines), VUE);
+  assert.equal(nodes.length, 1, "file node only");
+  assert.ok(!nodes.some((n) => n.name === "inTemplate"));
 });


### PR DESCRIPTION
> Stacked on #271 — the container row for Astro. Please merge that first; this branch contains its commit and the diff here will shrink to one commit once it lands.

## What

The fence was half the file. An Astro page's *client* behaviour lives in `<script>` tags inside the markup — in the repo this was verified against, one page keeps a **900-line block** there and a layout has four of them at **depth 3** — and none of it was reachable, because `blocks()` walked the root's named children looking for a single `block`/`body` pair.

`ContainerLang` now carries `embeds: EmbeddedBlock[]`, so a language can declare several shapes:

```js
{
  name: "astro", exts: [".astro"], wasm: "astro",
  embeds: [
    { block: "frontmatter",    body: "frontmatter_js_block" },
    { block: "script_element", body: "raw_text", nested: true, accept: isJavaScriptScript },
  ],
  inner: "typescript",
}
```

Vue becomes `embeds: [{ block: "script_element", body: "raw_text" }]` — same behaviour, one indirection.

## Three decisions worth reviewing

**`nested` is opt-in per shape, not a change to the walk.** A Vue SFC's `<script>` is always top-level. Descending for it would newly index a `<script>` written inside a `<template>` — a `.vue` behaviour change smuggled in with the Astro work. There's a test pinning that Vue still ignores it.

**`accept` exists because not every `<script>` holds code.** `<script type="application/ld+json">` is structured data, and its body — `{"@type": "Organization"}` — parses as a perfectly valid TypeScript block, so without a check the graph mints nodes out of a JSON-LD blob and nothing downstream complains. `isJavaScriptScript` reads the `type` attribute: absent or valueless is JavaScript per the HTML spec; `module` / `text/javascript` / `text/typescript` and friends are code; `ld+json`, `importmap`, `speculationrules` are not. A `type={dynamic}` that can't be read statically is treated as data — one un-indexed block beats guessing at content we cannot see.

**Blocks now come back in document order across shapes**, not registry order. Not cosmetic: `extractContainer` mints ids in arrival order, so a name defined in both the fence and a script would otherwise take its `~2` suffix from however the registry happens to be written.

## Verification

Six new tests (22 in the file, `npm test` = **1170 tests, 0 failures**): a script three levels down with a non-zero, non-frontmatter offset; document order and per-block offsets across a fence and two scripts; duplicate names across shapes; the JSON-LD/`importmap`/dynamic-type matrix; and the Vue non-descent regression.

Spans were also checked by hand against real source rather than only against fixtures:

| symbol | reported | actual |
|---|---|---|
| `reclassifyHikes` | `[lang]/hikes/index.astro:L826-L845` | line 826 of a 2,114-line page ✓ |
| `loadMoreActivity` | `admin/UserProfileModal.astro:L2165-L2201` | line 2165 of a 2,596-line component ✓ |

On that repo, over #271: **2,808 → 3,120 nodes, 6,561 → 7,262 edges**, functions 1,641 → 1,906, methods 64 → 95. `reclassifyHikes` answered "no hits in 486 indexed files" before this work started.

## Still out

Component usage in the markup (`<Card />`) is not a call in any script block, so it still produces no edge — "who renders this component" remains unanswerable for Astro. That needs the markup itself modelled, which is a different tier of work.
