### PR TITLE
fix(deep): chunk crux calls for symbol-dense files (#260)

### DIFF
--- a/src/ai/crux.ts
+++ b/src/ai/crux.ts
@@ -1,8 +1,10 @@
 /**
- * Tier-2 "meaning" call for the code graph — batched one request per file.
+ * Tier-2 "meaning" call for the code graph — batched per file, chunked by symbol
+ * count so a dense file cannot blow `maxTokens` and drop the whole reply (#260).
  *
  * Given a source file (with 1-based line numbers) and the list of definitions in
- * it, one call returns, for each definition:
+ * it, one call (or several chunks of {@link CRUX_CHUNK_SIZE}) returns, for each
+ * definition:
  *   1. `summary` — one plain-English sentence: what the symbol is *for*, at the
  *      business-logic level, not a restatement of its signature.
  *   2. `crux_start`/`crux_end` — the smallest contiguous range of FILE line
@@ -10,9 +12,10 @@
  *      the decision or rule the code encodes. `0/0` means there is no single
  *      crux (a trivial getter, a plain data holder).
  *
- * Batching per file means N definitions cost one request, not N — and the model
- * sees each symbol's neighbours, which sharpens the summaries. Line numbers are
- * consumed once, at write time, to slice the crux text verbatim from source.
+ * Small files still cost one request. Files denser than {@link CRUX_CHUNK_SIZE}
+ * are split, the chunks merged, and a `finish_reason=length` stop is logged
+ * instead of silently discarding every target. Line numbers are consumed once,
+ * at write time, to slice the crux text verbatim from source.
  */
 import type { ChatModel, ChatResponse } from "./llm/types.js";
 import { recoverToolArgsFromContent, warnToolChoiceIgnored } from "./llm/recover-tool.js";
@@ -78,6 +81,19 @@ export function formatCruxMiss(kind: CruxMissKind, finishReason: string | null):
   return `model returned no usable symbol summaries [${kind}, finish_reason=${fr}]`;
 }
 
+/** One stderr line when a crux call stopped because the completion hit maxTokens (#260). */
+function warnCruxTruncated(
+  path: string,
+  requested: number,
+  parsed: number,
+  finishReason: string | null,
+): void {
+  const fr = finishReason == null || finishReason === "" ? "null" : finishReason;
+  console.error(
+    `⚠ crux: ${path}: truncated tool response [finish_reason=${fr}] for ${requested} targets (${parsed} parsed) — keeping any other chunks instead of dropping the file`,
+  );
+}
+
 const SYSTEM_PROMPT = `You explain code definitions for a code graph that helps engineers navigate a codebase.
 
 You are given ONE source file with 1-based line numbers, and a list of TARGET definitions in it. Describe EVERY target via the record_symbols tool.
@@ -109,6 +125,21 @@ const SYMBOLS_SCHEMA = {
   },
   required: ["symbols"],
 } as const;
+
+/**
+ * Max targets packed into one crux LLM call (#260). At ~90 completion tokens per
+ * entry, 80 × 90 stays under `maxTokens: 8192`. A file with more symbols is split
+ * and the chunks merged; raising maxTokens cannot cover a 698-symbol file.
+ * Pinned by `test/crux-chunk.test.ts` — do not raise it silently.
+ */
+export const CRUX_CHUNK_SIZE = 80;
+
+/** Split `nodes` into batches of at most `size` (default {@link CRUX_CHUNK_SIZE}). */
+export function chunkCruxTargets<T>(nodes: readonly T[], size = CRUX_CHUNK_SIZE): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < nodes.length; i += size) out.push(nodes.slice(i, i + size));
+  return out;
+}
 
 /** Cap the file text sent per request so one huge file can't blow the context. */
 const MAX_CODE_CHARS = 18_000;
@@ -180,6 +211,29 @@ export class ChatCruxSummarizer implements CruxSummarizer {
   async describeFile(input: FileCruxInput): Promise<NodeCrux[]> {
     this.lastMiss = null;
     if (input.nodes.length === 0) return [];
+    const merged: NodeCrux[] = [];
+    const seen = new Set<string>();
+    let miss: CruxMiss | null = null;
+
+    for (const nodes of chunkCruxTargets(input.nodes)) {
+      const { parsed, res } = await this.describeChunk({ ...input, nodes });
+      if (isTruncatedStop(res.stopReason)) {
+        warnCruxTruncated(input.path, nodes.length, parsed.length, res.stopReason);
+      }
+      const chunkMiss = classifyCruxMiss(res, parsed);
+      if (chunkMiss) miss = chunkMiss;
+      for (const r of parsed) {
+        if (seen.has(r.id)) continue;
+        seen.add(r.id);
+        merged.push(r);
+      }
+    }
+
+    this.lastMiss = merged.some((p) => p.summary.trim()) ? null : miss;
+    return merged;
+  }
+
+  private async describeChunk(input: FileCruxInput): Promise<{ parsed: NodeCrux[]; res: ChatResponse }> {
     const res = await this.model.create({
       temperature: 0,
       maxTokens: 8192,
@@ -196,8 +250,6 @@ export class ChatCruxSummarizer implements CruxSummarizer {
         { role: "user", content: userContent(input) },
       ],
     });
-    const parsed = parseResults(argsFromResponse(res));
-    this.lastMiss = classifyCruxMiss(res, parsed);
-    return parsed;
+    return { parsed: parseResults(argsFromResponse(res)), res };
   }
 }

--- a/test/crux-chunk.test.ts
+++ b/test/crux-chunk.test.ts
@@ -1,0 +1,244 @@
+/**
+ * #260: one crux call per file hits maxTokens (~8192) around 125 symbols. The
+ * adapter's JSON.parse of the truncated tool arguments fails, parseResults
+ * returns [], and the whole file is dropped. Re-running --deep hits the same
+ * ceiling, so those files stay failed forever.
+ *
+ * Fix: chunk targets at {@link CRUX_CHUNK_SIZE} (pinned here; not a silent 125),
+ * merge chunk results, and log truncation instead of swallowing it. Small files
+ * still cost one call. Empty chunks must not be cached as ready (#177).
+ *
+ * All of this is a fake ChatModel — no provider key, no network.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { ChatCruxSummarizer, chunkCruxTargets, CRUX_CHUNK_SIZE } from "../src/ai/crux.js";
+import { enrichGraph } from "../src/graph/enrich.js";
+import type { ChatModel, ChatRequest, ChatResponse, ToolCall } from "../src/ai/llm/types.js";
+import type { FileCruxInput, NodeRef } from "../src/ai/crux.js";
+import type { NodeV1 } from "../src/graph/types.js";
+
+/** Observed production cliff from #260 — test-only. Production chunks at CRUX_CHUNK_SIZE. */
+const TRUNCATE_ABOVE = 125;
+const DENSE = 200;
+
+test("#260: CRUX_CHUNK_SIZE is pinned and dense files split, small files do not", () => {
+  assert.equal(CRUX_CHUNK_SIZE, 80);
+  assert.ok(CRUX_CHUNK_SIZE < TRUNCATE_ABOVE, "chunk size must sit under the observed truncation cliff");
+  assert.deepEqual(
+    chunkCruxTargets(Array.from({ length: 80 }, (_, i) => i)).map((c) => c.length),
+    [80],
+  );
+  assert.deepEqual(
+    chunkCruxTargets(Array.from({ length: 81 }, (_, i) => i)).map((c) => c.length),
+    [80, 1],
+  );
+  assert.deepEqual(
+    chunkCruxTargets(Array.from({ length: DENSE }, (_, i) => i)).map((c) => c.length),
+    [80, 80, 40],
+  );
+  assert.deepEqual(chunkCruxTargets([]), []);
+});
+
+test("#260: a 200-symbol file truncated in one call is not silently dropped", async () => {
+  const model = new CeilingModel();
+  const { result, err } = await withCapturedError(() =>
+    new ChatCruxSummarizer(model).describeFile(denseInput(DENSE)),
+  );
+
+  assert.ok(result.length > 0, "chunking must keep at least some summaries instead of dropping the file");
+  assert.equal(result.length, DENSE, "every target in a dense file should come back once chunks fit under the cliff");
+  assert.ok(model.calls >= 2, `dense file must take more than one LLM call, saw ${model.calls}`);
+  assert.ok(
+    model.sizes.every((n) => n <= CRUX_CHUNK_SIZE),
+    `every call must pack ≤ ${CRUX_CHUNK_SIZE} targets, saw ${model.sizes.join(",")}`,
+  );
+  assert.equal(err.filter((l) => /truncated/i.test(l)).length, 0, "successful chunks must not log truncation");
+});
+
+test("#260: a small file is still one LLM call", async () => {
+  const model = new CeilingModel();
+  const out = await new ChatCruxSummarizer(model).describeFile(denseInput(5));
+  assert.equal(out.length, 5);
+  assert.equal(model.calls, 1);
+  assert.deepEqual(model.sizes, [5]);
+});
+
+test("#260: finish_reason=length is logged, not swallowed", async () => {
+  const model = new TruncatedModel();
+  const { result, err } = await withCapturedError(() =>
+    new ChatCruxSummarizer(model).describeFile(denseInput(3)),
+  );
+  assert.equal(result.length, 0);
+  assert.ok(
+    err.some((l) => /truncated/i.test(l) && /finish_reason=length/.test(l)),
+    `truncation must be logged, got: ${err.join(" | ") || "(silence)"}`,
+  );
+});
+
+test("#260: empty chunks stay pending and are not cached as ready (#177)", async () => {
+  const { nodes, sources } = denseNodes(DENSE);
+  const summarizer = new ChatCruxSummarizer(new EmptyModel());
+  const stats = await enrichGraph(nodes, new Map(), sources, { summarizer, concurrency: 1 });
+
+  assert.equal(stats.computed, 0);
+  assert.equal(stats.failedFiles, 1);
+  assert.ok(stats.errors.length > 0);
+  for (const n of nodes) {
+    assert.equal(n.summary_state, "pending", "empty chunk must not flip the node to ready");
+    assert.equal(n.summary, null);
+  }
+});
+
+test("#260: a later empty chunk does not wipe earlier summaries or cache the empty ids", async () => {
+  const { nodes, sources } = denseNodes(DENSE);
+  const summarizer = new ChatCruxSummarizer(new FirstChunkOnlyModel());
+  const stats = await enrichGraph(nodes, new Map(), sources, { summarizer, concurrency: 1 });
+
+  assert.ok(stats.computed >= CRUX_CHUNK_SIZE, "first chunk's summaries must be kept");
+  assert.ok(stats.pending > 0, "ids the later chunks missed must remain retryable");
+  const ready = nodes.filter((n) => n.summary_state === "ready");
+  const pending = nodes.filter((n) => n.summary_state === "pending");
+  assert.equal(ready.length, stats.computed);
+  assert.equal(pending.length, stats.pending);
+  for (const n of pending) assert.equal(n.summary, null);
+});
+
+function denseInput(n: number): FileCruxInput {
+  return {
+    path: "dense.ts",
+    source: "export const x = 1;\n",
+    nodes: Array.from({ length: n }, (_, i) => ref(i)),
+  };
+}
+
+function ref(i: number): NodeRef {
+  return {
+    id: `dense.ts#f${i}`,
+    kind: "function",
+    signature: `f${i}()`,
+    startLine: 1,
+    endLine: 1,
+  };
+}
+
+function denseNodes(n: number): { nodes: NodeV1[]; sources: Map<string, string> } {
+  const path = "dense.ts";
+  return {
+    nodes: Array.from({ length: n }, (_, i) => ({
+      id: `${path}#f${i}`,
+      name: `f${i}`,
+      kind: "function",
+      path,
+      span: "L1-L1",
+      signature: `f${i}()`,
+      exported: true,
+      origin: "ast",
+      body_hash: `h-${i}`,
+      summary_state: "pending",
+      summary: null,
+      crux: null,
+    })),
+    sources: new Map([[path, "export const x = 1;\n"]]),
+  };
+}
+
+function requestedIds(req: ChatRequest): string[] {
+  const user = req.messages.find((m) => m.role === "user")?.content ?? "";
+  return [...user.matchAll(/^- id=(\S+)/gm)].map((m) => m[1]);
+}
+
+function okReply(ids: string[]): ChatResponse {
+  const toolCalls: ToolCall[] = [
+    {
+      id: "1",
+      name: "record_symbols",
+      args: {
+        symbols: ids.map((id) => ({ id, summary: `purpose of ${id}`, crux_start: 0, crux_end: 0 })),
+      },
+    },
+  ];
+  return {
+    text: "",
+    toolCalls,
+    usage: { input: 0, output: 0, cacheRead: 0, cacheCreate: 0 },
+    stopReason: "stop",
+    assistant: { role: "assistant", content: "", toolCalls },
+  };
+}
+
+/** Same shape the OpenAI adapter yields when JSON.parse of truncated tool args fails. */
+function truncatedReply(): ChatResponse {
+  const toolCalls: ToolCall[] = [{ id: "1", name: "record_symbols", args: {} }];
+  return {
+    text: "",
+    toolCalls,
+    usage: { input: 0, output: 8192, cacheRead: 0, cacheCreate: 0 },
+    stopReason: "length",
+    assistant: { role: "assistant", content: "", toolCalls },
+  };
+}
+
+function emptyReply(): ChatResponse {
+  return {
+    text: "",
+    toolCalls: [],
+    usage: { input: 0, output: 0, cacheRead: 0, cacheCreate: 0 },
+    stopReason: "stop",
+    assistant: { role: "assistant", content: "" },
+  };
+}
+
+/** Truncates (and drops) any call packed above the observed ~125-symbol cliff. */
+class CeilingModel implements ChatModel {
+  readonly label = "fake:ceiling";
+  calls = 0;
+  sizes: number[] = [];
+  async create(req: ChatRequest): Promise<ChatResponse> {
+    this.calls++;
+    const ids = requestedIds(req);
+    this.sizes.push(ids.length);
+    if (ids.length > TRUNCATE_ABOVE) return truncatedReply();
+    return okReply(ids);
+  }
+}
+
+class TruncatedModel implements ChatModel {
+  readonly label = "fake:truncated";
+  async create(_req: ChatRequest): Promise<ChatResponse> {
+    return truncatedReply();
+  }
+}
+
+class EmptyModel implements ChatModel {
+  readonly label = "fake:empty";
+  async create(_req: ChatRequest): Promise<ChatResponse> {
+    return emptyReply();
+  }
+}
+
+/** Succeeds only for f0..f79 — later chunks (and the collectFileCrux retry) stay empty. */
+class FirstChunkOnlyModel implements ChatModel {
+  readonly label = "fake:first-chunk";
+  async create(req: ChatRequest): Promise<ChatResponse> {
+    const ids = requestedIds(req).filter((id) => {
+      const n = Number(/#f(\d+)$/.exec(id)?.[1]);
+      return Number.isFinite(n) && n < CRUX_CHUNK_SIZE;
+    });
+    if (ids.length === 0) return emptyReply();
+    return okReply(ids);
+  }
+}
+
+async function withCapturedError<T>(fn: () => Promise<T>): Promise<{ result: T; err: string[] }> {
+  const err: string[] = [];
+  const orig = console.error;
+  console.error = (...args: unknown[]) => {
+    err.push(args.map((a) => String(a)).join(" "));
+  };
+  try {
+    return { result: await fn(), err };
+  } finally {
+    console.error = orig;
+  }
+}


### PR DESCRIPTION
## Summary
- One crux call per file hits `maxTokens: 8192` around ~125 symbols. The OpenAI adapter's `JSON.parse` of the truncated tool arguments fails, `parseResults` returns `[]`, and the whole file is dropped. Re-running `--deep` hits the same ceiling, so those files stay failed forever.
- **A (this PR):** chunk targets at `CRUX_CHUNK_SIZE = 80` (pinned by test; ~90 completion tokens/entry stays under 8192). Dense files take several sequential calls; results are merged. Small files still cost one call. `finish_reason=length` is logged instead of swallowed. Empty chunks stay `pending` and are not cached as `ready` (#177).
- **B (not this PR):** bump `maxTokens` and retry once on `finish_reason=length`. Rejected: `public/js/app.js` has 698 targets (~65k completion tokens); there is no ceiling that covers that in one call.

Orthogonal to the #254 circuit breaker (quality misses vs quota) and Draft #270 (echoed TARGET-line ids). Does not touch `--only-dir` (#262), `recover-tool` (#269), or the echo peel.

Closes #260

## Rebase vs Draft #270
Both PRs edit `src/ai/crux.ts`. This one only changes packing (`describeFile` splits + merges; `parseResults` untouched). #270 peels echoed ids inside `parseResults`. They compose: chunk, then peel per chunk.

Suggested order: land this, rebase #270 onto it (conflict should be `describeFile` vs `parseResults`, not overlapping hunks). If #270 lands first, rebase this onto it — the `describeFile` rewrite is the larger hunk.

## Test plan
- [x] Mock ceiling at 125 symbols (the observed cliff, **test-only** — not a production constant). 200 targets in one call → 0 summaries; after chunking at 80 → 3 calls (80/80/40), 200 summaries. No DeepSeek key, no live API.
- [x] Small file (5 targets) is still one `model.create`
- [x] `finish_reason=length` with empty `{}` tool args logs `truncated` / `finish_reason=length` (the silent-drop shape)
- [x] Empty chunks: 200 nodes stay `pending`, not cached `ready` (#177)
- [x] A later empty chunk keeps the first chunk's summaries; missed ids stay `pending`
- [x] `node --import tsx --test test/crux-chunk.test.ts test/llm-ops.test.ts test/graph-enrich-pending.test.ts test/graph-enrich-quality.test.ts test/graph-enrich-failures.test.ts`
- [x] `npm run build`
- [ ] No DeepSeek/OpenAI key in this window — did not replay a live dense PHP/JS file


Made with [Cursor](https://cursor.com)