### PR TITLE
feat(ingest): allow --include-dir to opt into named dot-directories (#221)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **`graft build --include-dir` can opt a named hidden directory into the
+  repo-root walk** (#221). Default is unchanged: `.github`, `.vscode`, `.kb`
+  and every other dot-directory stay skipped. Pass `--include-dir .kb` (a
+  bare name, same switch as `build/` / `vendor/`) and the walk descends into
+  that directory so its nodes land on the same root graph the MCP server and
+  hooks already point at. The choice persists in `.graft/config.json`, so a
+  later no-flag build still includes it. `.git` is never overridable — the
+  CLI rejects `--include-dir .git` with a non-zero exit. Git's ignore rules
+  stay authoritative; the flag only lifts graft's own skip.
+
 ## 0.18.0
 
 ### Added

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,6 +44,7 @@ import { formatNonInteractiveHelp, formatPlan, runPicker } from "./cli-picker.js
 import { homedir } from "node:os";
 import { formatUpgradeReport, formatVersionReport, getNpmViewVersion, readCurrentVersion, runUpgrade } from "./cli-meta.js";
 import { patchBuildConfig, type BuildConfig } from "./util/state.js";
+import { NEVER_INCLUDE_DIRS } from "./ingest/fs.js";
 import { normalizePathPrefix } from "./util/paths.js";
 import { latestSession, formatSessionStats, sessionInputRate } from "./claude/session-metrics.js";
 import { setInputRate } from "./context/savings.js";
@@ -350,8 +351,9 @@ program
   )
   .option(
     "--include-dir <name>",
-    "override SKIP_DIRS for this repo's walks — repeatable (e.g. --include-dir build --include-dir tools); " +
-      "persisted, so a later build (and the hooks/refresh path) include it without the flag; dot-dirs are never overridable",
+    "override SKIP_DIRS (and named hidden directories) for this repo's walks — repeatable " +
+      "(e.g. --include-dir build --include-dir .kb); persisted, so a later build (and the " +
+      "hooks/refresh path) include it without the flag; .git is never overridable",
     (val: string, prev: string[]) => [...prev, val],
     [] as string[],
   )
@@ -397,14 +399,13 @@ program
     // walkDir call sites read it from state, not from a threaded option.
     const buildConfigPatch: BuildConfig = {};
     if (opts.includeDir && opts.includeDir.length > 0) {
-      // --include-dir takes bare SKIP_DIRS-style directory NAMES (shouldSkipDir
-      // compares a single path segment), never paths, and dot-dirs are never
-      // overridable at all (see the option's own help text) — reject anything
-      // else up front instead of silently persisting a value that can never
-      // match a real directory name.
+      // --include-dir takes bare directory NAMES (shouldSkipDir compares a
+      // single path segment), never paths. Named hidden directories (.kb) are
+      // the same opt-in as SKIP_DIRS names; NEVER_INCLUDE_DIRS (.git) stay
+      // forbidden — reject those up front instead of persisting a no-op.
       for (const name of opts.includeDir) {
-        if (name.startsWith(".")) {
-          console.error(`✗ --include-dir "${name}": dot-directories are never overridable`);
+        if (NEVER_INCLUDE_DIRS.has(name)) {
+          console.error(`✗ --include-dir "${name}": ${name} is never overridable`);
           process.exit(1);
         }
         if (name.includes("/") || name.includes("\\")) {

--- a/src/ingest/fs.ts
+++ b/src/ingest/fs.ts
@@ -28,8 +28,16 @@ export const SKIP_DIRS = new Set([
 export const MAX_FILE_BYTES = 1_000_000;
 
 /**
+ * Directory names `--include-dir` can never un-skip. `.git` is the
+ * repository's own metadata, not source — indexing it would drown the graph
+ * in objects and refs. Shared with the CLI validator so a forbidden name is
+ * rejected up front instead of persisting a no-op.
+ */
+export const NEVER_INCLUDE_DIRS = new Set([".git"]);
+
+/**
  * Whether a directory named `name` should be skipped when walking a repo tree:
- * any dot-prefixed directory (`.git`, `.github`, `.vscode`, ...) or one of
+ * any dot-prefixed directory (`.git`, `.github`, `.vscode`, `.kb`, ...) or one of
  * {@link SKIP_DIRS} not named in `includes`. The single source of truth for
  * "is this dir source" — `skippedPath` and `walkFilesystem` below and the
  * git-child discovery in `graph/scopes.ts` share it, so they can never
@@ -38,23 +46,22 @@ export const MAX_FILE_BYTES = 1_000_000;
  * `includes` is the explicit, per-repo `graft build --include-dir` override
  * (persisted via `util/state.ts`'s `readIncludeDirs`, threaded in by each
  * caller) — a name in it is removed from the effective skip set for THIS
- * repo's walks. Absent/empty ≡ today's default behavior. It lifts only
- * graft's own skip list: in a Git repo, Git's ignore rules stay authoritative
- * (see {@link walkDir}).
- *
- * KNOWN LIMITATION: a dot-directory is skipped WHOLESALE and is NEVER
- * overridable, even via `includes` — unlike `SKIP_DIRS`, there is no path to
- * un-skip one. A repo that keeps real, hand-written source under a
- * dot-prefixed directory is out of scope.
+ * repo's walks, including a named hidden directory such as `.kb`. Absent/empty
+ * ≡ today's default behavior (every dot-directory stays skipped). Names in
+ * {@link NEVER_INCLUDE_DIRS} (at least `.git`) stay skipped even when listed.
+ * It lifts only graft's own skip list: in a Git repo, Git's ignore rules stay
+ * authoritative (see {@link walkDir}).
  */
 export function shouldSkipDir(name: string, includes?: ReadonlySet<string>): boolean {
-  if (name.startsWith(".")) return true;
+  if (NEVER_INCLUDE_DIRS.has(name)) return true;
   if (includes?.has(name)) return false;
+  if (name.startsWith(".")) return true;
   return SKIP_DIRS.has(name);
 }
 
 /**
- * Recursively list all files under a directory. Skips dot-directories,
+ * Recursively list all files under a directory. Skips dot-directories
+ * (unless named in `includes`, except {@link NEVER_INCLUDE_DIRS}),
  * dependency/build directories (node_modules, dist, …) not named in
  * `includes`, and files over 1 MB.
  * In a Git worktree, tracked files plus untracked, non-ignored files come from

--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -87,9 +87,10 @@ export function writeStats(d: string, s: Stats): void { writeJsonAtomic(statsPat
  * Missing fields always retain backwards-compatible defaults.
  */
 export interface BuildConfig {
-  /** SKIP_DIRS names to include in this repo's walks, persisted so a LATER
-   * no-flag build — and the fingerprint/refresh path, which never sees CLI
-   * flags at all — behave identically to the invocation that set it. */
+  /** SKIP_DIRS names and named hidden directories (except `.git`) to include
+   * in this repo's walks, persisted so a LATER no-flag build — and the
+   * fingerprint/refresh path, which never sees CLI flags at all — behave
+   * identically to the invocation that set it. */
   includeDirs?: string[];
   /** Whether initialized Git submodules (gitlinks) are folded into this repo's
    * graph. Absent/false keeps the historical boundary at the superproject. */

--- a/test/graph-include-dir.test.ts
+++ b/test/graph-include-dir.test.ts
@@ -25,6 +25,16 @@ function repoWithBuildDir(): string {
   return d;
 }
 
+function repoWithHiddenDir(): string {
+  const d = mkdtempSync(join(tmpdir(), "graft-include-hidden-"));
+  mkdirSync(join(d, ".kb"), { recursive: true });
+  writeFileSync(join(d, ".kb", "engine.ts"), "export function fromKb(): number {\n  return 1;\n}\n");
+  mkdirSync(join(d, ".github"), { recursive: true });
+  writeFileSync(join(d, ".github", "ci.ts"), "export function fromGithub(): number {\n  return 2;\n}\n");
+  writeFileSync(join(d, "main.ts"), "export function main(): number {\n  return 3;\n}\n");
+  return d;
+}
+
 function runCli(args: string[]): void {
   execFileSync(process.execPath, ["--import", "tsx", "src/cli.ts", ...args], { stdio: "pipe" });
 }
@@ -116,21 +126,66 @@ test("A5: custom --dir builds keep repository config outside both output directo
   }
 });
 
-// --include-dir takes bare SKIP_DIRS-style directory NAMES, never paths, and
-// dot-dirs are (per the option's own help text) never overridable at all.
-// Without validation, a value like ".github" or "foo/bar" would silently
+// --include-dir takes bare directory NAMES, never paths. Named hidden
+// directories (.kb) are the same opt-in as SKIP_DIRS names; .git is never
+// overridable. Without validation, a value like "foo/bar" would silently
 // persist and then just never match any real directory name walkDir compares
-// against (shouldSkipDir compares against a single path segment), so the flag
-// would look accepted while doing nothing.
+// against (shouldSkipDir compares against a single path segment).
 
-test("A5: --include-dir rejects a dot-prefixed name", () => {
+test("A5: --include-dir rejects .git", () => {
   const d = repoWithBuildDir();
   try {
-    const r = runCliCapture(["build", d, "--include-dir", ".github"]);
+    const r = runCliCapture(["build", d, "--include-dir", ".git"]);
     assert.equal(r.status, 1, `expected exit 1, got ${r.status}\nstdout: ${r.stdout}\nstderr: ${r.stderr}`);
     assert.match(r.stderr, /--include-dir/);
-    assert.match(r.stderr, /\.github/);
+    assert.match(r.stderr, /\.git/);
     assert.equal(existsSync(join(d, ".graft", "config.json")), false, "must not persist an invalid value");
+  } finally {
+    rmSync(d, { recursive: true, force: true });
+  }
+});
+
+test("A5: .kb/ is absent by default, present with --include-dir .kb, persists across a no-flag rebuild; .github stays skipped", () => {
+  const d = repoWithHiddenDir();
+  try {
+    runCli(["build", d]);
+    const cold = graphOf(d);
+    assert.ok(cold, "expected a built graph.json");
+    assert.ok(!cold!.nodes.some((n) => n.path.startsWith(".kb/")), ".kb/ must be absent by default");
+    assert.ok(!cold!.nodes.some((n) => n.path.startsWith(".github/")), ".github/ must be absent by default");
+    assert.ok(cold!.nodes.some((n) => n.id === "main.ts#main"), "sanity: the non-skipped file is indexed");
+
+    runCli(["build", d, "--include-dir", ".kb"]);
+    const withFlag = graphOf(d);
+    assert.ok(withFlag);
+    assert.ok(
+      withFlag!.nodes.some((n) => n.id === ".kb/engine.ts#fromKb"),
+      ".kb/ must be included this run, with the flag, on the same root graph",
+    );
+    assert.ok(
+      withFlag!.nodes.some((n) => n.id === "main.ts#main"),
+      "the root file stays on the same graph as .kb/",
+    );
+    assert.ok(
+      !withFlag!.nodes.some((n) => n.path.startsWith(".github/")),
+      "including .kb must not pull in .github",
+    );
+
+    runCli(["build", d]);
+    const persisted = graphOf(d);
+    assert.ok(persisted);
+    assert.ok(
+      persisted!.nodes.some((n) => n.id === ".kb/engine.ts#fromKb"),
+      "a follow-up NO-FLAG rebuild must still include .kb/ (state-persisted)",
+    );
+    assert.ok(
+      !persisted!.nodes.some((n) => n.path.startsWith(".github/")),
+      "persisted .kb must not start indexing .github",
+    );
+
+    const drift = probeDrift(d, join(d, "graft"));
+    assert.ok(drift, "expected a fingerprint to probe against");
+    assert.ok(isClean(drift!), `probe must report clean, got ${JSON.stringify(drift)}`);
   } finally {
     rmSync(d, { recursive: true, force: true });
   }

--- a/test/ingest-fs.test.ts
+++ b/test/ingest-fs.test.ts
@@ -4,7 +4,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, renameSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, relative, resolve, sep, isAbsolute } from "node:path";
-import { shouldSkipDir, walkDir, SKIP_DIRS } from "../src/ingest/fs.js";
+import { shouldSkipDir, walkDir, SKIP_DIRS, NEVER_INCLUDE_DIRS } from "../src/ingest/fs.js";
 import { discoverScopes, discoverWorkspaceChildren } from "../src/graph/scopes.js";
 
 function fixture(tag: string): string {
@@ -190,8 +190,8 @@ test("walkDir retains fixed skips and filesystem fallback outside Git", () => {
  * git-child filter (src/graph/scopes.ts). This introduces `shouldSkipDir` as
  * the single source of truth, with an optional `includes` param: a name in it
  * is removed from the effective skip set for this repo's walks (persisted via
- * `graft build --include-dir`), while a dot-directory stays non-overridable
- * regardless.
+ * `graft build --include-dir`), including a named hidden directory such as
+ * `.kb`. Names in NEVER_INCLUDE_DIRS (`.git`) stay skipped even when listed.
  *
  * `--include-dir` lifts only graft's OWN skip list. In a Git repo, Git's
  * ignore rules stay authoritative: an ignored directory remains excluded even
@@ -203,16 +203,23 @@ test("shouldSkipDir: every SKIP_DIRS name and any dot-prefixed name is skipped; 
   for (const name of SKIP_DIRS) assert.equal(shouldSkipDir(name), true, `${name} should be skipped`);
   assert.equal(shouldSkipDir(".git"), true);
   assert.equal(shouldSkipDir(".github"), true);
+  assert.equal(shouldSkipDir(".vscode"), true);
+  assert.equal(shouldSkipDir(".kb"), true);
   assert.equal(shouldSkipDir("."), true);
   assert.equal(shouldSkipDir("src"), false);
   assert.equal(shouldSkipDir("app"), false);
 });
 
-test("A5: shouldSkipDir(name, includes) removes a SKIP_DIRS name from the skip set, but never a dot-dir", () => {
-  const includes = new Set(["build", ".git"]);
+test("A5: shouldSkipDir(name, includes) removes a SKIP_DIRS name from the skip set, and a named hidden dir except .git", () => {
+  const includes = new Set(["build", ".kb", ".git"]);
   assert.equal(shouldSkipDir("build", includes), false, "an included SKIP_DIRS name is no longer skipped");
   assert.equal(shouldSkipDir("vendor", includes), true, "a SKIP_DIRS name NOT in includes is still skipped");
-  assert.equal(shouldSkipDir(".git", includes), true, "a dot-dir is never overridable, even if explicitly included");
+  assert.equal(shouldSkipDir(".kb", includes), false, "a named hidden dir is walked once included");
+  assert.equal(shouldSkipDir(".github", includes), true, ".github stays skipped unless it is the named include");
+  assert.equal(shouldSkipDir(".git", includes), true, ".git is never overridable, even if explicitly included");
+  for (const name of NEVER_INCLUDE_DIRS) {
+    assert.equal(shouldSkipDir(name, new Set([name])), true, `${name} is never overridable`);
+  }
   assert.equal(shouldSkipDir("src", includes), false);
 });
 
@@ -230,6 +237,33 @@ test("A5: walkDir(dir, includes) descends into an included SKIP_DIRS-named direc
     const withIncludes = walkDir(dir, new Set(["build"])).map((f) => f.slice(dir.length + 1));
     assert.ok(withIncludes.some((f) => f.startsWith("build")), "build/ is walked once included");
     assert.ok(!withIncludes.some((f) => f.startsWith("vendor")), "vendor/ stays skipped — only the named dir is included");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("A5: walkDir(dir, includes) descends into a named hidden directory; .git stays skipped (filesystem fallback)", () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-walkdir-hidden-"));
+  try {
+    mkdirSync(join(dir, ".kb"), { recursive: true });
+    writeFileSync(join(dir, ".kb", "engine.ts"), "export const X = 1;\n");
+    mkdirSync(join(dir, ".github"), { recursive: true });
+    writeFileSync(join(dir, ".github", "ci.ts"), "export const Y = 1;\n");
+    mkdirSync(join(dir, ".git"), { recursive: true });
+    writeFileSync(join(dir, ".git", "HEAD"), "ref: refs/heads/main\n");
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "src", "app.ts"), "export const Z = 1;\n");
+
+    const withoutIncludes = walkDir(dir).map((f) => f.slice(dir.length + 1));
+    assert.ok(withoutIncludes.some((f) => f.endsWith("app.ts")), "src/ is walked");
+    assert.ok(!withoutIncludes.some((f) => f.startsWith(".kb")), "default: .kb/ is skipped");
+    assert.ok(!withoutIncludes.some((f) => f.startsWith(".github")), "default: .github/ is skipped");
+    assert.ok(!withoutIncludes.some((f) => f.startsWith(".git")), "default: .git/ is skipped");
+
+    const withIncludes = walkDir(dir, new Set([".kb", ".git"])).map((f) => f.slice(dir.length + 1));
+    assert.ok(withIncludes.some((f) => f.startsWith(".kb")), ".kb/ is walked once included");
+    assert.ok(!withIncludes.some((f) => f.startsWith(".github")), ".github/ stays skipped — only the named dir is included");
+    assert.ok(!withIncludes.some((f) => f.startsWith(".git")), ".git stays skipped even when named in includes");
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -256,6 +290,32 @@ test("A5: --include-dir does not override gitignore — an ignored directory sta
     write(dir, "build/gen.ts");
 
     assert.deepEqual(walked(dir, new Set(["build"])), ["src/app.ts"]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("A5: in a Git repo, --include-dir .kb lifts the built-in skip for git-visible files", () => {
+  const dir = fixture("include-hidden-git");
+  try {
+    write(dir, "src/app.ts");
+    write(dir, ".kb/engine.ts");
+
+    assert.ok(!walked(dir).includes(".kb/engine.ts"), "default: .kb/ is skipped by the built-in list");
+    assert.deepEqual(walked(dir, new Set([".kb"])), [".kb/engine.ts", "src/app.ts"]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("A5: --include-dir .kb does not override gitignore — an ignored hidden directory stays excluded even when named", () => {
+  const dir = fixture("include-hidden-ignored");
+  try {
+    write(dir, ".gitignore", ".kb/\n");
+    write(dir, "src/app.ts");
+    write(dir, ".kb/engine.ts");
+
+    assert.deepEqual(walked(dir, new Set([".kb"])), ["src/app.ts"]);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- Default is unchanged: every dot-directory (`.kb`, `.github`, `.vscode`, …) is still skipped unless named.
- `graft build --include-dir .kb` is the same persisted switch as `--include-dir build`. The walk descends into that directory and its nodes land on the **repo-root graph** the MCP server and hooks already point at — not a disjoint `graft build .kb` side graph.
- `.git` is never overridable. `--include-dir .git` is rejected with a non-zero exit and is not persisted.
- Still a bare directory name (no `/` or `\`). Git's ignore rules stay authoritative; the flag only lifts graft's own skip.

Closes #221

## Test plan
- [x] No flag / no persisted `includeDirs`: `.kb`, `.github`, `.vscode` stay skipped
- [x] `graft build --include-dir .kb`: `.kb` nodes on the same root graph as `main.ts`; `.github` still skipped
- [x] Follow-up no-flag `graft build` still includes `.kb` (`.graft/config.json` persist); fingerprint probe is clean
- [x] `--include-dir .git` exits 1 and does not persist
- [x] `--include-dir` still rejects paths (`foo/bar`, `foo\bar`)
- [x] Git-visible `.kb` is walked once included; a gitignored `.kb/` stays excluded
- [x] `npx tsc -p tsconfig.json --noEmit`
- [x] `npm test` — 1224 pass, 0 fail

Made with [Cursor](https://cursor.com)