### PR TITLE
fix(claude): report a workspace parent's children in the statusline

### DIFF
--- a/src/claude/statusline.ts
+++ b/src/claude/statusline.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { renderStatusline, renderSubagent } from './format.js';
-import { readStats, readSession, emptyStats, type Stats } from './state.js';
+import { readStats, readSession, emptyStats, resolveContextDir, type Stats } from './state.js';
 import { readWiring, computeStats } from './stats.js';
 
 /**
@@ -12,13 +13,66 @@ import { readWiring, computeStats } from './stats.js';
  * is missing. The graph carries no drift signal, so it reads as synced until the next
  * edit repopulates the cache. Still a pure read (no subprocess): the cache is preferred
  * because it carries live dirty/stale state.
+ *
+ * A workspace parent has neither artifact and is still built: its graph IS
+ * `graft/workspace.json`, and the nodes live in the children. Both reads above miss
+ * there, so the bar said "not built" for a workspace that `graft check`, `graft ask`
+ * and the MCP server were all serving (#311). `init.ts` already knows this shape —
+ * it tests `hasGraftIndex` rather than wiring.json for exactly this reason.
  */
 export function resolveStats(dir: string): Stats | null {
+  return resolveRepoStats(dir) ?? resolveWorkspaceStats(dir);
+}
+
+function resolveRepoStats(dir: string): Stats | null {
   const cached = readStats(dir);
   if (cached && cached.nodeCount > 0) return cached;
   const wiring = readWiring(dir);
   if (wiring) return { ...emptyStats(), ...computeStats(wiring) };
   return null;
+}
+
+/** The children named by `<dir>/graft/workspace.json`, or null when this isn't a
+ * workspace parent (absent, unparseable, or foreign json — all the same thing).
+ *
+ * Read here rather than through `graph/workspace.js`: that module pulls in ask,
+ * grep and scope fusion to answer federated queries, and this file runs on every
+ * statusline render. Same reason `stats.ts` reads wiring.json directly. */
+function readWorkspaceChildren(dir: string): string[] | null {
+  try {
+    const parsed = JSON.parse(readFileSync(join(resolveContextDir(dir), 'workspace.json'), 'utf8'));
+    if (parsed?.version !== 1 || !Array.isArray(parsed.children)) return null;
+    return parsed.children.map(String);
+  } catch { return null; }
+}
+
+/** Sum the children a workspace parent federates. One level, because that is how
+ * the index is written: `children` are immediate directories that are git repos.
+ *
+ * Every child resolves through {@link resolveRepoStats} — the same path it would
+ * take if Claude Code were opened in it — so the parent can't disagree with its own
+ * children. `syncedAt` and `lastFile` stay empty: both describe one repo's last
+ * sync, and there is no honest parent-level answer to either. Null when no child is
+ * built, which is the one case where "not built" is the truth. */
+function resolveWorkspaceStats(dir: string): Stats | null {
+  const children = readWorkspaceChildren(dir);
+  if (!children) return null;
+  const parts = children
+    .map((child) => resolveRepoStats(join(dir, child)))
+    .filter((s): s is Stats => s !== null);
+  if (parts.length === 0) return null;
+  const sum = (pick: (s: Stats) => number): number => parts.reduce((n, s) => n + pick(s), 0);
+  return {
+    ...emptyStats(),
+    nodeCount: sum((s) => s.nodeCount),
+    edgeCount: sum((s) => s.edgeCount),
+    languages: [...new Set(parts.flatMap((s) => s.languages))].sort(),
+    totalCount: sum((s) => s.totalCount),
+    readyCount: sum((s) => s.readyCount),
+    staleCount: sum((s) => s.staleCount),
+    dirty: parts.some((s) => s.dirty),
+    syncing: parts.some((s) => s.syncing),
+  };
 }
 
 export function main(): void {

--- a/test/claude-statusline.test.ts
+++ b/test/claude-statusline.test.ts
@@ -14,6 +14,10 @@ function writeWiring(dir: string, obj: unknown): void {
   mkdirSync(join(dir, 'graft', '.graph'), { recursive: true });
   writeFileSync(join(dir, 'graft', '.graph', 'wiring.json'), JSON.stringify(obj));
 }
+function writeWorkspaceIndex(dir: string, children: string[]): void {
+  mkdirSync(join(dir, 'graft'), { recursive: true });
+  writeFileSync(join(dir, 'graft', 'workspace.json'), JSON.stringify({ version: 1, children }));
+}
 
 test('resolveStats returns the hook-maintained cache when present and non-empty', () => {
   const d = repo();
@@ -59,6 +63,47 @@ test('empty wiring.json is a built graph: statusline shows 0 nodes, not "not bui
   assert.doesNotMatch(line, /not built/);
   assert.doesNotMatch(line, /graft build/);
   assert.match(line, /0 nodes \/ 0 edges/);
+});
+
+test('a workspace parent reports the sum of its children, not "not built" (#311)', () => {
+  const d = repo();
+  writeWorkspaceIndex(d, ['svc-a', 'svc-b']);
+  // One child built by a plain `graft build` (graph only), one carrying a live
+  // hook cache — the parent has to reach both the same way each child would.
+  writeWiring(join(d, 'svc-a'), {
+    meta: { nodeCount: 1919, edgeCount: 5679, languages: ['java'] },
+    nodes: [{ id: 'a', summary_state: 'ready' }, { id: 'b', summary_state: 'pending' }],
+    edges: [],
+  });
+  writeStats(join(d, 'svc-b'), {
+    ...emptyStats(), nodeCount: 81, edgeCount: 120, languages: ['rust'],
+    totalCount: 4, readyCount: 3, dirty: true, staleCount: 2,
+  });
+
+  const s = resolveStats(d)!;
+  assert.equal(s.nodeCount, 2000, 'nodes live in the children; the parent is their sum');
+  assert.equal(s.edgeCount, 5799);
+  assert.deepEqual(s.languages, ['java', 'rust'], 'every child language, deduped');
+  assert.equal(s.readyCount, 4);
+  assert.equal(s.dirty, true, 'one drifting child makes the workspace drift');
+  assert.equal(s.staleCount, 2);
+  const line = strip(renderStatusline(s, null, { ctxPct: null })[0]);
+  assert.doesNotMatch(line, /not built/);
+  assert.match(line, /2000 nodes \/ 5799 edges/);
+});
+
+test('a workspace parent whose children are all unbuilt is still not built', () => {
+  const d = repo();
+  writeWorkspaceIndex(d, ['svc-a', 'svc-b']);
+  assert.equal(resolveStats(d), null, 'an index of unbuilt children is not a built graph');
+});
+
+test('a foreign workspace.json is not a workspace', () => {
+  const d = repo();
+  mkdirSync(join(d, 'graft'), { recursive: true });
+  writeFileSync(join(d, 'graft', 'workspace.json'), JSON.stringify({ version: 2, children: ['svc-a'] }));
+  writeWiring(join(d, 'svc-a'), { meta: { nodeCount: 5, edgeCount: 5, languages: [] }, nodes: [], edges: [] });
+  assert.equal(resolveStats(d), null, 'a version this build does not know is treated as absent, not guessed at');
 });
 
 test('a 0-node cache without wiring.json is still not built', () => {


### PR DESCRIPTION
## What

`resolveStats` now falls back to the workspace index when the cwd has no graph of its own, and sums the children it names.

```
◤ graft · not built · run graft build        →   ◤ graft · 2000 nodes / 5799 edges · ✓ synced
```

Fixes #311

## Shape

`resolveStats` keeps its exact current behaviour, moved verbatim into `resolveRepoStats`, and gains one fallback:

```ts
export function resolveStats(dir: string): Stats | null {
  return resolveRepoStats(dir) ?? resolveWorkspaceStats(dir);
}
```

Repo-first, so nothing about a normal checkout changes — a directory that has both a graph and a `workspace.json` still reads its own graph.

Each child resolves through `resolveRepoStats`, i.e. the same path it would take if Claude Code were opened in it. That is deliberate: it is what makes the parent's number unable to disagree with the child's, and it is the comparison the report already ran by hand, piping a `cwd` for the parent and for a child into the same statusline script.

Aggregation: nodes/edges/ready/stale summed, languages unioned and sorted, `dirty` and `syncing` OR-ed. `syncedAt` and `lastFile` stay empty — both describe one repo's last sync, and there is no honest parent-level answer to either (`renderStatusline` reads `lastFile` for the "last: …" chip and never reads `syncedAt`).

## Read directly, not through `graph/workspace.js`

`readWorkspace` is right there and does exactly this parse. I didn't import it: that module exists to answer federated `ask`/`grep` queries and pulls in `ask.ts`, `file-selection`, `fuse`, `search/grep` and `context/savings` with it. The statusline runs on every render, and `stats.ts` already sets the precedent by reading `wiring.json` with `readFileSync` + `JSON.parse` instead of importing the graph reader. The check is the same one `readWorkspace` makes — `version === 1` and an array of children, anything else treated as absent.

## Two things that deliberately still say "not built"

- a `workspace.json` whose children are all unbuilt — that is the one case where "not built" is the truth, and the message is actionable
- a `workspace.json` with a version this build doesn't know — treated as absent rather than guessed at, matching `readWorkspace`

Both have tests, and both pass with or without the fix. They're there so the fallback can't quietly turn "not built" into a number it made up.

## Tests

Three in `test/claude-statusline.test.ts`. The first builds a parent with two children — one with only a `wiring.json` (a plain `graft build`), one with only a hook `stats.json` — because the parent has to reach both kinds, and asserts the summed counts, the merged language list, `dirty` propagating from the single drifting child, and the rendered line no longer containing `not built`.

Two-way: reverting only `src/claude/statusline.ts` fails that one and leaves the other eight in the file passing.

## Not in scope

The report asks for aggregated freshness "across children", which this does for `dirty`/`staleCount` — the two the bar actually renders. It does not add a per-child breakdown; that's a different surface (`graft check` already prints one).
