### PR TITLE
fix: include PHP type usages in reference edges

### DIFF
--- a/src/graph/extract.ts
+++ b/src/graph/extract.ts
@@ -699,6 +699,12 @@ function walk(node: Parser.SyntaxNode, ctx: WalkCtx, out: NodeV1[], edges: RawEd
   }
 
   // not a definition — capture calls/imports/references, then descend with the same context
+  if (ctx.lang === "php") {
+    const ref = phpTypeReference(node, ctx);
+    if (ref) {
+      edges.push({ source: ctx.parentId, relation: "references", ...ref, file: ctx.rel });
+    }
+  }
   // R's `call` node is also its ONLY vehicle for library()/require()/source() —
   // there's no separate import-statement grammar construct to key off, so isImport
   // must be checked before the generic calls path or every import call would be
@@ -968,7 +974,36 @@ function phpAttributeClassRef(
   const nameNode =
     attr.childForFieldName("name") ??
     attr.namedChildren.find((c) => c.type === "name" || c.type === "qualified_name");
-  if (!nameNode) return null;
+  return phpClassRef(nameNode, ctx);
+}
+
+/** Only class-name positions count: a variable, member name or declaration is not a type use. */
+function phpTypeReference(node: Parser.SyntaxNode, ctx: WalkCtx): { name: string; specifier?: string } | null {
+  let nameNode: Parser.SyntaxNode | null | undefined;
+  switch (node.type) {
+    case "named_type":
+    case "object_creation_expression":
+    case "class_constant_access_expression":
+      nameNode = node.namedChildren[0];
+      break;
+    case "scoped_call_expression":
+    case "scoped_property_access_expression":
+      nameNode = node.childForFieldName("scope");
+      break;
+    case "binary_expression":
+      if (node.childForFieldName("operator")?.text === "instanceof") nameNode = node.childForFieldName("right");
+      break;
+  }
+  // This grammar also parses object and relative class keywords as named_type.
+  if (nameNode?.type === "name" && /^(object|self|parent|static)$/i.test(nameNode.text)) return null;
+  return phpClassRef(nameNode, ctx);
+}
+
+function phpClassRef(
+  nameNode: Parser.SyntaxNode | null | undefined,
+  ctx: WalkCtx,
+): { name: string; specifier?: string } | null {
+  if (!nameNode || (nameNode.type !== "name" && nameNode.type !== "qualified_name")) return null;
   if (nameNode.type === "qualified_name") {
     const fqn = nameNode.text.replace(/^\\/, "");
     return { name: fqn.replace(/^.*\\/, ""), specifier: fqn };

--- a/src/graph/resolve.ts
+++ b/src/graph/resolve.ts
@@ -237,7 +237,7 @@ export function resolveEdges(
         const candidates = perFileName.get(targetFile)?.get(e.name) ?? [];
         if (candidates.length === 1) add(e.source, candidates[0].id, "references", "extracted");
       } else if (e.file.endsWith(".php") && byId.get(e.source)?.origin === "ast") {
-        // PHP attribute without a `use` import (same-file or globally unique class).
+        // PHP type/attribute without a `use` import (same-file or globally unique type).
         const refKinds: Kind[] = ["class", "interface", "trait", "enum"];
         const hit = resolveName(e.name, e.file, refKinds, perFileName, globalName);
         if (hit && hit.id !== e.source) add(e.source, hit.id, "references", hit.confidence);

--- a/test/graph-php-references.test.ts
+++ b/test/graph-php-references.test.ts
@@ -1,0 +1,96 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { extractFile } from "../src/graph/extract.js";
+import { buildGraph } from "../src/graph/build.js";
+import { readGraph, wiringPath } from "../src/graph/write.js";
+import { callersOf } from "../src/graph/traverse.js";
+
+const uses = String.raw`<?php
+namespace App;
+use App\Types\{Color as Shade, Widget, Runnable, Failure};
+`;
+
+for (const [label, source, names] of [
+  ["nullable property", "class Painter { public ?Shade $favourite = null; }", ["Color"]],
+  ["parameter", "function paint(Shade $color): void {}", ["Color"]],
+  ["return type", "function paint(): Shade { throw new \\Exception(); }", ["Color", "Exception"]],
+  ["union and intersection", "function paint((Widget&Runnable)|Shade $value): void {}", ["Color", "Runnable", "Widget"]],
+  ["constructor", "function paint() { return new Widget(); }", ["Widget"]],
+  ["instanceof", "function paint($value) { return $value instanceof Widget; }", ["Widget"]],
+  ["enum constant", "function paint() { return Shade::RED; }", ["Color"]],
+  ["class literal", "function paint() { return Widget::class; }", ["Widget"]],
+  ["static method", "function paint() { return Shade::warm(); }", ["Color"]],
+  ["static property", "function paint() { return Widget::$current; }", ["Widget"]],
+  ["catch type", "function paint() { try {} catch (Failure $e) {} }", ["Failure"]],
+] as const) {
+  test(`PHP type references: ${label}`, () => {
+    const result = extractFile("Painter.php", uses + source, "php");
+    const refs = result.rawEdges.filter(edge => edge.relation === "references");
+    assert.deepEqual(refs.map(edge => edge.name).sort(), [...names]);
+    for (const ref of refs) {
+      assert.equal(ref.source, source.startsWith("class") ? "Painter.php#Painter" : "Painter.php#paint");
+      assert.equal(ref.specifier, ref.name === "Exception" ? "Exception" : `App\\Types\\${ref.name}`);
+    }
+  });
+}
+
+test("PHP type references do not treat declarations, primitives or dynamic expressions as types", () => {
+  const result = extractFile("Painter.php", uses + `
+class Painter {
+  public string $Shade;
+  public function identity(): self { return $this; }
+  public function paint(int $Widget, object $value): array {
+    $Shade = 'Widget';
+    Shade();
+    $value->Shade();
+    $value->Shade;
+    new $Shade();
+    $value instanceof $Shade;
+    $Shade::RED;
+    self::paint();
+    static::paint();
+    parent::paint();
+    return [];
+  }
+}
+`, "php");
+  assert.deepEqual(result.rawEdges.filter(edge => edge.relation === "references"), []);
+});
+
+test("PHP callers finds enum/type users across aliases and qualified names (#324)", async () => {
+  const root = mkdtempSync(join(tmpdir(), "graft-php-references-"));
+  try {
+    mkdirSync(join(root, "src"));
+    const files = {
+      "Color.php": String.raw`<?php namespace App; enum Color: string { case RED = 'red'; public static function warm(): array { return [self::RED]; } }`,
+      "Widget.php": String.raw`<?php namespace App; class Widget {}`,
+      "Painter.php": String.raw`<?php namespace App; use App\Color; class Painter { public ?Color $favourite = null; public function paint(Color $color): string { return $color->value; } }`,
+      "Decorator.php": String.raw`<?php namespace App; use App\Color as C; class Decorator { public function decorate(): string { return C::RED->value; } }`,
+      "Factory.php": String.raw`<?php namespace App; function make(): \App\Widget { return new \App\Widget(); } function matches($value): bool { return $value instanceof \App\Widget; }`,
+      "Local.php": String.raw`<?php class LocalType {} function makeLocal(): LocalType { return new LocalType(); }`,
+    };
+    for (const [path, source] of Object.entries(files)) writeFileSync(join(root, "src", path), source);
+    await buildGraph(root, { reuse: false });
+    const graph = readGraph(wiringPath(join(root, "graft")))!;
+    const color = graph.nodes.find(node => node.id === "src/Color.php#Color")!;
+    assert.deepEqual(callersOf(graph, color).map(hit => [hit.id, hit.relation]).sort(), [
+      ["src/Decorator.php#Decorator.decorate", "references"],
+      ["src/Painter.php#Painter", "references"],
+      ["src/Painter.php#Painter.paint", "references"],
+    ]);
+    const widget = graph.nodes.find(node => node.id === "src/Widget.php#Widget")!;
+    assert.deepEqual(callersOf(graph, widget).map(hit => [hit.id, hit.relation]).sort(), [
+      ["src/Factory.php#make", "references"],
+      ["src/Factory.php#matches", "references"],
+    ]);
+    const local = graph.nodes.find(node => node.id === "src/Local.php#LocalType")!;
+    assert.deepEqual(callersOf(graph, local).map(hit => [hit.id, hit.relation]), [
+      ["src/Local.php#makeLocal", "references"],
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Fixes #324.

Emit references for PHP type annotations, construction, instanceof and static class accesses. Reuse existing PHP import resolution for aliases and qualified names. Exclude dynamic expressions, declarations and primitive types.

Add 13 regressions, including the reported enum case through buildGraph and callersOf.

Validation: 12 new cases fail before the fix. Afterwards, the graph suite has 342 passes, 4 skips and zero failures. Typecheck and git diff --check pass.