### PR TITLE
fix(map): list breadth-tier languages in the repo-map header

### DIFF
--- a/src/graph/map.ts
+++ b/src/graph/map.ts
@@ -20,6 +20,7 @@
  */
 import type { GraphV1, NodeV1 } from "./types.js";
 import { languageLabelOf } from "./extract.js";
+import { genericLangOf } from "./generic.js";
 import { WALK_RELATIONS } from "./relations.js";
 import { scopeLabel, scopeOf, scopesOfGraph } from "./scopes.js";
 import { withSavings, savingsFor, type Savings } from "../context/savings.js";
@@ -128,11 +129,13 @@ function topHubs(nodes: NodeV1[], inDegree: Map<string, number>, cap: number): H
 }
 
 /** Display labels, not tree-sitter grammars: a `scripts/` tree of `.mjs` files is
- * "javascript" here, not "typescript". See {@link languageLabelOf}. */
+ * "javascript" here, not "typescript". See {@link languageLabelOf}. Breadth-tier
+ * files (Rust, ReScript, …) are labelled by their generic-tier language — the
+ * header used to list a Rust repo's languages as nothing at all. */
 function sortedLanguages(paths: string[]): string[] {
   const set = new Set<string>();
   for (const p of paths) {
-    const label = languageLabelOf(p);
+    const label = languageLabelOf(p) ?? genericLangOf(p)?.name;
     if (label) set.add(label);
   }
   return [...set].sort();

--- a/test/graph-map.test.ts
+++ b/test/graph-map.test.ts
@@ -76,15 +76,16 @@ test("buildRepoMap: totals count files, symbols, edges, and languages across the
     fileNode("src/a.ts"),
     symNode("src/a.ts", "fnA"),
     fileNode("docs/readme.py"), // deliberately mixed languages
+    fileNode("core/lib.rs"), // a breadth-tier language counts too
     symNode("docs/readme.py", "fnB"),
   ];
   const edges = [edge("src/a.ts#fnA", "docs/readme.py#fnB")];
   const map = buildRepoMap(graphOf(nodes, edges));
 
-  assert.equal(map.totals.files, 2);
+  assert.equal(map.totals.files, 3);
   assert.equal(map.totals.symbols, 2);
   assert.equal(map.totals.edges, 1);
-  assert.deepEqual(map.totals.languages, ["python", "typescript"]);
+  assert.deepEqual(map.totals.languages, ["python", "rust", "typescript"]);
 });
 
 test("buildRepoMap: dirs are grouped by first path segment and sorted by symbol count desc", () => {


### PR DESCRIPTION
## What

`graft map` printed the header's language list from the depth tier's labels only, so a repo whose files are all breadth-tier (Rust, Lua, OCaml, …) showed an empty list, and a mixed repo under-reported what was indexed.

The header now unions the depth-tier label with the breadth-tier language name for every indexed file, the same way the build banner already does.

## Test

`test/graph-map.test.ts` gains a Rust fixture and asserts `rust` appears in the header. `node --import tsx --test test/graph-map.test.ts` is green.

Split out of #294 so the language-neutral fix can land on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)