### PR TITLE
fix: keep Codex hooks in config TOML

### DIFF
--- a/src/hosts/codex-hooks.ts
+++ b/src/hosts/codex-hooks.ts
@@ -1,9 +1,9 @@
 /**
- * Active-layer install for CLI agents that read user-level hooks.json with
- * PostToolUse semantics. Writes the shared hook shim and one PostToolUse
- * entry that runs post-edit + background sync after every file edit.
+ * Codex has one canonical hook representation: `~/.codex/config.toml`.
+ * Older Graft releases wrote `hooks.json`; this installer migrates Graft-only
+ * legacy files once, then never recreates them.
  */
-import { writeFileSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { hooksShim } from '../claude/shim-template.js';
 import { claudeDistDir } from '../claude/paths.js';
@@ -14,12 +14,18 @@ function dirExists(p: string): boolean {
   try { return statSync(p).isDirectory(); } catch { return false; }
 }
 
-/**
- * The files installing the Codex hook would touch — pure, no writes. Both live
- * under `~/.codex`, so both are scoped 'global': the hook entries fire in every
- * repo opened with Codex, not just this one. Empty when the CLI isn't installed,
- * mirroring `installCodexHooks`' early return.
- */
+interface DesiredEntry { event: string; matcher?: string; sub: string; timeout: number; }
+
+function desiredEntries(): DesiredEntry[] {
+  return [
+    { event: 'SessionStart', matcher: 'startup|resume|compact', sub: 'session-start', timeout: 10 },
+    { event: 'UserPromptSubmit', sub: 'prompt', timeout: 15 },
+    { event: 'PostToolUse', matcher: 'apply_patch|Write|Edit|MultiEdit', sub: 'post-edit', timeout: 10 },
+    { event: 'Stop', sub: 'stop', timeout: 10 },
+  ];
+}
+
+/** The files installing the Codex hook would touch — pure, no writes. */
 export function hookTargets(home: string): PlannedWrite[] {
   const base = join(home, '.codex');
   if (!dirExists(base)) return [];
@@ -31,60 +37,80 @@ export function hookTargets(home: string): PlannedWrite[] {
     },
     {
       hostId: 'agents', id: 'codex-hooks',
-      path: join(base, 'hooks.json'),
+      path: join(base, 'config.toml'),
       scope: 'global', kind: 'hook', what: 'SessionStart / UserPromptSubmit / PostToolUse / Stop',
+    },
+    {
+      hostId: 'agents', id: 'codex-hooks-legacy',
+      path: join(base, 'hooks.json'),
+      scope: 'global', kind: 'hook', what: 'legacy Graft hooks retired only when Graft is their sole owner',
     },
   ];
 }
 
-/**
- * The graft hook entries Codex should carry, mirroring the Claude Code set:
- *   - SessionStart → orientation from `graft/INDEX.md`
- *   - UserPromptSubmit → the coupling-seed retrieval pack (the accuracy hook)
- *   - PostToolUse (an edit) → blast radius + mark the graph dirty
- *   - Stop → one background graph sync at turn end (not after every edit)
- * `matcher` is omitted where Codex ignores it (UserPromptSubmit, Stop). The edit
- * matcher includes `apply_patch` — Codex's native edit tool — alongside the
- * Claude Code edit-tool names, and `hooks.ts`'s `editedFilePath` reads the touched
- * file out of either shape.
- */
-interface DesiredEntry { event: string; matcher?: string; sub: string; timeout: number; }
-function desiredEntries(): DesiredEntry[] {
-  return [
-    { event: 'SessionStart', matcher: 'startup|resume|compact', sub: 'session-start', timeout: 10000 },
-    { event: 'UserPromptSubmit', sub: 'prompt', timeout: 15000 },
-    { event: 'PostToolUse', matcher: 'apply_patch|Write|Edit|MultiEdit', sub: 'post-edit', timeout: 10000 },
-    { event: 'Stop', sub: 'stop', timeout: 10000 },
-  ];
+function renderTomlEntries(shimPath: string): string {
+  return desiredEntries().map((entry) => {
+    const matcher = entry.matcher === undefined ? '' : `matcher = ${JSON.stringify(entry.matcher)}\n`;
+    const command = `node ${JSON.stringify(shimPath)} ${entry.sub}`;
+    return `[[hooks.${entry.event}]]\n${matcher}\n[[hooks.${entry.event}.hooks]]\ntype = "command"\ncommand = ${JSON.stringify(command)}\ntimeout = ${entry.timeout}\n`;
+  }).join('\n');
 }
 
+/**
+ * A Codex hook group starts at `[[hooks.<event>]]` and owns its nested handler
+ * tables until the next group. Reject a mixed group rather than deleting a
+ * foreign handler while replacing Graft's stale command.
+ */
+function stripGraftTomlGroups(content: string): string | null {
+  const starts = [...content.matchAll(/^\s*\[\[hooks\.[A-Za-z]+\]\]\s*$/gm)];
+  if (starts.length === 0) return content;
+  let result = '';
+  let offset = 0;
+  for (let index = 0; index < starts.length; index += 1) {
+    const start = starts[index].index!;
+    const end = starts[index + 1]?.index ?? content.length;
+    const group = content.slice(start, end);
+    if (!group.includes('graft-hooks.cjs')) continue;
+    const handlerBlocks = group.split(/^\s*\[\[hooks\.[A-Za-z]+\.hooks\]\]\s*$/m).slice(1);
+    if (handlerBlocks.some((block) => !block.includes('graft-hooks.cjs'))) return null;
+    result += content.slice(offset, start);
+    offset = end;
+  }
+  return result + content.slice(offset);
+}
+
+function removeGraftOnlyLegacyHooks(path: string): ConfigWrite {
+  if (!existsSync(path)) return { id: 'codex-hooks-legacy', path, action: 'unchanged' };
+  const loaded = readJsonObject(path);
+  if (loaded === 'unparseable') return { id: 'codex-hooks-legacy', path, action: 'skipped-unparseable' };
+  const hooks = loaded.root.hooks;
+  if (typeof hooks !== 'object' || hooks === null || Array.isArray(hooks)) {
+    return { id: 'codex-hooks-legacy', path, action: 'skipped-unparseable' };
+  }
+  const entries = Object.values(hooks).flatMap((value) => Array.isArray(value) ? value : [value]);
+  if (!entries.every(isGraftEntry)) return { id: 'codex-hooks-legacy', path, action: 'unchanged' };
+  unlinkSync(path);
+  return { id: 'codex-hooks-legacy', path, action: 'deleted' };
+}
+
+/** Install Graft's Codex hooks in config.toml and retire its JSON-only legacy. */
 export function installCodexHooks(home: string): ConfigWrite[] {
   const targets = hookTargets(home);
   if (targets.length === 0) return [];
 
   const shimPath = targets[0].path;
   const shimWrite = writeOwned('codex-hook-shim', shimPath, hooksShim(claudeDistDir()), 0o755);
-  const cfgPath = targets[1].path;
-  const skipped: ConfigWrite = { id: 'codex-hooks', path: cfgPath, action: 'skipped-unparseable' };
-
-  const loaded = readJsonObject(cfgPath);
-  if (loaded === 'unparseable') return [shimWrite, skipped];
-  const { root, existed } = loaded;
-  const before = JSON.stringify(root);
-  const hooks = (root.hooks ??= {});
-  if (typeof hooks !== 'object' || hooks === null || Array.isArray(hooks)) return [shimWrite, skipped];
-
-  for (const d of desiredEntries()) {
-    if (hooks[d.event] !== undefined && !Array.isArray(hooks[d.event])) return [shimWrite, skipped];
-    const prior: unknown[] = Array.isArray(hooks[d.event]) ? hooks[d.event] : [];
-    const handler = { type: 'command', command: `node "${shimPath}" ${d.sub}`, timeout: d.timeout };
-    const entry = d.matcher ? { matcher: d.matcher, hooks: [handler] } : { hooks: [handler] };
-    // Preserve foreign entries in this event; replace any prior graft entry so an
-    // upgrade re-points to the current shim/sub-command instead of stacking.
-    hooks[d.event] = [...prior.filter((e) => !isGraftEntry(e)), entry];
+  const configPath = targets[1].path;
+  const existing = existsSync(configPath) ? readFileSync(configPath, 'utf8') : '';
+  const withoutGraft = stripGraftTomlGroups(existing);
+  if (withoutGraft === null) {
+    return [shimWrite, { id: 'codex-hooks', path: configPath, action: 'skipped-unparseable' }];
   }
+  const next = `${withoutGraft.trimEnd()}${withoutGraft.trimEnd() ? '\n\n' : ''}${renderTomlEntries(shimPath)}`;
+  const configAction: ConfigWrite['action'] =
+    next === existing ? 'unchanged' : existsSync(configPath) ? 'updated' : 'created';
+  if (next !== existing) writeFileSync(configPath, next);
 
-  if (JSON.stringify(root) === before) return [shimWrite, { id: 'codex-hooks', path: cfgPath, action: 'unchanged' }];
-  writeFileSync(cfgPath, `${JSON.stringify(root, null, 2)}\n`);
-  return [shimWrite, { id: 'codex-hooks', path: cfgPath, action: existed ? 'updated' : 'created' }];
+  const legacyWrite = removeGraftOnlyLegacyHooks(targets[2].path);
+  return [shimWrite, { id: 'codex-hooks', path: configPath, action: configAction }, legacyWrite];
 }

--- a/src/hosts/config-write.ts
+++ b/src/hosts/config-write.ts
@@ -14,7 +14,7 @@ import { dirname } from 'node:path';
 export interface ConfigWrite {
   id: string;
   path: string;
-  action: 'created' | 'updated' | 'unchanged' | 'skipped-unparseable';
+  action: 'created' | 'updated' | 'unchanged' | 'deleted' | 'skipped-unparseable';
 }
 
 /**

--- a/test/hosts-codex-hooks.test.ts
+++ b/test/hosts-codex-hooks.test.ts
@@ -1,127 +1,106 @@
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, existsSync, statSync, chmodSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import { installCodexHooks } from '../src/hosts/codex-hooks.js';
-import { editedFilePath } from '../src/claude/hooks.js';
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { chmodSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { installCodexHooks } from "../src/hosts/codex-hooks.js";
+import { editedFilePath } from "../src/claude/hooks.js";
 
-function fresh(): string { return mkdtempSync(join(tmpdir(), 'graft-cxhooks-')); }
+function fresh(): string { return mkdtempSync(join(tmpdir(), "graft-cxhooks-")); }
+import { mkdtempSync } from "node:fs";
 
-/**
- * Windows has no POSIX exec bit — `statSync().mode & 0o111` is always 0 there, and
- * `chmod` cannot strip a bit the filesystem doesn't have. So assert the property
- * that exists on both platforms (the shim is installed where the hook config points)
- * and check the mode only where there is one. Skipping the whole test instead would
- * drop Windows coverage of the install path, which is the part that can actually
- * break.
- */
-const HAS_EXEC_BIT = process.platform !== 'win32';
+const HAS_EXEC_BIT = process.platform !== "win32";
 
-function assertRunnableShim(shim: string, note: string): void {
-  assert.ok(existsSync(shim), `${note}: shim missing at ${shim}`);
-  if (HAS_EXEC_BIT) assert.ok(statSync(shim).mode & 0o111, note);
+function assertRunnableShim(shim: string): void {
+  assert.ok(existsSync(shim), "shim missing");
+  if (HAS_EXEC_BIT) assert.ok(statSync(shim).mode & 0o111, "shim not executable");
 }
 
-test('no-op when the CLI home dir is absent', () => {
+test("no-op when the CLI home dir is absent", () => {
   assert.deepEqual(installCodexHooks(fresh()), []);
 });
 
-test('writes shim + hooks.json entry, idempotent on re-run', () => {
+test("writes config TOML hooks and retires a Graft-only legacy JSON file", () => {
   const home = fresh();
-  mkdirSync(join(home, '.codex'), { recursive: true });
-  const w = installCodexHooks(home);
-  assert.equal(w.length, 2);
-  const shim = join(home, '.codex', 'hooks', 'graft', 'graft-hooks.cjs');
-  assertRunnableShim(shim, 'shim is executable');
-  const cfg = JSON.parse(readFileSync(join(home, '.codex', 'hooks.json'), 'utf8'));
-  // Full Claude-Code parity: retrieval on prompt, orientation on start, blast
-  // radius on edit, one background sync at turn end.
-  const sub = (event: string) => cfg.hooks[event][0].hooks[0].command.match(/cjs" (\S+)$/)?.[1];
-  assert.equal(sub('UserPromptSubmit'), 'prompt', 'the coupling-seed retrieval hook');
-  assert.equal(sub('SessionStart'), 'session-start', 'orientation hook');
-  assert.equal(sub('PostToolUse'), 'post-edit', 'edit hook (sync split out to Stop)');
-  assert.equal(sub('Stop'), 'stop', 'background-sync hook');
-  // the edit matcher must include Codex's native edit tool
-  assert.match(cfg.hooks.PostToolUse[0].matcher, /apply_patch/);
-  // Codex ignores matcher for these, so we omit it rather than write a dead field
-  assert.ok(!('matcher' in cfg.hooks.UserPromptSubmit[0]), 'no matcher on UserPromptSubmit');
-  assert.ok(!('matcher' in cfg.hooks.Stop[0]), 'no matcher on Stop');
+  const base = join(home, ".codex");
+  mkdirSync(base, { recursive: true });
+  const legacy = {
+    hooks: {
+      Stop: [{ hooks: [{ type: "command", command: "node old/graft-hooks.cjs stop" }] }],
+    },
+  };
+  writeFileSync(join(base, "hooks.json"), JSON.stringify(legacy));
 
-  const again = installCodexHooks(home);
-  assert.deepEqual(again.map((x) => x.action), ['unchanged', 'unchanged'], 'idempotent');
-  const after = JSON.parse(readFileSync(join(home, '.codex', 'hooks.json'), 'utf8'));
-  for (const ev of ['SessionStart', 'UserPromptSubmit', 'PostToolUse', 'Stop'])
-    assert.equal(after.hooks[ev].length, 1, `${ev} not duplicated on re-run`);
+  const writes = installCodexHooks(home);
+  assert.deepEqual(writes.map((item) => item.action), ["created", "created", "deleted"]);
+  const shim = join(base, "hooks", "graft", "graft-hooks.cjs");
+  assertRunnableShim(shim);
+  assert.ok(!existsSync(join(base, "hooks.json")), "legacy source was retired");
+
+  const config = readFileSync(join(base, "config.toml"), "utf8");
+  assert.match(config, /\[\[hooks\.UserPromptSubmit\]\][\s\S]*graft-hooks\.cjs\\\" prompt/);
+  assert.match(config, /\[\[hooks\.SessionStart\]\][\s\S]*graft-hooks\.cjs\\\" session-start/);
+  assert.match(config, /\[\[hooks\.PostToolUse\]\][\s\S]*graft-hooks\.cjs\\\" post-edit/);
+  assert.match(config, /\[\[hooks\.Stop\]\][\s\S]*graft-hooks\.cjs\\\" stop/);
+  assert.match(config, /matcher = "apply_patch\|Write\|Edit\|MultiEdit"/);
+
+  const second = installCodexHooks(home);
+  assert.deepEqual(second.map((item) => item.action), ["unchanged", "unchanged", "unchanged"]);
+  assert.equal((readFileSync(join(base, "config.toml"), "utf8").match(/graft-hooks\.cjs/g) ?? []).length, 4);
 });
 
-test('foreign hook entries are preserved; stale graft entries replaced', () => {
+test("preserves foreign hooks JSON without rewriting it", () => {
   const home = fresh();
-  mkdirSync(join(home, '.codex'), { recursive: true });
-  writeFileSync(join(home, '.codex', 'hooks.json'), JSON.stringify({
-    hooks: { PostToolUse: [
-      { matcher: 'Bash', hooks: [{ type: 'command', command: 'other-tool' }] },
-      { matcher: 'Write', hooks: [{ type: 'command', command: 'node /old/graft-hooks.cjs post-edit' }] },
-    ] },
-  }));
-  installCodexHooks(home);
-  const entries = JSON.parse(readFileSync(join(home, '.codex', 'hooks.json'), 'utf8')).hooks.PostToolUse;
-  assert.equal(entries.length, 2, 'foreign kept, stale graft replaced by fresh');
-  assert.ok(entries.some((e: any) => e.hooks[0].command === 'other-tool'), 'foreign entry preserved');
-  assert.ok(entries.some((e: any) => /graft-hooks\.cjs" post-edit$/.test(e.hooks[0].command)), 'fresh graft entry present');
-  assert.ok(!JSON.stringify(entries).includes('/old/'), 'stale graft entry removed');
-});
-
-test('editedFilePath reads the touched file from BOTH host edit-tool shapes', () => {
-  const dir = '/repo';
-  // Claude Code: Write/Edit state the absolute path directly
-  assert.equal(
-    editedFilePath({ tool_input: { file_path: '/repo/src/a.ts' } }, dir),
-    '/repo/src/a.ts',
-  );
-  // Codex: apply_patch names the file (repo-relative) in the patch header → resolved absolute
-  const patch = '*** Begin Patch\n*** Update File: src/b.ts\n@@\n-old\n+new\n*** End Patch';
-  assert.equal(editedFilePath({ tool_input: { command: patch } }, dir), join(dir, 'src/b.ts'));
-  // an Add File header works too
-  const add = '*** Begin Patch\n*** Add File: pkg/new.rs\n+content\n*** End Patch';
-  assert.equal(editedFilePath({ tool_input: { command: add } }, dir), join(dir, 'pkg/new.rs'));
-  // neither shape present → null (hook stays a clean no-op)
-  assert.equal(editedFilePath({ tool_input: {} }, dir), null);
-  assert.equal(editedFilePath({}, dir), null);
-});
-
-test('unparseable hooks.json is never rewritten', () => {
-  const home = fresh();
-  mkdirSync(join(home, '.codex'), { recursive: true });
-  writeFileSync(join(home, '.codex', 'hooks.json'), '{ nope');
-  const w = installCodexHooks(home);
-  assert.ok(w.some((x) => x.action === 'skipped-unparseable'));
-  assert.equal(readFileSync(join(home, '.codex', 'hooks.json'), 'utf8'), '{ nope');
-});
-
-test('non-array PostToolUse (foreign single object) is never rewritten', () => {
-  const home = fresh();
-  mkdirSync(join(home, '.codex'), { recursive: true });
+  const base = join(home, ".codex");
+  mkdirSync(base, { recursive: true });
   const original = JSON.stringify({
-    hooks: { PostToolUse: { matcher: 'Bash', hooks: [{ type: 'command', command: 'other-tool' }] } },
+    hooks: {
+      PostToolUse: [{ hooks: [{ type: "command", command: "other-tool" }] }],
+    },
   });
-  writeFileSync(join(home, '.codex', 'hooks.json'), original);
-  const w = installCodexHooks(home);
-  assert.ok(w.some((x) => x.action === 'skipped-unparseable'));
-  assert.equal(readFileSync(join(home, '.codex', 'hooks.json'), 'utf8'), original);
+  writeFileSync(join(base, "hooks.json"), original);
+
+  const writes = installCodexHooks(home);
+  assert.ok(writes.some((item) => item.id === "codex-hooks-legacy" && item.action === "unchanged"));
+  assert.equal(readFileSync(join(base, "hooks.json"), "utf8"), original);
+  assert.match(readFileSync(join(base, "config.toml"), "utf8"), /graft-hooks\.cjs/);
 });
 
-test('re-heals shim exec bit when a prior install had its mode stripped', () => {
+test("unparseable legacy JSON remains untouched", () => {
   const home = fresh();
-  mkdirSync(join(home, '.codex'), { recursive: true });
+  const base = join(home, ".codex");
+  mkdirSync(base, { recursive: true });
+  writeFileSync(join(base, "hooks.json"), "{ nope");
+
+  const writes = installCodexHooks(home);
+  assert.ok(writes.some((item) => item.action === "skipped-unparseable"));
+  assert.equal(readFileSync(join(base, "hooks.json"), "utf8"), "{ nope");
+});
+
+test("rejects an existing TOML group that mixes Graft and foreign hooks", () => {
+  const home = fresh();
+  const base = join(home, ".codex");
+  mkdirSync(base, { recursive: true });
+  const original = "[[hooks.Stop]]\n\n[[hooks.Stop.hooks]]\ntype = \"command\"\ncommand = \"node graft-hooks.cjs stop\"\n\n[[hooks.Stop.hooks]]\ntype = \"command\"\ncommand = \"other-tool\"\n";
+  writeFileSync(join(base, "config.toml"), original);
+
+  const writes = installCodexHooks(home);
+  assert.ok(writes.some((item) => item.id === "codex-hooks" && item.action === "skipped-unparseable"));
+  assert.equal(readFileSync(join(base, "config.toml"), "utf8"), original);
+});
+
+test("editedFilePath accepts the Codex patch shape", () => {
+  const patch = "*** Begin Patch\n*** Update File: src/b.ts\n@@\n-old\n+new\n*** End Patch";
+  assert.equal(editedFilePath({ tool_input: { command: patch } }, "/repo"), join("/repo", "src/b.ts"));
+});
+
+test("re-heals a stripped shim exec bit", () => {
+  const home = fresh();
+  const base = join(home, ".codex");
+  mkdirSync(base, { recursive: true });
   installCodexHooks(home);
-  const shim = join(home, '.codex', 'hooks', 'graft', 'graft-hooks.cjs');
-  if (HAS_EXEC_BIT) {
-    chmodSync(shim, 0o644);
-    assert.ok(!(statSync(shim).mode & 0o111), 'exec bit stripped before re-run');
-  }
-  // On Windows this is the plain re-run case: the install must still converge on a
-  // shim in place, which is all "re-healing" can mean without an exec bit.
+  const shim = join(base, "hooks", "graft", "graft-hooks.cjs");
+  if (HAS_EXEC_BIT) chmodSync(shim, 0o644);
   installCodexHooks(home);
-  assertRunnableShim(shim, 'exec bit restored after re-run');
+  assertRunnableShim(shim);
 });


### PR DESCRIPTION
Moves Graft-managed Codex hooks to config.toml and retires hooks.json only when it is exclusively Graft-owned. Mixed or invalid legacy files remain untouched.\n\nValidation:\n- node --import tsx --test test/hosts-codex-hooks.test.ts\n- npm run build\n- git diff --check