### PR TITLE
Review closed PRs too, so a merged PR keeps a working graph link

### DIFF
--- a/src/app/events.ts
+++ b/src/app/events.ts
@@ -45,6 +45,13 @@ const ACTIONS = new Set(["opened", "synchronize", "reopened", "ready_for_review"
  * a bot commenting on every push to one is the fastest way to be uninstalled.
  * `ready_for_review` is in the accepted set so the comment appears the moment the
  * author asks for eyes.
+ *
+ * A CLOSED pull request is not skipped. The graph is most useful to whoever reads
+ * the PR later, and a merged PR is exactly what gets read — so the comment has to
+ * keep working after the merge. This costs nothing on live traffic: none of the
+ * four accepted actions fire on an already-merged PR, so in practice this only
+ * admits a `synchronize` that raced a merge, and a deliberate re-delivery. The
+ * accepted-action set, not the PR state, is what bounds the work.
  */
 export function reviewJobFor(event: string, payload: unknown): { job: ReviewJob } | { skip: string } {
   if (event === "ping") return { skip: "ping" };
@@ -66,7 +73,6 @@ export function reviewJobFor(event: string, payload: unknown): { job: ReviewJob 
     return { skip: "payload missing installation, repository or pull request fields" };
   }
   if (pr?.draft === true && action !== "ready_for_review") return { skip: "draft" };
-  if (pr?.state === "closed") return { skip: "closed" };
 
   const base = pr?.base?.repo?.full_name;
   const head = pr?.head?.repo?.full_name;

--- a/test/app-events.test.ts
+++ b/test/app-events.test.ts
@@ -46,12 +46,20 @@ test("events: a pull request that changed its diff becomes a job", () => {
   assert.equal(fork.job.owner, "NanoNets", "the comment belongs on the BASE repo, not the contributor's copy");
 });
 
+test("events: a merged pull request is still reviewed, so the link survives the merge", () => {
+  // The graph is read most often after the fact, on a PR that already landed.
+  // Skipping closed PRs left every merged comment pointing at a page that could
+  // never be regenerated.
+  const merged = reviewJobFor("pull_request", delivery({ action: "synchronize" }, { state: "closed" }));
+  assert.ok("job" in merged, `a closed PR must still produce a job, got ${JSON.stringify(merged)}`);
+  assert.equal(merged.job.number, 180);
+});
+
 test("events: noise is skipped with a reason", () => {
   const skipped = [
     reviewJobFor("pull_request", delivery({ action: "labeled" })),
     reviewJobFor("pull_request", delivery({ action: "edited" })),
     reviewJobFor("pull_request", delivery({}, { draft: true })),
-    reviewJobFor("pull_request", delivery({}, { state: "closed" })),
     reviewJobFor("issue_comment", delivery()),
     reviewJobFor("ping", {}),
     reviewJobFor("pull_request", delivery({ installation: undefined })),


### PR DESCRIPTION
## Why

`reviewJobFor` returned `skip: "closed"` for any closed pull request, so a merged PR could never be re-reviewed and its graph link could never be regenerated. The graph is read most often *after* the fact — on a PR that already landed — which is exactly the case that was excluded.

This is the guard that #279 needs: without it, a merged PR is rejected before checkout is ever reached, and #279's head-ref fallback never runs.

## Why this is safe

The accepted-action set, not the PR state, is what bounds the work:

```js
const ACTIONS = new Set(["opened", "synchronize", "reopened", "ready_for_review"]);
```

None of those four fire on an already-merged PR in normal GitHub operation, so live traffic cost is nil. In practice this admits two things:

- a `synchronize` that raced a merge — already seen in production (#2412 arrived as a live delivery for a PR that merged between push and delivery), and
- a deliberate re-delivery, which is what makes backfilling old comments possible at all.

Drafts are still skipped, with `ready_for_review` still in the accepted set — that behaviour is untouched.

## Tests

`test/app-events.test.ts`: `state: "closed"` moved out of the skip list, and a new test asserts a merged PR still produces a job.

`npm test` green.