### PR TITLE
fix: preserve edge confidence in call trace results

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,14 @@ Method calls resolve through the receiver's type — constructor assignments
 name — so `callers`/`grep --in` return calls bound to the right
 type on method-heavy code, not every method anywhere with that name.
 
+`callers` and MCP `graft_trace_calls` label each hit with its edge confidence:
+`lsp_resolved`, `lsp_dispatch`, `extracted`, or `inferred` (strongest first).
+For a transitive walk, `[extracted; path inferred]` means the final edge was
+extracted but an earlier hop was inferred. `callers --json` exposes both
+`confidence` and `pathConfidence`; the latter is the weakest edge on the first
+BFS path that reached the hit, not a score over every possible path. Direct
+hits have the same value in both fields.
+
 ## Search & orient (`graft grep` / `graft map`)
 
 `graft grep "<regex>"` is exhaustive over every indexed file and groups hits

--- a/src/graph/traverse-cli.ts
+++ b/src/graph/traverse-cli.ts
@@ -17,7 +17,7 @@ import { contextDirFor } from "../context/node-file.js";
 import { withSavings, savingsFor, type Savings } from "../context/savings.js";
 import { loadGraphCached } from "./load.js";
 import { resolveSymbol, edgeWalk, type Direction, type EdgeHit } from "./traverse.js";
-import type { GraphV1, NodeV1 } from "./types.js";
+import type { Confidence, GraphV1, NodeV1 } from "./types.js";
 
 export interface CallersCliOptions {
   in?: string;
@@ -50,8 +50,11 @@ export function headerOf(n: NodeV1): string {
 export function hitLine(direction: Direction, hit: EdgeHit, showDepth: boolean, quote?: Quote): string {
   const arrow = ARROW[direction];
   const depthTag = showDepth ? ` [depth ${hit.depth}]` : "";
+  const confidenceTag = hit.pathConfidence === hit.confidence
+    ? ` [${hit.confidence}]`
+    : ` [${hit.confidence}; path ${hit.pathConfidence}]`;
   const label = hit.node ? `${hit.node.name} (${hit.node.path}:${hit.node.span})` : `${hit.id} (unresolved import)`;
-  const line = `  ${hit.relation} ${arrow} ${label}${depthTag}`;
+  const line = `  ${hit.relation} ${arrow} ${label}${depthTag}${confidenceTag}`;
   return quote ? `${line}\n      ${quote.n}: ${quote.text.trim()}` : line;
 }
 
@@ -132,6 +135,8 @@ interface HitJson {
   span?: string;
   relation: string;
   depth: number;
+  confidence: Confidence;
+  pathConfidence: Confidence;
 }
 
 function symbolJson(n: NodeV1): SymbolJson {
@@ -139,7 +144,10 @@ function symbolJson(n: NodeV1): SymbolJson {
 }
 
 function hitJson(hit: EdgeHit): HitJson {
-  const out: HitJson = { id: hit.id, relation: hit.relation, depth: hit.depth };
+  const out: HitJson = {
+    id: hit.id, relation: hit.relation, depth: hit.depth,
+    confidence: hit.confidence, pathConfidence: hit.pathConfidence,
+  };
   if (hit.node) {
     out.name = hit.node.name;
     out.kind = hit.node.kind;

--- a/src/graph/traverse.ts
+++ b/src/graph/traverse.ts
@@ -12,7 +12,7 @@
  * `loadGraphCached`), which keeps this module trivially unit-testable against
  * hand-built fixture graphs.
  */
-import type { EdgeV1, GraphV1, NodeV1, Relation } from "./types.js";
+import type { Confidence, EdgeV1, GraphV1, NodeV1, Relation } from "./types.js";
 import { WALK_RELATIONS } from "./relations.js";
 import { assertPrefixIndexed, pathUnderPrefix } from "./scopes.js";
 import { normalizePathPrefix } from "../util/paths.js";
@@ -119,6 +119,23 @@ export interface EdgeHit {
   id: string;
   relation: Relation;
   depth: number;
+  /** Confidence of the edge that reached this hit. */
+  confidence: Confidence;
+  /** Weakest edge on the first BFS path to this hit; equals `confidence` at
+   * depth 1. Describes the selected path, not all possible paths to the node. */
+  pathConfidence: Confidence;
+}
+
+// Keep the best-first provenance order documented by Confidence in types.ts.
+const CONFIDENCE_RANK: Record<Confidence, number> = {
+  lsp_resolved: 0,
+  lsp_dispatch: 1,
+  extracted: 2,
+  inferred: 3,
+};
+
+function weakestConfidence(a: Confidence, b: Confidence): Confidence {
+  return CONFIDENCE_RANK[a] >= CONFIDENCE_RANK[b] ? a : b;
 }
 
 /** Depth-1: nodes with a walk-relation edge whose target is `symbol`. */
@@ -127,7 +144,8 @@ export function callersOf(graph: GraphV1, symbol: NodeV1): EdgeHit[] {
   const hits: EdgeHit[] = [];
   for (const e of graph.edges as EdgeV1[]) {
     if (!WALK_RELATIONS.has(e.relation) || e.target !== symbol.id) continue;
-    hits.push({ node: byId.get(e.source) ?? null, id: e.source, relation: e.relation, depth: 1 });
+    hits.push({ node: byId.get(e.source) ?? null, id: e.source, relation: e.relation, depth: 1,
+      confidence: e.confidence, pathConfidence: e.confidence });
   }
   return hits;
 }
@@ -138,7 +156,8 @@ export function calleesOf(graph: GraphV1, symbol: NodeV1): EdgeHit[] {
   const hits: EdgeHit[] = [];
   for (const e of graph.edges as EdgeV1[]) {
     if (!WALK_RELATIONS.has(e.relation) || e.source !== symbol.id) continue;
-    hits.push({ node: byId.get(e.target) ?? null, id: e.target, relation: e.relation, depth: 1 });
+    hits.push({ node: byId.get(e.target) ?? null, id: e.target, relation: e.relation, depth: 1,
+      confidence: e.confidence, pathConfidence: e.confidence });
   }
   return hits;
 }
@@ -167,7 +186,8 @@ export function impactOf(graph: GraphV1, symbol: NodeV1, maxDepth = 2): EdgeHit[
  * Every seed is pre-marked visited (so a seed can never appear as its own
  * hit, and an edge between two seeds is never reported), then the walk
  * proceeds exactly like `impactOf`'s: each reached node deduped by id and
- * reported once, at the depth it was first reached from *any* seed.
+ * reported once, at the depth it was first reached from *any* seed. Confidence
+ * follows that same first path; it does not change which path is selected.
  */
 export function impactOfMany(graph: GraphV1, seeds: NodeV1[], maxDepth = 2, direction: Direction = "in"): EdgeHit[] {
   const byId = new Map(graph.nodes.map((n) => [n.id, n]));
@@ -175,12 +195,12 @@ export function impactOfMany(graph: GraphV1, seeds: NodeV1[], maxDepth = 2, dire
   // Adjacency keyed for the walk direction, restricted to walk relations:
   //   'in'  → key = edge.target, neighbour = edge.source (who points AT key)
   //   'out' → key = edge.source, neighbour = edge.target (what key points TO)
-  const adj = new Map<string, { other: string; relation: Relation }[]>();
+  const adj = new Map<string, { other: string; relation: Relation; confidence: Confidence }[]>();
   for (const e of graph.edges as EdgeV1[]) {
     if (!WALK_RELATIONS.has(e.relation)) continue;
     const key = direction === "in" ? e.target : e.source;
     const other = direction === "in" ? e.source : e.target;
-    const entry = { other, relation: e.relation };
+    const entry = { other, relation: e.relation, confidence: e.confidence };
     const arr = adj.get(key);
     if (arr) arr.push(entry);
     else adj.set(key, [entry]);
@@ -188,16 +208,18 @@ export function impactOfMany(graph: GraphV1, seeds: NodeV1[], maxDepth = 2, dire
 
   const visited = new Set<string>(seeds.map((s) => s.id));
   const hits: EdgeHit[] = [];
-  let frontier = [...visited];
+  // A seed has no traversed edges yet, so the strongest grade is neutral.
+  let frontier = [...visited].map((id) => ({ id, pathConfidence: "lsp_resolved" as Confidence }));
 
   for (let depth = 1; depth <= maxDepth && frontier.length > 0; depth++) {
-    const next: string[] = [];
+    const next: typeof frontier = [];
     for (const current of frontier) {
-      for (const { other, relation } of adj.get(current) ?? []) {
+      for (const { other, relation, confidence } of adj.get(current.id) ?? []) {
         if (visited.has(other)) continue;
         visited.add(other);
-        hits.push({ node: byId.get(other) ?? null, id: other, relation, depth });
-        next.push(other);
+        const pathConfidence = weakestConfidence(current.pathConfidence, confidence);
+        hits.push({ node: byId.get(other) ?? null, id: other, relation, depth, confidence, pathConfidence });
+        next.push({ id: other, pathConfidence });
       }
     }
     frontier = next;

--- a/test/graph-confidence.test.ts
+++ b/test/graph-confidence.test.ts
@@ -1,0 +1,120 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { callersOf, calleesOf, impactOfMany, impactOfFile } from "../src/graph/traverse.js";
+import { hitLine } from "../src/graph/traverse-cli.js";
+import { callTool } from "../src/mcp/tools.js";
+import type { Confidence, GraphV1, NodeV1 } from "../src/graph/types.js";
+
+function node(name: string): NodeV1 {
+  return {
+    id: `src/${name}.ts#${name}`, name, kind: "function", path: `src/${name}.ts`,
+    span: "L1-L3", signature: null, exported: true, origin: "ast",
+    body_hash: name, summary_state: "pending", summary: null, crux: null,
+  };
+}
+
+function chain(first: Confidence, second: Confidence): GraphV1 {
+  const nodes = [node("leaf"), node("middle"), node("top")];
+  return {
+    meta: { version: 1, nodeCount: 3, edgeCount: 2, languages: ["ts"] }, nodes,
+    edges: [
+      { source: nodes[1].id, target: nodes[0].id, relation: "calls", confidence: first },
+      { source: nodes[2].id, target: nodes[1].id, relation: "references", confidence: second },
+    ],
+  };
+}
+
+test("direct incoming and outgoing hits preserve all four confidence grades", () => {
+  for (const confidence of ["lsp_resolved", "lsp_dispatch", "extracted", "inferred"] as const) {
+    const graph = chain(confidence, "extracted");
+    for (const hit of [callersOf(graph, graph.nodes[0])[0], calleesOf(graph, graph.nodes[1])[0]]) {
+      assert.equal(hit.confidence, confidence);
+      assert.equal(hit.pathConfidence, confidence);
+      assert.match(hitLine("in", hit, false), new RegExp(`\\[${confidence}\\]`));
+    }
+  }
+});
+
+test("an extracted final edge cannot hide an earlier inferred hop", () => {
+  for (const direction of ["in", "out"] as const) {
+    const graph = direction === "in" ? chain("inferred", "extracted") : chain("extracted", "inferred");
+    const seed = graph.nodes[direction === "in" ? 0 : 2];
+    const hits = impactOfMany(graph, [seed], Infinity, direction);
+    assert.equal(hits.length, 2);
+    assert.equal(hits[1].confidence, "extracted");
+    assert.equal(hits[1].pathConfidence, "inferred");
+    assert.match(hitLine(direction, hits[1], true), /\[extracted; path inferred\]/);
+  }
+});
+
+test("LSP dispatch remains weaker than exact LSP resolution on a path", () => {
+  const graph = chain("lsp_dispatch", "lsp_resolved");
+  const hit = impactOfMany(graph, [graph.nodes[0]], 2)[1];
+  assert.equal(hit.confidence, "lsp_resolved");
+  assert.equal(hit.pathConfidence, "lsp_dispatch");
+});
+
+test("a stronger alternative path does not change the first BFS path's confidence", () => {
+  const graph = chain("inferred", "extracted");
+  const alternative = node("alternative");
+  graph.nodes.push(alternative);
+  graph.edges.push(
+    { source: alternative.id, target: graph.nodes[0].id, relation: "calls", confidence: "lsp_resolved" },
+    { source: graph.nodes[2].id, target: alternative.id, relation: "calls", confidence: "lsp_resolved" },
+  );
+  const hits = impactOfMany(graph, [graph.nodes[0]], 2);
+  const convergence = hits.filter((hit) => hit.id === graph.nodes[2].id);
+  assert.equal(convergence.length, 1);
+  assert.equal(convergence[0].depth, 2);
+  assert.equal(convergence[0].relation, "references");
+  assert.equal(convergence[0].confidence, "extracted");
+  assert.equal(convergence[0].pathConfidence, "inferred");
+});
+
+test("file seeds and cycles retain the first BFS path and its provenance", () => {
+  const graph = chain("inferred", "extracted");
+  const file = { ...node("file"), id: "src/leaf.ts", path: "src/leaf.ts", kind: "file" as const };
+  graph.nodes.push(file);
+  graph.edges.push({ source: graph.nodes[0].id, target: graph.nodes[2].id, relation: "calls", confidence: "extracted" });
+  const hits = impactOfFile(graph, file, Infinity);
+  assert.deepEqual(hits.map((hit) => hit.id), [graph.nodes[1].id, graph.nodes[2].id]);
+  assert.equal(hits[1].pathConfidence, "inferred");
+  assert.deepEqual(impactOfMany(graph, [graph.nodes[0], graph.nodes[1]], Infinity).map((hit) => hit.pathConfidence), ["extracted"]);
+});
+
+test("unresolved endpoints retain their edge confidence", () => {
+  const graph = chain("extracted", "extracted");
+  graph.edges.push({ source: graph.nodes[0].id, target: "ExternalBase", relation: "extends", confidence: "inferred" });
+  const hit = calleesOf(graph, graph.nodes[0])[0];
+  assert.equal(hit.node, null);
+  assert.equal(hit.confidence, "inferred");
+  assert.match(hitLine("out", hit, false), /ExternalBase.*\[inferred\]/);
+});
+
+test("CLI JSON, human output, and MCP report inference along the same real call chain", async (t) => {
+  const root = mkdtempSync(join(tmpdir(), "graft-confidence-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  mkdirSync(join(root, "src"));
+  writeFileSync(join(root, "src/leaf.ts"), "export function leaf() { return 1; }\n");
+  // The cross-file bare name uses the existing inferred fallback. The same-file
+  // top -> middle call is extracted: the second hop must not upgrade the path.
+  writeFileSync(join(root, "src/entry.ts"), "export function middle() { return leaf(); }\nexport function top() { return middle(); }\n");
+  const cli = (...args: string[]) => execFileSync(process.execPath, ["--import", "tsx", "src/cli.ts", ...args], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+  cli("build", root);
+  const args = ["callers", "leaf", root, "--depth", "all", "--no-refresh"];
+  const parsed = JSON.parse(cli(...args, "--json"));
+  const hits = parsed.matches[0].hits;
+  assert.deepEqual(hits.map((hit: { confidence: string }) => hit.confidence), ["inferred", "extracted"]);
+  assert.deepEqual(hits.map((hit: { pathConfidence: string }) => hit.pathConfidence), ["inferred", "inferred"]);
+  const human = cli(...args);
+  assert.match(human, /middle.*\[inferred\]/);
+  assert.match(human, /top.*\[extracted; path inferred\]/);
+  const mcp = await callTool(root, "graft_trace_calls", { symbol: "leaf", depth: "all" });
+  assert.equal(mcp.isError, false, mcp.text);
+  assert.match(mcp.text, /middle.*\[inferred\]/);
+  assert.match(mcp.text, /top.*\[extracted; path inferred\]/);
+});

--- a/test/graph-traverse-cli.test.ts
+++ b/test/graph-traverse-cli.test.ts
@@ -202,13 +202,13 @@ test('graft callers: quotes the call site, and only where it is the right line',
   assert.equal(r.status, 0);
   // `sub` calls `add` on line 5 of the fixture. The edge is a claim; this is the
   // evidence, and it saves opening the file to check.
-  assert.match(r.stdout, /calls ← sub \(src\/math\.ts:[^)]*\)\n\s+5: return add\(a, -b\);/);
+  assert.match(r.stdout, /calls ← sub \(src\/math\.ts:[^)]*\) \[extracted\]\n\s+5: return add\(a, -b\);/);
 
   // A second-hop hit references what is BETWEEN it and the symbol, not the symbol
   // itself, so quoting it would point at the wrong line.
   const deep = runCli(['callers', 'add', d, '--depth', '2']);
-  assert.match(deep.stdout, /calls ← compute \(src\/math\.ts:[^)]*\) \[depth 2\]\n/);
-  assert.ok(!/\[depth 2\]\n\s+\d+:/.test(deep.stdout), 'no quote on a second-hop hit');
+  assert.match(deep.stdout, /calls ← compute \(src\/math\.ts:[^)]*\) \[depth 2\] \[extracted\]\n/);
+  assert.ok(!/\[depth 2\] \[extracted\]\n\s+\d+:/.test(deep.stdout), 'no quote on a second-hop hit');
 
   // --json is a data contract: the quote is a text-output nicety and must stay out.
   const json = JSON.parse(runCli(['callers', 'add', d, '--json']).stdout);


### PR DESCRIPTION
Preserve confidence in call trace results (point 4 of #330), complementing #335's import-resolution fix.

- Keep the original edge confidence in direct and BFS hits.
- Expose pathConfidence as the weakest grade on the existing first BFS path.
- Include both fields in CLI JSON and show confidence in shared CLI/MCP output.
- Document the semantics; cover all four grades, both directions, cycles, diamonds, multi/file seeds, unresolved endpoints, and a real CLI/MCP fixture.

Traversal order, deduplication, depth, and resolution remain unchanged.

Validation:
- All 7 new regressions pass; the initial 6 fail on main before the fix.
- A targeted run had 153/154 passing tests; the remaining exact-output assertion was updated for the label. The final CLI/confidence run passes all 21 tests; the other 133 passed in the earlier run.
- npm run build and git diff --check passed.