### PR TITLE
feat(lsp): definition and references walks for servers without call hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,9 @@ compiler-grade layer — all `$0` and deterministic (no model, no key):
   `lsp_resolved` call edges (member calls the static pass can't type) when a
   language server is on your `PATH`: **rust-analyzer** (Rust), **clangd** (C/C++),
   **gopls** (Go), **pyright** (Python), **typescript-language-server** (TS/JS).
+  A server without call hierarchy still contributes: graft asks it for the
+  definition of each call the static pass had to drop as ambiguous, or walks its
+  references when there is nothing to ask about.
   It's best-effort — with no server installed the graph is unchanged.
 
 Twenty-three languages in total. A file whose language isn't listed is skipped, not

--- a/src/graph/build.ts
+++ b/src/graph/build.ts
@@ -288,7 +288,11 @@ export async function buildGraph(
     files: entries,
   });
 
-  const edges = resolveEdges(nodes, rawEdges, { goModules: readGoModules(root, repoFiles) });
+  // Calls the name resolver had to drop (unknown or ambiguous callee) keep their
+  // positions here, so the opt-in LSP pass below can ask a language server for each
+  // one's definition instead of re-guessing by name.
+  const unresolvedCalls: RawEdge[] = [];
+  const edges = resolveEdges(nodes, rawEdges, { goModules: readGoModules(root, repoFiles), unresolvedCalls });
 
   // Guard 5 (minimum-substance): node counts aren't known until nodes are
   // assembled, so the merge-tiny-scopes-into-root guard runs here.
@@ -331,9 +335,9 @@ export async function buildGraph(
   // touches the extraction cache (Tier-1 stays pristine, cold==incremental).
   if (opts.lsp) {
     const { enrichWithLsp } = await import("./lsp/enrich.js");
-    const r = await enrichWithLsp(graph, root);
+    const r = await enrichWithLsp(graph, root, { callSites: unresolvedCalls });
     graph.meta.edgeCount = graph.edges.length;
-    opts.onProgress?.({ phase: "enrich", index: r.added, total: r.queried, file: `lsp:${r.server ?? "none"}` });
+    opts.onProgress?.({ phase: "enrich", index: r.added, total: r.queried, file: `lsp:${r.server ?? "none"}${r.probe ? ` (${r.probe})` : ""}` });
   }
 
   const graphPath = writeGraph(graph, outDir);

--- a/src/graph/extract.ts
+++ b/src/graph/extract.ts
@@ -94,6 +94,10 @@ export interface RawEdge {
   targetId?: string; // already-resolved target (contains)
   specifier?: string; // module path to resolve (imports / imported-symbol references)
   name?: string; // symbol name to resolve (extends/implements/calls)
+  /** calls: where the callee's name token sits (0-indexed line + UTF-16 column, LSP
+   * style). Lets the opt-in LSP pass ask a language server for the definition of a
+   * call the name resolver had to drop. Only the breadth tier stamps it today. */
+  pos?: { line: number; character: number };
   viaMember?: boolean; // calls: was it `obj.foo()` (→ prefer method targets)?
   /** calls with viaMember: the receiver's resolved type name (from bindings /
    * self / this / Go receiver), when a confident local clue exists. */

--- a/src/graph/generic.ts
+++ b/src/graph/generic.ts
@@ -390,7 +390,7 @@ function tagsExtract(
   // @reference.call too (Ruby tags `def foo`'s `foo` as both @name and a call),
   // producing bogus self-loops (foo→foo). Skip any call at a definition's name token.
   const defNameAt = new Set<number>();
-  const calls: Array<{ name: string; at: number }> = [];
+  const calls: Array<{ name: string; at: number; pos: { line: number; character: number } }> = [];
   const refs: Array<{ name: string; at: number }> = [];
   for (const m of matches) {
     const cap: Record<string, TsNode> = {};
@@ -400,8 +400,11 @@ function tagsExtract(
       defNameAt.add(cap.name.startIndex);
       mkDef(cap.name.text, KIND[defKey.slice("definition.".length)] ?? "function", defScope(cap[defKey], langName));
     }
-    if (("reference.call" in cap || "reference.send" in cap) && cap.name)
-      calls.push({ name: cap.name.text, at: cap.name.startIndex });
+    if (("reference.call" in cap || "reference.send" in cap) && cap.name) {
+      // web-tree-sitter reports columns in UTF-16 code units, which is what LSP wants.
+      const { row, column } = cap.name.startPosition;
+      calls.push({ name: cap.name.text, at: cap.name.startIndex, pos: { line: row, character: column } });
+    }
     // Structural references the grammar already marks: a supertype (extends), an
     // implemented interface, an object creation (`new Foo`), a module alias. Grammars
     // label these @reference.class/.interface/.implementation/.module — heterogeneous
@@ -421,7 +424,7 @@ function tagsExtract(
   for (const c of calls) {
     if (defNameAt.has(c.at)) continue;
     const enc = enclosing(c.at);
-    rawEdges.push({ source: enc ? enc.id : rel, relation: "calls", file: rel, name: c.name });
+    rawEdges.push({ source: enc ? enc.id : rel, relation: "calls", file: rel, name: c.name, pos: c.pos });
   }
   for (const r of refs) {
     if (defNameAt.has(r.at)) continue;

--- a/src/graph/lsp/client.ts
+++ b/src/graph/lsp/client.ts
@@ -25,6 +25,12 @@ export interface CallHierarchyItem {
   range: LspRange;
   selectionRange: LspRange;
 }
+export interface LspLocation { uri: string; range: LspRange }
+
+/** Which request the enrichment pass drives: outgoing call hierarchy where the server
+ * has it; else the definition of each call the static resolver dropped; else every
+ * reference to a symbol (its callers seen from the callee's side). */
+export type LspProbe = "callHierarchy" | "definition" | "references";
 
 const uriOf = (abs: string): string => pathToFileURL(abs).toString();
 
@@ -34,6 +40,7 @@ export class LspClient {
   private opened = new Set<string>();
   private ready = false;
   private spawnFailed = false;
+  private capabilities: Record<string, unknown> = {};
 
   constructor(
     command: string,
@@ -116,9 +123,17 @@ export class LspClient {
       }).then((r) => { clearTimeout(t); resolve(r); }, () => { clearTimeout(t); resolve(null); });
     });
     if (!init) return false;
+    this.capabilities = (init as { capabilities?: Record<string, unknown> }).capabilities ?? {};
     this.conn.sendNotification("initialized", {});
     this.ready = true;
     return true;
+  }
+
+  /** Does the server advertise a capability (`callHierarchyProvider`, `referencesProvider`, …)?
+   * Read off the initialize result; a server registering it dynamically instead is not
+   * seen, so callers treat a missing flag as "not advertised", never as "absent". */
+  supports(capability: string): boolean {
+    return !!this.capabilities[capability];
   }
 
   /** Open a document (idempotent). Servers resolve cross-file refs from disk, but
@@ -135,18 +150,53 @@ export class LspClient {
     } catch { /* stream closed mid-write */ }
   }
 
-  /** Poll one probe position until call-hierarchy returns something — servers
-   * like rust-analyzer/clangd index AFTER `initialized` and answer empty until
-   * ready. Returns true once ready (or false at the cap). */
-  async waitUntilReady(abs: string, pos: LspPosition, maxMs = 90000): Promise<boolean> {
+  /** Poll one probe position until the request the pass will drive returns something —
+   * servers like rust-analyzer/clangd index AFTER `initialized` and answer empty until
+   * ready. The references probe includes the declaration, so a symbol nobody references
+   * still answers once the server is up. Returns true once ready (or false at the cap). */
+  async waitUntilReady(abs: string, pos: LspPosition, probe: LspProbe = "callHierarchy", maxMs = 90000): Promise<boolean> {
     this.didOpen(abs);
     const deadline = Date.now() + maxMs;
     while (Date.now() < deadline) {
-      const items = await this.prepareCallHierarchy(abs, pos);
-      if (items.length) return true;
+      const ready = probe === "references"
+        ? (await this.references(abs, pos, true)).length > 0
+        : probe === "definition"
+          ? (await this.definition(abs, pos)).length > 0
+          : (await this.prepareCallHierarchy(abs, pos)).length > 0;
+      if (ready) return true;
       await new Promise((r) => setTimeout(r, 2000));
     }
     return false;
+  }
+
+  /** Where the symbol at `pos` is defined — the one request every server answers, and
+   * the instrument for a call the name resolver dropped: the server says which of the
+   * same-named definitions this call actually reaches. Normalises the spec's three
+   * result shapes (Location, Location[], LocationLink[]) to locations. */
+  async definition(abs: string, pos: LspPosition): Promise<LspLocation[]> {
+    if (!this.ready) return [];
+    type Link = { targetUri: string; targetSelectionRange?: LspRange; targetRange: LspRange };
+    const r = await this.call<LspLocation | Array<LspLocation | Link> | null>("textDocument/definition", {
+      textDocument: { uri: uriOf(abs) },
+      position: pos,
+    });
+    if (!r) return [];
+    return (Array.isArray(r) ? r : [r]).map((l) =>
+      "targetUri" in l ? { uri: l.targetUri, range: l.targetSelectionRange ?? l.targetRange } : l,
+    );
+  }
+
+  /** Every location that names the symbol at `pos`. The fallback instrument for a server
+   * without call hierarchy: an in-repo reference from inside another definition is that
+   * definition calling (or at least using) this one. */
+  async references(abs: string, pos: LspPosition, includeDeclaration = false): Promise<LspLocation[]> {
+    if (!this.ready) return [];
+    const r = await this.call<LspLocation[] | null>("textDocument/references", {
+      textDocument: { uri: uriOf(abs) },
+      position: pos,
+      context: { includeDeclaration },
+    });
+    return r ?? [];
   }
 
   async prepareCallHierarchy(abs: string, pos: LspPosition): Promise<CallHierarchyItem[]> {

--- a/src/graph/lsp/enrich.ts
+++ b/src/graph/lsp/enrich.ts
@@ -4,20 +4,25 @@
  * graft can't infer, and every call in the generic breadth tier (which has no
  * receiver typing at all). For each function/method node we ask the language
  * server for its outgoing calls (call hierarchy) and map each callee's definition
- * back to a graft node, adding a `calls` edge stamped `lsp_resolved`. Precision is
- * the server's (compiler-grade), so this closes the edge-recall gap WITHOUT the
- * name-guessing that halved precision (see resolve.ts). Best-effort: no server /
- * a timeout / an error → the graph is returned unchanged.
+ * back to a graft node, adding a `calls` edge stamped `lsp_resolved`. A server with
+ * no call hierarchy (@rescript/language-server) is asked, for each call the static
+ * resolver dropped as unknown or ambiguous, where the callee is defined — the exact
+ * question name resolution could not answer — or, when the build passed no call
+ * sites, for each function's references (the same edges seen from the callee: every
+ * in-repo location that names it, inside another function, is a caller). Precision
+ * is the server's (compiler-grade), so this closes the edge-recall gap WITHOUT the
+ * name-guessing that halved precision (see resolve.ts). Best-effort: no server / a
+ * timeout / an error → the graph is returned unchanged.
  */
 import { join } from "node:path";
 import { readFileSync, realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { relPosix } from "../../util/paths.js";
-import { languageLabelOf } from "../extract.js";
+import { languageLabelOf, type RawEdge } from "../extract.js";
 import { genericLangOf } from "../generic.js";
 import type { GraphV1, NodeV1, EdgeV1 } from "../types.js";
-import { LspClient, type CallHierarchyItem } from "./client.js";
-import { pickServer } from "./registry.js";
+import { LspClient, type LspProbe } from "./client.js";
+import { pickServer, type LspServer } from "./registry.js";
 
 const CALLABLE = new Set<NodeV1["kind"]>(["function", "method"]);
 const DEFN = new Set<NodeV1["kind"]>(["function", "method", "class", "struct", "interface", "type", "enum"]);
@@ -30,16 +35,25 @@ const parseSpan = (s: string): [number, number] | null => {
   return m ? [Number(m[1]), Number(m[2])] : null;
 };
 
-export interface LspEnrichResult { added: number; queried: number; server: string | null }
+export interface LspEnrichResult { added: number; queried: number; server: string | null; probe?: LspProbe }
 
 export async function enrichWithLsp(
   graph: GraphV1,
   root: string,
-  opts: { onProgress?: (done: number, total: number) => void; maxNodes?: number } = {},
+  opts: {
+    onProgress?: (done: number, total: number) => void;
+    maxNodes?: number;
+    /** Test seam: the server to spawn, instead of the registry's pick for the repo's languages. */
+    server?: LspServer;
+    /** The `calls` raw edges the resolver dropped, with their positions (resolve.ts's
+     * `unresolvedCalls` sink). With a server that has no call hierarchy these are what
+     * gets asked about — one definition request per dropped call. */
+    callSites?: RawEdge[];
+  } = {},
 ): Promise<LspEnrichResult> {
   const languagesPresent = new Set<string>();
   for (const n of graph.nodes) { const l = langOf(n.path); if (l) languagesPresent.add(l); }
-  const server = pickServer(languagesPresent);
+  const server = opts.server ?? pickServer(languagesPresent);
   if (!server) return { added: 0, queried: 0, server: null };
 
   // Canonicalize the root: servers (rust-analyzer/clangd) report callee URIs
@@ -73,6 +87,24 @@ export async function enrichWithLsp(
 
   const client = new LspClient(server.command, server.args, root, server.languageId);
   if (!(await client.initialize())) { await client.dispose(); return { added: 0, queried: 0, server: server.command }; }
+  // Outgoing call hierarchy is the instrument where a server advertises it. Without
+  // it: the definition of each dropped call, when the build handed us call sites and
+  // the server answers definition (every server does); else, references. A server
+  // advertising neither flag keeps the call-hierarchy path exactly as before (it may
+  // register the capability dynamically).
+  const sites = (opts.callSites ?? []).filter((e) => {
+    if (!e.pos || !e.name || !serverLangs.has(langOf(e.file) ?? "")) return false;
+    const src = byId.get(e.source);
+    return !!src && CALLABLE.has(src.kind);
+  });
+  const probe: LspProbe = client.supports("callHierarchyProvider")
+    ? "callHierarchy"
+    : sites.length && client.supports("definitionProvider")
+      ? "definition"
+      : client.supports("referencesProvider")
+        ? "references"
+        : "callHierarchy";
+  if (probe === "definition" && opts.maxNodes && sites.length > opts.maxNodes) sites.length = opts.maxNodes;
 
   const existing = new Set(graph.edges.map((e) => `${e.source}\0${e.relation}\0${e.target}`));
   const fileLines = new Map<string, string[]>();
@@ -97,44 +129,88 @@ export async function enrichWithLsp(
   };
 
   // Wait for the server to finish indexing (it answers call-hierarchy empty
-  // until ready). Warm up on the first source node that has a findable position.
-  const warm = sources.find((s) => namePos(s));
-  if (warm) {
-    const wp = namePos(warm)!;
-    if (!(await client.waitUntilReady(join(root, warm.path), wp))) {
-      await client.dispose();
-      return { added: 0, queried: 0, server: server.command }; // never became ready
+  // until ready). Warm up on the first source node that has a findable position —
+  // or, for the definition walk, on the first call site, without insisting: a call
+  // whose callee lives outside the repo legitimately has no definition to give.
+  if (probe === "definition") {
+    await client.waitUntilReady(join(root, sites[0].file), sites[0].pos!, probe, 10000);
+  } else {
+    const warm = sources.find((s) => namePos(s));
+    if (warm) {
+      const wp = namePos(warm)!;
+      if (!(await client.waitUntilReady(join(root, warm.path), wp, probe))) {
+        await client.dispose();
+        return { added: 0, queried: 0, server: server.command, probe }; // never became ready
+      }
     }
   }
 
   let added = 0, queried = 0;
+  // The graft node a server location lands in, or null when it is outside the repo
+  // (a dependency) or outside every definition. In-repo iff the repo-relative path
+  // doesn't escape the root (a raw `startsWith(root)` is separator-unsafe: root=/a/foo
+  // matches /a/foo-bar).
+  const nodeAtUri = (uri: string, line0: number): NodeV1 | null => {
+    let abs: string;
+    try { abs = fileURLToPath(uri); } catch { return null; }
+    const rel = relPosix(root, abs);
+    if (rel.startsWith("..") || rel.startsWith("/")) return null;
+    return nodeAt(rel, line0 + 1);
+  };
+  const link = (from: NodeV1, to: NodeV1): void => {
+    if (from.id === to.id) return;
+    const key = `${from.id}\0calls\0${to.id}`;
+    if (existing.has(key)) return;
+    existing.add(key);
+    graph.edges.push({ source: from.id, target: to.id, relation: "calls", confidence: "lsp_resolved" } as EdgeV1);
+    added++;
+  };
+  if (probe === "definition") {
+    for (const site of sites) {
+      const abs = join(root, site.file);
+      client.didOpen(abs);
+      const locs = await client.definition(abs, site.pos!);
+      if (!locs.length) continue;
+      queried++;
+      opts.onProgress?.(queried, sites.length);
+      const caller = byId.get(site.source)!;
+      for (const loc of locs) {
+        const target = nodeAtUri(loc.uri, loc.range.start.line);
+        if (target) link(caller, target);
+      }
+    }
+    await client.dispose();
+    return { added, queried, server: server.command, probe };
+  }
+
   for (const src of sources) {
     const abs = join(root, src.path);
     client.didOpen(abs);
     const pos = namePos(src);
     if (!pos) continue;
 
-    const items = await client.prepareCallHierarchy(abs, pos);
-    if (!items.length) continue;
-    queried++;
-    opts.onProgress?.(queried, sources.length);
-    const callees = await client.outgoingCalls(items[0]);
-    for (const callee of callees) {
-      let calleeAbs: string;
-      try { calleeAbs = fileURLToPath(callee.uri); } catch { continue; }
-      const rel = relPosix(root, calleeAbs);
-      // In-repo iff the repo-relative path doesn't escape the root. (A raw
-      // `startsWith(root)` is separator-unsafe: root=/a/foo matches /a/foo-bar.)
-      if (rel.startsWith("..") || rel.startsWith("/")) continue; // external/dependency
-      const target = nodeAt(rel, (callee.selectionRange?.start.line ?? callee.range.start.line) + 1);
-      if (!target || target.id === src.id) continue;
-      const key = `${src.id}\0calls\0${target.id}`;
-      if (existing.has(key)) continue;
-      existing.add(key);
-      graph.edges.push({ source: src.id, target: target.id, relation: "calls", confidence: "lsp_resolved" } as EdgeV1);
-      added++;
+    if (probe === "callHierarchy") {
+      const items = await client.prepareCallHierarchy(abs, pos);
+      if (!items.length) continue;
+      queried++;
+      opts.onProgress?.(queried, sources.length);
+      for (const callee of await client.outgoingCalls(items[0])) {
+        const target = nodeAtUri(callee.uri, callee.selectionRange?.start.line ?? callee.range.start.line);
+        if (target) link(src, target);
+      }
+    } else {
+      // Each reference is a caller when it sits inside another callable definition; a
+      // reference from a type or from module level (a constant initialiser) is not a call.
+      const refs = await client.references(abs, pos);
+      if (!refs.length) continue;
+      queried++;
+      opts.onProgress?.(queried, sources.length);
+      for (const ref of refs) {
+        const caller = nodeAtUri(ref.uri, ref.range.start.line);
+        if (caller && CALLABLE.has(caller.kind)) link(caller, src);
+      }
     }
   }
   await client.dispose();
-  return { added, queried, server: server.command };
+  return { added, queried, server: server.command, probe };
 }

--- a/src/graph/resolve.ts
+++ b/src/graph/resolve.ts
@@ -96,6 +96,11 @@ export interface ResolveOptions {
    * (`example.com/app/pkg/util`) to the in-repo directory they name, relative to the
    * owning module's `go.mod` location. Empty/absent → Go imports stay external strings. */
   goModules?: GoModule[];
+  /** Sink for the `calls` raw edges this pass drops — an unknown or ambiguous callee
+   * name — that carry a position. The opt-in LSP pass (enrich.ts) asks a language
+   * server for each one's definition, which is precisely the question name
+   * resolution could not answer. Absent → dropped calls are simply dropped. */
+  unresolvedCalls?: RawEdge[];
 }
 
 export function resolveEdges(
@@ -331,6 +336,7 @@ export function resolveEdges(
         hit = resolveName(e.name!, e.file, SWIFT_CTOR_KINDS, perFileName, globalName);
       }
       if (hit) add(e.source, hit.id, "calls", hit.confidence); // drop unresolved calls (too noisy)
+      else if (e.pos) opts.unresolvedCalls?.push(e);
     }
   }
   return out;

--- a/test/lsp-enrich.test.ts
+++ b/test/lsp-enrich.test.ts
@@ -42,3 +42,94 @@ test("enrichWithLsp is a no-op when no server matches the repo's languages", asy
   assert.equal(r.added, 0);
   assert.equal(graph.edges.length, before, "graph edges untouched");
 });
+
+// ---------------------------------------------------------------------------
+// The three instruments, driven end to end against a stand-in server spawned over
+// stdio (test/lsp-fake-server-probe.ts). The fixture is chosen so the breadth tier
+// CANNOT resolve the edge itself — `compute` is defined in two files, so bare-name
+// resolution drops it — which is exactly the gap the LSP tier exists to close.
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { extractGeneric, warmGenericGrammars } from "../src/graph/generic.js";
+import { resolveEdges } from "../src/graph/resolve.js";
+import type { RawEdge } from "../src/graph/extract.js";
+import type { LspServer } from "../src/graph/lsp/registry.js";
+
+const PROBE = join(dirname(fileURLToPath(import.meta.url)), "lsp-fake-server-probe.ts");
+// The client spawns the server with the FIXTURE as cwd, where a bare `--import tsx`
+// would not resolve — hand node the loader's absolute URL instead.
+const TSX = pathToFileURL(createRequire(import.meta.url).resolve("tsx")).href;
+
+const FIXTURE: Record<string, string> = {
+  "src/model.rs": "pub fn compute(x: i32) -> i32 {\n    x + 1\n}\n\npub fn unused() -> i32 {\n    2\n}\n",
+  "src/other.rs": "pub fn compute(x: i32) -> i32 {\n    x * 2\n}\n",
+  "src/loader.rs": "pub fn loader() -> i32 {\n    let v = model::compute(1);\n    v\n}\n\npub static CONFIG: i32 = model::compute(3);\n",
+};
+
+async function fixtureGraph(): Promise<{ dir: string; graph: GraphV1; callSites: RawEdge[] }> {
+  const dir = mkdtempSync(join(tmpdir(), "graft-lsp-"));
+  mkdirSync(join(dir, "src"), { recursive: true });
+  await warmGenericGrammars(["rust"]);
+  const nodes = [], raw = [];
+  for (const [rel, src] of Object.entries(FIXTURE)) {
+    writeFileSync(join(dir, rel), src);
+    const r = extractGeneric(rel, src, "rust");
+    nodes.push(...r.nodes); raw.push(...r.rawEdges);
+  }
+  const callSites: RawEdge[] = [];
+  const edges = resolveEdges(nodes, raw, { unresolvedCalls: callSites });
+  assert.ok(!edges.some((e) => e.relation === "calls" && e.target.endsWith("#compute")), "precondition: the ambiguous call is unresolved before enrichment");
+  // Both `model::compute(…)` calls were dropped as ambiguous, and both kept their position.
+  assert.deepEqual(callSites.map((c) => `${c.source}:${c.pos!.line}:${c.pos!.character}`), ["src/loader.rs#loader:1:19", "src/loader.rs#CONFIG:5:32"]);
+  return { dir, graph: { meta: { version: 1, nodeCount: nodes.length, edgeCount: edges.length, languages: ["rust"], scopes: [] }, nodes, edges }, callSites };
+}
+
+const fakeServer = (mode: "references" | "callHierarchy"): LspServer & { env: NodeJS.ProcessEnv } => ({
+  languages: ["rust"], command: process.execPath, args: ["--import", TSX, PROBE], languageId: "rust",
+  env: { ...process.env, FAKE_LSP_MODE: mode },
+});
+
+test("no call hierarchy + the build's dropped call sites → the definition walk settles each one", async () => {
+  const { dir, graph, callSites } = await fixtureGraph();
+  const server = fakeServer("references");
+  process.env.FAKE_LSP_MODE = server.env.FAKE_LSP_MODE;
+  const r = await enrichWithLsp(graph, dir, { server, callSites });
+  assert.equal(r.probe, "definition", "definition is preferred over references when there are call sites to ask about");
+  const added = graph.edges.filter((e) => e.confidence === "lsp_resolved").map((e) => `${e.source}→${e.target}`);
+  // `model::compute` inside `loader` → the server names model.rs's definition, not
+  // other.rs's. The same call inside `CONFIG` is not asked: a constant is not a caller.
+  assert.deepEqual(added, ["src/loader.rs#loader→src/model.rs#compute"]);
+  assert.equal(r.added, 1);
+  assert.equal(r.queried, 1, "one dropped call site from a callable was asked about");
+});
+
+test("no call hierarchy and no call sites → the references walk: callers become lsp_resolved edges", async () => {
+  const { dir, graph } = await fixtureGraph();
+  const server = fakeServer("references");
+  process.env.FAKE_LSP_MODE = server.env.FAKE_LSP_MODE;
+  const r = await enrichWithLsp(graph, dir, { server });
+  assert.equal(r.probe, "references", "chose the references walk");
+  assert.equal(r.server, process.execPath);
+  const added = graph.edges.filter((e) => e.confidence === "lsp_resolved").map((e) => `${e.source}→${e.target}`);
+  // loader's reference is inside a function → a caller. `CONFIG`'s reference is a
+  // module-level static → not a call. other.rs's `compute` is a declaration, and the
+  // queried definition itself is excluded — neither is a caller.
+  assert.deepEqual(added, ["src/loader.rs#loader→src/model.rs#compute"]);
+  assert.equal(r.added, 1);
+  assert.ok(r.queried >= 1, "at least the referenced function was queried");
+});
+
+test("a server that advertises call hierarchy keeps the call-hierarchy walk, call sites or not", async () => {
+  const { dir, graph, callSites } = await fixtureGraph();
+  const server = fakeServer("callHierarchy");
+  process.env.FAKE_LSP_MODE = server.env.FAKE_LSP_MODE;
+  const r = await enrichWithLsp(graph, dir, { server, callSites });
+  assert.equal(r.probe, "callHierarchy");
+  const added = graph.edges.filter((e) => e.confidence === "lsp_resolved").map((e) => `${e.source}→${e.target}`);
+  // Outgoing from `loader`: its body calls `compute`, whose (first) declaration the
+  // stand-in finds in model.rs — the same edge, discovered from the caller's side.
+  assert.deepEqual(added, ["src/loader.rs#loader→src/model.rs#compute"]);
+});

--- a/test/lsp-fake-server-probe.ts
+++ b/test/lsp-fake-server-probe.ts
@@ -1,0 +1,131 @@
+/**
+ * A stand-in language server for `lsp-enrich.test.ts`, spawned over stdio the way a
+ * real one is. It speaks just enough LSP to drive both of enrich.ts's instruments, and
+ * answers them from the fixture's own text instead of a compiler — a reference is a
+ * whole-word occurrence of the identifier under the cursor in any `.rs`/`.res` file
+ * under the workspace root, a declaration is a line that binds it (`fn name`,
+ * `let name`), and a qualifier (`model::compute`, `Model.compute`) names the file the
+ * symbol lives in. Which instrument it ADVERTISES is the whole point: enrich.ts must
+ * pick the definition walk (over the call sites the build hands it) or the references
+ * walk when a server has no call hierarchy, and stay on call hierarchy when it does.
+ * `FAKE_LSP_MODE` selects what is advertised: `references` (default — definition and
+ * references, the shape of a server without call hierarchy) or `callHierarchy`.
+ */
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { basename, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { createMessageConnection, StreamMessageReader, StreamMessageWriter } from "vscode-jsonrpc/node.js";
+
+const MODE = process.env.FAKE_LSP_MODE === "callHierarchy" ? "callHierarchy" : "references";
+const conn = createMessageConnection(new StreamMessageReader(process.stdin), new StreamMessageWriter(process.stdout));
+
+let root = "";
+interface Pos { line: number; character: number }
+interface Loc { uri: string; range: { start: Pos; end: Pos } }
+
+const sourceFiles = (dir: string): string[] => {
+  const out: string[] = [];
+  for (const f of readdirSync(dir).sort()) {
+    const abs = join(dir, f);
+    if (statSync(abs).isDirectory()) { if (f !== "node_modules" && f !== "graft") out.push(...sourceFiles(abs)); }
+    else if (/\.(res|rs)$/.test(f)) out.push(abs);
+  }
+  return out;
+};
+const wordAt = (abs: string, pos: Pos): string | null => {
+  const line = readFileSync(abs, "utf8").split("\n")[pos.line] ?? "";
+  for (const m of line.matchAll(/[A-Za-z_][A-Za-z0-9_']*/g)) {
+    if (m.index! <= pos.character && pos.character < m.index! + m[0].length) return m[0];
+  }
+  return null;
+};
+const isDeclaration = (line: string, word: string): boolean => new RegExp(`^\\s*(pub\\s+)?(let|fn|and)\\s+(rec\\s+)?${word}\\b`).test(line);
+/** The module a qualified occurrence names: `model::compute` → `model`, `Model.compute` → `Model`. */
+const QUALIFIER = /([A-Za-z_][A-Za-z0-9_]*)(?:::|\.)\s*$/;
+/** Whole-word occurrences of `word`. A qualified occurrence counts only when the
+ * qualifier is `module` — the file the symbol was asked about — which is the one
+ * thing a real compiler would know that a text search would not. */
+const occurrences = (word: string, module: string, includeDeclaration: boolean): Loc[] => {
+  const out: Loc[] = [];
+  for (const abs of sourceFiles(root)) {
+    readFileSync(abs, "utf8").split("\n").forEach((line, i) => {
+      if (!includeDeclaration && isDeclaration(line, word)) return;
+      for (const m of line.matchAll(new RegExp(`\\b${word}\\b`, "g"))) {
+        const qualifier = QUALIFIER.exec(line.slice(0, m.index!))?.[1];
+        if (qualifier && qualifier !== module) continue;
+        out.push({ uri: pathToFileURL(abs).toString(), range: { start: { line: i, character: m.index! }, end: { line: i, character: m.index! + word.length } } });
+      }
+    });
+  }
+  return out;
+};
+const moduleOf = (abs: string): string => basename(abs).replace(/\.(res|rs)$/, "");
+/** The declaration of `word`, preferring the file a qualifier names: at `model::compute`
+ * the answer is model.rs's `compute`, however many other files declare one. */
+const declarationOf = (word: string, preferModule?: string): Loc | null => {
+  const files = sourceFiles(root).sort((a, b) => Number(moduleOf(b) === preferModule) - Number(moduleOf(a) === preferModule));
+  for (const abs of files) {
+    const lines = readFileSync(abs, "utf8").split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      if (isDeclaration(lines[i], word)) {
+        const c = lines[i].indexOf(word);
+        return { uri: pathToFileURL(abs).toString(), range: { start: { line: i, character: c }, end: { line: i, character: c + word.length } } };
+      }
+    }
+  }
+  return null;
+};
+/** The body of the definition starting at `line`: down to the next blank line. */
+const bodyLines = (abs: string, line: number): string[] => {
+  const lines = readFileSync(abs, "utf8").split("\n");
+  const out: string[] = [];
+  for (let i = line; i < lines.length && (i === line || lines[i].trim() !== ""); i++) out.push(lines[i]);
+  return out;
+};
+
+conn.onRequest("initialize", (p: { rootUri?: string }) => {
+  root = p.rootUri ? fileURLToPath(p.rootUri) : process.cwd();
+  return {
+    capabilities: MODE === "callHierarchy"
+      ? { textDocumentSync: 1, callHierarchyProvider: true }
+      : { textDocumentSync: 1, definitionProvider: true, referencesProvider: true },
+  };
+});
+conn.onNotification(() => {}); // initialized, didOpen, …
+conn.onRequest("textDocument/references", (p: { textDocument: { uri: string }; position: Pos; context?: { includeDeclaration?: boolean } }) => {
+  const abs = fileURLToPath(p.textDocument.uri);
+  const word = wordAt(abs, p.position);
+  return word ? occurrences(word, moduleOf(abs), !!p.context?.includeDeclaration) : [];
+});
+conn.onRequest("textDocument/definition", (p: { textDocument: { uri: string }; position: Pos }) => {
+  const abs = fileURLToPath(p.textDocument.uri);
+  const word = wordAt(abs, p.position);
+  if (!word) return null;
+  const line = readFileSync(abs, "utf8").split("\n")[p.position.line] ?? "";
+  const qualifier = QUALIFIER.exec(line.slice(0, p.position.character))?.[1];
+  const decl = declarationOf(word, qualifier);
+  return decl ? [decl] : null;
+});
+conn.onRequest("textDocument/prepareCallHierarchy", (p: { textDocument: { uri: string }; position: Pos }) => {
+  const abs = fileURLToPath(p.textDocument.uri);
+  const word = wordAt(abs, p.position);
+  const decl = word ? declarationOf(word) : null;
+  return decl ? [{ name: word, kind: 12, uri: decl.uri, range: decl.range, selectionRange: decl.range }] : [];
+});
+conn.onRequest("callHierarchy/outgoingCalls", (p: { item: { name: string; uri: string; range: { start: Pos } } }) => {
+  const abs = fileURLToPath(p.item.uri);
+  const body = bodyLines(abs, p.item.range.start.line).join("\n");
+  const seen = new Set<string>();
+  const out: Array<{ to: unknown; fromRanges: unknown[] }> = [];
+  for (const m of body.matchAll(/[A-Za-z_][A-Za-z0-9_']*(?=\()/g)) {
+    const callee = m[0];
+    if (callee === p.item.name || seen.has(callee)) continue;
+    seen.add(callee);
+    const decl = declarationOf(callee);
+    if (decl) out.push({ to: { name: callee, kind: 12, uri: decl.uri, range: decl.range, selectionRange: decl.range }, fromRanges: [] });
+  }
+  return out;
+});
+conn.onRequest("shutdown", () => null);
+conn.onNotification("exit", () => process.exit(0));
+conn.listen();


### PR DESCRIPTION
## Why

`graft build --lsp` only speaks call hierarchy. A server that offers definition and references but no call hierarchy (several do) answers the readiness probe empty for 90 s and the pass adds nothing, silently. This teaches the pass two more instruments and lets the server's advertised capabilities pick one.

## What

- **Definition walk.** `resolveEdges(nodes, raw, { unresolvedCalls })` now reports the calls it dropped as ambiguous, each with the callee token's position (breadth-tier raw calls carry `pos`; depth-tier calls are unchanged). When the server has `definitionProvider` but no `callHierarchyProvider`, the pass asks `textDocument/definition` at each dropped call site inside a callable and maps the answer to a node. Only the edges the static pass could not settle are asked about.
- **References walk.** With nothing to ask about, each in-repo reference to a function that sits inside another callable becomes a caller edge.
- A server advertising `callHierarchyProvider` keeps the existing walk unchanged (`nodeAtUri`/`link` are shared helpers now). `LspClient` gains `supports()`, `definition()`, `references()`; the readiness probe follows the chosen instrument.
- `enrichWithLsp` takes an optional `server` (test seam) and `callSites`.

## Tests

`test/lsp-fake-server-probe.ts` is a stand-in language server spawned over stdio that answers from the fixture's text and advertises either shape (`FAKE_LSP_MODE`). Three end-to-end tests on a Rust fixture where `compute` is defined in two files (so the breadth tier drops the call): the definition walk settles it, the references walk finds the caller, and a call-hierarchy server still takes the old path. `node --import tsx --test test/lsp-enrich.test.ts test/generic-extract.test.ts test/graph-resolve-typed.test.ts test/graph-references.test.ts test/graph-cross-language.test.ts` is green; `tsc --noEmit` clean.

Split out of #294; no new registry rows here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)