### PR TITLE
Green main: clear every CI var in the telemetry test, align the CodeQL pins

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,9 +26,9 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v3
+        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           languages: javascript-typescript
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v3
+        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8

--- a/src/telemetry/gate.ts
+++ b/src/telemetry/gate.ts
@@ -30,16 +30,31 @@ export function doNotTrack(env: NodeJS.ProcessEnv = process.env): boolean {
 }
 
 /**
+ * Every variable {@link inCi} reads, named once.
+ *
+ * Exported because a test that needs telemetry actually ON has to clear all of
+ * them, and clearing a hand-copied subset is how this list silently drifts: the
+ * `cursor-session-end` test cleared `CI` alone, so it passed on a laptop and failed
+ * on GitHub Actions — where `GITHUB_ACTIONS` is set — for every run until someone
+ * read the log. One list, both callers.
+ */
+export const CI_ENV_VARS = [
+  'CI', 'GITHUB_ACTIONS', 'GITLAB_CI', 'BUILDKITE', 'CIRCLECI',
+  'TEAMCITY_VERSION', 'JENKINS_URL', 'TF_BUILD', 'BUILD_NUMBER',
+] as const;
+
+/**
  * CI detection. `CI` covers essentially every provider; the rest are the ones
  * that historically did not set it. Deliberately generous — a false positive
  * costs one uncounted user, a false negative pollutes the dataset.
+ *
+ * `CI` is the one read with a value test: `CI=false` is a real thing a user sets
+ * to mean "not CI", while the provider-specific vars are presence-only — none of
+ * them is ever deliberately set to a falsy string.
  */
 export function inCi(env: NodeJS.ProcessEnv = process.env): boolean {
   if (env.CI !== undefined && env.CI !== '' && env.CI !== '0' && env.CI !== 'false') return true;
-  return Boolean(
-    env.GITHUB_ACTIONS || env.GITLAB_CI || env.BUILDKITE || env.CIRCLECI ||
-    env.TEAMCITY_VERSION || env.JENKINS_URL || env.TF_BUILD || env.BUILD_NUMBER,
-  );
+  return CI_ENV_VARS.some((name) => name !== 'CI' && Boolean(env[name]));
 }
 
 /** Null when telemetry may run, otherwise the first gate that closed. */

--- a/test/claude-hooks.test.ts
+++ b/test/claude-hooks.test.ts
@@ -7,6 +7,7 @@ import { underGraft, main, lastFileScopeHint, promptAskTimeout } from '../src/cl
 import { readStats, readSession } from '../src/claude/state.js';
 import { runSync } from '../src/claude/sync-run.js';
 import { savingsLine } from '../src/context/savings.js';
+import { CI_ENV_VARS } from '../src/telemetry/gate.js';
 import { writeStats, emptyStats, acquireLock, resolveContextDir } from '../src/claude/state.js';
 
 test('underGraft detects edits inside graft/', () => {
@@ -551,21 +552,24 @@ test('cursor-session-end force-closes THIS conversation even though its file was
 
   // Turn telemetry on against a scratch $HOME so the rollup actually queues (and
   // marks the file), the observable proof the force-close ran — not just no-throw.
-  const saved = {
-    HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE,
-    KEY: process.env.GRAFT_POSTHOG_KEY, CI: process.env.CI, DNT: process.env.DO_NOT_TRACK,
-  };
+  //
+  // EVERY CI variable has to go, not just `CI`: `inCi` is deliberately generous and
+  // also reads GITHUB_ACTIONS, GITLAB_CI and six more. Clearing `CI` alone passed on
+  // a laptop and failed on GitHub Actions, where GITHUB_ACTIONS is set — so the list
+  // comes from `CI_ENV_VARS` rather than being copied here, and cannot drift from it.
+  const scrubbed = ['HOME', 'USERPROFILE', 'GRAFT_POSTHOG_KEY', 'DO_NOT_TRACK', ...CI_ENV_VARS];
+  const saved = Object.fromEntries(scrubbed.map((k) => [k, process.env[k]]));
+  for (const k of [...CI_ENV_VARS, 'DO_NOT_TRACK']) delete process.env[k];
   process.env.HOME = home; process.env.USERPROFILE = home;
   process.env.GRAFT_POSTHOG_KEY = 'phc_test_key';
-  delete process.env.CI; delete process.env.DO_NOT_TRACK;
   process.env.CLAUDE_PROJECT_DIR = d;
   try {
     await runWithStdin(JSON.stringify({ conversation_id: 'c1' }), () => main('cursor-session-end'));
     assert.equal(readSession(d, 'c1').summarized, true, 'the just-ended conversation was rolled up');
   } finally {
     delete process.env.CLAUDE_PROJECT_DIR;
-    for (const [k, v] of Object.entries({ HOME: saved.HOME, USERPROFILE: saved.USERPROFILE, GRAFT_POSTHOG_KEY: saved.KEY, CI: saved.CI, DO_NOT_TRACK: saved.DNT }))
-      if (v === undefined) delete (process.env as any)[k]; else (process.env as any)[k] = v;
+    for (const [k, v] of Object.entries(saved))
+      if (v === undefined) delete process.env[k]; else process.env[k] = v;
   }
 });
 


### PR DESCRIPTION
`main` has been red since before `release: 0.16.0`. Two unrelated causes.

## 1. `not ok 197 — cursor-session-end force-closes THIS conversation`

The test needs telemetry actually **on** to observe the rollup, so it clears the gates — but only `CI`:

```js
delete process.env.CI; delete process.env.DO_NOT_TRACK;
```

[`inCi`](../blob/main/src/telemetry/gate.ts) is deliberately generous and reads eight more:

```
CI  GITHUB_ACTIONS  GITLAB_CI  BUILDKITE  CIRCLECI
TEAMCITY_VERSION  JENKINS_URL  TF_BUILD  BUILD_NUMBER
```

On GitHub Actions `GITHUB_ACTIONS=true`, so `offReason` returned `'ci'`, nothing queued, and `readSession(d,'c1').summarized` was `undefined` instead of `true`. Deterministic, both platforms, invisible on a laptop.

Reproduce on `main`:

```bash
GITHUB_ACTIONS=true node --import tsx --test test/claude-hooks.test.ts
```

Fixed at the root rather than by adding one more `delete`: the list is now an exported `CI_ENV_VARS`, and both `inCi` and the test read it. A provider added to the gate can no longer leave the test behind. `CI` keeps its value check (`CI=false` is a real thing people set); the rest stay presence-only.

## 2. `analyze` — CodeQL version mismatch

```
Loaded a configuration file for version '4.37.8', but running version '4.37.7'
```

Dependabot #240 bumped `codeql-action/init` to 4.37.8 and left `analyze` on 4.37.7. CodeQL requires the pair to match. Both now use the same 4.37.8 SHA that `scorecard.yml` was already on — all three pins in the repo are identical again.

The `# v3` comments were the reason this drifted unnoticed on a SHA-pinned action, so they now name the real version, matching `scorecard.yml`'s convention.

## Verification

| run | result |
|---|---|
| `npm test` | 1174 pass / 0 fail / 1 skipped |
| `CI=true GITHUB_ACTIONS=true npm test` | 1174 pass / 0 fail / 1 skipped |

No production behaviour changes: `inCi` returns exactly what it did for every input, and the only source edit is the extracted constant.