### PR TITLE
fix(claude): write hook timeouts in seconds and stop putting footerLinksRegexes in project settings (#283)

### DIFF
--- a/src/claude/hooks.ts
+++ b/src/claude/hooks.ts
@@ -34,13 +34,29 @@ export function underGraft(dir: string, file: string): boolean {
   return rel.replace(/^[/\\]+/, '').replace(/\\/g, '/').startsWith('graft/');
 }
 /** Default budget for a graft child process invoked from a hook, matching the 8s
- * the installed hook entries carry. */
+ * the installed hook entries carry. Always milliseconds — this is `execFileSync`'s
+ * unit, not the seconds Claude Code stores on the hook entry. */
 const CHILD_TIMEOUT_MS = 8000;
 /** Headroom left for the hook's own work (read stdin, score, write session, emit)
  * after its `graft ask` child returns. */
 const HOOK_OVERHEAD_MS = 2000;
 /** Floor, so a hand-edited tiny timeout can't leave the child no time at all. */
 const MIN_CHILD_TIMEOUT_MS = 4000;
+/**
+ * Claude Code documents hook `timeout` as seconds. Values at or above this were
+ * written by 0.16.0 as milliseconds (8000 / 10000 / 15000) and are left as-is
+ * until SessionStart rewrites the file, so a child isn't given an hours-long
+ * budget — and so treating `8` as milliseconds can't shrink it to 6ms.
+ */
+const LEGACY_HOOK_TIMEOUT_MS = 1000;
+
+/**
+ * Claude Code's hook `timeout` field is seconds. Convert to milliseconds for
+ * `execFileSync`, keeping leftover 0.16.0 millisecond values as milliseconds.
+ */
+function hookTimeoutMs(timeout: number): number {
+  return timeout >= LEGACY_HOOK_TIMEOUT_MS ? timeout : timeout * 1000;
+}
 
 /**
  * How long the prompt hook may let `graft ask` run — derived from the budget that is
@@ -55,6 +71,10 @@ const MIN_CHILD_TIMEOUT_MS = 4000;
  * `writeSession()` never run, the turn gets no retrieval pack at all, and the SIGKILLed
  * child can't even release the build lock. Reading the installed number keeps the child
  * strictly inside whatever budget this repo really has.
+ *
+ * The return value is always milliseconds. The installed JSON is seconds (or a
+ * leftover millisecond value from 0.16.0); converting here is what keeps
+ * `timeout: 8` at a 6s child instead of 6ms.
  */
 export function promptAskTimeout(dir: string): number {
   const installed = installedHookTimeout(dir, 'UserPromptSubmit');
@@ -98,22 +118,25 @@ function hookTimeoutIn(file: string, event: string): number | null {
 }
 
 /**
- * The budget this hook is actually running under, or null when no settings file
- * declares one.
+ * The budget this hook is actually running under, in milliseconds, or null when
+ * no settings file declares one.
  *
  * The smallest declared timeout wins rather than the nearest, because when more
  * than one file declares the hook Claude Code runs every matching entry and this
  * process cannot tell which one launched it. Guessing high is the expensive
  * mistake: an overrunning child gets the whole hook SIGKILLed, so `emit()` and
  * `writeSession()` never run and the turn silently gets no retrieval at all.
- * Guessing low only shortens one query.
+ * Guessing low only shortens one query. Conversion to milliseconds happens
+ * *before* the min, so a leftover `8000` (ms) is not treated as smaller than a
+ * current `15` (seconds).
  */
 function installedHookTimeout(dir: string, event: string): number | null {
   let smallest: number | null = null;
   for (const file of hookSettingsFiles(dir)) {
     const timeout = hookTimeoutIn(file, event);
     if (timeout === null) continue;
-    if (smallest === null || timeout < smallest) smallest = timeout;
+    const ms = hookTimeoutMs(timeout);
+    if (smallest === null || ms < smallest) smallest = ms;
   }
   return smallest;
 }

--- a/src/claude/settings-merge.ts
+++ b/src/claude/settings-merge.ts
@@ -31,10 +31,26 @@ const REPO_HELPERS = '${CLAUDE_PROJECT_DIR:-.}/.claude/helpers';
 function hookCmd(arg: string, helpers: string = REPO_HELPERS): string {
   return `node "${helpers}/graft-hooks.cjs" ${arg}`;
 }
+
+/**
+ * Hook `timeout` values Claude Code writes into settings.json.
+ *
+ * Claude Code documents this field as **seconds** (default 600). 0.16.0 wrote
+ * 8000 / 10000 / 15000 intending milliseconds; a stalled hook then blocked the
+ * session for hours. These numbers are the same budgets as before, in the unit
+ * the host actually reads. `hooks.ts` converts back to milliseconds when it
+ * caps the `graft ask` child just under the installed hook.
+ */
+const POST_EDIT_TIMEOUT_S = 10;
+const TOOL_SAVINGS_TIMEOUT_S = 8;
+const PROMPT_TIMEOUT_S = 15;
+const SESSION_TIMEOUT_S = 8;
+const STOP_TIMEOUT_S = 8;
+
 function graftBlocks(helpers?: string): Record<string, Json[]> {
   return {
     PostToolUse: [
-      { matcher: 'Write|Edit|MultiEdit', hooks: [{ type: 'command', command: hookCmd('post-edit', helpers), timeout: 10000 }] },
+      { matcher: 'Write|Edit|MultiEdit', hooks: [{ type: 'command', command: hookCmd('post-edit', helpers), timeout: POST_EDIT_TIMEOUT_S }] },
       // Score the usage mix and sum token savings. A graft retrieval (CLI `graft …`
       // via Bash, or the `graft_*` MCP tools) prints a `[graft] tokens saved ≈ N`
       // footer this hook sums into the session total; the same hook classifies
@@ -42,7 +58,7 @@ function graftBlocks(helpers?: string): Record<string, Json[]> {
       // `graft stats` and the `session_summary` graft-vs-grep ratio. Broad matcher,
       // but the handler no-ops instantly unless there is something to record, so an
       // unrelated Bash or a plain Read costs only a stdin read.
-      { matcher: 'Bash|mcp__graft__|Read|Grep|Glob', hooks: [{ type: 'command', command: hookCmd('tool-savings', helpers), timeout: 8000 }] },
+      { matcher: 'Bash|mcp__graft__|Read|Grep|Glob', hooks: [{ type: 'command', command: hookCmd('tool-savings', helpers), timeout: TOOL_SAVINGS_TIMEOUT_S }] },
     ],
     // Longer budget than the other hooks: its `graft ask` is a real query, and a
     // query now brings the graph up to date first (graph/refresh.ts) — usually
@@ -52,11 +68,12 @@ function graftBlocks(helpers?: string): Record<string, Json[]> {
     // this bump (8s) keeps a child that fits inside 8s. Changing the number here is
     // therefore safe on its own — but it only reaches an existing repo when someone
     // re-runs `graft init`, since that is the only caller of this function.
-    UserPromptSubmit: [{ hooks: [{ type: 'command', command: hookCmd('prompt', helpers), timeout: 15000 }] }],
-    SessionStart: [{ hooks: [{ type: 'command', command: hookCmd('session-start', helpers), timeout: 8000 }] }],
-    Stop: [{ hooks: [{ type: 'command', command: hookCmd('stop', helpers), timeout: 8000 }] }],
+    UserPromptSubmit: [{ hooks: [{ type: 'command', command: hookCmd('prompt', helpers), timeout: PROMPT_TIMEOUT_S }] }],
+    SessionStart: [{ hooks: [{ type: 'command', command: hookCmd('session-start', helpers), timeout: SESSION_TIMEOUT_S }] }],
+    Stop: [{ hooks: [{ type: 'command', command: hookCmd('stop', helpers), timeout: STOP_TIMEOUT_S }] }],
   };
 }
+
 /**
  * Is this allowlist entry one graft wrote?
  *
@@ -135,10 +152,11 @@ export function mergeGraftSettings(
     merged.hooks[event] = [...foreign, ...blocks];
   }
 
-  // Drop graft's own prior regex before re-adding, so a change to FOOTER replaces
-  // the old pattern instead of stacking beside it. The user's regexes are kept.
-  const priorFooter = Array.isArray(merged.footerLinksRegexes) ? merged.footerLinksRegexes : [];
-  merged.footerLinksRegexes = [...priorFooter.filter((r: unknown) => !isGraftFooterRegex(r)), FOOTER];
+  // Claude Code honors `footerLinksRegexes` only in user/managed settings, not in
+  // a project file. Drop graft's own pattern so a SessionStart refresh doesn't
+  // keep rewriting an inert key into `.claude/settings.json`. The user's regexes
+  // stay — same shape as statusLine: we don't clear what we didn't put there.
+  dropGraftFooter(merged);
 
   // headless/subagent runs hard-deny Bash by default; without an allowlist entry
   // `graft ask`'s own Bash calls (and the skill it installs) can't run out-of-box.
@@ -153,16 +171,16 @@ export function mergeGraftSettings(
 }
 
 /**
- * The hook blocks alone, merged into a settings file, with the shims addressed by
- * absolute path — `~/.claude/settings.json`, where a write reaches every project on
- * the machine (see hosts/claude-global.ts for why that copy has to exist).
+ * The hook blocks (and the footer regex Claude Code actually honors), merged into
+ * a settings file with the shims addressed by absolute path — `~/.claude/settings.json`,
+ * where a write reaches every project on the machine (see hosts/claude-global.ts
+ * for why that copy has to exist).
  *
- * Hooks only, deliberately. `mergeGraftSettings` also claims the statusline, the
- * footer regex and a Bash allowlist, and each of those is a reasonable thing to
- * accept for a repo you ran `graft init` in and an unreasonable thing to impose on
- * every repo you ever open — a statusline especially, since a session allows exactly
- * one and taking it globally would silently outrank the user's own. The hooks are the
- * piece that has to be global, because they are what a worktree loses.
+ * Statusline and Bash allowlist stay repo-only: a session allows exactly one
+ * statusline, and taking it globally would silently outrank the user's own.
+ * `footerLinksRegexes` is the other way around — Claude Code ignores it in
+ * project settings, so the user file is the only place the graft card badge can
+ * appear. User regexes are kept; graft's own pattern is replaced, not stacked.
  *
  * Same idempotent shape as the repo merge: graft's prior entries are dropped before
  * the current set is added, so re-running converges instead of stacking.
@@ -175,5 +193,20 @@ export function mergeGraftHooks(existing: Json, helpers: string): { merged: Json
     const foreign = prior.filter((e: Json) => !isGraftEntry(e));
     merged.hooks[event] = [...foreign, ...blocks];
   }
+  applyGraftFooter(merged);
   return { merged };
+}
+
+/** Drop graft's footer pattern; keep everyone else's. No-op when the key is absent. */
+function dropGraftFooter(merged: Json): void {
+  if (!Array.isArray(merged.footerLinksRegexes)) return;
+  const kept = merged.footerLinksRegexes.filter((r: unknown) => !isGraftFooterRegex(r));
+  if (kept.length === 0) delete merged.footerLinksRegexes;
+  else merged.footerLinksRegexes = kept;
+}
+
+/** Replace graft's prior footer pattern, then append the current one. User regexes stay. */
+function applyGraftFooter(merged: Json): void {
+  const prior = Array.isArray(merged.footerLinksRegexes) ? merged.footerLinksRegexes : [];
+  merged.footerLinksRegexes = [...prior.filter((r: unknown) => !isGraftFooterRegex(r)), FOOTER];
 }

--- a/test/claude-hooks.test.ts
+++ b/test/claude-hooks.test.ts
@@ -579,6 +579,9 @@ test('cursor-session-end force-closes THIS conversation even though its file was
  * only during `graft init`, so an npm upgrade leaves every already-wired repo on its
  * old `timeout` — and a child that outlives it gets the whole hook killed by Claude
  * Code, which means no retrieval pack and no session write at all.
+ *
+ * Claude Code stores hook timeout in seconds. The child budget is still milliseconds
+ * (`execFileSync`), with the same headroom as before: a 8s hook → 6000ms child.
  */
 function withSettings(timeout: unknown): string {
   const d = mkdtempSync(join(tmpdir(), 'graft-hooktimeout-'));
@@ -597,12 +600,15 @@ test('promptAskTimeout is derived from the installed hook budget', () => {
   const previous = process.env.CLAUDE_CONFIG_DIR;
   process.env.CLAUDE_CONFIG_DIR = mkdtempSync(join(tmpdir(), 'graft-nouser-'));
   try {
-    // A repo wired before the budget was raised.
+    // Seconds, as Claude Code documents the field. 8s hook → 6s child, not 6ms.
+    assert.equal(promptAskTimeout(withSettings(8)), 6000);
+    // A repo wired after the prompt budget was raised to 15s.
+    assert.equal(promptAskTimeout(withSettings(15)), 13000);
+    // Leftover 0.16.0 millisecond values until SessionStart rewrites the file.
     assert.equal(promptAskTimeout(withSettings(8000)), 6000);
-    // A repo wired after.
     assert.equal(promptAskTimeout(withSettings(15000)), 13000);
     // Never so small the child has no chance.
-    assert.equal(promptAskTimeout(withSettings(1000)), 4000);
+    assert.equal(promptAskTimeout(withSettings(1)), 4000);
 
     // Nothing readable: assume the conservative 8s budget the other hooks carry.
     assert.equal(promptAskTimeout(withSettings(undefined)), 6000);
@@ -632,16 +638,21 @@ function withUserSettings(timeout: unknown): string {
 test('promptAskTimeout reads a user-level hook when the repo declares none', () => {
   const previous = process.env.CLAUDE_CONFIG_DIR;
   try {
-    process.env.CLAUDE_CONFIG_DIR = withUserSettings(15000);
+    process.env.CLAUDE_CONFIG_DIR = withUserSettings(15);
     // A repo with no .claude/ of its own still gets the budget it truly runs under.
     assert.equal(promptAskTimeout(mkdtempSync(join(tmpdir(), 'graft-nosettings-'))), 13000);
 
     // Declared in both places: Claude Code fires both entries and this process
     // cannot tell which launched it, so the smallest budget is the only safe one.
-    assert.equal(promptAskTimeout(withSettings(8000)), 6000);
+    assert.equal(promptAskTimeout(withSettings(8)), 6000);
 
+    process.env.CLAUDE_CONFIG_DIR = withUserSettings(8);
+    assert.equal(promptAskTimeout(withSettings(15)), 6000);
+
+    // Leftover millisecond user settings vs current seconds in the repo: compare
+    // after converting, so 8000ms is not treated as smaller than 15s.
     process.env.CLAUDE_CONFIG_DIR = withUserSettings(8000);
-    assert.equal(promptAskTimeout(withSettings(15000)), 6000);
+    assert.equal(promptAskTimeout(withSettings(15)), 6000);
 
     // Nothing anywhere still means the conservative default.
     process.env.CLAUDE_CONFIG_DIR = withUserSettings(undefined);

--- a/test/claude-settings-merge.test.ts
+++ b/test/claude-settings-merge.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mergeGraftSettings } from '../src/claude/settings-merge.js';
+import { mergeGraftHooks, mergeGraftSettings } from '../src/claude/settings-merge.js';
 
 const SL = 'node "${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-statusline.cjs"';
 
@@ -19,7 +19,13 @@ test('empty settings gets the full Graft blocks', () => {
   const savings = merged.hooks.PostToolUse[1];
   assert.equal(savings.matcher, 'Bash|mcp__graft__|Read|Grep|Glob');
   assert.ok(savings.hooks[0].command.includes('tool-savings'), 'savings hook wired');
-  assert.ok(merged.footerLinksRegexes.includes('graft/[\\w./-]+\\.md'));
+  // Claude Code ignores footerLinksRegexes in project settings — don't write it.
+  assert.equal(merged.footerLinksRegexes, undefined);
+  assert.equal(merged.hooks.PostToolUse[0].hooks[0].timeout, 10);
+  assert.equal(savings.hooks[0].timeout, 8);
+  assert.equal(merged.hooks.UserPromptSubmit[0].hooks[0].timeout, 15);
+  assert.equal(merged.hooks.SessionStart[0].hooks[0].timeout, 8);
+  assert.equal(merged.hooks.Stop[0].hooks[0].timeout, 8);
   assert.deepEqual(warnings, []);
 });
 
@@ -88,12 +94,61 @@ test('existing foreign hooks are preserved; Graft appended', () => {
   assert.ok(merged.hooks.PostToolUse[2].hooks[0].command.includes('graft-hooks.cjs'));
 });
 
-test('re-running is idempotent (no duplicate Graft entries or footer)', () => {
+test('re-running is idempotent (no duplicate Graft entries; timeouts stay seconds)', () => {
   const once = mergeGraftSettings({}).merged;
   const twice = mergeGraftSettings(once).merged;
   assert.equal(twice.hooks.PostToolUse.length, 2); // post-edit + tool-savings, not duplicated
   assert.equal(twice.hooks.Stop.length, 1);
-  assert.equal(twice.footerLinksRegexes.filter((r: string) => r === 'graft/[\\w./-]+\\.md').length, 1);
+  assert.equal(twice.footerLinksRegexes, undefined);
+  // A SessionStart refresh must not write the 0.16.0 millisecond values back.
+  assert.equal(twice.hooks.PostToolUse[0].hooks[0].timeout, 10);
+  assert.equal(twice.hooks.PostToolUse[1].hooks[0].timeout, 8);
+  assert.equal(twice.hooks.UserPromptSubmit[0].hooks[0].timeout, 15);
+  assert.equal(twice.hooks.SessionStart[0].hooks[0].timeout, 8);
+  assert.equal(twice.hooks.Stop[0].hooks[0].timeout, 8);
+});
+
+test('a refresh replaces leftover millisecond timeouts with seconds', () => {
+  const stale = mergeGraftSettings({}).merged;
+  stale.hooks.PostToolUse[0].hooks[0].timeout = 10000;
+  stale.hooks.PostToolUse[1].hooks[0].timeout = 8000;
+  stale.hooks.UserPromptSubmit[0].hooks[0].timeout = 15000;
+  stale.hooks.SessionStart[0].hooks[0].timeout = 8000;
+  stale.hooks.Stop[0].hooks[0].timeout = 8000;
+  const { merged } = mergeGraftSettings(stale);
+  assert.equal(merged.hooks.PostToolUse[0].hooks[0].timeout, 10);
+  assert.equal(merged.hooks.PostToolUse[1].hooks[0].timeout, 8);
+  assert.equal(merged.hooks.UserPromptSubmit[0].hooks[0].timeout, 15);
+  assert.equal(merged.hooks.SessionStart[0].hooks[0].timeout, 8);
+  assert.equal(merged.hooks.Stop[0].hooks[0].timeout, 8);
+});
+
+test('project merge strips graft footer regexes and keeps the user\'s', () => {
+  const { merged } = mergeGraftSettings({
+    footerLinksRegexes: ['graft/[\\w./-]+\\.md', 'docs/.*'],
+  });
+  assert.deepEqual(merged.footerLinksRegexes, ['docs/.*']);
+});
+
+test('project merge drops footerLinksRegexes when only graft\'s pattern was there', () => {
+  const { merged } = mergeGraftSettings({
+    footerLinksRegexes: ['graft/[\\w./-]+\\.md'],
+  });
+  assert.equal(merged.footerLinksRegexes, undefined);
+});
+
+test('user-level merge writes footerLinksRegexes and keeps the user\'s regexes', () => {
+  const { merged } = mergeGraftHooks({ footerLinksRegexes: ['docs/.*'] }, '/tmp/helpers');
+  assert.deepEqual(merged.footerLinksRegexes, ['docs/.*', 'graft/[\\w./-]+\\.md']);
+  assert.equal(merged.hooks.UserPromptSubmit[0].hooks[0].timeout, 15);
+  assert.equal(merged.hooks.SessionStart[0].hooks[0].timeout, 8);
+});
+
+test('user-level footer merge is idempotent and replaces a superseded graft pattern', () => {
+  const once = mergeGraftHooks({ footerLinksRegexes: ['graft/OLD-PATTERN\\.md', 'docs/.*'] }, '/tmp/helpers').merged;
+  const twice = mergeGraftHooks(structuredClone(once), '/tmp/helpers').merged;
+  assert.deepEqual(twice.footerLinksRegexes, ['docs/.*', 'graft/[\\w./-]+\\.md']);
+  assert.deepEqual(twice.hooks, once.hooks);
 });
 
 test('foreign top-level keys survive', () => {

--- a/test/hosts-claude-global.test.ts
+++ b/test/hosts-claude-global.test.ts
@@ -131,10 +131,26 @@ test('an existing settings.json keeps every key graft does not own', () => {
   assert.equal(s.theme, 'light');
   assert.equal(s.effortLevel, 'high');
   assert.ok(s.hooks.Stop);
-  // Hooks only: the statusline is a single per-session slot and taking it for every
-  // repo would silently outrank the user's own.
+  // Hooks (and footer regexes, which Claude Code ignores in project settings):
+  // the statusline is a single per-session slot and taking it for every repo
+  // would silently outrank the user's own. The footer badge only works here.
   assert.equal(s.statusLine, undefined, 'no global statusline');
   assert.equal(s.permissions, undefined, 'no global allowlist');
+  assert.deepEqual(s.footerLinksRegexes, ['graft/[\\w./-]+\\.md']);
+});
+
+test('an existing user footer regex is kept next to graft\'s', () => {
+  const home = tmpRepo('cgfooter');
+  mkdirSync(join(home, '.claude'), { recursive: true });
+  writeFileSync(settingsOf(home), JSON.stringify({ footerLinksRegexes: ['docs/.*'] }, null, 2));
+
+  installClaudeGlobal(home);
+
+  const s = readJson(settingsOf(home));
+  assert.deepEqual(s.footerLinksRegexes, ['docs/.*', 'graft/[\\w./-]+\\.md']);
+  const again = installClaudeGlobal(home);
+  assert.ok(again.every((w) => w.action === 'unchanged'), `idempotent footer, got ${JSON.stringify(again)}`);
+  assert.deepEqual(readJson(settingsOf(home)).footerLinksRegexes, ['docs/.*', 'graft/[\\w./-]+\\.md']);
 });
 
 test('an existing user-scope MCP server survives, and re-running converges', () => {
@@ -208,6 +224,7 @@ test('uninstall removes exactly what the global install added', () => {
   assert.equal(existsSync(shimOf(home)), false, 'shim gone');
   const s = readJson(settingsOf(home));
   assert.equal(s.hooks, undefined, 'graft hooks gone');
+  assert.equal(s.footerLinksRegexes, undefined, 'graft footer gone');
   assert.equal(s.theme, 'light', "the user's own settings survive");
   const mcp = readJson(userMcpOf(home));
   assert.equal(mcp.mcpServers.graft, undefined, 'graft server gone');

--- a/test/hosts-retract.test.ts
+++ b/test/hosts-retract.test.ts
@@ -305,13 +305,14 @@ test('a renamed allowlist entry is dropped; the user\'s own rules stay', () => {
   assert.equal(allow.filter((a) => a === 'Bash(graft-dev:*)').length, 1, 'no duplicate of graft\'s own entry');
 });
 
-test('a superseded footer regex is replaced rather than stacked', () => {
+test('a superseded footer regex is stripped from project settings; the user\'s stays', () => {
   const { merged } = mergeGraftSettings({
     footerLinksRegexes: ['graft/OLD-PATTERN\\.md', 'docs/.*'],
   });
   assert.ok(!merged.footerLinksRegexes.includes('graft/OLD-PATTERN\\.md'), 'old graft pattern gone');
   assert.ok(merged.footerLinksRegexes.includes('docs/.*'), 'user pattern kept');
-  assert.equal(merged.footerLinksRegexes.filter((r: string) => r.startsWith('graft/')).length, 1);
+  assert.equal(merged.footerLinksRegexes.filter((r: string) => r.startsWith('graft/')).length, 0,
+    'graft footer is not rewritten into the project file');
 });
 
 test('mergeGraftSettings stays idempotent over repeated runs', () => {


### PR DESCRIPTION
## Summary

- Claude Code documents hook `timeout` as **seconds** (default 600). `mergeGraftSettings` / `mergeGraftHooks` were writing `8000` / `10000` / `15000`, so a stalled hook could block a session for hours. The installed values are now `8` / `10` / `15` — the same budgets, in the unit the host actually reads.
- `promptAskTimeout` still returns a **millisecond** child budget with the same headroom as before (`timeout: 8` → 6000 ms `graft ask`, not 6 ms). Leftover 0.16.0 millisecond values are kept as milliseconds until SessionStart rewrites them.
- `footerLinksRegexes` is ignored in project settings. Graft no longer writes it into `.claude/settings.json`; it lands in `~/.claude/settings.json` (the #276 user-level path). User regexes are kept; graft's own pattern is replaced, not stacked.

Closes #283

## Test plan

- [x] `node --import tsx --test test/claude-settings-merge.test.ts test/claude-hooks.test.ts test/hosts-retract.test.ts test/hosts-claude-global.test.ts` — 89 pass
- [x] `node --import tsx --test test/claude-init.test.ts` — 17 pass
- [ ] SessionStart refresh on a repo still carrying `timeout: 8000` rewrites `8`/`10`/`15` and does not put `footerLinksRegexes` back into the project file
- [ ] User `~/.claude/settings.json` gains the graft footer regex and keeps any regex the user already had


Made with [Cursor](https://cursor.com)