### PR TITLE
GDScript support, plus two fixes: Windows blast radius and sticky --only-dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ compiler-grade layer — all `$0` and deterministic (no model, no key):
 - **Broad** — symbols (functions, classes, methods, types, …) plus name-resolved
   call edges via a generic tree-sitter extractor, one grammar per language:
   **Rust, C, C++, C#, Ruby, Scala, Elixir, Solidity,
-  OCaml, Zig, Dart, Clojure, Nix, Lua**.
+  OCaml, Zig, Dart, Clojure, Nix, Lua, GDScript**.
 
 - **Compiler-grade edges (opt-in)** — `graft build --lsp` adds precise
   `lsp_resolved` call edges (member calls the static pass can't type) when a
@@ -212,7 +212,7 @@ compiler-grade layer — all `$0` and deterministic (no model, no key):
   **gopls** (Go), **pyright** (Python), **typescript-language-server** (TS/JS).
   It's best-effort — with no server installed the graph is unchanged.
 
-Twenty-three languages in total. A file whose language isn't listed is skipped, not
+Twenty-four languages in total. A file whose language isn't listed is skipped, not
 indexed. Adding a broad-tier language is a small contribution — see
 [CREDITS.md](CREDITS.md) for the folks who added the current set.
 

--- a/src/claude/format.ts
+++ b/src/claude/format.ts
@@ -1,4 +1,5 @@
 import { basename } from 'node:path';
+import { toPosixPath } from '../util/paths.js';
 import type { Stats, SessionState } from './state.js';
 import type { GraphV1, EdgeV1 } from '../graph/types.js';
 // The injection gate reuses the federation floors rather than inventing its own:
@@ -53,8 +54,14 @@ export function renderStatusline(
 
 function nodeIdsInFile(w: GraphV1, filePath: string): Set<string> {
   const nodes = w.nodes ?? [];
+  // The hook is handed whatever the host wrote in `tool_input.file_path` — on
+  // Windows that is a backslash path (`E:\repo\src\a.gd`), while every
+  // `node.path` is posix by construction. Without this normalization the suffix
+  // test could never match on Windows and the blast radius was silently empty
+  // for every language, not just one.
+  const target = toPosixPath(filePath);
   return new Set(
-    nodes.filter((n) => n.path && (filePath === n.path || filePath.endsWith(`/${n.path}`)))
+    nodes.filter((n) => n.path && (target === n.path || target.endsWith(`/${n.path}`)))
       .map((n) => n.id),
   );
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -343,6 +343,10 @@ program
     (val: string, prev: string[]) => [...prev, val],
     [] as string[],
   )
+  .option(
+    "--all-dirs",
+    "clear a persisted --only-dir whitelist and index the whole repo again",
+  )
   .option("--no-gitignore", "skip writing graft/ into .gitignore (same as GRAFT_NO_GITIGNORE=1)")
   .option("--no-ignore", "skip writing .ignore for ripgrep re-admit (same as GRAFT_NO_IGNORE=1)")
   .action(async (
@@ -356,6 +360,7 @@ program
       allowPartial?: boolean;
       includeDir?: string[];
       onlyDir?: string[];
+      allDirs?: boolean;
       followSubmodules?: boolean;
       followNestedRepos?: boolean;
       gitignore?: boolean;
@@ -410,6 +415,8 @@ program
         process.exit(1);
       }
       onlyDirs = normalized;
+    } else if (opts.allDirs) {
+      onlyDirs = []; // an empty list is the explicit "clear the whitelist" signal
     }
     const followSubmodulesWasExplicit = command.getOptionValueSource("followSubmodules") === "cli";
     if (followSubmodulesWasExplicit && typeof opts.followSubmodules === "boolean") {

--- a/src/graph/build.ts
+++ b/src/graph/build.ts
@@ -23,7 +23,7 @@ import { containerLangOf, extractContainer, warmContainerGrammars } from "./cont
 import { contentHash } from "../util/id.js";
 import { relPosix } from "../util/paths.js";
 import { readSourceFile } from "../util/source.js";
-import { readFollowNestedRepos, readFollowSubmodules, readIncludeDirs } from "../util/state.js";
+import { readFollowNestedRepos, readFollowSubmodules, readIncludeDirs, readOnlyDirs, writeOnlyDirs } from "../util/state.js";
 import {
   emptyExtractCache,
   readExtractCache,
@@ -161,9 +161,14 @@ export async function buildGraph(
     followSubmodules: readFollowSubmodules(root),
     followNestedRepos: readFollowNestedRepos(root),
   });
-  const onlyDirs = opts.onlyDirs && opts.onlyDirs.length > 0 ? new Set(opts.onlyDirs) : undefined;
+  // A flag wins and sticks; with none, the graph's persisted whitelist stands.
+  // Without that fallback the hooks' bare `graft build .` re-indexes the whole
+  // repo and quietly undoes every `--only-dir` the user set. An empty array is
+  // `--all-dirs`: clear the whitelist and index everything again.
+  if (opts.onlyDirs !== undefined) writeOnlyDirs(root, opts.onlyDirs);
+  const onlyDirs = readOnlyDirs(root);
   const repoFiles = filterByOnlyDirs(walked, root, onlyDirs);
-  const files = listSourceStats(root, outDir, repoFiles);
+  const files = listSourceStats(root, outDir, repoFiles, onlyDirs);
   const discoveredScopes = discoverScopes(root, repoFiles);
 
   const nodes: NodeV1[] = [];
@@ -358,7 +363,7 @@ export async function buildGraph(
   // these source bytes." Nothing about the projections below — which is why it is
   // safe to write here, and why `graphOnly` builds (the query path, which stops
   // right after this line) are still recorded as fresh.
-  writeFingerprint(outDir, entries, opts.onlyDirs);
+  writeFingerprint(outDir, entries, onlyDirs ? [...onlyDirs] : undefined);
 
   // Tier-2 passive surface: project the nodes into per-file markdown cards, and
   // refresh the INDEX roster. Pure projection — no LLM, no network.

--- a/src/graph/generic.ts
+++ b/src/graph/generic.ts
@@ -58,6 +58,7 @@ export const GENERIC_LANGS: readonly GenericLang[] = [
   { name: "clojure", exts: [".clj", ".cljs", ".cljc", ".bb"], wasm: "clojure" },
   { name: "nix", exts: [".nix"], wasm: "nix" },
   { name: "lua", exts: [".lua"], wasm: "lua" },
+  { name: "gdscript", exts: [".gd"], wasm: "gdscript" },
 ];
 
 const byExt = new Map<string, GenericLang>();

--- a/src/graph/generic.ts
+++ b/src/graph/generic.ts
@@ -11,8 +11,9 @@
  * `extractGeneric` degrades to a file node only (never throws).
  *
  * What it emits (signature-only): a file node + one node per `@definition.<kind>`
- * capture, and bare-name `calls` raw edges from `@reference.call` attributed to
- * the innermost enclosing definition. resolve.ts then resolves those calls by
+ * capture, bare-name `calls` raw edges from `@reference.call` attributed to the
+ * innermost enclosing definition, and file-level `imports` edges from any
+ * `@reference.import` specifier. resolve.ts then resolves those calls by
  * name for free (same-file → extracted, unique-global → inferred). Member-call
  * receiver typing (recvType) is NOT produced here — that needs a per-language
  * binding pass; the opt-in LSP tier fills that gap for popular languages.
@@ -393,6 +394,7 @@ function tagsExtract(
   const defNameAt = new Set<number>();
   const calls: Array<{ name: string; at: number }> = [];
   const refs: Array<{ name: string; at: number }> = [];
+  const imports: string[] = [];
   for (const m of matches) {
     const cap: Record<string, TsNode> = {};
     for (const c of m.captures) cap[c.name] = c.node;
@@ -403,6 +405,19 @@ function tagsExtract(
     }
     if (("reference.call" in cap || "reference.send" in cap) && cap.name)
       calls.push({ name: cap.name.text, at: cap.name.startIndex });
+    // A module specifier the grammar marks. Unlike a call or a type reference
+    // this is a STRING, not a name to resolve, and it belongs to the FILE rather
+    // than to whatever definition encloses it — that is what makes it land as an
+    // incoming edge on the imported file, which is what a blast radius reads.
+    if ("reference.import" in cap && cap.name) {
+      const raw = cap.name.text;
+      const quote = raw[0];
+      const spec =
+        (quote === '"' || quote === "'") && raw.endsWith(quote) && raw.length >= 2
+          ? raw.slice(1, -1)
+          : raw;
+      if (spec) imports.push(spec);
+    }
     // Structural references the grammar already marks: a supertype (extends), an
     // implemented interface, an object creation (`new Foo`), a module alias. Grammars
     // label these @reference.class/.interface/.implementation/.module — heterogeneous
@@ -423,6 +438,9 @@ function tagsExtract(
     if (defNameAt.has(c.at)) continue;
     const enc = enclosing(c.at);
     rawEdges.push({ source: enc ? enc.id : rel, relation: "calls", file: rel, name: c.name });
+  }
+  for (const spec of new Set(imports)) {
+    rawEdges.push({ source: rel, relation: "imports", file: rel, specifier: spec });
   }
   for (const r of refs) {
     if (defNameAt.has(r.at)) continue;

--- a/src/graph/queries/gdscript.scm
+++ b/src/graph/queries/gdscript.scm
@@ -1,0 +1,55 @@
+; GDScript (Godot). Grammar: tree-sitter-gdscript (wasm bundle).
+; A .gd file IS a class, so `class_name X` is the file's own definition and
+; `class Inner:` is a nested one. Both surface as @definition.class.
+
+(class_name_statement
+  name: (name) @name) @definition.class
+
+(class_definition
+  name: (name) @name) @definition.class
+
+; Methods: any func inside a `class Inner:` body.
+(class_definition
+  body: (class_body
+    (function_definition
+      name: (name) @name) @definition.method))
+
+; Top-level funcs (a .gd file's own methods) and constructors.
+(function_definition
+  name: (name) @name) @definition.function
+
+(constructor_definition) @definition.method
+
+; Signals are the wiring of a Godot codebase — name them so `graft callers`
+; finds every emit/connect site.
+(signal_statement
+  name: (name) @name) @definition.property
+
+(enum_definition
+  name: (name) @name) @definition.enum
+
+; Class-level const/var only. A bare `(variable_statement)` would also match
+; every local inside a function body — on a real Godot repo that is ~40k nodes
+; of noise that buries the symbols an agent is actually looking for.
+(source
+  (const_statement
+    name: (name) @name) @definition.constant)
+
+(class_body
+  (const_statement
+    name: (name) @name) @definition.constant)
+
+(source
+  (variable_statement
+    name: (name) @name) @definition.property)
+
+(class_body
+  (variable_statement
+    name: (name) @name) @definition.property)
+
+; Calls: bare `foo()` and receiver calls `node.foo()`.
+(call
+  (identifier) @name) @reference.call
+
+(attribute_call
+  (identifier) @name) @reference.call

--- a/src/graph/queries/gdscript.scm
+++ b/src/graph/queries/gdscript.scm
@@ -53,3 +53,19 @@
 
 (attribute_call
   (identifier) @name) @reference.call
+
+; GDScript has no import statement — a script pulls in another script with
+; `preload("res://...")` (compile time) or `load(...)` (runtime). Capturing the
+; literal is what gives a .gd file incoming `imports` edges, and with them a
+; blast radius: edit a script and graft can say who preloads it.
+(call
+  (identifier) @_fn
+  arguments: (arguments
+    . (string) @name)
+  (#eq? @_fn "preload")) @reference.import
+
+(call
+  (identifier) @_fn
+  arguments: (arguments
+    . (string) @name)
+  (#eq? @_fn "load")) @reference.import

--- a/src/graph/resolve.ts
+++ b/src/graph/resolve.ts
@@ -128,6 +128,7 @@ export function resolveEdges(
   // node ids. A `use App\Models\User` names a PSR-4 class whose file mirrors the namespace
   // tail under some (unknown) source root, so the suffix is the portable key.
   const phpFilesBySuffix = new Map<string, string[]>();
+  const gdFilesBySuffix = new Map<string, string[]>();
   const hasGoModules = !!opts.goModules?.length;
   for (const n of nodes) {
     if (n.kind === "file") {
@@ -149,6 +150,15 @@ export function resolveEdges(
       if (n.path.endsWith(".php")) {
         const parts = toPosixPath(n.path).split("/");
         for (let i = 0; i < parts.length; i++) push(phpFilesBySuffix, parts.slice(i).join("/"), n.id);
+      }
+      if (n.path.endsWith(".gd")) {
+        // Same suffix trick as Java/C/PHP, for the same reason: a `res://` path is
+        // relative to the GODOT project root, which sits at an unknown depth under
+        // the repo root (and there may be several — a repo can hold more than one
+        // Godot project). Indexing every boundary suffix lets the specifier itself
+        // pick the depth, and an ambiguous match is dropped rather than guessed.
+        const parts = toPosixPath(n.path).split("/");
+        for (let i = 0; i < parts.length; i++) push(gdFilesBySuffix, parts.slice(i).join("/"), n.id);
       }
       {
         const p = toPosixPath(n.path);
@@ -216,7 +226,9 @@ export function resolveEdges(
                 ? resolveRustUse(e.specifier, e.file, byId, rustCrateRoots)
                 : e.file.endsWith(".php")
                   ? resolvePhpUse(e.specifier, phpFilesBySuffix)
-                  : resolveImport(e.specifier, e.file, byId);
+                  : e.file.endsWith(".gd")
+                    ? resolveGodotRes(e.specifier, gdFilesBySuffix)
+                    : resolveImport(e.specifier, e.file, byId);
       add(e.source, target, "imports", "extracted");
     } else if (e.relation === "extends" || e.relation === "implements") {
       // `implements` also resolves to a `trait` — PHP models trait composition
@@ -505,6 +517,25 @@ function resolveImport(spec: string, file: string, byId: Map<string, NodeV1>): s
   ];
   for (const c of candidates) if (byId.has(c)) return c;
   return spec;
+}
+
+/**
+ * Resolve a GDScript `preload("res://...")` / `load(...)` path to an in-repo file
+ * node; otherwise return the raw specifier.
+ *
+ * `res://` is the Godot project root, not the repo root, so the prefix is stripped
+ * and what remains is matched as a path suffix. Only a unique hit resolves: two
+ * Godot projects in one repo can each own a `scripts/save/cache.gd`, and pointing
+ * an edge at the wrong one is worse than leaving it unresolved. A non-`res://`
+ * specifier is a runtime `load()` of a user:// or computed path — nothing static
+ * to resolve, so it is returned as written.
+ */
+function resolveGodotRes(spec: string, gdFilesBySuffix: Map<string, string[]>): string {
+  if (!spec.startsWith("res://")) return spec;
+  const rest = spec.slice("res://".length).replace(/^\/+/, "");
+  if (!rest) return spec;
+  const hits = gdFilesBySuffix.get(rest);
+  return hits && hits.length === 1 ? hits[0] : spec;
 }
 
 /**

--- a/src/graph/source-files.ts
+++ b/src/graph/source-files.ts
@@ -10,7 +10,7 @@ import { statSync } from "node:fs";
 import { resolve } from "node:path";
 import { walkDir } from "../ingest/fs.js";
 import { relPosix } from "../util/paths.js";
-import { readFollowNestedRepos, readFollowSubmodules, readIncludeDirs } from "../util/state.js";
+import { readFollowNestedRepos, readFollowSubmodules, readIncludeDirs, readOnlyDirs } from "../util/state.js";
 import { languageOf, depthExtensions } from "./extract.js";
 import { genericLangOf, genericExtensions } from "./generic.js";
 import { containerLangOf, containerExtensions } from "./container.js";
@@ -68,7 +68,7 @@ export function listSourceFiles(
     followSubmodules: readFollowSubmodules(resolve(root)),
     followNestedRepos: readFollowNestedRepos(resolve(root)),
   }),
-  onlyDirs?: ReadonlySet<string>,
+  onlyDirs: ReadonlySet<string> | undefined = readOnlyDirs(resolve(root)),
 ): string[] {
   // A file is a source file if a depth-tier grammar (languageOf), a breadth-tier
   // grammar (genericLangOf) or a container (containerLangOf) claims its extension.

--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -149,6 +149,32 @@ export function readIncludeDirs(d: string): Set<string> | undefined {
   return dirs && dirs.length ? new Set(dirs) : undefined;
 }
 
+/**
+ * The sticky `--only-dir` whitelist, kept with the GRAPH (`graft/.cache/`), never
+ * in the source repo — the same boundary the fingerprint respects, so a
+ * `--only-dir` build still leaves no trace under the tree being indexed.
+ *
+ * The fingerprint alone was not enough. It is keyed by extractor identity and
+ * rewritten by every build, and the hooks shell a bare `graft build .` that sees
+ * no CLI flags — so the first post-edit rebuild dropped the whitelist and silently
+ * re-indexed the whole repo. This file is what a no-flag rebuild reads back.
+ */
+function onlyDirsPath(d: string): string { return join(cacheDir(d), 'only-dirs.json'); }
+
+export function readOnlyDirs(d: string): Set<string> | undefined {
+  const dirs = readJson<string[]>(onlyDirsPath(d));
+  return Array.isArray(dirs) && dirs.length ? new Set(dirs) : undefined;
+}
+
+/** Persist (or, with an empty list, clear) the whitelist. Best-effort: losing it
+ * costs the next no-flag build its scope, never correctness. */
+export function writeOnlyDirs(d: string, dirs: string[]): void {
+  try {
+    if (dirs.length === 0) { rmSync(onlyDirsPath(d), { force: true }); return; }
+    writeJsonAtomic(onlyDirsPath(d), dirs);
+  } catch { /* best-effort */ }
+}
+
 /** Missing and explicit false both retain the backwards-compatible default. */
 export function readFollowSubmodules(d: string): boolean {
   return readBuildConfig(d)?.followSubmodules === true;

--- a/test/claude-format.test.ts
+++ b/test/claude-format.test.ts
@@ -228,3 +228,19 @@ test('renderStatusline shows tokens alone until a turn has been billed', () => {
   assert.match(line, /~100,000 tok saved/);
   assert.doesNotMatch(line, /\$/);
 });
+
+test('incomingEdges matches a Windows path against posix node paths', () => {
+  // The post-edit hook forwards `tool_input.file_path` exactly as the host wrote
+  // it. On Windows that is a backslash path, while every node.path is posix — so
+  // the suffix test used to miss on every file and the blast radius came back
+  // empty for every language, silently.
+  const win = String.raw`E:\projetos\repo\src\pkce.ts`;
+  const e = incomingEdges(wiring2, win);
+  assert.equal(e.length, 1, 'a backslash path must resolve to the same nodes');
+  assert.equal(e[0].source, 'src/client.ts#exchange');
+
+  assert.match(strip(formatBlastRadius(wiring2, win)!), /blast radius for pkce\.ts/);
+
+  // A backslash path that names no indexed file still resolves to nothing.
+  assert.equal(formatBlastRadius(wiring2, String.raw`E:\projetos\repo\src\unknown.ts`), null);
+});

--- a/test/generic-extract.test.ts
+++ b/test/generic-extract.test.ts
@@ -523,3 +523,58 @@ test("GDScript: class_name/nested class/signal/enum/const become symbols, body l
     .map((e) => `${e.source.split("#")[1]}→${e.target.split("#")[1]}`);
   assert.ok(calls.includes("_ready→_build"), `_ready → _build (got ${calls.join(", ")})`);
 });
+
+const GD_TARGET = `extends Node
+class_name WaterCache
+
+func build() -> void:
+	pass
+`;
+
+const GD_USER = `extends Node
+
+const WaterCacheScript := preload("res://scripts/save/water_cache.gd")
+const Missing := preload("res://scripts/does_not_exist.gd")
+
+func run() -> void:
+	var runtime := load("res://scripts/save/water_cache.gd")
+`;
+
+test("GDScript: preload/load give the imported FILE an incoming edge (blast radius)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-gd-import-"));
+  mkdirSync(join(dir, "scripts", "save"), { recursive: true });
+  writeFileSync(join(dir, "scripts", "save", "water_cache.gd"), GD_TARGET);
+  writeFileSync(join(dir, "scripts", "save", "user.gd"), GD_USER);
+
+  await buildGraph(dir, { reuse: false });
+  const g = readGraph(wiringPath(join(dir, "graft")))!;
+  const imports = g.edges.filter((e) => e.relation === "imports");
+
+  // `res://` is the Godot project root, so the prefix is stripped and the rest
+  // matched as a path suffix — this is the edge a post-edit blast radius reads.
+  assert.ok(
+    imports.some(
+      (e) =>
+        e.source === "scripts/save/user.gd" && e.target === "scripts/save/water_cache.gd",
+    ),
+    `user.gd imports water_cache.gd (got ${imports.map((e) => `${e.source}→${e.target}`).join(", ")})`,
+  );
+
+  // preload and load of the SAME path are one edge, not two.
+  assert.equal(
+    imports.filter((e) => e.target === "scripts/save/water_cache.gd").length,
+    1,
+    "preload + load of one path must not double the edge",
+  );
+
+  // A path with no file behind it keeps the raw specifier as its target — the
+  // same shape every other resolver uses for an unresolved import — rather than
+  // being pointed at some same-named node elsewhere in the repo.
+  const dangling = imports.filter((e) => e.target.includes("does_not_exist"));
+  assert.equal(dangling.length, 1, "the dangling import is still recorded");
+  assert.equal(
+    dangling[0].target,
+    "res://scripts/does_not_exist.gd",
+    "an unresolvable res:// path stays the raw specifier, never a node id",
+  );
+});

--- a/test/generic-extract.test.ts
+++ b/test/generic-extract.test.ts
@@ -471,3 +471,55 @@ test("a throwing grammar is a per-file build error, cached as a failure (#139)",
     swapGrammarForTest("rust", prev);
   }
 });
+
+// GDScript: a .gd file IS a class, so `class_name` names the file's own type and
+// `class Inner:` is a nested one. Locals inside a func body must stay out.
+const GDSCRIPT = `extends Node
+class_name WaterCache
+
+signal chunk_ready(id: int)
+
+enum Mode { FAST, SLOW }
+
+const MAX_CHUNKS := 32
+var cache := {}
+
+class Inner:
+\thelper_placeholder
+
+func _ready() -> void:
+\tvar local_only := 1
+\t_build(local_only)
+
+func _build(n: int) -> int:
+\treturn n + MAX_CHUNKS
+`.replace(/helper_placeholder/, "func helper() -> void:\n\t\tpass");
+
+test("genericLangOf routes .gd to the breadth tier", () => {
+  assert.equal(genericLangOf("scripts/save/water_cache.gd")?.name, "gdscript");
+});
+
+test("GDScript: class_name/nested class/signal/enum/const become symbols, body locals do not", async () => {
+  await warmGenericGrammars(["gdscript"]);
+  assert.ok(isWarm("gdscript"), "gdscript grammar should warm");
+  const { nodes, rawEdges } = extractGeneric("water_cache.gd", GDSCRIPT, "gdscript");
+  const symbols = nodes.filter((n) => n.kind !== "file");
+  const byName = new Map(symbols.map((n) => [n.name, n]));
+
+  assert.equal(byName.get("WaterCache")?.kind, "class", "class_name is the file's own class");
+  assert.equal(byName.get("Inner")?.kind, "class", "nested class");
+  assert.equal(byName.get("helper")?.kind, "method", "func inside a class body is a method");
+  assert.equal(byName.get("_build")?.kind, "function", "top-level func");
+  assert.equal(byName.get("Mode")?.kind, "enum");
+  assert.equal(byName.get("MAX_CHUNKS")?.kind, "constant");
+  assert.equal(byName.get("chunk_ready")?.kind, "variable", "signals are named so callers can find emits");
+  assert.equal(byName.get("cache")?.kind, "variable", "class-level var");
+
+  assert.ok(!symbols.some((n) => n.name === "local_only"), "function-body local is not a symbol");
+
+  const edges = resolveEdges(nodes, rawEdges);
+  const calls = edges
+    .filter((e) => e.relation === "calls")
+    .map((e) => `${e.source.split("#")[1]}→${e.target.split("#")[1]}`);
+  assert.ok(calls.includes("_ready→_build"), `_ready → _build (got ${calls.join(", ")})`);
+});

--- a/test/graph-only-dir.test.ts
+++ b/test/graph-only-dir.test.ts
@@ -87,3 +87,31 @@ test("--only-dir rejects a prefix that normalizes to empty", () => {
     rmSync(d, { recursive: true, force: true });
   }
 });
+
+test("the whitelist survives a no-flag rebuild, and --all-dirs clears it", () => {
+  const d = repoWithDirs();
+  try {
+    runCli(["build", d, "--only-dir", "src/a"]);
+    assert.ok(!graphOf(d)!.nodes.some((n) => n.path === "src/b/b.ts"), "src/b starts excluded");
+
+    // The regression: the hooks shell a bare `graft build .` with no flags at all.
+    // Before the whitelist was made sticky this re-indexed the whole repo, so one
+    // file edit silently undid the user's scope.
+    runCli(["build", d]);
+    const after = graphOf(d)!;
+    assert.ok(after.nodes.some((n) => n.path === "src/a/a.ts"), "src/a still indexed");
+    assert.ok(!after.nodes.some((n) => n.path === "src/b/b.ts"), "src/b must STILL be skipped");
+    assert.ok(!after.nodes.some((n) => n.path === "top.ts"), "top.ts must STILL be skipped");
+    assert.deepEqual(readFingerprint(join(d, "graft"))?.onlyDirs, ["src/a"]);
+    assert.ok(!existsSync(join(d, ".graft", "config.json")), "source repo config still untouched");
+
+    // And the escape hatch puts the whole repo back.
+    runCli(["build", d, "--all-dirs"]);
+    const full = graphOf(d)!;
+    assert.ok(full.nodes.some((n) => n.path === "src/b/b.ts"), "--all-dirs re-indexes src/b");
+    assert.ok(full.nodes.some((n) => n.path === "top.ts"), "--all-dirs re-indexes top.ts");
+    assert.equal(readFingerprint(join(d, "graft"))?.onlyDirs, undefined, "whitelist cleared");
+  } finally {
+    rmSync(d, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Four changes, found while wiring graft into a 1,619-file Godot + Go game repo. Two are bug fixes that stand on their own; two add GDScript. Happy to split this into separate PRs if you'd rather review them apart — the files don't overlap.

Every claim below is measured on that repo (1,273 files indexed after scoping, 846 of them `.gd`).

---

### 1. `fix(claude): match the edited file on Windows, so blast radius fires` (c4f39b9)

The post-edit hook forwards `tool_input.file_path` exactly as the host wrote it. On Windows that is a backslash path, while every `node.path` in the graph is posix by construction. `nodeIdsInFile` compared them with `filePath.endsWith("/" + n.path)`, which cannot match across separators — so the lookup returned an empty set and `formatBlastRadius` returned `null`.

**On every edit, in every language, with no error anywhere.** Editing a file with eight dependents cost the hook's full ~9s and printed nothing. Normalizing the incoming path turns that same edit into the eight-line radius the hook was written to produce.

This one is independent of the GDScript work and affects every Windows user today.

### 2. `fix(build): make --only-dir survive a no-flag rebuild` (4408ba9)

`--only-dir`'s whitelist was recorded only in the graph fingerprint, and the fingerprint is rewritten by every build. `sync-run.ts` shells a bare `graft build .` that never sees a CLI flag, so the first post-edit rebuild after a `--only-dir` build silently re-indexed the whole repo.

Where the excluded directories are vendored reference code, that is not cosmetic: on this repo an unscoped index put four of six hits for "player movement" in sample FPS templates and none in the actual game. One file edit undid the scope, with nothing in the output saying so.

The list now persists in `graft/.cache/only-dirs.json` and is read back when no flag is passed. Keeping it under `graft/` rather than in `.graft/config.json` preserves the property `test/graph-only-dir.test.ts` guards — a `--only-dir` build still leaves no trace in the repo being indexed, and that test passes unchanged. `--all-dirs` clears it, since a sticky whitelist otherwise has no escape hatch short of deleting the graph.

Measured: `--only-dir` build indexes 1,273 files; a subsequent bare `graft build .` used to return to 1,619 and now stays at 1,273.

### 3. `feat(graph): add GDScript to the breadth tier` (c06d6ad)

Godot projects are a large unserved corpus — a mid-size game is a four-figure count of `.gd` files, and today every one is skipped, so graft indexes the C#/C++/Go edges of a Godot repo and none of the game logic. `tree-sitter-wasm` already ships the gdscript grammar, so this is one registry row plus a tags query.

The query is deliberately narrow on variables. A bare `(variable_statement)` also matches every local inside a function body — on this repo that was ~36k extra nodes (66.5k vs 30.5k total), which buries the symbols an agent is searching for. Scoping const/var to `(source ...)` and `(class_body ...)` keeps the class-level API and drops the locals, at the cost of ~1.4k local-to-local call edges.

Signals get a name of their own so `graft callers <signal>` finds every emit and connect site — that is the wiring an agent most needs in a Godot codebase, and the thing grep is worst at.

### 4. `feat(graph): GDScript preload/load become import edges` (d1cb17c)

GDScript has no import statement; a script reaches another through `preload("res://...")` or `load(...)`. Without those, `.gd` files had symbol-level call edges and no file-level edges at all, so anything reading incoming edges on a file — blast radius, `graft callers <file>` — had nothing to report for an entire language.

`res://` is the Godot project root, which sits at an unknown depth under the repo root and may appear more than once, so the specifier is matched as a path suffix over an index of every directory boundary — the same approach already used for Java, C and PHP. Only a unique hit resolves; an ambiguous or absent one keeps the raw specifier rather than pointing the edge at a same-named file in a different project.

`@reference.import` is handled generically rather than as a GDScript special case: any breadth-tier grammar can now mark a specifier and get file-level import edges, and the edge is attributed to the file, not to whatever definition encloses the call.

Measured: 3,301 import edges, 3,252 resolved to a file (the 49 left are runtime `load()` of computed paths); total edges 29,166 → 31,204.

---

### Tests

New regression tests in `test/generic-extract.test.ts` (GDScript symbols, and preload/load import edges including the dedupe and the dangling-specifier case), `test/graph-only-dir.test.ts` (whitelist survives a no-flag rebuild; `--all-dirs` clears it), and `test/claude-format.test.ts` (a Windows path resolves to the same nodes).

`npx tsx --test` over `test/graph-*.test.ts` plus `generic-extract`, `covers`, `regression-single-repo`, `supported-extensions`, `util-state`, `context-only-dir`: **377 pass, 0 fail, 5 skipped.**

Three tests in `claude-format` and four in `claude-hooks`/`session-metrics` fail on my machine, all in the token/dollar accounting paths. They fail identically on a clean checkout of `main` — I verified with `git stash` — so they are not from this branch.

### Docs

`README.md`'s breadth-tier list gains GDScript (23 → 24 languages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
