### PR TITLE
fix(graph): re-parse a cached entry that holds a parse error

### DIFF
--- a/src/graph/build.ts
+++ b/src/graph/build.ts
@@ -244,14 +244,19 @@ export async function buildGraph(
     }
 
     const hash = contentHash(source);
-    if (cached && hash === cached.hash) {
+    // A cached `error` is not a parse result, it is the absence of one — and the
+    // absence need not be the file's fault. A wasm grammar that aborts because the
+    // run before it exhausted the heap fails whichever file happened to be in
+    // flight, so that error belongs to the *run*, not to the bytes this entry is
+    // keyed on. Replaying it pins the accident to the content hash: an untouched
+    // file stays broken on every later build, and a whole language can vanish from
+    // a graph that still exits 0 (#312). So an entry carrying an error falls
+    // through and is re-parsed — it produced no nodes, which is exactly what makes
+    // re-parsing it affordable, and a run that now succeeds repairs the entry.
+    if (cached && hash === cached.hash && !cached.error) {
       entries[rel] = { ...cached, size: f.size, mtimeMs: f.mtimeMs };
       sources.set(rel, source);
       reused++;
-      if (cached.error) {
-        errors.push(cached.error); // this file failed to parse last time too
-        return;
-      }
       nodes.push(...cached.nodes);
       rawEdges.push(...cached.rawEdges);
       langs.add(label);

--- a/src/graph/extract-cache.ts
+++ b/src/graph/extract-cache.ts
@@ -44,9 +44,11 @@ export interface ExtractEntry {
   nodes: NodeV1[];
   rawEdges: RawEdge[];
   /** Set when this file couldn't be read or parsed. The entry exists anyway so the
-   * freshness probe doesn't flag the file as new on every query; replaying it
-   * re-reports the same error and contributes no nodes, exactly as a cold build
-   * would. */
+   * freshness probe doesn't flag the file as new on every query — but it is never
+   * replayed as a result: {@link buildGraph} re-parses an entry carrying an error,
+   * because the failure can belong to the run (a wasm grammar aborting after the
+   * heap ran out) rather than to the bytes this entry is keyed on, and a cold build
+   * would have re-parsed it. See #312. */
   error?: string;
 }
 

--- a/test/graph-incremental.test.ts
+++ b/test/graph-incremental.test.ts
@@ -11,7 +11,7 @@ import { chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, readdirSyn
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import { buildGraph } from "../src/graph/build.js";
-import { extractCachePath, extractorStamp, readExtractCache, stampDir } from "../src/graph/extract-cache.js";
+import { extractCachePath, extractorStamp, readExtractCache, stampDir, writeExtractCache } from "../src/graph/extract-cache.js";
 import { fingerprintPath, isClean, probeDrift, readFingerprint } from "../src/graph/fingerprint.js";
 import { readAskIndex } from "../src/ask/index-file.js";
 import { readGraph, wiringPath } from "../src/graph/write.js";
@@ -311,6 +311,38 @@ test("an unreadable file is still recorded, so it can't look new on every probe"
   assert.deepEqual(recovered.errors, []);
   const g = readGraph(wiringPath(outOf(d))) as GraphV1;
   assert.ok(g.nodes.some((n) => n.id === "src/secret.ts#secretFn"), "the once-unreadable file is indexed now");
+});
+
+test("a cached parse error is re-parsed, not replayed as a permanent failure (#312)", async () => {
+  const d = repo();
+  const cold = await buildGraph(d, { reuse: false });
+  const coldWiring = wiringOf(d);
+  assert.ok(cold.languages.length > 0, "the fixture has to contribute a language for one to be able to drop out");
+
+  // Poison the memo the way a transient grammar abort does. A wasm grammar that
+  // aborts because the run before it exhausted the heap fails whichever file was
+  // in flight, and the entry keeps that file's real content hash — so nothing
+  // about the file itself ever looks stale, and no later build reconsiders it.
+  const out = outOf(d);
+  const cache = readExtractCache(out);
+  const entry = cache.files["src/math.ts"];
+  assert.ok(entry, "fixture file must be in the memo");
+  cache.files["src/math.ts"] = {
+    ...entry,
+    nodes: [],
+    rawEdges: [],
+    error: "src/math.ts: parse failed — typescript grammar threw: Aborted(). Build with -sASSERTIONS for more info.",
+  };
+  writeExtractCache(out, cache);
+
+  const after = await buildGraph(d);
+  assert.equal(wiringOf(d), coldWiring, "a file whose last run aborted has to come back, nodes and all");
+  assert.deepEqual(after.languages, cold.languages, "a language must not drop out of a graph that still reports success");
+  assert.deepEqual(after.errors, cold.errors, "last run's failure is not this run's error");
+  assert.ok(
+    !readExtractCache(out).files["src/math.ts"]?.error,
+    "the successful re-parse clears the entry, so the next build is cheap again",
+  );
 });
 
 /**


### PR DESCRIPTION
## What

An extraction-cache entry that carries an `error` is no longer replayed. `buildGraph` re-parses it instead, so a failure that belonged to the *run* cannot outlive the run.

```ts
-    if (cached && hash === cached.hash) {
+    if (cached && hash === cached.hash && !cached.error) {
       entries[rel] = { ...cached, size: f.size, mtimeMs: f.mtimeMs };
       sources.set(rel, source);
       reused++;
-      if (cached.error) {
-        errors.push(cached.error); // this file failed to parse last time too
-        return;
-      }
```

Fixes #312

## Why this option

@Ercaner1988 listed three. This is option 2 — persist the entry, never let it stand in for a result — and the other two both have a hole:

- **Never persisting the entry** costs the thing the entry exists for. The comment on the read-error path spells it out: without a record, the freshness probe reports the file as new on every query, so `graft check` reports drift that a rebuild can't clear. Persisting without the `error` field is worse still: the file would then replay as *successfully parsed with zero nodes*, and the error disappears instead of merely being wrong.
- **Classifying transient vs deterministic** means string-matching `Aborted()` and `RuntimeError: memory access out of bounds` against messages that come out of wasm, which is a list to keep up to date and a silent wrong answer whenever it's out of date.

Re-parsing is cheap by construction: the only entries it re-parses are the ones that produced no nodes. On a healthy repo that's zero files.

The self-healing property matters as much as the fix. A cache poisoned by a run that has since been fixed — a smaller workspace, a `--only-dir`, more memory — repairs itself on the next ordinary `graft build`. Today it needs someone to know that `--no-reuse` exists, which requires first noticing a graph that reports `✓` and exit 0.

## The docstring already promised this

`ExtractEntry.error` in `src/graph/extract-cache.ts` said:

> replaying it re-reports the same error and contributes no nodes, **exactly as a cold build would**

That is the invariant the whole file is built on — its header states it twice ("an incremental build must produce a byte-identical `wiring.json` to a cold one"). A replayed abort breaks it: the cold build parses `kanit.rs` and gets 11 nodes, the incremental one replays a failure and gets none. The comment has been updated to say what the code now does.

## The same repo already gets this right one line up

A file that can't be *read* recovers by itself. `an unreadable file is still recorded, so it can't look new on every probe` chmods a file to `000`, builds twice, chmods it back, and asserts the next ordinary build indexes it — no `--no-reuse` needed. That works because a read error is recorded with `hash: ""`, which can never match, so the entry is retried every build.

A file that can't be *parsed* gets a real hash, so it is never retried. Same cache, same kind of entry, opposite lifetime — and the parse case is the one that can fail for a reason that has nothing to do with the file.

## Test

One test in `test/graph-incremental.test.ts`, which is where that invariant lives.

It builds cold, then poisons the memo the way a grammar abort does — the entry keeps the file's real content hash, so nothing about the file looks stale — and rebuilds normally. It asserts the three things the report distinguishes:

- `wiring.json` is byte-identical to the cold build (the nodes come back)
- `languages` still contains the language (the symptom: `[python]` vs `[python, rust]`)
- `errors` is empty (the stale message is not re-reported), and the entry on disk no longer carries one, so the next build is cheap again

Two-way: reverting only `src/graph/build.ts` fails it on the first assertion.

## Not in scope

The report also suggests warning when a language that has files in the index produces zero nodes, and surfacing it in `graft check`. That's a real gap and it stays open with #312 — but it's a new signal with its own false-positive question (a language whose files are all `.d.ts`-shaped, say), not part of making the cache honest. Happy to follow up separately if you want it.
