### PR TITLE
fix(ingest): stop spreading a child subtree into push in walkFilesystem

### DIFF
--- a/src/ingest/fs.ts
+++ b/src/ingest/fs.ts
@@ -332,7 +332,12 @@ function walkFilesystem(dir: string, includes?: ReadonlySet<string>): string[] {
     const full = join(dir, entry.name);
     if (entry.isDirectory()) {
       if (shouldSkipDir(entry.name, includes)) continue;
-      out.push(...walkFilesystem(full, includes));
+      // Append one at a time rather than spreading: the child array becomes the
+      // argument list of push(), and V8 caps that at ~128k. A single unignored
+      // subtree with more paths than that (a browser profile or dataset under a
+      // non-git repo, where listGitFiles returns null and this walker runs)
+      // throws "Maximum call stack size exceeded" at trivial directory depth.
+      for (const file of walkFilesystem(full, includes)) out.push(file);
     } else if (entry.isFile()) {
       if (entry.name.startsWith(".")) continue; // dot-files are not source either
       try {

--- a/test/ingest-fs.test.ts
+++ b/test/ingest-fs.test.ts
@@ -181,6 +181,66 @@ test("walkDir retains fixed skips and filesystem fallback outside Git", () => {
   }
 });
 
+test("walkDir collects a large nested subtree outside Git without dropping paths", () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-walk-bigsubtree-"));
+  try {
+    // The non-git walker accumulates a child subtree into the parent array.
+    // Spreading the child in did that in one push() call, whose argument list
+    // V8 caps at ~128k — see the comment in walkFilesystem. This pins the
+    // accumulation itself: every path from a deep, wide subtree comes back, in
+    // one flat list, with none lost at a directory boundary.
+    const expected: string[] = [];
+
+    for (let branch = 0; branch < 8; branch += 1) {
+      for (let leaf = 0; leaf < 120; leaf += 1) {
+        const rel = `data/branch-${branch}/nested/deep/file-${leaf}.ts`;
+        write(dir, rel);
+        expected.push(rel);
+      }
+    }
+
+    write(dir, "src/app.ts");
+    expected.push("src/app.ts");
+    expected.sort();
+
+    assert.deepEqual(walked(dir), expected);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+/**
+ * The crash this guards against needs a child subtree larger than V8's argument
+ * cap (~128k), which is a real cost to set up: ~2.5s to create the files on
+ * Linux. CI also runs windows-latest, where creating that many files is far
+ * slower, so this is POSIX-only — the cheap semantic test above runs everywhere.
+ */
+test("walkDir survives a subtree larger than V8's argument limit (#314)", { skip: process.platform === "win32" ? "POSIX-only: file creation cost on Windows CI" : false }, () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-walk-argcap-"));
+
+  try {
+    const bulk = join(dir, "data");
+    mkdirSync(bulk, { recursive: true });
+
+    // Above the cap, so spreading the child array into push() throws. Files are
+    // empty and flat: the walker stats each one, and depth is not the issue.
+    const count = 150_000;
+
+    for (let i = 0; i < count; i += 1) {
+      writeFileSync(join(bulk, `f${i}.ts`), "");
+    }
+
+    write(dir, "src/app.ts");
+
+    const found = walkDir(dir);
+
+    assert.equal(found.length, count + 1);
+    assert.ok(found.includes(join(dir, "src", "app.ts")));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 /**
  * A5 — `shouldSkipDir` and its `--include-dir` override.
  *


### PR DESCRIPTION
## What

`walkFilesystem` appends a child subtree with

```js
out.push(...walkFilesystem(full, includes));
```

which makes the child array the argument list of `push()`. V8 caps that at roughly 128k, so a single unignored subtree with more paths than that throws `RangeError: Maximum call stack size exceeded` at trivial directory depth — the message is about the argument list, not recursion depth.

Appending in a loop removes the cap. Nothing else changes: same paths, same order.

Fixes #314

## Why it only bites some repos

Only the git-less path reaches this. When `listGitFiles` returns `null` the walker collects every non-dot file first and filters by language later, so any large cache, browser profile or dataset directory in a repo that was never `git init`-ed is fatal — while the same tree under Git is fine because `git ls-files` respects `.gitignore`. That is what makes it look nondeterministic across a fleet, as the reporter described.

## Tests

Two, deliberately split, because one of them cannot do the other's job:

1. **`walkDir collects a large nested subtree outside Git without dropping paths`** — a wide, deep subtree outside Git comes back flat and complete. Runs on every platform, ~40ms. It pins the accumulation and would catch a botched loop, but it **cannot** reach the argument cap, so it passes on the old code too. I am flagging that rather than presenting it as proof.
2. **`walkDir survives a subtree larger than V8's argument limit (#314)`** — the real reproduction, 150k files. On the previous code it fails with exactly `Maximum call stack size exceeded`; with this change it passes.

Verified both directions: reverting only `src/ingest/fs.ts` and re-running gives `# pass 18 / # fail 1`, and the one failure is test 2 with that message. With the fix, `# pass 19 / # fail 0` in 6.9s.

**The heavy test is skipped on Windows.** CI runs `windows-latest` too, and creating 150k files there is far slower than the ~2.5s it takes on Linux. If you would rather not pay even the Linux cost in CI, say so and I will drop test 2 and keep test 1 — the fix stands on its own either way.

## Measurements taken while writing this

- On Node 22, a spread of 125k elements still succeeds; 150k throws. The reporter's ~65k figure is the commonly quoted number but the real boundary is higher, which is why the test uses 150k rather than something just over 65k.
- `--stack-size` does not move that boundary. I tried 500/200/100 with 2k–10k elements: all fine. It is an argument-count limit, not stack depth — worth knowing if anyone later tries to make the test cheaper by shrinking the stack.
- The other `push(...)` sites in `src/graph/build.ts` (`nodes`, `rawEdges`) accumulate per file rather than per subtree, so they do not reach the cap. Left untouched to keep this focused.
