### PR TITLE
Follow symlinked child repos in workspace discovery

### DIFF
--- a/src/graph/scopes.ts
+++ b/src/graph/scopes.ts
@@ -21,8 +21,8 @@
  *  7. `label` = `prefix` (both "" for root); ordering is prefix-length desc,
  *     then lexicographic.
  */
-import { existsSync, readdirSync, readFileSync, type Dirent } from "node:fs";
-import { join, resolve } from "node:path";
+import { existsSync, readdirSync, readFileSync, realpathSync, statSync, type Dirent } from "node:fs";
+import { join, resolve, sep } from "node:path";
 import { shouldSkipDir, walkDir } from "../ingest/fs.js";
 import { relPosix } from "../util/paths.js";
 import { readFollowNestedRepos, readFollowSubmodules, readIncludeDirs } from "../util/state.js";
@@ -336,8 +336,30 @@ export function discoverWorkspaceChildren(root: string): string[] {
     return [];
   }
   return entries
-    .filter((e) => e.isDirectory() && !shouldSkipDir(e.name, includes) && existsSync(join(absRoot, e.name, ".git")))
+    .filter(
+      (e) =>
+        isChildDirectory(absRoot, e) && !shouldSkipDir(e.name, includes) && existsSync(join(absRoot, e.name, ".git")),
+    )
     .map((e) => e.name);
+}
+
+/** A workspace child is a real directory, or a symlink to one: ticket workspaces
+ * are routinely assembled from worktrees plus symlinks to the repos a change
+ * touches, and `Dirent.isDirectory()` is false for a symlink. A symlinked child
+ * is followed one level, like `walkDir` follows a symlinked root. Dangling links
+ * and links that point back at the workspace root or one of its ancestors (a
+ * cycle) are not children. */
+function isChildDirectory(absRoot: string, e: Dirent): boolean {
+  if (e.isDirectory()) return true;
+  if (!e.isSymbolicLink()) return false;
+  try {
+    const target = realpathSync(join(absRoot, e.name));
+    const root = realpathSync(absRoot);
+    if (target === root || root.startsWith(target + sep)) return false;
+    return statSync(target).isDirectory();
+  } catch {
+    return false;
+  }
 }
 
 /** Every consumer's entry point to a graph's scopes: absent `meta.scopes` (old

--- a/test/graph-scopes.test.ts
+++ b/test/graph-scopes.test.ts
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -169,6 +169,20 @@ test("discoverWorkspaceChildren finds immediate git children only", () => {
   mkdirSync(join(d, "repoB/vendored/.git"), { recursive: true }); // nested: not a child of d
   assert.deepEqual(discoverWorkspaceChildren(d).sort(), ["repoA", "repoB"]);
   rmSync(d, { recursive: true, force: true });
+});
+
+test("discoverWorkspaceChildren follows a symlinked child repo, not dangling or cyclic links (#319)", () => {
+  const d = fx({ "repoA/x.ts": "1" });
+  mkdirSync(join(d, "repoA/.git"), { recursive: true });
+  const outside = fx({ "repoC/src/a.py": "1" });
+  mkdirSync(join(outside, "repoC/.git"), { recursive: true });
+  symlinkSync(join(outside, "repoC"), join(d, "repoC-link")); // a symlink to a repo elsewhere
+  symlinkSync(join(d, "does-not-exist"), join(d, "dangling"));
+  symlinkSync(d, join(d, "self-link")); // points back at the workspace root
+  symlinkSync(join(outside, "repoC/src/a.py"), join(d, "file-link")); // a file, not a repo
+  assert.deepEqual(discoverWorkspaceChildren(d).sort(), ["repoA", "repoC-link"]);
+  rmSync(d, { recursive: true, force: true });
+  rmSync(outside, { recursive: true, force: true });
 });
 
 test("A5: discoverScopes finds a marker under a SKIP_DIRS name once persisted via --include-dir state, absent otherwise", () => {


### PR DESCRIPTION
Fixes #319

`discoverWorkspaceChildren()` filtered `readdirSync(root, { withFileTypes: true })` with `e.isDirectory()`, which is `false` for a symlink, so a child that is a symlink to a git repo was silently left out of `graft build <workspace>` (not built, not in `workspace.json`, no warning). A git worktree (`.git` file) was fine, and `graft build ws/repoC-link` on its own worked, which made the omission surprising.

Change: an entry is a workspace child when it is a real directory or a symlink that resolves to a directory. A symlinked child is followed one level, consistent with how `walkDir` canonicalises a symlinked root once. Dangling links, links to files, and links that resolve to the workspace root or one of its ancestors (a cycle) are not children.

Test: `discoverWorkspaceChildren follows a symlinked child repo, not dangling or cyclic links (#319)` in `test/graph-scopes.test.ts` builds a workspace with a real repo, a symlink to a repo outside the workspace, a dangling link, a link to a file and a link back to the workspace itself, and expects `["repoA", "repoC-link"]`. It fails on `main` (`["repoA"]`) and passes with the change; the rest of `graph-scopes.test.ts` (16 tests) passes.
