### PR TITLE
Tolerate a model echoing the whole target line as the symbol id

### DIFF
--- a/src/ai/crux.ts
+++ b/src/ai/crux.ts
@@ -135,6 +135,21 @@ function userContent(input: FileCruxInput): string {
 }
 
 /** Normalize the tool's parsed argument object into a {@link NodeCrux} list. */
+/**
+ * The prompt lists targets as `- id=<id> | <kind> | lines L<a>-L<b>` and asks for
+ * the id "verbatim". Some models (Grok, #327) copy the whole displayed line, or
+ * the `id=` prefix, into the returned `id`; enrich then looks the result up by
+ * the bare node id, misses, and reports a complete summary as `empty-parsed`.
+ * Strip the echoed decoration so the summary lands on its node.
+ */
+export function normalizeTargetId(raw: string): string {
+  let id = raw.trim();
+  const sep = id.indexOf(" | ");
+  if (sep !== -1) id = id.slice(0, sep).trimEnd();
+  if (id.startsWith("id=")) id = id.slice(3).trim();
+  return id;
+}
+
 function parseResults(obj: { symbols?: unknown } | undefined): NodeCrux[] {
   if (!obj || !Array.isArray(obj.symbols)) return [];
   const num = (v: unknown) => (typeof v === "number" && Number.isFinite(v) ? Math.trunc(v) : 0);
@@ -142,7 +157,7 @@ function parseResults(obj: { symbols?: unknown } | undefined): NodeCrux[] {
     .map((s) => s as Record<string, unknown>)
     .filter((s) => typeof s.id === "string")
     .map((s) => ({
-      id: s.id as string,
+      id: normalizeTargetId(s.id as string),
       summary: typeof s.summary === "string" ? s.summary.trim() : "",
       crux_start: num(s.crux_start),
       crux_end: num(s.crux_end),

--- a/src/ai/crux.ts
+++ b/src/ai/crux.ts
@@ -134,30 +134,40 @@ function userContent(input: FileCruxInput): string {
   return `FILE: ${input.path}\n\n${numberLines(input.source)}\n\nTARGETS (${n} — return all ${n}, one entry per id):\n${targets}`;
 }
 
-/** Normalize the tool's parsed argument object into a {@link NodeCrux} list. */
 /**
  * The prompt lists targets as `- id=<id> | <kind> | lines L<a>-L<b>` and asks for
- * the id "verbatim". Some models (Grok, #327) copy the whole displayed line, or
- * the `id=` prefix, into the returned `id`; enrich then looks the result up by
- * the bare node id, misses, and reports a complete summary as `empty-parsed`.
- * Strip the echoed decoration so the summary lands on its node.
+ * the id "verbatim". Some models (Grok, #327; deepseek, #259) copy the whole
+ * displayed line, or the `id=` prefix, into the returned `id`; enrich then looks
+ * the result up by the bare node id, misses, and reports a complete summary as
+ * `empty-parsed`. Strip the echoed decoration so the summary lands on its node.
+ *
+ * With `expectedIds` (the ids we asked for) the peel only applies when it lands
+ * on one of them. An id we did not request keeps its raw text even if it happens
+ * to contain ` | `, so a genuine miss is still reported as a miss.
  */
-export function normalizeTargetId(raw: string): string {
-  let id = raw.trim();
-  const sep = id.indexOf(" | ");
-  if (sep !== -1) id = id.slice(0, sep).trimEnd();
-  if (id.startsWith("id=")) id = id.slice(3).trim();
-  return id;
+export function normalizeTargetId(raw: string, expectedIds?: ReadonlySet<string>): string {
+  const id = raw.trim();
+  if (expectedIds?.has(id)) return id;
+  let peeled = id;
+  const sep = peeled.indexOf(" | ");
+  if (sep !== -1) peeled = peeled.slice(0, sep).trimEnd();
+  if (peeled.startsWith("id=")) peeled = peeled.slice(3).trim();
+  if (expectedIds && !expectedIds.has(peeled)) return id;
+  return peeled;
 }
 
-function parseResults(obj: { symbols?: unknown } | undefined): NodeCrux[] {
+/** Normalize the tool's parsed argument object into a {@link NodeCrux} list. */
+function parseResults(
+  obj: { symbols?: unknown } | undefined,
+  expectedIds: ReadonlySet<string>,
+): NodeCrux[] {
   if (!obj || !Array.isArray(obj.symbols)) return [];
   const num = (v: unknown) => (typeof v === "number" && Number.isFinite(v) ? Math.trunc(v) : 0);
   return obj.symbols
     .map((s) => s as Record<string, unknown>)
     .filter((s) => typeof s.id === "string")
     .map((s) => ({
-      id: normalizeTargetId(s.id as string),
+      id: normalizeTargetId(s.id as string, expectedIds),
       summary: typeof s.summary === "string" ? s.summary.trim() : "",
       crux_start: num(s.crux_start),
       crux_end: num(s.crux_end),
@@ -211,7 +221,10 @@ export class ChatCruxSummarizer implements CruxSummarizer {
         { role: "user", content: userContent(input) },
       ],
     });
-    const parsed = parseResults(argsFromResponse(res));
+    const parsed = parseResults(
+      argsFromResponse(res),
+      new Set(input.nodes.map((n) => n.id)),
+    );
     this.lastMiss = classifyCruxMiss(res, parsed);
     return parsed;
   }

--- a/test/llm-ops.test.ts
+++ b/test/llm-ops.test.ts
@@ -80,6 +80,8 @@ test("ChatCruxSummarizer tolerates a model echoing the whole target line as the 
             { id: "a.ts | file | lines L1-L5", summary: "whole file", crux_start: 1, crux_end: 5 },
             { id: "id=sym1", summary: "does x", crux_start: 2, crux_end: 3 },
             { id: "  sym2  ", summary: "does y", crux_start: 4, crux_end: 5 },
+            // Not a requested id: the ` | ` is not an echoed target line, so it stays as returned.
+            { id: "nope | function | lines L1-L2", summary: "unknown", crux_start: 1, crux_end: 2 },
           ],
         },
       },
@@ -96,15 +98,31 @@ test("ChatCruxSummarizer tolerates a model echoing the whole target line as the 
   });
   assert.deepEqual(
     out.map((r) => r.id),
-    ["a.ts", "sym1", "sym2"],
+    ["a.ts", "sym1", "sym2", "nope | function | lines L1-L2"],
   );
 });
 
-test("normalizeTargetId leaves ids that contain ' | ' only inside the kind suffix alone", () => {
+test("normalizeTargetId peels the echoed target line and the id= prefix", () => {
   assert.equal(normalizeTargetId("src/a.ts#f"), "src/a.ts#f");
   assert.equal(normalizeTargetId("src/a.ts#f | function | lines L3-L9"), "src/a.ts#f");
   assert.equal(normalizeTargetId("id=src/a.ts#f | function | lines L3-L9"), "src/a.ts#f");
   assert.equal(normalizeTargetId("id=src/a.ts#f"), "src/a.ts#f");
+  // deepseek (#259) also appends the signature, which may itself contain ` | `.
+  assert.equal(
+    normalizeTargetId("app/User.php#User.__construct | method | lines L40-L58 | public function __construct($object = null)"),
+    "app/User.php#User.__construct",
+  );
+});
+
+test("normalizeTargetId only rewrites onto a requested id when given the expected set", () => {
+  const expected = new Set(["src/a.ts#f", "odd | id"]);
+  assert.equal(normalizeTargetId("src/a.ts#f | function | lines L3-L9", expected), "src/a.ts#f");
+  assert.equal(normalizeTargetId("id=src/a.ts#f", expected), "src/a.ts#f");
+  // A requested id is returned verbatim even when it contains the separator.
+  assert.equal(normalizeTargetId("odd | id", expected), "odd | id");
+  // Garbage that merely contains ` | ` is not truncated into something we never asked for.
+  assert.equal(normalizeTargetId("garbage | x", expected), "garbage | x");
+  assert.equal(normalizeTargetId("id=other#g | function | lines L1-L2", expected), "id=other#g | function | lines L1-L2");
 });
 
 test("structured ops degrade gracefully when the model returns no tool call", async () => {

--- a/test/llm-ops.test.ts
+++ b/test/llm-ops.test.ts
@@ -8,7 +8,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { ChatSummarizer } from "../src/ai/summarize.js";
 import { ChatSynthesizer } from "../src/ai/synthesize.js";
-import { ChatCruxSummarizer } from "../src/ai/crux.js";
+import { ChatCruxSummarizer, normalizeTargetId } from "../src/ai/crux.js";
 import { recoverToolArgsFromContent } from "../src/ai/llm/recover-tool.js";
 import type { ChatModel, ChatRequest, ChatResponse, ToolCall } from "../src/ai/llm/types.js";
 
@@ -66,6 +66,45 @@ test("ChatCruxSummarizer forces record_symbols and normalizes numbers", async ()
   });
   assert.deepEqual(m.last?.responseFormat, { kind: "tool", name: "record_symbols" });
   assert.deepEqual(out, [{ id: "sym1", summary: "does x", crux_start: 3, crux_end: 5 }]);
+});
+
+test("ChatCruxSummarizer tolerates a model echoing the whole target line as the id (#327)", async () => {
+  // Grok copies `id=<id> | <kind> | lines L1-L5` verbatim into `id`; the summary must still land on the node.
+  const m = new FakeChatModel({
+    toolCalls: [
+      {
+        id: "1",
+        name: "record_symbols",
+        args: {
+          symbols: [
+            { id: "a.ts | file | lines L1-L5", summary: "whole file", crux_start: 1, crux_end: 5 },
+            { id: "id=sym1", summary: "does x", crux_start: 2, crux_end: 3 },
+            { id: "  sym2  ", summary: "does y", crux_start: 4, crux_end: 5 },
+          ],
+        },
+      },
+    ],
+  });
+  const out = await new ChatCruxSummarizer(m).describeFile({
+    path: "a.ts",
+    source: "l1\nl2\nl3\nl4\nl5\n",
+    nodes: [
+      { id: "a.ts", kind: "file", signature: null, startLine: 1, endLine: 5 },
+      { id: "sym1", kind: "function", signature: null, startLine: 2, endLine: 3 },
+      { id: "sym2", kind: "function", signature: null, startLine: 4, endLine: 5 },
+    ],
+  });
+  assert.deepEqual(
+    out.map((r) => r.id),
+    ["a.ts", "sym1", "sym2"],
+  );
+});
+
+test("normalizeTargetId leaves ids that contain ' | ' only inside the kind suffix alone", () => {
+  assert.equal(normalizeTargetId("src/a.ts#f"), "src/a.ts#f");
+  assert.equal(normalizeTargetId("src/a.ts#f | function | lines L3-L9"), "src/a.ts#f");
+  assert.equal(normalizeTargetId("id=src/a.ts#f | function | lines L3-L9"), "src/a.ts#f");
+  assert.equal(normalizeTargetId("id=src/a.ts#f"), "src/a.ts#f");
 });
 
 test("structured ops degrade gracefully when the model returns no tool call", async () => {


### PR DESCRIPTION
Fixes #327

`graft build --deep` lists each target as `- id=<id> | <kind> | lines L<a>-L<b>` and asks the model to return the id "verbatim". Grok (reproduced by the reporter on `grok-4.6` via the OpenAI-compatible endpoint, with raw provider logs) copies the whole displayed line into the returned `id`. `parseResults()` stored the result under that mangled key, `enrich`'s `results.get(node.id)` missed, and a complete, well-formed summary was discarded and reported as `model returned no usable symbol summaries [empty-parsed, ...]`, which points at the wrong cause.

Change: `parseResults()` now runs the returned id through `normalizeTargetId()`, which cuts at the first ` | ` and drops a leading `id=`. A bare id is unchanged, so nothing changes for models that follow the instruction. The prompt wording is left as is.

Tests (`test/llm-ops.test.ts`):
- `ChatCruxSummarizer` with symbols returned as `a.ts | file | lines L1-L5`, `id=sym1` and `  sym2  ` yields results keyed `a.ts`, `sym1`, `sym2` (fails on `main`, passes with the change).
- `normalizeTargetId` unit cases, including an id that itself contains `#`.

`node --import tsx --test test/llm-ops.test.ts`: 11 pass.
