### PR TITLE
fix(deep): match file-node crux ids when the model echoes the decorated target (#298)

### DIFF
--- a/src/ai/crux.ts
+++ b/src/ai/crux.ts
@@ -47,7 +47,12 @@ export interface CruxSummarizer {
 }
 
 /** Why a crux call produced no usable summaries (#235). */
-export type CruxMissKind = "empty-toolCalls" | "unparseable" | "truncated" | "empty-parsed";
+export type CruxMissKind =
+  | "empty-toolCalls"
+  | "unparseable"
+  | "truncated"
+  | "empty-parsed"
+  | "id-mismatch";
 
 export interface CruxMiss {
   kind: CruxMissKind;
@@ -75,7 +80,21 @@ export function classifyCruxMiss(res: ChatResponse, parsed: NodeCrux[]): CruxMis
 /** Per-file error text: miss class + the provider's finish_reason (#235). */
 export function formatCruxMiss(kind: CruxMissKind, finishReason: string | null): string {
   const fr = finishReason == null || finishReason === "" ? "null" : finishReason;
+  if (kind === "id-mismatch") {
+    return `model returned symbol summaries that matched no requested id [id-mismatch, finish_reason=${fr}]`;
+  }
   return `model returned no usable symbol summaries [${kind}, finish_reason=${fr}]`;
+}
+
+/**
+ * `userContent` renders each target as `id=${n.id} | ${kind} | lines Lx-Ly`.
+ * Node ids never contain `" | "`; models that follow "use that id verbatim"
+ * often echo the whole decoration for file nodes (whose id is a bare path).
+ * Strip it so `collectFileCrux` can look up the real node (#298).
+ */
+export function normalizeCruxId(id: string): string {
+  const cut = id.indexOf(" | ");
+  return (cut === -1 ? id : id.slice(0, cut)).trim();
 }
 
 const SYSTEM_PROMPT = `You explain code definitions for a code graph that helps engineers navigate a codebase.
@@ -142,11 +161,12 @@ function parseResults(obj: { symbols?: unknown } | undefined): NodeCrux[] {
     .map((s) => s as Record<string, unknown>)
     .filter((s) => typeof s.id === "string")
     .map((s) => ({
-      id: s.id as string,
+      id: normalizeCruxId(s.id as string),
       summary: typeof s.summary === "string" ? s.summary.trim() : "",
       crux_start: num(s.crux_start),
       crux_end: num(s.crux_end),
-    }));
+    }))
+    .filter((s) => s.id.length > 0);
 }
 
 /**

--- a/src/graph/enrich.ts
+++ b/src/graph/enrich.ts
@@ -19,7 +19,14 @@
  * once, to cut `crux.code` verbatim from the source. `crux.span` is a pointer
  * only and is never used to re-slice.
  */
-import { formatCruxMiss, type CruxMissKind, type CruxSummarizer, type NodeCrux, type NodeRef } from "../ai/crux.js";
+import {
+  formatCruxMiss,
+  normalizeCruxId,
+  type CruxMissKind,
+  type CruxSummarizer,
+  type NodeCrux,
+  type NodeRef,
+} from "../ai/crux.js";
 import { LlmFailureGate } from "../ai/failure.js";
 import type { Crux, NodeV1 } from "./types.js";
 
@@ -257,12 +264,21 @@ async function collectFileCrux(
   refs: NodeRef[],
 ): Promise<{ results: Map<string, NodeCrux>; error?: string; quality?: boolean }> {
   const results = new Map<string, NodeCrux>();
+  const wanted = new Set(refs.map((r) => r.id));
   let missing = refs;
   let error: string | undefined;
+  let unmatched = false;
   for (let attempt = 0; attempt < 2 && missing.length > 0; attempt++) {
     try {
       const list = await summarizer.describeFile({ path, source, nodes: missing });
-      for (const r of list) if (!results.has(r.id)) results.set(r.id, r);
+      for (const r of list) {
+        const id = normalizeCruxId(r.id);
+        if (!wanted.has(id)) {
+          if (r.summary.trim()) unmatched = true;
+          continue;
+        }
+        if (!results.has(id)) results.set(id, { ...r, id });
+      }
       missing = refs.filter((r) => !results.has(r.id));
     } catch (err) {
       error = err instanceof Error ? err.message : String(err);
@@ -274,7 +290,8 @@ async function collectFileCrux(
   // re-run `--deep` forever (#172). Surface it as a failure like a thrown error.
   // Content-quality, not quota: count the file, keep going (#235).
   if (!error && refs.length > 0 && results.size === 0) {
-    return { results, error: cruxMissMessage(summarizer, "empty-toolCalls"), quality: true };
+    const kind: CruxMissKind = unmatched ? "id-mismatch" : "empty-toolCalls";
+    return { results, error: cruxMissMessage(summarizer, kind), quality: true };
   }
   return { results, error };
 }

--- a/test/crux-file-id.test.ts
+++ b/test/crux-file-id.test.ts
@@ -1,0 +1,169 @@
+/**
+ * #298: `userContent` renders targets as `id=${n.id} | kind | lines Lx-Ly`.
+ * File-node ids are bare paths, so models that "use that id verbatim" echo the
+ * whole decoration. Matching must strip it — never apply by list order.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { ChatCruxSummarizer, normalizeCruxId } from "../src/ai/crux.js";
+import { enrichGraph } from "../src/graph/enrich.js";
+import type { CruxSummarizer, FileCruxInput, NodeCrux } from "../src/ai/crux.js";
+import type { ChatModel, ChatRequest, ChatResponse, ToolCall } from "../src/ai/llm/types.js";
+import type { NodeV1 } from "../src/graph/types.js";
+
+class CannedModel implements ChatModel {
+  readonly label = "fake:file-id";
+  last?: ChatRequest;
+  constructor(private readonly symbols: unknown[]) {}
+  async create(req: ChatRequest): Promise<ChatResponse> {
+    this.last = req;
+    const toolCalls: ToolCall[] = [
+      { id: "1", name: "record_symbols", args: { symbols: this.symbols } },
+    ];
+    return {
+      text: "",
+      toolCalls,
+      usage: { input: 0, output: 0, cacheRead: 0, cacheCreate: 0 },
+      stopReason: "tool_calls",
+      assistant: { role: "assistant", content: "" },
+    };
+  }
+}
+
+function fileNode(path: string, span = "L1-L243"): NodeV1 {
+  return {
+    id: path,
+    name: path.split("/").pop() ?? path,
+    kind: "file",
+    path,
+    span,
+    signature: null,
+    exported: true,
+    origin: "ast",
+    body_hash: `h-${path}`,
+    summary_state: "pending",
+    summary: null,
+    crux: null,
+  };
+}
+
+function fnNode(path: string, name: string): NodeV1 {
+  return {
+    id: `${path}#${name}`,
+    name,
+    kind: "function",
+    path,
+    span: "L1-L3",
+    signature: `${name}()`,
+    exported: true,
+    origin: "ast",
+    body_hash: `h-${name}`,
+    summary_state: "pending",
+    summary: null,
+    crux: null,
+  };
+}
+
+test("#298: normalizeCruxId strips the TARGET decoration and leaves bare symbol ids", () => {
+  assert.equal(
+    normalizeCruxId("src/some/dir/file.py | file | lines L1-L243"),
+    "src/some/dir/file.py",
+  );
+  assert.equal(normalizeCruxId("src/calc.py#add"), "src/calc.py#add");
+  assert.equal(
+    normalizeCruxId("src/calc.py#add | function | lines L1-L3 | add()"),
+    "src/calc.py#add",
+  );
+});
+
+test("#298: describeFile maps a decorated file-node echo onto the bare path", async () => {
+  const path = "src/some/dir/file.py";
+  const m = new CannedModel([
+    {
+      id: `${path} | file | lines L1-L243`,
+      summary: "module that wires the parser",
+      crux_start: 158,
+      crux_end: 184,
+    },
+  ]);
+  const out = await new ChatCruxSummarizer(m).describeFile({
+    path,
+    source: "x\n".repeat(243),
+    nodes: [{ id: path, kind: "file", signature: null, startLine: 1, endLine: 243 }],
+  });
+  assert.equal(m.last?.maxTokens, 8192);
+  assert.equal(out.length, 1);
+  assert.equal(out[0].id, path);
+  assert.equal(out[0].summary, "module that wires the parser");
+});
+
+test("#298: describeFile keeps path#Symbol ids that were already echoed bare", async () => {
+  const out = await new ChatCruxSummarizer(
+    new CannedModel([
+      { id: "src/calc.py#add", summary: "adds two numbers", crux_start: 0, crux_end: 0 },
+    ]),
+  ).describeFile({
+    path: "src/calc.py",
+    source: "def add(a, b):\n  return a + b\n",
+    nodes: [{ id: "src/calc.py#add", kind: "function", signature: "add()", startLine: 1, endLine: 2 }],
+  });
+  assert.equal(out[0].id, "src/calc.py#add");
+});
+
+test("#298: enrich applies a decorated file-node id and a bare function id in the same file", async () => {
+  const path = "src/calc.py";
+  const nodes = [fileNode(path), fnNode(path, "add")];
+  const sources = new Map([[path, "def add(a, b):\n  return a + b\n"]]);
+  const summarizer: CruxSummarizer = {
+    async describeFile(input: FileCruxInput): Promise<NodeCrux[]> {
+      return input.nodes.map((n) =>
+        n.kind === "file"
+          ? {
+              id: `${n.id} | file | lines L${n.startLine}-L${n.endLine}`,
+              summary: "calc module",
+              crux_start: 0,
+              crux_end: 0,
+            }
+          : { id: n.id, summary: `purpose of ${n.id}`, crux_start: 0, crux_end: 0 },
+      );
+    },
+  };
+
+  const stats = await enrichGraph(nodes, new Map(), sources, { summarizer, concurrency: 1 });
+  assert.equal(stats.computed, 2);
+  assert.equal(stats.pending, 0);
+  assert.equal(stats.failedFiles, 0);
+  assert.equal(nodes[0].summary_state, "ready");
+  assert.equal(nodes[0].summary, "calc module");
+  assert.equal(nodes[1].summary_state, "ready");
+  assert.equal(nodes[1].summary, "purpose of src/calc.py#add");
+});
+
+test("#298: unmatched ids are dropped, not applied by order, and stay uncached", async () => {
+  const path = "src/calc.py";
+  const nodes = [fileNode(path), fnNode(path, "add")];
+  const sources = new Map([[path, "def add(a, b):\n  return a + b\n"]]);
+  const summarizer: CruxSummarizer = {
+    async describeFile(): Promise<NodeCrux[]> {
+      return [
+        {
+          id: "other.py | file | lines L1-L10",
+          summary: "must not land on the first node by position",
+          crux_start: 0,
+          crux_end: 0,
+        },
+      ];
+    },
+  };
+
+  const stats = await enrichGraph(nodes, new Map(), sources, { summarizer, concurrency: 1 });
+  assert.equal(stats.computed, 0);
+  assert.equal(stats.pending, 2);
+  assert.equal(stats.failedFiles, 1);
+  assert.match(stats.errors[0] ?? "", /id-mismatch/);
+  assert.match(stats.errors[0] ?? "", /matched no requested id/);
+  for (const n of nodes) {
+    assert.equal(n.summary_state, "pending");
+    assert.equal(n.summary, null);
+  }
+});

--- a/test/llm-ops.test.ts
+++ b/test/llm-ops.test.ts
@@ -65,6 +65,7 @@ test("ChatCruxSummarizer forces record_symbols and normalizes numbers", async ()
     nodes: [{ id: "sym1", kind: "function", signature: null, startLine: 1, endLine: 5 }],
   });
   assert.deepEqual(m.last?.responseFormat, { kind: "tool", name: "record_symbols" });
+  assert.equal(m.last?.maxTokens, 8192);
   assert.deepEqual(out, [{ id: "sym1", summary: "does x", crux_start: 3, crux_end: 5 }]);
 });
 


### PR DESCRIPTION
## Summary
- Bug 2 of #298: `userContent` paints each target as `id=${n.id} | kind | lines Lx-Ly`. File-node ids are the bare path, so models that echo that decoration never hit `results.get(node.id)`, `applied === 0`, and a valid summary is reported as `empty-parsed`.
- Strip on `" | "` (node ids never contain it) in `parseResults`, and again in `collectFileCrux` against the requested id set. Unmatched entries are discarded — never applied by list order. Empty / mismatched replies stay `pending` (#177).
- When the model returned summaries that match no requested id, the error is now `id-mismatch` instead of the `empty-parsed` / `finish_reason=null` fallback.
- Does **not** bump `maxTokens` from 8192 to 32768.

Partially addresses #298 (bug 2). Bug 1 (tool-call JSON truncated at 8192) stays with #269 (recover truncated JSON) and #274 (chunk symbol-dense crux calls).

## Overlap with other Drafts
- Draft #270 peels echoed TARGET-line ids in `parseResults` (#259, including function ids with signatures). This PR is the narrower file-node decoration case plus wanted-set matching in `collectFileCrux`. Not merged together.
- Draft #274 chunks `describeFile`; it does not touch `parseResults`. This PR does not chunk.

Suggested order: this and #274 have independent hunks. #270 also edits `parseResults` — rebase whichever lands second.

## Test plan
- [x] Decorated file-node id `path | file | lines L1-L243` applies to the bare path
- [x] `path#Symbol` still matches when echoed bare
- [x] Unmatched ids are not applied by order; nodes stay `pending`, not cached `ready`
- [x] Error names `id-mismatch` / "matched no requested id"
- [x] `maxTokens` remains 8192 (asserted on the crux request)

Made with [Cursor](https://cursor.com)