### PR TITLE
Resolve TypeScript calls through named imports inside the imported module

### DIFF
--- a/src/graph/extract.ts
+++ b/src/graph/extract.ts
@@ -92,7 +92,11 @@ export interface RawEdge {
   relation: Relation;
   file: string; // the file this edge originates in (scopes name resolution)
   targetId?: string; // already-resolved target (contains)
-  specifier?: string; // module path to resolve (imports / imported-symbol references)
+  /** module path to resolve (imports / imported-symbol references). On a
+   * `calls` edge (TypeScript): the callee is a named import from this module,
+   * and `name` is its EXPORTED name; resolve.ts then confines resolution to
+   * that module instead of guessing from a unique repo-wide name match (#330). */
+  specifier?: string;
   name?: string; // symbol name to resolve (extends/implements/calls)
   viaMember?: boolean; // calls: was it `obj.foo()` (→ prefer method targets)?
   /** calls with viaMember: the receiver's resolved type name (from bindings /
@@ -722,12 +726,23 @@ function walk(node: Parser.SyntaxNode, ctx: WalkCtx, out: NodeV1[], edges: RawEd
       consumedCallee === "R6Class" || (consumedCallee === "list" && rIsMixinContainer(node));
     const callee = isConsumedRClassCall ? null : calleeName(node, ctx.lang);
     if (callee) {
+      // A bare TypeScript call through a named import carries where the callee
+      // comes from. `ctx.importedSymbols` already excludes bindings shadowed by
+      // a local declaration in scope, so `useRouter()` under a local
+      // `function useRouter` stays a bare name. Without this, resolve.ts's
+      // unique-name fallback bound a call to `useRouter` from "next/navigation"
+      // to an unrelated test mock of the same name (#330).
+      const imported =
+        !callee.viaMember && (ctx.lang === "typescript" || ctx.lang === "tsx")
+          ? ctx.importedSymbols.get(callee.name)
+          : undefined;
       const callEdge: RawEdge = {
         source: ctx.parentId,
         relation: "calls",
-        name: callee.name,
+        name: imported ? imported.name : callee.name,
         viaMember: callee.viaMember,
         file: ctx.rel,
+        ...(imported ? { specifier: imported.specifier } : {}),
         ...(callee.kinds ? { kinds: callee.kinds } : {}),
       };
       // Overloading languages: the call site's argument count, to pick the right

--- a/src/graph/resolve.ts
+++ b/src/graph/resolve.ts
@@ -317,6 +317,25 @@ export function resolveEdges(
           : e.file.endsWith(".java")
             ? ["class", "struct", "enum", "interface"]
             : ["function"]);
+      // A call through a named import (TypeScript, extract.ts) names its module.
+      // An external or unresolved module means the callee is not in this repo:
+      // drop the edge rather than let the unique-name fallback bind it to an
+      // unrelated same-named local function (a test mock, a helper named
+      // `expect`) and report it as a production dependency (#330). An in-repo
+      // module that defines the name resolves to that definition alone; one
+      // that does not (a barrel re-export) keeps the name-based fallback.
+      if (e.specifier) {
+        const targetFile = resolveImport(e.specifier, e.file, byId);
+        if (!byId.has(targetFile)) continue;
+        const inModule = (perFileName.get(targetFile)?.get(e.name!) ?? []).filter((n) =>
+          callKinds.includes(n.kind),
+        );
+        if (inModule.length === 1) {
+          add(e.source, inModule[0].id, "calls", "extracted");
+          continue;
+        }
+        if (inModule.length > 1) continue;
+      }
       let hit = resolveName(e.name!, e.file, callKinds, perFileName, globalName);
       // Python is the Java case without the `new` to mark it: `Widget()` is an
       // ordinary call node, so a constructor edge dies against the function-only

--- a/test/graph-resolve-imported-calls.test.ts
+++ b/test/graph-resolve-imported-calls.test.ts
@@ -1,0 +1,97 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { extractFile } from "../src/graph/extract.js";
+import { resolveEdges } from "../src/graph/resolve.js";
+import type { NodeV1 } from "../src/graph/types.js";
+
+// #330: a TypeScript call through a named import must not resolve to an
+// unrelated same-named local function when the import is external or points at
+// a different in-repo module.
+
+function n(id: string, kind: NodeV1["kind"]): NodeV1 {
+  const post = id.includes("#") ? id.split("#")[1] : id;
+  const name = post.split(".").pop()!;
+  return { id, name, kind, path: id.split("#")[0], span: "L1-L1", signature: null,
+    exported: true, origin: "ast", body_hash: "h", summary_state: "pending", summary: null, crux: null } as NodeV1;
+}
+
+test("extract: a bare call through a named import carries the module and exported name", () => {
+  const { rawEdges: edges } = extractFile(
+    "src/component.ts",
+    [
+      'import { useRouter } from "next/navigation";',
+      'import { helper as h } from "./lib/util";',
+      "export function Component() {",
+      "  h();",
+      "  return useRouter();",
+      "}",
+    ].join("\n"),
+    "typescript",
+  );
+  const calls = edges.filter((e) => e.relation === "calls" && e.source === "src/component.ts#Component");
+  assert.deepEqual(
+    calls.map((e) => ({ name: e.name, specifier: e.specifier })).sort((a, b) => a.name!.localeCompare(b.name!)),
+    [
+      { name: "helper", specifier: "./lib/util" },
+      { name: "useRouter", specifier: "next/navigation" },
+    ],
+  );
+});
+
+test("extract: a local declaration shadowing the import keeps the call a bare name", () => {
+  const { rawEdges: edges } = extractFile(
+    "src/a.ts",
+    [
+      'import { useRouter } from "next/navigation";',
+      "export function Component() {",
+      "  const useRouter = () => 1;",
+      "  return useRouter();",
+      "}",
+    ].join("\n"),
+    "typescript",
+  );
+  const call = edges.find((e) => e.relation === "calls" && e.name === "useRouter");
+  assert.ok(call);
+  assert.equal(call.specifier, undefined);
+});
+
+const NODES = [
+  n("src/component.ts", "file"), n("src/component.ts#Component", "function"),
+  n("test/next-navigation-mock.ts", "file"), n("test/next-navigation-mock.ts#useRouter", "function"),
+  n("src/lib/router.ts", "file"), n("src/lib/router.ts#useRouter", "function"),
+  n("src/index.ts", "file"),
+];
+
+test("resolve: a call imported from an external package does not bind to a local same-named function", () => {
+  const edges = resolveEdges(NODES.filter((x) => !x.id.startsWith("src/lib/router")), [
+    { source: "src/component.ts#Component", relation: "calls", name: "useRouter", file: "src/component.ts", specifier: "next/navigation" },
+  ]);
+  assert.equal(edges.filter((e) => e.relation === "calls").length, 0);
+});
+
+test("resolve: without import provenance the unique-name fallback still applies (unchanged)", () => {
+  const edges = resolveEdges(NODES.filter((x) => !x.id.startsWith("src/lib/router")), [
+    { source: "src/component.ts#Component", relation: "calls", name: "useRouter", file: "src/component.ts" },
+  ]);
+  const call = edges.find((e) => e.relation === "calls");
+  assert.equal(call?.target, "test/next-navigation-mock.ts#useRouter");
+  assert.equal(call?.confidence, "inferred");
+});
+
+test("resolve: a call imported from an in-repo module resolves inside that module, not the mock", () => {
+  const edges = resolveEdges(NODES, [
+    { source: "src/component.ts#Component", relation: "calls", name: "useRouter", file: "src/component.ts", specifier: "./lib/router" },
+  ]);
+  const call = edges.find((e) => e.relation === "calls");
+  assert.equal(call?.target, "src/lib/router.ts#useRouter");
+  assert.equal(call?.confidence, "extracted");
+});
+
+test("resolve: an in-repo barrel that does not define the name keeps the name-based fallback", () => {
+  const edges = resolveEdges(NODES.filter((x) => !x.id.startsWith("test/")), [
+    { source: "src/component.ts#Component", relation: "calls", name: "useRouter", file: "src/component.ts", specifier: "./index" },
+  ]);
+  const call = edges.find((e) => e.relation === "calls");
+  assert.equal(call?.target, "src/lib/router.ts#useRouter");
+  assert.equal(call?.confidence, "inferred");
+});

--- a/test/graph-traverse-cli.test.ts
+++ b/test/graph-traverse-cli.test.ts
@@ -114,9 +114,14 @@ function ambiguousRepo(): string {
   mkdirSync(join(d, 'src'), { recursive: true });
   writeFileSync(join(d, 'src', 'a.ts'), 'export function shared(): number {\n  return 1;\n}\n');
   writeFileSync(join(d, 'src', 'b.ts'), 'export function shared(): number {\n  return 2;\n}\n');
-  // A cross-file call to the ambiguous name — resolve.ts drops it rather than
-  // guessing which `shared` it means, so NEITHER definition gets a caller edge.
-  writeFileSync(join(d, 'src', 'user.ts'), 'import { shared } from "./a.js";\nexport function use(): number {\n  return shared();\n}\n');
+  // A cross-file call to the ambiguous name through a barrel that re-exports
+  // both. The barrel defines no `shared` itself, so resolve.ts falls back to
+  // the name index, finds two candidates and drops the edge rather than
+  // guessing which `shared` it means — NEITHER definition gets a caller edge.
+  // (An import straight from "./a.js" would now resolve to a.ts's `shared`,
+  // see graph-resolve-imported-calls.test.ts.)
+  writeFileSync(join(d, 'src', 'index.ts'), 'export * from "./a.js";\nexport * from "./b.js";\n');
+  writeFileSync(join(d, 'src', 'user.ts'), 'import { shared } from "./index.js";\nexport function use(): number {\n  return shared();\n}\n');
   execFileSync(process.execPath, ['--import', 'tsx', 'src/cli.ts', 'build', d], { stdio: 'pipe' });
   return d;
 }


### PR DESCRIPTION
Fixes #330

## Problem

For TypeScript/TSX, a bare call to a symbol imported by name from an external package (`import { useRouter } from "next/navigation"; … useRouter()`) went through `resolveName()`'s unique-global fallback: if exactly one same-family function with that name existed anywhere in the repo (a test mock, a helper named `expect`), the call was bound to it with `confidence: "inferred"`. `graft callers`, hotspots and blast-radius walks then reported production code depending on a mock it never imports, and the edge looked exactly like an extracted one.

The extractor already collected named-import bindings (`collectImportedSymbols` / `collectTsImportBindings`, with lexical shadowing handled by `withoutShadowedImports`) and used them for `references`, but not for `calls`.

## Change

- `src/graph/extract.ts`: a bare TypeScript/TSX call whose callee is a (non-shadowed) named import is emitted with the import's module `specifier` and its **exported** name (aliases are unwrapped). Member calls and other languages are untouched.
- `src/graph/resolve.ts`: a call edge carrying a `specifier` is resolved inside that module only:
  - external or unresolved module → the edge is dropped (no repo-wide guess);
  - in-repo module that defines the name → that definition, `extracted`;
  - in-repo module without the definition (a barrel re-export) → the existing name-based fallback, so barrel imports keep their recall.
- The `ambiguousRepo()` fixture in `test/graph-traverse-cli.test.ts` now imports `shared` through a barrel: a direct `import { shared } from "./a.js"` is no longer ambiguous, it correctly resolves to `a.ts#shared` — which is the point of this change. The A6 zero-hit assertions are unchanged.

Not included: surfacing `confidence` in `EdgeHit` / `callers --json` / MCP output (point 4 of the issue) — that is output plumbing rather than resolution and would be a separate change.

## Tests

`test/graph-resolve-imported-calls.test.ts`:
- extractor: a call through `import { useRouter } from "next/navigation"` and an aliased `import { helper as h }` carry `{ name, specifier }`; a local `const useRouter = …` shadowing the import keeps the call a bare name;
- resolver: external specifier → no edge (fails on `main`, the mock got the edge); no provenance → unchanged unique-name fallback; in-repo module → `extracted` edge to that module even though a same-named mock exists; in-repo barrel without the name → name-based fallback.

`node --import tsx --test test/graph-traverse-cli.test.ts test/graph-resolve-imported-calls.test.ts test/graph-resolve-typed.test.ts`: 35 pass; `tsc --noEmit` clean. (The `savings` / `session-metrics` / `claude-format` suites fail identically on `main` in my environment — number formatting under a non-English locale — and are unrelated.)
