### PR TITLE
feat(graph): add C# tree-sitter support to the code graph

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "gray-matter": "^4.0.3",
         "openai": "^6.45.0",
         "tree-sitter": "^0.21.1",
+        "tree-sitter-c-sharp": "^0.21.3",
         "tree-sitter-go": "^0.23.4",
         "tree-sitter-java": "^0.23.5",
         "tree-sitter-kotlin": "^0.3.8",
@@ -1078,6 +1079,25 @@
       "dependencies": {
         "node-addon-api": "^8.0.0",
         "node-gyp-build": "^4.8.0"
+      }
+    },
+    "node_modules/tree-sitter-c-sharp": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/tree-sitter-c-sharp/-/tree-sitter-c-sharp-0.21.3.tgz",
+      "integrity": "sha512-TVsl5EhmqetO/mhzDPVnMK6TPFnpNMKP0OTNuAQIprshk5Hx672ODRxoIoG5WqvUUlsnBu8J0zmn35hmJqelsA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.0.0",
+        "node-gyp-build": "^4.8.1"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.0"
+      },
+      "peerDependenciesMeta": {
+        "tree_sitter": {
+          "optional": true
+        }
       }
     },
     "node_modules/tree-sitter-cli": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "gray-matter": "^4.0.3",
     "openai": "^6.45.0",
     "tree-sitter": "^0.21.1",
+    "tree-sitter-c-sharp": "^0.21.3",
     "tree-sitter-go": "^0.23.4",
     "tree-sitter-java": "^0.23.5",
     "tree-sitter-kotlin": "^0.3.8",
@@ -95,7 +96,8 @@
     "tree-sitter-kotlin@0.3.8": true,
     "tree-sitter-php@0.23.12": true,
     "@davisvaughan/tree-sitter-r@1.3.0": true,
-    "tree-sitter-swift@0.7.1": true
+    "tree-sitter-swift@0.7.1": true,
+    "tree-sitter-c-sharp@0.21.3": true
   },
   "overrides": {
     "tree-sitter-swift": {

--- a/src/graph/bindings.ts
+++ b/src/graph/bindings.ts
@@ -34,6 +34,47 @@ export class FileBindings {
 
 const FN_VALUE_TYPES = new Set(["arrow_function", "function", "function_expression", "generator_function"]);
 
+// Duplicated from extract.ts's own CS_METHOD_TYPES/CS_TYPE_KINDS (keys only) —
+// same no-value-import-of-extract rule as goReceiverTypeOf below.
+const CS_METHOD_TYPES = new Set(["method_declaration", "constructor_declaration", "destructor_declaration"]);
+const CS_TYPE_NODE_TYPES = new Set([
+  "class_declaration",
+  "struct_declaration",
+  "interface_declaration",
+  "record_declaration",
+  "enum_declaration",
+  "delegate_declaration",
+]);
+
+/** Resolve a C# type-reference node to a bare type name. Duplicated from
+ * extract.ts's own `csTypeName` (same no-value-import-of-extract rule). */
+function csTypeNameOf(node: Parser.SyntaxNode | null | undefined): string | null {
+  if (!node) return null;
+  switch (node.type) {
+    case "identifier":
+    case "predefined_type":
+      return node.text;
+    case "generic_name":
+      return node.namedChildren.find((c) => c.type === "identifier")?.text ?? null;
+    case "qualified_name": {
+      const name = node.childForFieldName("name");
+      return name ? csTypeNameOf(name) : null;
+    }
+    case "nullable_type":
+      return csTypeNameOf(node.namedChildren[0]);
+    default:
+      return null;
+  }
+}
+
+/** The interface name qualifying an explicit interface implementation
+ * (`void IFoo.Bar() {}` → `"IFoo"`), else null. Duplicated from extract.ts's own
+ * `csExplicitInterface`. */
+function csExplicitInterfaceOf(node: Parser.SyntaxNode): string | null {
+  const spec = node.namedChildren.find((c) => c.type === "explicit_interface_specifier");
+  return csTypeNameOf(spec?.namedChildren[0]);
+}
+
 /** Definition-node types that push a new scope segment, mirroring extract.ts's
  * `describe()` closely enough to keep the two scope stacks in lockstep — but
  * duplicated here (not imported) to keep bindings.ts free of a value import on
@@ -60,6 +101,18 @@ export function defName(node: Parser.SyntaxNode, lang: Language): string | null 
   }
   if (lang === "r") return rDefName(node);
   if (lang === "swift") return swiftDefName(node);
+  if (lang === "csharp") {
+    if (CS_METHOD_TYPES.has(node.type)) {
+      const name = node.childForFieldName("name")?.text;
+      if (!name) return null;
+      const iface = csExplicitInterfaceOf(node);
+      return iface ? `${iface}.${name}` : name;
+    }
+    if (CS_TYPE_NODE_TYPES.has(node.type)) {
+      return node.childForFieldName("name")?.text ?? null;
+    }
+    return null;
+  }
   if (lang === "php") {
     const phpDefTypes = new Set([
       "class_declaration",
@@ -231,6 +284,16 @@ function isClassNode(node: Parser.SyntaxNode, lang: Language): boolean {
   if (lang === "typescript" || lang === "tsx") {
     return node.type === "class_declaration" || node.type === "abstract_class_declaration";
   }
+  if (lang === "csharp") {
+    // Interfaces included too: C# has no implicit-`this` field access to bind for
+    // one, but default interface methods can still call sibling members bare.
+    return (
+      node.type === "class_declaration" ||
+      node.type === "struct_declaration" ||
+      node.type === "record_declaration" ||
+      node.type === "interface_declaration"
+    );
+  }
   // Swift: class_declaration covers class/struct/enum/actor/extension — all can
   // hold members whose `self.field` bindings live at the type's scope.
   if (lang === "swift") {
@@ -307,6 +370,7 @@ function visit(
   else if (lang === "java") handleJava(node, scope, classScope, bindings);
   else if (lang === "swift") handleSwift(node, scope, classScope, bindings);
   else if (lang === "php") handlePhp(node, scope, bindings);
+  else if (lang === "csharp") handleCSharp(node, scope, classScope, bindings);
   else handleTs(node, scope, classScope, bindings, aliases);
 
   const name = defName(node, lang);
@@ -723,5 +787,61 @@ function handleGo(node: Parser.SyntaxNode, scope: string[], bindings: FileBindin
       if (fn?.type === "identifier" && /^New[A-Z]/.test(fn.text)) typeName = fn.text.slice(3);
     }
     if (typeName) bindings.set(scopePath, nameNode.text, typeName);
+  }
+}
+
+/** C# binds every declared-type site it can read cheaply: fields, properties,
+ * parameters, and locals (explicit type, or `var` with a `new T()` initializer).
+ * Fields/properties are set under both the bare name and a `this.`-prefixed name —
+ * C# needs no `this.` to reach its own members, so a bare receiver (`_foo.Bar()`)
+ * must resolve too, not just an explicit `this._foo.Bar()` (which resolveRecvType
+ * already checks the `this.`-prefixed key for, same as TS/Python). */
+function handleCSharp(node: Parser.SyntaxNode, scope: string[], classScope: string | null, bindings: FileBindings): void {
+  const scopePath = scope.join(".");
+  if (node.type === "field_declaration") {
+    const varDecl = node.namedChildren.find((c) => c.type === "variable_declaration");
+    const typeName = csTypeNameOf(varDecl?.childForFieldName("type"));
+    if (!typeName || !varDecl) return;
+    const target = classScope ?? scopePath;
+    for (const decl of varDecl.namedChildren.filter((c) => c.type === "variable_declarator")) {
+      const name = decl.childForFieldName("name")?.text;
+      if (!name) continue;
+      bindings.set(target, name, typeName);
+      bindings.set(target, `this.${name}`, typeName);
+    }
+    return;
+  }
+  if (node.type === "property_declaration") {
+    const typeName = csTypeNameOf(node.childForFieldName("type"));
+    const name = node.childForFieldName("name")?.text;
+    if (!typeName || !name) return;
+    const target = classScope ?? scopePath;
+    bindings.set(target, name, typeName);
+    bindings.set(target, `this.${name}`, typeName);
+    return;
+  }
+  if (node.type === "parameter") {
+    const typeName = csTypeNameOf(node.childForFieldName("type"));
+    const name = node.childForFieldName("name")?.text;
+    if (typeName && name) bindings.set(scopePath, name, typeName);
+    return;
+  }
+  if (node.type !== "local_declaration_statement") return;
+  const varDecl = node.namedChildren.find((c) => c.type === "variable_declaration");
+  if (!varDecl) return;
+  const typeNode = varDecl.childForFieldName("type");
+  for (const decl of varDecl.namedChildren.filter((c) => c.type === "variable_declarator")) {
+    const nameField = decl.childForFieldName("name");
+    const name = nameField?.text;
+    if (!name) continue;
+    let typeName: string | null = null;
+    if (typeNode && typeNode.type !== "implicit_type") {
+      typeName = csTypeNameOf(typeNode);
+    } else {
+      // `var x = new Foo();` — infer from the initializer's constructed type.
+      const init = decl.namedChildren.find((c) => c !== nameField);
+      if (init?.type === "object_creation_expression") typeName = csTypeNameOf(init.childForFieldName("type"));
+    }
+    if (typeName) bindings.set(scopePath, name, typeName);
   }
 }

--- a/src/graph/bindings.ts
+++ b/src/graph/bindings.ts
@@ -35,7 +35,9 @@ export class FileBindings {
 const FN_VALUE_TYPES = new Set(["arrow_function", "function", "function_expression", "generator_function"]);
 
 // Duplicated from extract.ts's own CS_METHOD_TYPES/CS_TYPE_KINDS (keys only) —
-// same no-value-import-of-extract rule as goReceiverTypeOf below.
+// same no-value-import-of-extract rule as goReceiverTypeOf below. `defName` also
+// handles `property_declaration`/`local_function_statement`, which extract.ts
+// recognizes individually rather than through either set.
 const CS_METHOD_TYPES = new Set(["method_declaration", "constructor_declaration", "destructor_declaration"]);
 const CS_TYPE_NODE_TYPES = new Set([
   "class_declaration",
@@ -102,13 +104,13 @@ export function defName(node: Parser.SyntaxNode, lang: Language): string | null 
   if (lang === "r") return rDefName(node);
   if (lang === "swift") return swiftDefName(node);
   if (lang === "csharp") {
-    if (CS_METHOD_TYPES.has(node.type)) {
+    if (CS_METHOD_TYPES.has(node.type) || node.type === "property_declaration") {
       const name = node.childForFieldName("name")?.text;
       if (!name) return null;
       const iface = csExplicitInterfaceOf(node);
       return iface ? `${iface}.${name}` : name;
     }
-    if (CS_TYPE_NODE_TYPES.has(node.type)) {
+    if (CS_TYPE_NODE_TYPES.has(node.type) || node.type === "local_function_statement") {
       return node.childForFieldName("name")?.text ?? null;
     }
     return null;

--- a/src/graph/extract.ts
+++ b/src/graph/extract.ts
@@ -15,12 +15,23 @@ import Java from "tree-sitter-java";
 import Kotlin from "tree-sitter-kotlin";
 import Swift from "tree-sitter-swift";
 import PHP from "tree-sitter-php";
+import CSharp from "tree-sitter-c-sharp";
 import { basename } from "node:path";
 import { contentHash } from "../util/id.js";
 import { collectBindings, goReceiverVarOf, resolveRecvType, type FileBindings } from "./bindings.js";
 import type { Kind, NodeV1, Relation } from "./types.js";
 
-export type Language = "typescript" | "tsx" | "python" | "go" | "java" | "kotlin" | "swift" | "php" | "r";
+export type Language =
+  | "typescript"
+  | "tsx"
+  | "python"
+  | "go"
+  | "csharp"
+  | "java"
+  | "kotlin"
+  | "swift"
+  | "php"
+  | "r";
 
 /**
  * Extension → the tree-sitter grammar that parses it, and the label a human expects
@@ -49,6 +60,7 @@ const EXTENSIONS: ReadonlyArray<{ ext: string; grammar: Language; label: string 
   { ext: ".pyi", grammar: "python", label: "python" },
   { ext: ".py", grammar: "python", label: "python" },
   { ext: ".go", grammar: "go", label: "go" },
+  { ext: ".cs", grammar: "csharp", label: "csharp" },
   { ext: ".java", grammar: "java", label: "java" },
   { ext: ".kt", grammar: "kotlin", label: "kotlin" },
   { ext: ".kts", grammar: "kotlin", label: "kotlin" },
@@ -263,11 +275,17 @@ const PHP_KINDS: Record<string, Kind> = {
   enum_declaration: "enum",
 };
 
+// C# is handled dynamically in describeCSharp() (method-shaped nodes need
+// explicit-interface-qualified idName, same as Go's receiver qualifying), so
+// this map is unused — kept only so every Language has an entry.
+const CS_KINDS: Record<string, Kind> = {};
+
 const KINDS_BY_LANG: Record<Language, Record<string, Kind>> = {
   typescript: TS_KINDS,
   tsx: TS_KINDS,
   python: PY_KINDS,
   go: GO_KINDS,
+  csharp: CS_KINDS,
   r: R_KINDS,
   java: JAVA_KINDS,
   kotlin: KOTLIN_KINDS,
@@ -299,6 +317,7 @@ const CALL_TYPES: Record<Language, ReadonlySet<string>> = {
     "scoped_call_expression",
   ]),
   r: new Set(["call"]),
+  csharp: new Set(["invocation_expression"]),
 };
 
 const FUNCTION_VALUE_TYPES = new Set([
@@ -316,6 +335,7 @@ const GRAMMARS: Record<Language, unknown> = {
   tsx: TypeScript.tsx,
   python: Python,
   go: Go,
+  csharp: CSharp,
   r: R,
   java: Java,
   kotlin: Kotlin,
@@ -592,17 +612,19 @@ function walk(node: Parser.SyntaxNode, ctx: WalkCtx, out: NodeV1[], edges: RawEd
           ? !desc.name.startsWith("_")
           : ctx.lang === "go"
             ? goExported(desc.name)
-            : ctx.lang === "r"
-              ? rExported(desc.name, ctx, node)
-              : ctx.lang === "java"
-                ? javaExported(node)
-                : ctx.lang === "kotlin"
-                  ? kotlinExported(node)
-                  : ctx.lang === "swift"
-                    ? swiftExported(node)
-                    : ctx.lang === "php"
-                      ? phpExported(node)
-                      : tsExported(node),
+            : ctx.lang === "csharp"
+              ? csExported(node)
+              : ctx.lang === "r"
+                ? rExported(desc.name, ctx, node)
+                : ctx.lang === "java"
+                  ? javaExported(node)
+                  : ctx.lang === "kotlin"
+                    ? kotlinExported(node)
+                    : ctx.lang === "swift"
+                      ? swiftExported(node)
+                      : ctx.lang === "php"
+                        ? phpExported(node)
+                        : tsExported(node),
       origin: "ast",
       body_hash: contentHash(desc.hashNode.text),
       body_text: searchBody(desc.hashNode.text),
@@ -617,20 +639,24 @@ function walk(node: Parser.SyntaxNode, ctx: WalkCtx, out: NodeV1[], edges: RawEd
     edges.push({ source: ctx.parentId, relation: "contains", targetId: id, file: ctx.rel });
     // class heritage — in Java an interface may also `extends`, and a record/enum
     // may `implements`, so every type declaration is a heritage site, not just a class.
+    // C# structs/interfaces likewise carry a heritage clause (unlike TS/Python/Go,
+    // where only "class" does).
     const javaTypeDecl = ctx.lang === "java" && JAVA_TYPE_KINDS.has(desc.kind);
     const kotlinTypeDecl = ctx.lang === "kotlin" && KOTLIN_TYPE_KINDS.has(desc.kind);
     const swiftTypeDecl = ctx.lang === "swift" && SWIFT_TYPE_KINDS.has(desc.kind);
-    if (desc.kind === "class" || javaTypeDecl || kotlinTypeDecl || swiftTypeDecl)
-      edges.push(...heritageEdges(node, id, ctx));
+    const csharpTypeDecl =
+      ctx.lang === "csharp" && (desc.kind === "struct" || desc.kind === "interface");
+    const isClassLike =
+      desc.kind === "class" || javaTypeDecl || kotlinTypeDecl || swiftTypeDecl || csharpTypeDecl;
+    if (isClassLike) edges.push(...heritageEdges(node, id, ctx));
     if (ctx.lang === "php") edges.push(...phpAttributeReferenceEdges(node, id, ctx));
     if (ctx.lang === "java") edges.push(...javaAnnotationReferenceEdges(node, id, ctx));
 
-    const enclosingClass =
-      desc.kind === "class" || javaTypeDecl || kotlinTypeDecl || swiftTypeDecl
-        ? desc.name
-        : isGoMethod
-          ? goReceiverType(node)
-          : (desc.owner ?? ctx.enclosingClass);
+    const enclosingClass = isClassLike
+      ? desc.name
+      : isGoMethod
+        ? goReceiverType(node)
+        : (desc.owner ?? ctx.enclosingClass);
     const childCtx: WalkCtx = {
       ...ctx,
       scope: [...ctx.scope, idPart],
@@ -1107,6 +1133,7 @@ function isDeclarationName(node: Parser.SyntaxNode): boolean {
  * TS arrow-consts. */
 function describe(node: Parser.SyntaxNode, ctx: WalkCtx): DefDescriptor | null {
   if (ctx.lang === "go") return describeGo(node, ctx);
+  if (ctx.lang === "csharp") return describeCSharp(node);
   if (ctx.lang === "r") return describeR(node, ctx);
   if (ctx.lang === "java") return describeJava(node, ctx);
   if (ctx.lang === "kotlin") return describeKotlin(node, ctx);
@@ -1482,6 +1509,105 @@ function findUseMethodArg(node: Parser.SyntaxNode | null | undefined): string | 
   for (const child of node.namedChildren) {
     const found = findUseMethodArg(child);
     if (found !== undefined) return found;
+  }
+  return undefined;
+}
+
+const CS_TYPE_KINDS: Record<string, Kind> = {
+  class_declaration: "class",
+  struct_declaration: "struct",
+  interface_declaration: "interface",
+  // tree-sitter-c-sharp emits the same node for `record`, `record class`, and
+  // `record struct` — the struct/class keyword isn't distinguishable in the
+  // tree without re-scanning raw tokens, so all three land on "class".
+  record_declaration: "class",
+  enum_declaration: "enum",
+  delegate_declaration: "type",
+};
+
+// Method-shaped members. Operator/conversion-operator declarations are
+// intentionally excluded: neither carries a `name` field in this grammar (the
+// operator symbol/target type isn't a nameable identifier), so describeCSharp
+// would just return null for them anyway — this documents that as deliberate.
+const CS_METHOD_TYPES = new Set(["method_declaration", "constructor_declaration", "destructor_declaration"]);
+
+/** C# definition shapes: type declarations (class/struct/interface/record/enum/
+ * delegate) and method-shaped members. Methods get an explicit-interface-qualified
+ * `idName` when present (`void IFoo.Bar() {}`) because the bare name can legally
+ * collide with a public member of the same name in the same class — mirrors how
+ * Go's `idName` disambiguates receiver-qualified methods. */
+function describeCSharp(node: Parser.SyntaxNode): DefDescriptor | null {
+  const typeKind = CS_TYPE_KINDS[node.type];
+  if (typeKind) {
+    const name = node.childForFieldName("name")?.text;
+    if (!name) return null;
+    const body = node.childForFieldName("body");
+    return { name, kind: typeKind, headerEnd: body ? body.startIndex : node.endIndex, hashNode: node };
+  }
+  if (CS_METHOD_TYPES.has(node.type)) {
+    const name = node.childForFieldName("name")?.text;
+    if (!name) return null;
+    const body = node.childForFieldName("body");
+    const iface = csExplicitInterface(node);
+    return {
+      name,
+      idName: iface ? `${iface}.${name}` : undefined,
+      kind: "method",
+      headerEnd: body ? body.startIndex : node.endIndex,
+      hashNode: node,
+    };
+  }
+  return null;
+}
+
+/** Resolve a C# type-reference node (identifier / qualified_name / generic_name /
+ * nullable_type / predefined_type) to a bare type name — the rightmost segment,
+ * unwrapping generics and nullability. Null for shapes with no single nameable
+ * type (tuple/array/pointer types, primary-constructor base-type calls). */
+function csTypeName(node: Parser.SyntaxNode | null | undefined): string | null {
+  if (!node) return null;
+  switch (node.type) {
+    case "identifier":
+    case "predefined_type":
+      return node.text;
+    case "generic_name":
+      return node.namedChildren.find((c) => c.type === "identifier")?.text ?? null;
+    case "qualified_name": {
+      const name = node.childForFieldName("name");
+      return name ? csTypeName(name) : null;
+    }
+    case "nullable_type":
+      return csTypeName(node.namedChildren[0]);
+    default:
+      return null;
+  }
+}
+
+/** The interface name qualifying an explicit interface implementation
+ * (`void IFoo.Bar() {}` → `"IFoo"`), else null. */
+function csExplicitInterface(node: Parser.SyntaxNode): string | null {
+  const spec = node.namedChildren.find((c) => c.type === "explicit_interface_specifier");
+  return csTypeName(spec?.namedChildren[0]);
+}
+
+/** C# visibility: true iff the node has an explicit `public` modifier. Unlike Go's
+ * name-based convention, C# accessibility is a keyword, and unmarked members default
+ * to private/internal depending on context — so "no modifier" reads as not exported. */
+function csExported(node: Parser.SyntaxNode): boolean {
+  return node.namedChildren.some((c) => c.type === "modifier" && c.text === "public");
+}
+
+/** C# member-call receiver text (from a `member_access_expression`): `this`, a bare
+ * identifier (covers both a local/param and an implicit-`this` field/property access —
+ * C# needs no `this.` to reach its own members), or one level of `this.field` chain. */
+function csReceiver(fn: Parser.SyntaxNode): string | undefined {
+  const obj = fn.childForFieldName("expression");
+  if (obj?.type === "this") return "this";
+  if (obj?.type === "identifier") return obj.text;
+  if (obj?.type === "member_access_expression") {
+    const innerObj = obj.childForFieldName("expression");
+    const innerName = obj.childForFieldName("name");
+    if (innerObj?.type === "this" && innerName) return `this.${innerName.text}`;
   }
   return undefined;
 }
@@ -2111,6 +2237,18 @@ function heritageEdges(node: Parser.SyntaxNode, classId: string, ctx: WalkCtx): 
     }
     return edges;
   }
+  if (ctx.lang === "csharp") {
+    // `class Foo : Base, IBar` — base_list doesn't syntactically distinguish a base
+    // class from an interface, so every entry is emitted as "extends"; resolve.ts's
+    // "extends" already matches class-or-interface targets, so an interface base
+    // still resolves — it just isn't labeled "implements".
+    const baseList = node.namedChildren.find((c) => c.type === "base_list");
+    for (const t of baseList?.namedChildren ?? []) {
+      const name = csTypeName(t);
+      if (name) edges.push({ source: classId, relation: "extends", name, file: ctx.rel });
+    }
+    return edges;
+  }
   const heritage = node.namedChildren.find((c) => c.type === "class_heritage");
   for (const clause of heritage?.namedChildren ?? []) {
     const relation: Relation | null =
@@ -2270,7 +2408,15 @@ if (lang === "kotlin") {
 
   const fn = node.childForFieldName("function");
   if (!fn) return null;
-  if (fn.type === "identifier") return { name: fn.text, viaMember: false };
+  if (fn.type === "identifier") {
+    // C# has no free-standing functions — every callable lives on a type, so a
+    // bare `Foo()` inside a method is an implicit-`this` member call (unlike
+    // TS/Python/Go, where a bare call is always a real free function). Route it
+    // through the member-call path so it resolves against the enclosing type's
+    // methods instead of the (always-empty, for C#) "function" kind.
+    if (lang === "csharp") return { name: fn.text, viaMember: true, receiver: "this" };
+    return { name: fn.text, viaMember: false };
+  }
   if (lang === "python" && fn.type === "attribute") {
     const a = fn.childForFieldName("attribute") ?? fn.namedChildren.at(-1);
     return a ? { name: a.text, viaMember: true, receiver: pyReceiver(fn) } : null;
@@ -2326,6 +2472,12 @@ if (lang === "kotlin") {
     // never an R6 method (those are only ever reached via `$` on an instance),
     // so no need to widen the match kinds here.
     return { name: rhs.text, viaMember: false };
+  }
+  if (lang === "csharp" && fn.type === "member_access_expression") {
+    const p = fn.childForFieldName("name");
+    if (!p) return null;
+    const name = p.type === "generic_name" ? p.namedChildren.find((c) => c.type === "identifier")?.text : p.text;
+    return name ? { name, viaMember: true, receiver: csReceiver(fn) } : null;
   }
   return null;
 }
@@ -2484,6 +2636,7 @@ if (lang === "kotlin") return node.type === "import_header";
   // PHP: one edge per imported symbol — the clause leaf inside a (possibly
   // grouped) `use A\B, C\D;` / `use A\{B, C};` declaration.
   if (lang === "php") return node.type === "namespace_use_clause";
+  if (lang === "csharp") return node.type === "using_directive";
   return node.type === "import_statement" || node.type === "import_from_statement";
 }
 
@@ -2533,6 +2686,16 @@ function importSpecifier(node: Parser.SyntaxNode, lang: Language): string | null
     // to a repo file only when a same-named module target exists; external
     // frameworks stay as unresolved (but truthful) import intents.
     return node.namedChildren.find((c) => c.type === "identifier")?.text ?? null;
+  }
+  if (lang === "csharp") {
+    // `using_directive`'s `name` field only holds an alias's own name
+    // (`using Alias = Namespace.Type;`) — the namespace/type actually being used
+    // is the other child. Kept as an unresolved external specifier: C# namespaces
+    // don't map onto file paths the way Go's module system does, so there's no
+    // in-repo resolution to attempt (see resolveImport/resolveGoImport in resolve.ts).
+    const nameField = node.childForFieldName("name");
+    const target = node.namedChildren.find((c) => c !== nameField);
+    return target?.text ?? null;
   }
   const str = node.namedChildren.find((c) => c.type === "string");
   if (!str) return null;

--- a/src/graph/extract.ts
+++ b/src/graph/extract.ts
@@ -1518,31 +1518,49 @@ const CS_TYPE_KINDS: Record<string, Kind> = {
   struct_declaration: "struct",
   interface_declaration: "interface",
   // tree-sitter-c-sharp emits the same node for `record`, `record class`, and
-  // `record struct` — the struct/class keyword isn't distinguishable in the
-  // tree without re-scanning raw tokens, so all three land on "class".
+  // `record struct`; the value here is the default for a bare `record`, and
+  // describeCSharp() narrows it per-declaration via csRecordKind().
   record_declaration: "class",
   enum_declaration: "enum",
   delegate_declaration: "type",
 };
 
-// Method-shaped members. Operator/conversion-operator declarations are
-// intentionally excluded: neither carries a `name` field in this grammar (the
-// operator symbol/target type isn't a nameable identifier), so describeCSharp
-// would just return null for them anyway — this documents that as deliberate.
+// Method-shaped members. Operator/conversion-operator and indexer declarations
+// are intentionally excluded: none carries a `name` field in this grammar (the
+// operator symbol / indexer `this[…]` isn't a nameable identifier), so
+// describeCSharp would just return null for them anyway — this documents that as
+// deliberate. Naming them would mean synthesizing one from positional children.
 const CS_METHOD_TYPES = new Set(["method_declaration", "constructor_declaration", "destructor_declaration"]);
 
+/** `record`, `record class`, and `record struct` all parse as `record_declaration`;
+ * the distinguishing keyword rides along as an *anonymous* child token, which the
+ * named-child/field reads elsewhere in this file never see. Only `record struct`
+ * is a value type — bare `record` and `record class` are both classes. */
+function csRecordKind(node: Parser.SyntaxNode): Kind {
+  return node.children.some((c) => !c.isNamed && c.type === "struct") ? "struct" : "class";
+}
+
+/** A property's body opener: the accessor block (`{ get; set; }`) or the
+ * expression-bodied arrow (`=> expr`). Neither is exposed as a `body` field, so
+ * the header span has to find it among the named children. */
+function csPropertyBody(node: Parser.SyntaxNode): Parser.SyntaxNode | null {
+  return node.namedChildren.find((c) => c.type === "accessor_list" || c.type === "arrow_expression_clause") ?? null;
+}
+
 /** C# definition shapes: type declarations (class/struct/interface/record/enum/
- * delegate) and method-shaped members. Methods get an explicit-interface-qualified
- * `idName` when present (`void IFoo.Bar() {}`) because the bare name can legally
- * collide with a public member of the same name in the same class — mirrors how
- * Go's `idName` disambiguates receiver-qualified methods. */
+ * delegate), method-shaped members, properties, and local functions. Methods and
+ * properties get an explicit-interface-qualified `idName` when present
+ * (`void IFoo.Bar() {}`) because the bare name can legally collide with a public
+ * member of the same name in the same class — mirrors how Go's `idName`
+ * disambiguates receiver-qualified methods. */
 function describeCSharp(node: Parser.SyntaxNode): DefDescriptor | null {
   const typeKind = CS_TYPE_KINDS[node.type];
   if (typeKind) {
     const name = node.childForFieldName("name")?.text;
     if (!name) return null;
+    const kind = node.type === "record_declaration" ? csRecordKind(node) : typeKind;
     const body = node.childForFieldName("body");
-    return { name, kind: typeKind, headerEnd: body ? body.startIndex : node.endIndex, hashNode: node };
+    return { name, kind, headerEnd: body ? body.startIndex : node.endIndex, hashNode: node };
   }
   if (CS_METHOD_TYPES.has(node.type)) {
     const name = node.childForFieldName("name")?.text;
@@ -1556,6 +1574,28 @@ function describeCSharp(node: Parser.SyntaxNode): DefDescriptor | null {
       headerEnd: body ? body.startIndex : node.endIndex,
       hashNode: node,
     };
+  }
+  if (node.type === "property_declaration") {
+    const name = node.childForFieldName("name")?.text;
+    if (!name) return null;
+    const body = csPropertyBody(node);
+    const iface = csExplicitInterface(node);
+    return {
+      name,
+      idName: iface ? `${iface}.${name}` : undefined,
+      kind: "property",
+      headerEnd: body ? body.startIndex : node.endIndex,
+      hashNode: node,
+    };
+  }
+  // A local function is a method-body statement, not a class member — the walk
+  // reaches it by descending through the enclosing method's `block`, so its id
+  // nests under that method (`File.cs#Class.Method.Local`).
+  if (node.type === "local_function_statement") {
+    const name = node.childForFieldName("name")?.text;
+    if (!name) return null;
+    const body = node.childForFieldName("body");
+    return { name, kind: "function", headerEnd: body ? body.startIndex : node.endIndex, hashNode: node };
   }
   return null;
 }
@@ -2239,9 +2279,9 @@ function heritageEdges(node: Parser.SyntaxNode, classId: string, ctx: WalkCtx): 
   }
   if (ctx.lang === "csharp") {
     // `class Foo : Base, IBar` — base_list doesn't syntactically distinguish a base
-    // class from an interface, so every entry is emitted as "extends"; resolve.ts's
-    // "extends" already matches class-or-interface targets, so an interface base
-    // still resolves — it just isn't labeled "implements".
+    // class from an interface, so every entry is emitted as "extends"; resolve.ts
+    // relabels the ones whose target resolves to an interface as "implements", and
+    // leaves an unresolved (external) base as "extends".
     const baseList = node.namedChildren.find((c) => c.type === "base_list");
     for (const t of baseList?.namedChildren ?? []) {
       const name = csTypeName(t);
@@ -2413,7 +2453,10 @@ if (lang === "kotlin") {
     // bare `Foo()` inside a method is an implicit-`this` member call (unlike
     // TS/Python/Go, where a bare call is always a real free function). Route it
     // through the member-call path so it resolves against the enclosing type's
-    // methods instead of the (always-empty, for C#) "function" kind.
+    // methods. The one C# shape this can't reach is a call to a local function
+    // (kind "function", nested under its declaring method): resolving those needs
+    // block-scoped lookup, since a bare name is scope-blind here and would happily
+    // wire a call to a same-named local function in a sibling method.
     if (lang === "csharp") return { name: fn.text, viaMember: true, receiver: "this" };
     return { name: fn.text, viaMember: false };
   }

--- a/src/graph/resolve.ts
+++ b/src/graph/resolve.ts
@@ -223,8 +223,16 @@ export function resolveEdges(
       // (`use SomeTrait;`) as an implements edge, and a trait is a valid target.
       const kinds: Kind[] = e.relation === "implements" ? ["interface", "trait"] : ["class", "interface"];
       const hit = resolveName(e.name!, e.file, kinds, perFileName, globalName);
+      // C#'s `base_list` can't syntactically tell a base class from an interface, so
+      // extract.ts emits every entry as "extends" and the resolved target's own kind
+      // settles it here. Restricted to C# on purpose: TS/Python already emit the right
+      // relation at extraction, and TS declaration merging (`interface Foo` alongside
+      // `class Foo`) can legitimately resolve a real `extends` to the interface half.
+      // An unresolved base — always an external type — stays "extends", as before.
+      const relation: Relation =
+        e.relation === "extends" && e.file.endsWith(".cs") && hit?.kind === "interface" ? "implements" : e.relation;
       // an unresolved base is usually an external/imported type — keep the name.
-      add(e.source, hit?.id ?? e.name!, e.relation, hit?.confidence ?? "inferred");
+      add(e.source, hit?.id ?? e.name!, relation, hit?.confidence ?? "inferred");
     } else if (e.relation === "references" && e.name) {
       if (e.specifier) {
         // A named import gives both halves needed for sound resolution: the module
@@ -353,6 +361,8 @@ function ownerFromMethodId(id: string): string | undefined {
 /**
  * Resolve a bare symbol name: same-file match first (certain → `extracted`),
  * else a unique cross-file match (→ `inferred`), else null (ambiguous/unknown).
+ * The matched node's own `kind` comes back with the hit — a heritage edge needs
+ * it to tell an interface base from a class one.
  */
 function resolveName(
   name: string,
@@ -360,21 +370,21 @@ function resolveName(
   kinds: Kind[],
   perFileName: Map<string, Map<string, NodeV1[]>>,
   globalName: Map<string, NodeV1[]>,
-): { id: string; confidence: EdgeV1["confidence"] } | null {
+): { id: string; kind: Kind; confidence: EdgeV1["confidence"] } | null {
   const local = (perFileName.get(file)?.get(name) ?? []).filter((n) => kinds.includes(n.kind));
   // Same-file requires a UNIQUE match, exactly as the cross-file branch below does.
   // Returning `local[0]` meant a file holding two same-named types (`Alpha.Builder` and
   // `Beta.Builder`, `Alpha.Inner` and `Beta.Inner`) silently resolved to whichever came
   // first in document order — and labelled it `extracted`, i.e. certain. That is the
   // guess this module's header says it does not make.
-  if (local.length === 1) return { id: local[0].id, confidence: "extracted" };
+  if (local.length === 1) return { id: local[0].id, kind: local[0].kind, confidence: "extracted" };
   // Cross-file: also require a language that could actually reach this one.
   // Without it a unique name match ANYWHERE in the repo wins, which is how a Go
   // builtin ended up resolving into a TypeScript test — see FAMILIES above.
   const global = (globalName.get(name) ?? []).filter(
     (n) => kinds.includes(n.kind) && reachable(file, n.path),
   );
-  if (global.length === 1) return { id: global[0].id, confidence: "inferred" };
+  if (global.length === 1) return { id: global[0].id, kind: global[0].kind, confidence: "inferred" };
   return null;
 }
 

--- a/src/graph/types.ts
+++ b/src/graph/types.ts
@@ -14,13 +14,13 @@
 /** What a node represents. LSP SymbolKind, narrowed to what our extractors produce. */
 export type Kind =
   | "file"
-  | "class"
+  | "class" // + C# record (class/struct-record variants are indistinguishable in the grammar)
   | "function"
   | "method"
-  | "interface" // TS + Go
-  | "type" // TS + Go (type alias / named type)
-  | "enum" // TS + PHP + Java
-  | "struct" // Go only
+  | "interface" // TS + Go + C#
+  | "type" // TS + Go (type alias / named type) + C# (delegate)
+  | "enum" // TS + PHP + Java + C#
+  | "struct" // Go + C#
   | "trait" // PHP only
   // The generic (tags.scm) breadth tier also emits these — every tree-sitter
   // grammar's tags.scm uses the tree-sitter tags @definition.<X> vocabulary, and

--- a/src/graph/types.ts
+++ b/src/graph/types.ts
@@ -14,13 +14,14 @@
 /** What a node represents. LSP SymbolKind, narrowed to what our extractors produce. */
 export type Kind =
   | "file"
-  | "class" // + C# record (class/struct-record variants are indistinguishable in the grammar)
-  | "function"
+  | "class" // + C# `record` / `record class`
+  | "function" // + C# local function
   | "method"
+  | "property" // C#
   | "interface" // TS + Go + C#
   | "type" // TS + Go (type alias / named type) + C# (delegate)
   | "enum" // TS + PHP + Java + C#
-  | "struct" // Go + C#
+  | "struct" // Go + C# (including `record struct`)
   | "trait" // PHP only
   // The generic (tags.scm) breadth tier also emits these — every tree-sitter
   // grammar's tags.scm uses the tree-sitter tags @definition.<X> vocabulary, and

--- a/test/graph-csharp.test.ts
+++ b/test/graph-csharp.test.ts
@@ -1,8 +1,8 @@
 /**
  * Tests for C# extraction in the Tier-1 code graph. Builds a small C# project in a
  * temp dir and asserts the emitted nodes (classes, structs, interfaces, records,
- * enums, delegates, methods) and edges (calls, heritage) match the AST walk in
- * extract.ts.
+ * enums, delegates, methods, properties, local functions) and edges (calls,
+ * heritage) match the AST walk in extract.ts.
  */
 import { test } from "node:test";
 import assert from "node:assert/strict";
@@ -62,7 +62,24 @@ namespace MyApp.Services
 
     public record PointR(int X, int Y);
 
+    public record class Boxed(int X);
+
+    public record struct Vec(int X, int Y);
+
     public delegate void Handler(object sender);
+
+    public class Holder
+    {
+        public int Count { get; set; }
+
+        public string Label => "label";
+
+        public int Compute()
+        {
+            int Inner(int a) => a + 1;
+            return Inner(Count);
+        }
+    }
 }
 `;
 
@@ -91,7 +108,11 @@ test("C# extraction: classes, structs, interfaces, records, enums, delegates", a
     assert.equal(nodeById(graph!, "Widget.cs#Point")?.kind, "struct");
     assert.equal(nodeById(graph!, "Widget.cs#IReader")?.kind, "interface");
     assert.equal(nodeById(graph!, "Widget.cs#Color")?.kind, "enum");
+    // `record` / `record class` are reference types; only `record struct` is a value
+    // type — all three parse as the same node, distinguished by an anonymous token.
     assert.equal(nodeById(graph!, "Widget.cs#PointR")?.kind, "class");
+    assert.equal(nodeById(graph!, "Widget.cs#Boxed")?.kind, "class");
+    assert.equal(nodeById(graph!, "Widget.cs#Vec")?.kind, "struct");
     assert.equal(nodeById(graph!, "Widget.cs#Handler")?.kind, "type");
 
     // methods — exported by explicit `public` modifier
@@ -119,16 +140,22 @@ test("C# extraction: heritage and call edges", async () => {
     await buildGraph(dir);
     const graph = readGraph(wiringPath(join(dir, "graft")))!;
 
-    // class heritage: base class and interface both land as "extends"
-    // (base_list doesn't syntactically distinguish the two)
+    // class heritage: base_list doesn't syntactically distinguish a base class from
+    // an interface, so the relation comes from the resolved target's own kind.
     const extendsBase = graph.edges.find(
       (e) => e.relation === "extends" && e.source === "Widget.cs#Widget" && e.target === "Widget.cs#Base",
     );
     assert.ok(extendsBase, "Widget should extend Base");
-    const extendsIFoo = graph.edges.find(
-      (e) => e.relation === "extends" && e.source === "Widget.cs#Widget" && e.target === "Widget.cs#IFoo",
+    const implementsIFoo = graph.edges.find(
+      (e) => e.relation === "implements" && e.source === "Widget.cs#Widget" && e.target === "Widget.cs#IFoo",
     );
-    assert.ok(extendsIFoo, "Widget should extend/implement IFoo");
+    assert.ok(implementsIFoo, "Widget should implement IFoo (target resolves to an interface)");
+    assert.ok(
+      !graph.edges.some(
+        (e) => e.relation === "extends" && e.source === "Widget.cs#Widget" && e.target === "Widget.cs#IFoo",
+      ),
+      "the interface base should not also remain an extends edge",
+    );
 
     // bare-identifier field receiver: `_foo.Bar()` resolves via the field's bound type
     const fieldCall = graph.edges.find(
@@ -147,6 +174,78 @@ test("C# extraction: heritage and call edges", async () => {
       (e) => e.relation === "calls" && e.source === "Widget.cs#Widget.Bar" && e.target === "Widget.cs#Widget.Local",
     );
     assert.ok(bareCall, "Local() should resolve to Widget.Local");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("C# extraction: unresolved external base stays an extends edge", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-csharp-external-"));
+  try {
+    writeFileSync(
+      join(dir, "External.cs"),
+      `namespace MyApp
+{
+    public class Derived : ControllerBase, IDisposable
+    {
+        public void Dispose() {}
+    }
+}
+`,
+    );
+    await buildGraph(dir);
+    const graph = readGraph(wiringPath(join(dir, "graft")))!;
+
+    // neither base resolves in-repo, so both keep the extraction-time "extends"
+    // and carry the bare name as the target.
+    for (const base of ["ControllerBase", "IDisposable"]) {
+      const edge = graph.edges.find((e) => e.source === "External.cs#Derived" && e.target === base);
+      assert.equal(edge?.relation, "extends", `${base} should stay an extends edge when unresolved`);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("C# extraction: properties and local functions", async () => {
+  const dir = makeFixture();
+  try {
+    await buildGraph(dir);
+    const graph = readGraph(wiringPath(join(dir, "graft")))!;
+
+    // auto-property: the header stops at the accessor list, not the class brace
+    const count = nodeById(graph, "Widget.cs#Holder.Count");
+    assert.equal(count?.kind, "property");
+    assert.equal(count?.name, "Count");
+    assert.equal(count?.exported, true);
+    assert.equal(count?.signature, "public int Count");
+    assert.equal(count?.span, "L58-L58");
+
+    // expression-bodied property: the header stops at the `=>`
+    const label = nodeById(graph, "Widget.cs#Holder.Label");
+    assert.equal(label?.kind, "property");
+    assert.equal(label?.signature, "public string Label");
+
+    // a local function nests under its enclosing method and reuses kind "function"
+    const inner = nodeById(graph, "Widget.cs#Holder.Compute.Inner");
+    assert.equal(inner?.kind, "function");
+    assert.equal(inner?.name, "Inner");
+    assert.equal(inner?.exported, false); // no `public` modifier is legal on one
+    assert.equal(inner?.span, "L64-L64");
+
+    // containment follows the nesting
+    assert.ok(
+      graph.edges.some(
+        (e) =>
+          e.relation === "contains" &&
+          e.source === "Widget.cs#Holder.Compute" &&
+          e.target === "Widget.cs#Holder.Compute.Inner",
+      ),
+      "Compute should contain its local function",
+    );
+    // `Inner(Count)` does NOT produce a call edge: C# bare calls route through the
+    // member-call path (calleeName in extract.ts), which only matches kind "method".
+    // Resolving them would need block-scoped lookup — see the note there.
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/test/graph-csharp.test.ts
+++ b/test/graph-csharp.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for C# extraction in the Tier-1 code graph. Builds a small C# project in a
+ * temp dir and asserts the emitted nodes (classes, structs, interfaces, records,
+ * enums, delegates, methods) and edges (calls, heritage) match the AST walk in
+ * extract.ts.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { buildGraph } from "../src/graph/build.js";
+import { readGraph, wiringPath } from "../src/graph/write.js";
+import type { GraphV1, NodeV1 } from "../src/graph/types.js";
+
+const WIDGET_CS = `using System;
+
+namespace MyApp.Services
+{
+    public interface IFoo
+    {
+        void Bar();
+    }
+
+    public class Base
+    {
+        protected void Helper() {}
+    }
+
+    public class Widget : Base, IFoo
+    {
+        private readonly IFoo _foo;
+
+        public Widget(IFoo foo)
+        {
+            _foo = foo;
+        }
+
+        public void Bar()
+        {
+            _foo.Bar();
+            this.Helper();
+            Local();
+        }
+
+        private void Local() {}
+
+        void IFoo.Bar() {}
+    }
+
+    public struct Point
+    {
+        public int X;
+    }
+
+    public interface IReader
+    {
+        int Read();
+    }
+
+    public enum Color { Red, Green }
+
+    public record PointR(int X, int Y);
+
+    public delegate void Handler(object sender);
+}
+`;
+
+function makeFixture(): string {
+  const dir = mkdtempSync(join(tmpdir(), "graft-csharp-"));
+  writeFileSync(join(dir, "Widget.cs"), WIDGET_CS);
+  return dir;
+}
+
+function nodeById(graph: GraphV1, id: string): NodeV1 | undefined {
+  return graph.nodes.find((n) => n.id === id);
+}
+
+test("C# extraction: classes, structs, interfaces, records, enums, delegates", async () => {
+  const dir = makeFixture();
+  try {
+    const result = await buildGraph(dir); // $0, Tier-1 only
+    assert.ok(result.languages.includes("csharp"), "languages should include csharp");
+
+    const graph = readGraph(wiringPath(join(dir, "graft")));
+    assert.ok(graph, "wiring graph should be written");
+
+    assert.equal(nodeById(graph!, "Widget.cs#IFoo")?.kind, "interface");
+    assert.equal(nodeById(graph!, "Widget.cs#Base")?.kind, "class");
+    assert.equal(nodeById(graph!, "Widget.cs#Widget")?.kind, "class");
+    assert.equal(nodeById(graph!, "Widget.cs#Point")?.kind, "struct");
+    assert.equal(nodeById(graph!, "Widget.cs#IReader")?.kind, "interface");
+    assert.equal(nodeById(graph!, "Widget.cs#Color")?.kind, "enum");
+    assert.equal(nodeById(graph!, "Widget.cs#PointR")?.kind, "class");
+    assert.equal(nodeById(graph!, "Widget.cs#Handler")?.kind, "type");
+
+    // methods — exported by explicit `public` modifier
+    const ctor = nodeById(graph!, "Widget.cs#Widget.Widget");
+    assert.equal(ctor?.kind, "method");
+    assert.equal(ctor?.exported, true);
+    const bar = nodeById(graph!, "Widget.cs#Widget.Bar");
+    assert.equal(bar?.kind, "method");
+    assert.equal(bar?.exported, true);
+    const local = nodeById(graph!, "Widget.cs#Widget.Local");
+    assert.equal(local?.exported, false);
+
+    // explicit interface implementation gets a distinct, interface-qualified id
+    // from the public `Bar()` of the same name in the same class
+    const explicitBar = nodeById(graph!, "Widget.cs#Widget.IFoo.Bar");
+    assert.equal(explicitBar?.kind, "method");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("C# extraction: heritage and call edges", async () => {
+  const dir = makeFixture();
+  try {
+    await buildGraph(dir);
+    const graph = readGraph(wiringPath(join(dir, "graft")))!;
+
+    // class heritage: base class and interface both land as "extends"
+    // (base_list doesn't syntactically distinguish the two)
+    const extendsBase = graph.edges.find(
+      (e) => e.relation === "extends" && e.source === "Widget.cs#Widget" && e.target === "Widget.cs#Base",
+    );
+    assert.ok(extendsBase, "Widget should extend Base");
+    const extendsIFoo = graph.edges.find(
+      (e) => e.relation === "extends" && e.source === "Widget.cs#Widget" && e.target === "Widget.cs#IFoo",
+    );
+    assert.ok(extendsIFoo, "Widget should extend/implement IFoo");
+
+    // bare-identifier field receiver: `_foo.Bar()` resolves via the field's bound type
+    const fieldCall = graph.edges.find(
+      (e) => e.relation === "calls" && e.source === "Widget.cs#Widget.Bar" && e.target === "Widget.cs#IFoo.Bar",
+    );
+    assert.ok(fieldCall, "_foo.Bar() should resolve to IFoo.Bar via the field's bound type");
+
+    // `this.Helper()` resolves to the base class's method through the extends chain
+    const thisCall = graph.edges.find(
+      (e) => e.relation === "calls" && e.source === "Widget.cs#Widget.Bar" && e.target === "Widget.cs#Base.Helper",
+    );
+    assert.ok(thisCall, "this.Helper() should resolve to Base.Helper");
+
+    // bare same-file call
+    const bareCall = graph.edges.find(
+      (e) => e.relation === "calls" && e.source === "Widget.cs#Widget.Bar" && e.target === "Widget.cs#Widget.Local",
+    );
+    assert.ok(bareCall, "Local() should resolve to Widget.Local");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Problem

Graft's structural graph is blind to `.cs` files, so a .NET codebase gets no node or edge coverage at all — no callers, no blast radius, no signature extraction, and coupling-based ranking has nothing to rank C# symbols by. On a real ~3,400-file .NET repo, `graft/.graph/wiring.json` had zero entries for any C# symbol.

This adds `csharp` as a first-class extractor alongside the existing TS/Python/Go/Java/Kotlin/Swift/PHP/R support.

Two commits: the extractor itself, then a follow-up sharpening record/struct kinds, extends-vs-implements, and property/local-function nodes.

## What it covers

- **Type declarations** — class, struct, interface, record, enum, delegate. `record` and `record class` map to `class`; `record struct` maps to `struct`. All three produce one `record_declaration`, with the distinguishing keyword riding along as an anonymous child token that the named-child and field reads never see, so `csRecordKind()` scans `node.children` for an unnamed `struct` child.
- **Method-shaped members** — method, constructor, destructor, plus `property_declaration` (new `property` kind) and `local_function_statement` (nested under its declaring method).
- **Explicit interface implementations** take an interface-qualified id (`void IFoo.Bar() {}` → `#Widget.IFoo.Bar`), since the bare name can legally collide with a public member of the same name on the same type — the same disambiguation Go's receiver-qualified methods already use.
- **Visibility is keyword-based, not name-based.** Unlike Go, C# accessibility is an explicit modifier and unmarked members default to private/internal, so "no modifier" reads as not exported.
- **Heritage edges** from `base_list`. The grammar cannot syntactically distinguish a base class from an implemented interface, so extraction emits every entry as `extends` and the resolver relabels to `implements` when the resolved target's own kind is `interface`. That relabel is gated to `.cs` on purpose: TS declaration merging (`interface Foo` alongside `class Foo`) can legitimately resolve a real `extends` to the interface half. An unresolved base — always an external type — stays `extends`.
- **Receiver-type bindings** so member calls resolve through the receiver's bound type: field, property, parameter and local-variable declarations all contribute, and a bare `Foo()` is treated as an implicit-`this` member call, since C# has no free-standing functions.

## A bug this surfaced

`walk()` hardcoded `call_expression` as the call-node type for every non-Python language, but C#'s grammar uses `invocation_expression`. Without that fix, zero C# call edges would ever be extracted. Fixed in the first commit.

## Known limitation, deliberately left

Calls to a **local function** produce no call edge. C# bare calls route through the member-call path, which matches only kind `method`, and widening the fallback kinds would let scope-blind resolution wire a call to a sibling method's block-scoped local function:

```csharp
class A {
    void M1() { void Helper() {} Helper(); }
    void M2() { Helper(); }   // not legal C#, but graft can't tell
}
```

Resolving these correctly needs a scope-prefix check in `resolve.ts` — a real design change rather than a widened kind list. Per graft's own stated philosophy of never wiring an edge to the wrong symbol, a missing edge is the correct interim outcome. This is documented at the `calleeName` C# branch and in the test.

## Note on `resolve.ts`

The second commit extends `resolveName` to return the matched node's own `kind` alongside its id, because the heritage relabel needs it to tell an interface base from a class one. That is additive — existing callers ignore the extra field.

## Testing

- `test/graph-csharp.test.ts` (new, modelled on `test/graph-go.test.ts`): structural node coverage; heritage and call-edge resolution; the explicit-interface-implementation id collision case; `record struct` vs `record`/`record class` kinds; an interface base producing `implements` with an assertion that no `extends` edge survives alongside it; an unresolved external base still emitting `extends`; and property/local-function nodes asserted on kind, name, signature, span and containment.
- Full suite green (1,219 passing, 5 skipped).
- Verified against a real .NET codebase of ~3,400 `.cs` files: 29,022 C# nodes extracted (3,193 class, 17,136 method, 4,737 property, 340 interface, 91 enum, 10 struct, 80 function, 9 type). Spot-checked `record struct` landing as `struct` while `record`/`sealed record` stayed `class`, one `implements` edge with all class bases still `extends` including an unresolved external base, and a local function correctly nested and spanned.
