### PR TITLE
feat(graph): language packs — bring a grammar graft doesn't ship, one directory away

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,20 @@ Twenty-three languages in total. A file whose language isn't listed is skipped, 
 indexed. Adding a broad-tier language is a small contribution — see
 [CREDITS.md](CREDITS.md) for the folks who added the current set.
 
+- **Bring your own (language packs)** — a language graft doesn't ship, or one only
+  your team uses, goes in `.graft/langs/<name>/` in the repo (or `~/.graft/langs/`
+  for every repo on the machine): a `pack.json` naming the extensions, the grammar
+  built with `tree-sitter build --wasm`, a tags query (`@definition.<kind>` +
+  `@name`, `@reference.call`) and optionally an `lsp` server row. The next
+  `graft build` indexes those files exactly like a broad-tier language. A pack that
+  would take a language away — a name or extension another tier already owns, a
+  missing file — is skipped with one warning, never a failed build.
+
+  ```json
+  { "name": "moon", "extensions": [".moon"], "grammar": "tree-sitter-moon.wasm",
+    "tags": "tags.scm", "lsp": { "command": "moon-lsp", "args": ["--stdio"] } }
+  ```
+
 ---
 
 ## What's in a node

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -127,15 +127,18 @@ const engineFrom = (): Graft => new Graft(cliConfig());
  * no-op — `graft build -e ".vue"` used to accept it, index nothing, and exit 0. The
  * supported set is listed so `-e` also answers "what is actually supported".
  */
-function warnUnsupportedExtensions(exts?: string[]): void {
+function warnUnsupportedExtensions(exts?: string[], dirArg?: string): void {
   if (!exts?.length) return;
-  const bad = unsupportedExtensions(exts);
+  // The repo's language packs (`.graft/langs`) count as parsers, so judge against the
+  // root the command was given — the walk that would load them has not run yet.
+  const root = resolve(dirArg ?? ".");
+  const bad = unsupportedExtensions(exts, root);
   if (bad.length === 0) return;
   for (const e of bad) {
     const shown = e.trim().startsWith(".") ? e.trim() : `.${e.trim()}`;
     console.error(`⚠ -e "${shown}": no parser registered for this extension — ignoring it.`);
   }
-  console.error(`  supported: ${supportedExtensions().join(" ")}`);
+  console.error(`  supported: ${supportedExtensions(root).join(" ")}`);
 }
 
 /** Text for the omitted-`[dir]` case, shared by every query command's help. */
@@ -371,7 +374,7 @@ program
       console.error(`✗ --concurrency must be a number, got "${opts.concurrency}"`);
       process.exit(1);
     }
-    warnUnsupportedExtensions(opts.extensions);
+    warnUnsupportedExtensions(opts.extensions, dirArg);
     // Persisted BEFORE the build itself runs, so this invocation's walks (and
     // every later no-flag build / hooks refresh) see it identically — the
     // walkDir call sites read it from state, not from a threaded option.
@@ -631,7 +634,7 @@ program
   .option("-e, --extensions <exts...>", "code extensions to include")
   .option("--json", "output the drift as JSON")
   .action(async (dirArg: string | undefined, opts: { extensions?: string[]; json?: boolean }) => {
-    warnUnsupportedExtensions(opts.extensions);
+    warnUnsupportedExtensions(opts.extensions, dirArg);
     const dir = noteQuery(queryRoot(dirArg));
     const checkGlobalDir = program.opts<GlobalOpts>().dir;
     if (readWorkspace(dir, checkGlobalDir)) {

--- a/src/graph/generic.ts
+++ b/src/graph/generic.ts
@@ -4,8 +4,9 @@
  * graft covers the long tail of languages for ~one registry row each, instead of
  * a hand-written extractor per language (the depth tier in extract.ts).
  *
- * Grammars are WASM (`tree-sitter-wasm` bundle) loaded via `web-tree-sitter`, so
- * a new language needs no native node-gyp build. Loading is async (WASM init), so
+ * Grammars are WASM loaded via `web-tree-sitter` — the `tree-sitter-wasm` bundle for
+ * the built-in rows, or a file a language pack points at (packs.ts) — so a new
+ * language needs no native node-gyp build. Loading is async (WASM init), so
  * callers MUST `await warmGenericGrammars([...])` once before the synchronous
  * `extractGeneric()` is used in a build/check loop. If a grammar isn't warmed,
  * `extractGeneric` degrades to a file node only (never throws).
@@ -31,11 +32,15 @@ const require = createRequire(import.meta.url);
 const QUERY_DIRS = [join(HERE, "queries"), join(HERE, "..", "..", "src", "graph", "queries")];
 
 /** A breadth-tier language: graft name, file extensions, and the wasm basename
- * in tree-sitter-wasm/<wasm>/tree-sitter-<wasm>.wasm. One row per language. */
+ * in tree-sitter-wasm/<wasm>/tree-sitter-<wasm>.wasm. One row per language. A
+ * language pack (packs.ts) instead names its own files: `wasmPath` for the grammar
+ * and `queryPath` for the tags query, both absolute. */
 export interface GenericLang {
   name: string;
   exts: string[];
   wasm: string;
+  wasmPath?: string;
+  queryPath?: string;
 }
 
 /** The breadth registry. Add a row + a queries/<name>.scm to support a language.
@@ -60,8 +65,26 @@ export const GENERIC_LANGS: readonly GenericLang[] = [
   { name: "lua", exts: [".lua"], wasm: "lua" },
 ];
 
+// Rows a language pack registered at runtime (packs.ts) — after the built-ins, so
+// they can never shadow one, and a pack's extension collision is refused there.
+const packLangs: GenericLang[] = [];
+const allLangs = (): GenericLang[] => [...GENERIC_LANGS, ...packLangs];
+
 const byExt = new Map<string, GenericLang>();
 for (const l of GENERIC_LANGS) for (const e of l.exts) byExt.set(e, l);
+
+/** Add a language pack's row. The caller (packs.ts) has already refused a name or an
+ * extension another tier owns, so this only wires the row into the lookups. */
+export function registerGenericLang(row: GenericLang): void {
+  packLangs.push(row);
+  for (const e of row.exts) byExt.set(e.toLowerCase(), row);
+}
+
+/** Test seam: forget every pack row, so one test's pack cannot leak into the next. */
+export function resetGenericLangsForTest(): void {
+  for (const l of packLangs) for (const e of l.exts) byExt.delete(e.toLowerCase());
+  packLangs.length = 0;
+}
 
 /** The generic language for a path, or null if no breadth grammar claims it. */
 export function genericLangOf(path: string): GenericLang | null {
@@ -72,7 +95,7 @@ export function genericLangOf(path: string): GenericLang | null {
 
 /** Every file extension a breadth-tier (generic tree-sitter) grammar claims. */
 export function genericExtensions(): string[] {
-  return GENERIC_LANGS.flatMap((l) => l.exts);
+  return allLangs().flatMap((l) => l.exts);
 }
 
 // tags.scm @definition.<X>  →  graft Kind (types.ts). Unmapped → "function".
@@ -90,28 +113,29 @@ const loaded = new Map<string, Loaded>();
 let tsMod: typeof import("web-tree-sitter") | null = null;
 let initPromise: Promise<void> | null = null;
 
-function requireWasm(wasm: string): Buffer | null {
-  // Resolve the grammar wasm from the tree-sitter-wasm bundle (its package.json
-  // `exports` maps the bare "<lang>/…" subpath to the actual "out/<lang>/…" file).
+function requireWasm(wasm: string, wasmPath?: string): Buffer | null {
   try {
-    const p = require.resolve(`tree-sitter-wasm/${wasm}/tree-sitter-${wasm}.wasm`);
+    // A language pack names its grammar file outright. Otherwise resolve it from the
+    // tree-sitter-wasm bundle (its package.json `exports` maps the bare "<lang>/…"
+    // subpath to the actual "out/<lang>/…" file).
+    const p = wasmPath ?? require.resolve(`tree-sitter-wasm/${wasm}/tree-sitter-${wasm}.wasm`);
     return readFileSync(p);
   } catch {
     return null;
   }
 }
 
-function loadQuery(name: string): string | null {
-  for (const dir of QUERY_DIRS) {
+// Sanitize editor-specific query predicates the tree-sitter Query compiler rejects.
+const sanitizeQuery = (raw: string): string =>
+  raw.replace(/\(#(?:strip!|set!|set-adjacent!|select-adjacent!|make-range!|offset!|gsub!)[^()]*\)/g, "");
+
+function loadQuery(name: string, queryPath?: string): string | null {
+  const candidates = queryPath ? [queryPath] : QUERY_DIRS.map((dir) => join(dir, `${name}.scm`));
+  for (const file of candidates) {
     try {
-      const raw = readFileSync(join(dir, `${name}.scm`), "utf8");
-      // Sanitize editor-specific query predicates the tree-sitter Query compiler rejects.
-      return raw.replace(
-        /\(#(?:strip!|set!|set-adjacent!|select-adjacent!|make-range!|offset!|gsub!)[^()]*\)/g,
-        "",
-      );
+      return sanitizeQuery(readFileSync(file, "utf8"));
     } catch {
-      /* try next dir */
+      /* try next */
     }
   }
   return null;
@@ -122,7 +146,7 @@ function loadQuery(name: string): string | null {
  * grammars are silently skipped (their files then extract as file-only). */
 export async function warmGenericGrammars(langNames: Iterable<string>): Promise<void> {
   const want = new Set(langNames);
-  const need = [...want].filter((n) => !loaded.has(n) && GENERIC_LANGS.some((l) => l.name === n));
+  const need = [...want].filter((n) => !loaded.has(n) && allLangs().some((l) => l.name === n));
   if (need.length === 0) return;
   if (!tsMod) {
     tsMod = await import("web-tree-sitter");
@@ -131,12 +155,12 @@ export async function warmGenericGrammars(langNames: Iterable<string>): Promise<
   await initPromise;
   const { Language, Query } = tsMod;
   for (const name of need) {
-    const row = GENERIC_LANGS.find((l) => l.name === name)!;
-    const bytes = requireWasm(row.wasm);
+    const row = allLangs().find((l) => l.name === name)!;
+    const bytes = requireWasm(row.wasm, row.wasmPath);
     if (!bytes) continue;
     try {
       const language = await Language.load(bytes);
-      const scm = loadQuery(name);
+      const scm = loadQuery(name, row.queryPath);
       let query: unknown | null = null;
       if (scm) {
         try { query = new Query(language, scm); } catch { query = null; }

--- a/src/graph/lsp/registry.ts
+++ b/src/graph/lsp/registry.ts
@@ -23,6 +23,17 @@ export const LSP_SERVERS: readonly LspServer[] = [
   { languages: ["typescript", "javascript", "tsx"], command: "typescript-language-server", args: ["--stdio"], languageId: "typescript" },
 ];
 
+// Servers a language pack declared (packs.ts). Considered after the built-in rows, so
+// a pack cannot steal a language a built-in server already covers.
+const packServers: LspServer[] = [];
+export function registerLspServer(row: LspServer): void {
+  packServers.push(row);
+}
+/** Test seam: forget every pack-declared server. */
+export function resetLspServersForTest(): void {
+  packServers.length = 0;
+}
+
 const resolved = new Map<string, string | null>();
 /** Resolve a command to its ABSOLUTE path via the login shell's PATH. `spawn`
  * resolves against `process.env.PATH`, which often omits `~/.cargo/bin`,
@@ -40,7 +51,7 @@ function resolveCommand(cmd: string): string | null {
  * languages present in the repo, with `command` resolved to an absolute path.
  * Returns null if none is installed. */
 export function pickServer(languagesPresent: Set<string>): LspServer | null {
-  for (const s of LSP_SERVERS) {
+  for (const s of [...LSP_SERVERS, ...packServers]) {
     if (!s.languages.some((l) => languagesPresent.has(l))) continue;
     const abs = resolveCommand(s.command);
     if (abs) return { ...s, command: abs };

--- a/src/graph/packs.ts
+++ b/src/graph/packs.ts
@@ -1,0 +1,164 @@
+/**
+ * Language packs — a language graft never heard of, one directory away.
+ *
+ * Every built-in breadth-tier language is a row in generic.ts plus a grammar the
+ * `tree-sitter-wasm` bundle happens to ship. A language the bundle lacks would need a
+ * vendored binary in graft's own tree, and a language only one team uses would need a
+ * row nobody else wants. A pack moves both out of graft: a directory holding the
+ * grammar wasm, the tags query and a manifest, discovered at build time from
+ *
+ *   <repo>/.graft/langs/<name>/pack.json    (travels with the repo)
+ *   ~/.graft/langs/<name>/pack.json         (this machine, every repo)
+ *
+ * with the repo-level pack winning a name clash. A pack contributes exactly what a
+ * built-in row does — extensions, grammar, tags query, optionally one LSP server row —
+ * and is refused, with one stderr line, when it would take a language away from a repo:
+ * a name or an extension another tier already owns, a grammar or query file that is
+ * not there. Refusal never fails the build; the repo indexes as it did before.
+ *
+ * The manifest:
+ *
+ *   {
+ *     "name": "moon",
+ *     "extensions": [".moon"],
+ *     "grammar": "tree-sitter-moon.wasm",
+ *     "tags": "tags.scm",
+ *     "lsp": { "command": "moon-lsp", "args": ["--stdio"], "languageId": "moon" }
+ *   }
+ *
+ * Paths are relative to the pack directory. `tags` is optional — without it the
+ * grammar goes through generic.ts's node-kind walker (symbols, no calls), as OCaml and
+ * Zig do today. `lsp.args` defaults to none, `lsp.languageId` to the pack's name.
+ */
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { languageOf } from "./extract.js";
+import { containerLangOf } from "./container.js";
+import { GENERIC_LANGS, genericLangOf, registerGenericLang } from "./generic.js";
+import { registerLspServer } from "./lsp/registry.js";
+
+export interface LanguagePack {
+  name: string;
+  extensions: string[];
+  grammar: string;
+  tags?: string;
+  lsp?: { command: string; args?: string[]; languageId?: string };
+}
+
+export interface PackLoadResult {
+  /** Pack names registered by this call (already-registered packs are not repeated). */
+  loaded: string[];
+  /** Directories that held a pack.json graft could not accept, with the reason. */
+  skipped: Array<{ dir: string; reason: string }>;
+}
+
+/** The directories searched for `<name>/pack.json`, in priority order. */
+export function packDirs(root: string, home: string = homedir()): string[] {
+  return [join(resolve(root), ".graft", "langs"), join(home, ".graft", "langs")];
+}
+
+const NAME = /^[a-z][a-z0-9_]*$/;
+const registered = new Set<string>(); // pack names
+const registeredDirs = new Set<string>(); // pack directories, so a re-scan is silent
+const seenRoots = new Set<string>();
+
+/**
+ * Discover and register the packs that apply to `root`. Idempotent per root: the walk
+ * (`listSourceFiles`), the `-e` validation and a test may each call it, and the first
+ * call does the work. Returns what it loaded and what it refused; a refused pack is
+ * also reported on stderr (`warn`), because silence here is how a language quietly
+ * goes missing from a graph.
+ */
+export function loadLanguagePacks(
+  root: string,
+  opts: { home?: string; warn?: (message: string) => void } = {},
+): PackLoadResult {
+  const home = opts.home ?? homedir();
+  const key = `${resolve(root)}\0${home}`;
+  const result: PackLoadResult = { loaded: [], skipped: [] };
+  if (seenRoots.has(key)) return result;
+  seenRoots.add(key);
+  const warn = opts.warn ?? ((m: string) => console.error(m));
+
+  for (const base of packDirs(root, home)) {
+    let entries: string[];
+    try {
+      entries = readdirSync(base).sort();
+    } catch {
+      continue; // no such directory — the common case
+    }
+    for (const entry of entries) {
+      const dir = join(base, entry);
+      try {
+        if (!statSync(dir).isDirectory() || !existsSync(join(dir, "pack.json"))) continue;
+      } catch {
+        continue;
+      }
+      if (registeredDirs.has(dir)) continue; // loaded for another (root, home) pair already
+      const outcome = loadPack(dir);
+      if (outcome.ok) {
+        registeredDirs.add(dir);
+        result.loaded.push(outcome.name);
+      } else {
+        result.skipped.push({ dir, reason: outcome.reason });
+        warn(`graft: language pack skipped (${dir}): ${outcome.reason}`);
+      }
+    }
+  }
+  return result;
+}
+
+type Outcome = { ok: true; name: string } | { ok: false; reason: string };
+const refuse = (reason: string): Outcome => ({ ok: false, reason });
+
+/** Register one pack, or say why it cannot be. */
+function loadPack(dir: string): Outcome {
+  let pack: LanguagePack;
+  try {
+    pack = JSON.parse(readFileSync(join(dir, "pack.json"), "utf8")) as LanguagePack;
+  } catch (err) {
+    return refuse(`pack.json is not valid JSON (${err instanceof Error ? err.message : String(err)})`);
+  }
+  if (typeof pack.name !== "string" || !NAME.test(pack.name)) return refuse(`"name" must match ${NAME} (got ${JSON.stringify(pack.name)})`);
+  if (registered.has(pack.name)) return refuse(`a pack named "${pack.name}" is already loaded (a repo-level pack wins over ~/.graft/langs)`);
+  if (GENERIC_LANGS.some((l) => l.name === pack.name)) return refuse(`"${pack.name}" is a built-in language`);
+  if (!Array.isArray(pack.extensions) || pack.extensions.length === 0 || !pack.extensions.every((e) => typeof e === "string" && /^\.[A-Za-z0-9_+-]+$/.test(e)))
+    return refuse(`"extensions" must be a non-empty list like [".moon"]`);
+  const exts = pack.extensions.map((e) => e.toLowerCase());
+  for (const e of exts) {
+    // A probe file name is enough: every tier decides by extension alone.
+    const owner = languageOf(`x${e}`) ?? containerLangOf(`x${e}`)?.name ?? genericLangOf(`x${e}`)?.name;
+    if (owner) return refuse(`extension ${e} is already indexed as ${owner}`);
+  }
+  if (typeof pack.grammar !== "string") return refuse(`"grammar" must name the wasm file`);
+  const wasmPath = join(dir, pack.grammar);
+  if (!existsSync(wasmPath)) return refuse(`grammar not found: ${pack.grammar}`);
+  let queryPath: string | undefined;
+  if (pack.tags !== undefined) {
+    if (typeof pack.tags !== "string") return refuse(`"tags" must name the tags query file`);
+    queryPath = join(dir, pack.tags);
+    if (!existsSync(queryPath)) return refuse(`tags query not found: ${pack.tags}`);
+  }
+  if (pack.lsp !== undefined && (typeof pack.lsp !== "object" || typeof pack.lsp.command !== "string"))
+    return refuse(`"lsp" must be { "command": "…", "args": […], "languageId": "…" }`);
+
+  registerGenericLang({ name: pack.name, exts, wasm: pack.name, wasmPath, queryPath });
+  if (pack.lsp) {
+    registerLspServer({
+      languages: [pack.name],
+      command: pack.lsp.command,
+      args: Array.isArray(pack.lsp.args) ? pack.lsp.args : [],
+      languageId: pack.lsp.languageId ?? pack.name,
+    });
+  }
+  registered.add(pack.name);
+  return { ok: true, name: pack.name };
+}
+
+/** Test seam: forget every loaded pack and root, so tests can load fixtures afresh. */
+export function resetLanguagePacksForTest(): void {
+  registered.clear();
+  registeredDirs.clear();
+  seenRoots.clear();
+}

--- a/src/graph/source-files.ts
+++ b/src/graph/source-files.ts
@@ -14,10 +14,14 @@ import { readFollowNestedRepos, readFollowSubmodules, readIncludeDirs } from "..
 import { languageOf, depthExtensions } from "./extract.js";
 import { genericLangOf, genericExtensions } from "./generic.js";
 import { containerLangOf, containerExtensions } from "./container.js";
+import { loadLanguagePacks } from "./packs.js";
 
 /** Every extension graft has a parser for (depth + breadth + container), sorted
  * and de-duped — the authoritative answer to "what does `-e` actually support". */
-export function supportedExtensions(): string[] {
+export function supportedExtensions(root?: string): string[] {
+  // A repo's language packs count as supported the moment `-e` is validated, which
+  // is before any walk has loaded them — so load here too (idempotent per root).
+  if (root) loadLanguagePacks(root);
   return [...new Set([...depthExtensions(), ...genericExtensions(), ...containerExtensions()])].sort();
 }
 
@@ -32,8 +36,8 @@ function normExt(e: string): string {
  * `graft build -e ".vue"` used to accept these silently and index nothing; the CLI warns
  * on whatever this returns so an unsupported extension is never a quiet no-op.
  */
-export function unsupportedExtensions(exts: string[]): string[] {
-  const supported = new Set(supportedExtensions());
+export function unsupportedExtensions(exts: string[], root?: string): string[] {
+  const supported = new Set(supportedExtensions(root));
   return exts.filter((e) => !supported.has(normExt(e)));
 }
 
@@ -70,6 +74,9 @@ export function listSourceFiles(
   }),
   onlyDirs?: ReadonlySet<string>,
 ): string[] {
+  // Language packs (`<root>/.graft/langs`, `~/.graft/langs`) add breadth-tier rows;
+  // they must be registered before the extension filter below decides what is source.
+  loadLanguagePacks(root);
   // A file is a source file if a depth-tier grammar (languageOf), a breadth-tier
   // grammar (genericLangOf) or a container (containerLangOf) claims its extension.
   // All three must agree here or `build` and `check` would enumerate different sets.

--- a/test/language-packs.test.ts
+++ b/test/language-packs.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Language packs: a language graft never heard of, loaded from `.graft/langs/<name>/`
+ * in the repo or `~/.graft/langs/<name>/` at home, contributing exactly what a built-in
+ * breadth row does — extensions, grammar, tags query, optionally an LSP server row.
+ *
+ * The fixture pack "moon" reuses the bundled Lua grammar and graft's own lua.scm under
+ * a new name and extension, so the tests prove the pack plumbing (discovery, registry,
+ * walk, `-e` validation, LSP pick) without needing a grammar of their own — and prove
+ * the refusals: a pack can add a language, never take one away.
+ */
+import { test, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { copyFileSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import { loadLanguagePacks, packDirs, resetLanguagePacksForTest } from "../src/graph/packs.js";
+import { genericLangOf, resetGenericLangsForTest, swapGrammarForTest } from "../src/graph/generic.js";
+import { supportedExtensions, unsupportedExtensions } from "../src/graph/source-files.js";
+import { pickServer, resetLspServersForTest } from "../src/graph/lsp/registry.js";
+import { buildGraph } from "../src/graph/build.js";
+import { readGraph, wiringPath } from "../src/graph/write.js";
+import { contextDirFor } from "../src/context/node-file.js";
+
+const require = createRequire(import.meta.url);
+const LUA_WASM = require.resolve("tree-sitter-wasm/lua/tree-sitter-lua.wasm");
+const LUA_TAGS = join(dirname(fileURLToPath(import.meta.url)), "..", "src", "graph", "queries", "lua.scm");
+const LUA_SRC = "local function helper()\n  return 1\nend\n\nlocal function run()\n  return helper()\nend\n";
+
+/** Write a pack dir: manifest + (by default) the Lua grammar and query under the pack's name. */
+function writePack(base: string, name: string, manifest: object, files: { grammar?: boolean; tags?: boolean } = {}): string {
+  const dir = join(base, name);
+  mkdirSync(dir, { recursive: true });
+  if (files.grammar !== false) copyFileSync(LUA_WASM, join(dir, `tree-sitter-${name}.wasm`));
+  if (files.tags !== false) copyFileSync(LUA_TAGS, join(dir, "tags.scm"));
+  writeFileSync(join(dir, "pack.json"), typeof manifest === "string" ? manifest : JSON.stringify(manifest));
+  return dir;
+}
+const manifest = (name: string, ext: string, extra: object = {}) =>
+  ({ name, extensions: [ext], grammar: `tree-sitter-${name}.wasm`, tags: "tags.scm", ...extra });
+const tmp = (tag: string) => mkdtempSync(join(tmpdir(), `graft-packs-${tag}-`));
+/** A repo with its pack dir, and an empty home so the developer's own packs stay out. */
+function repoAndHome(): { repo: string; home: string; langs: string } {
+  const repo = tmp("repo"), home = tmp("home");
+  const langs = packDirs(repo, home)[0];
+  mkdirSync(langs, { recursive: true });
+  return { repo, home, langs };
+}
+
+beforeEach(() => {
+  resetLanguagePacksForTest();
+  resetGenericLangsForTest();
+  resetLspServersForTest();
+  for (const n of ["moon", "sun", "star"]) swapGrammarForTest(n, null);
+});
+
+test("a repo-level pack adds a language: discovery, extension routing, -e validation, a built graph", async () => {
+  const { repo, home, langs } = repoAndHome();
+  writePack(langs, "moon", manifest("moon", ".moon"));
+  mkdirSync(join(repo, "src"));
+  writeFileSync(join(repo, "src", "a.moon"), LUA_SRC);
+
+  const warnings: string[] = [];
+  const r = loadLanguagePacks(repo, { home, warn: (m) => warnings.push(m) });
+  assert.deepEqual(r, { loaded: ["moon"], skipped: [] });
+  assert.deepEqual(warnings, []);
+  assert.equal(genericLangOf("src/a.moon")?.name, "moon", "the pack's extension routes to the pack");
+  assert.equal(genericLangOf("src/a.moon")?.wasmPath, join(langs, "moon", "tree-sitter-moon.wasm"));
+  assert.ok(supportedExtensions().includes(".moon"), "-e knows the pack's extension");
+  assert.deepEqual(unsupportedExtensions([".moon", ".nope"], repo), [".nope"]);
+
+  // The build's own walk loads packs too (idempotently — no second warning), and the
+  // pack's files come out as breadth-tier nodes with resolved calls.
+  await buildGraph(repo, { reuse: false });
+  const g = readGraph(wiringPath(contextDirFor(repo)));
+  const defs = g!.nodes.filter((n) => n.path === "src/a.moon" && n.kind !== "file");
+  assert.deepEqual(defs.map((n) => `${n.kind}:${n.name}`).sort(), ["function:helper", "function:run"]);
+  assert.ok(defs.every((n) => n.origin === "generic"));
+  assert.ok(g!.edges.some((e) => e.relation === "calls" && e.source === "src/a.moon#run" && e.target === "src/a.moon#helper"), "run → helper resolved");
+  assert.ok(g!.meta.languages.includes("moon"), `banner lists the pack language (got ${g!.meta.languages.join(", ")})`);
+});
+
+test("a pack can add a language but never take one away: every refusal is one warning, nothing else changes", () => {
+  const { repo, home, langs } = repoAndHome();
+  writePack(langs, "a_builtin_ext", manifest("a_builtin_ext", ".lua")); // breadth tier owns .lua
+  writePack(langs, "a_depth_ext", manifest("a_depth_ext", ".ts")); // depth tier owns .ts
+  writePack(langs, "rust", manifest("rust", ".rsx")); // a built-in name
+  writePack(langs, "no_grammar", manifest("no_grammar", ".ng"), { grammar: false });
+  writePack(langs, "no_tags", manifest("no_tags", ".nt"), { tags: false });
+  writePack(langs, "bad_json", "{ not json", {});
+  writePack(langs, "Bad-Name", manifest("Bad-Name", ".bn"));
+  writePack(langs, "bad_lsp", manifest("bad_lsp", ".bl", { lsp: { args: [] } }));
+
+  const warnings: string[] = [];
+  const r = loadLanguagePacks(repo, { home, warn: (m) => warnings.push(m) });
+  assert.deepEqual(r.loaded, []);
+  const reasons = Object.fromEntries(r.skipped.map((s) => [s.dir.split("/").pop(), s.reason]));
+  assert.match(reasons.a_builtin_ext, /\.lua is already indexed as lua/);
+  assert.match(reasons.a_depth_ext, /\.ts is already indexed as typescript/);
+  assert.match(reasons.rust, /built-in language/);
+  assert.match(reasons.no_grammar, /grammar not found/);
+  assert.match(reasons.no_tags, /tags query not found/);
+  assert.match(reasons.bad_json, /not valid JSON/);
+  assert.match(reasons["Bad-Name"], /"name" must match/);
+  assert.match(reasons.bad_lsp, /"lsp" must be/);
+  assert.equal(warnings.length, r.skipped.length, "exactly one stderr line per refused pack");
+  // and the built-ins are exactly as they were
+  assert.equal(genericLangOf("x.lua")?.name, "lua");
+  assert.equal(genericLangOf("x.rsx"), null);
+  assert.equal(genericLangOf("x.ng"), null);
+});
+
+test("a home-level pack applies to every repo; a repo-level pack of the same name wins", () => {
+  const { repo, home, langs } = repoAndHome();
+  const homeLangs = packDirs(repo, home)[1];
+  writePack(homeLangs, "star", manifest("star", ".star")); // home only
+  writePack(homeLangs, "sun", manifest("sun", ".sun_home")); // both — the repo's copy must win
+  writePack(langs, "sun", manifest("sun", ".sun"));
+
+  const r = loadLanguagePacks(repo, { home, warn: () => {} });
+  assert.deepEqual(r.loaded, ["sun", "star"], "repo packs first, then home");
+  assert.equal(r.skipped.length, 1);
+  assert.match(r.skipped[0].reason, /already loaded/);
+  assert.equal(genericLangOf("x.sun")?.name, "sun");
+  assert.equal(genericLangOf("x.sun_home"), null, "the losing home copy contributed nothing");
+  assert.equal(genericLangOf("x.star")?.name, "star");
+
+  // a second call for the same root is a no-op — no re-registration, no warnings
+  const again = loadLanguagePacks(repo, { home, warn: (m) => assert.fail(m) });
+  assert.deepEqual(again, { loaded: [], skipped: [] });
+});
+
+test("a pack's lsp row is picked for its language and shadows nothing built in", () => {
+  const { repo, home, langs } = repoAndHome();
+  // `node` is on PATH in any environment that runs this suite.
+  writePack(langs, "moon", manifest("moon", ".moon", { lsp: { command: "node", args: ["-e", "0"] } }));
+  loadLanguagePacks(repo, { home, warn: () => {} });
+  const picked = pickServer(new Set(["moon"]));
+  assert.ok(picked, "the pack's server is eligible");
+  assert.equal(picked!.languageId, "moon", "languageId defaults to the pack name");
+  assert.deepEqual(picked!.args, ["-e", "0"]);
+  assert.ok(picked!.command.endsWith("node") && picked!.command.startsWith("/"), "resolved to an absolute path");
+  assert.notEqual(pickServer(new Set(["rust"]))?.languageId, "moon", "a pack row never answers for another language");
+});


### PR DESCRIPTION
## Why

Every broad-tier language is a row in `generic.ts` plus a wasm the `tree-sitter-wasm` bundle happens to ship. A language the bundle lacks needs a vendored binary in graft's tree (#294 is that shape, for ReScript), and a language only one team uses needs a row nobody else wants. This moves both out of graft.

## What

A **language pack** is a directory with a manifest, a grammar and a tags query:

```
.graft/langs/moon/
  pack.json               {"name":"moon","extensions":[".moon"],"grammar":"tree-sitter-moon.wasm","tags":"tags.scm","lsp":{"command":"moon-lsp","args":["--stdio"]}}
  tree-sitter-moon.wasm   built with `tree-sitter build --wasm`
  tags.scm                @definition.<kind> + @name, @reference.call
```

- Discovered from `<repo>/.graft/langs/*/` (travels with the repo) then `~/.graft/langs/*/` (every repo on the machine); repo-level wins a name clash.
- Loaded by the source walk (`listSourceFiles`) before its extension filter, so pack files are indexed exactly like a built-in broad-tier language; `-e` validation judges against the same set (`warnUnsupportedExtensions` now knows the root).
- Optional `lsp` row joins `--lsp` after the built-in servers.
- **A pack can add a language, never take one away.** A name or extension another tier owns, a built-in name, a missing grammar/query, a malformed manifest → one stderr line, the pack is skipped, the build continues.
- `generic.ts`: `registerGenericLang` (rows may carry `wasmPath`/`queryPath`; `requireWasm`/`loadQuery` prefer them), `GENERIC_LANGS` untouched. `registry.ts`: `registerLspServer`, `LSP_SERVERS` untouched. New `src/graph/packs.ts` holds discovery and validation.

## Tests

`test/language-packs.test.ts` reuses the bundled Lua grammar and graft's own `lua.scm` under the name `moon`/`.moon`, so no new wasm is needed: discovery, extension routing, `-e`, a full `buildGraph` with resolved calls and the banner language, all eight refusals with exactly one warning each and built-ins unchanged, home vs repo precedence and idempotence, and the LSP pick. `tsc --noEmit` clean; `language-packs`, `supported-extensions`, `generic-extract`, `graph-languages`, `lsp-enrich`, `cli-meta` green.

README gains a short "Bring your own (language packs)" entry under the language list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)