### PR TITLE
Add pi host: wire .pi/skills/graft/SKILL.md via graft init

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,13 +267,13 @@ npx @nanonets/graft init
 # Claude Code additionally gets the live statusline + hooks below
 ```
 
-On a terminal, `init` shows you every agent it knows about — flagging the ones it detected (via their config directories) and listing the exact files each would write — and wires only the ones you select. Claude Code is pre-selected; nothing else is. Selected agents get a marker-fenced Graft section in their shared instruction file — `AGENTS.md` (Codex, OpenCode and other CLIs that read it), `GEMINI.md`, `.github/copilot-instructions.md` — or a wholly-owned rule/skill file for the agents that use one: `.claude/skills/graft/SKILL.md`, `.cursor/rules/graft.mdc`, `.kiro/steering/graft.md`, `.windsurf/rules/graft.md`, `.grok/skills/graft/SKILL.md` for Grok (xAI), `.adal/skills/graft/SKILL.md` for [AdaL](https://adal.sylph.ai). Claude Code is in the second group: `init` writes its own skill file and never touches your `CLAUDE.md`. Re-running only updates Graft's own section (or replaces the owned file) and never touches the rest of your content.
+On a terminal, `init` shows you every agent it knows about — flagging the ones it detected (via their config directories) and listing the exact files each would write — and wires only the ones you select. Claude Code is pre-selected; nothing else is. Selected agents get a marker-fenced Graft section in their shared instruction file — `AGENTS.md` (Codex, OpenCode and other CLIs that read it), `GEMINI.md`, `.github/copilot-instructions.md` — or a wholly-owned rule/skill file for the agents that use one: `.claude/skills/graft/SKILL.md`, `.cursor/rules/graft.mdc`, `.kiro/steering/graft.md`, `.windsurf/rules/graft.md`, `.grok/skills/graft/SKILL.md` for Grok (xAI), `.adal/skills/graft/SKILL.md` for [AdaL](https://adal.sylph.ai), `.pi/skills/graft/SKILL.md` for [Pi](https://pi.dev). Claude Code is in the second group: `init` writes its own skill file and never touches your `CLAUDE.md`. Re-running only updates Graft's own section (or replaces the owned file) and never touches the rest of your content.
 
 With no TTY to prompt on — CI, a Dockerfile, a piped shell — `init` writes **nothing** and prints the command to run instead. Pass `--agents <ids>` or `--yes` to make a scripted run explicit.
 
 | Flag | Effect |
 |---|---|
-| `--agents <ids...>` | wire only these, no prompt — ids: `agents`, `cursor`, `gemini`, `grok`, `copilot`, `kiro`, `windsurf`, `adal`, `claude` |
+| `--agents <ids...>` | wire only these, no prompt — ids: `agents`, `cursor`, `gemini`, `grok`, `copilot`, `kiro`, `windsurf`, `adal`, `claude`, `pi` |
 | `--yes`, `-y` | skip the prompt and wire every **detected** agent |
 | `--dry-run` | print every file `init` would touch, then exit without writing |
 | `--all-agents` | write instruction files for every known agent, detected or not |
@@ -298,7 +298,7 @@ Both configs are user-level, so they apply to **every** repo you open with Codex
 
 ### MCP server
 
-`graft init` also registers Graft's MCP server with agents that support it, so these six tools appear natively, no shell required. Claude Code gets this too: `graft init` writes the server into the project's `.mcp.json` (restart Claude Code to load it). Skip with `--no-mcp`; run it manually with `graft mcp [dir]`.
+`graft init` also registers Graft's MCP server with agents that support it, so these six tools appear natively, no shell required. Pi is the exception: it ships no built-in MCP client, so no server is registered for it — use the CLI (`graft ask --source`, `graft grep`, `graft callers`, `graft skeleton`, `graft map`, `graft check`) or a community pi extension exposing the same six operations as native tools. Claude Code gets this too: `graft init` writes the server into the project's `.mcp.json` (restart Claude Code to load it). Skip with `--no-mcp`; run it manually with `graft mcp [dir]`.
 
 | Tool | Takes | What it's for |
 |---|---|---|
@@ -390,7 +390,7 @@ graft viz --export site/ --title "PR #12"  # one self-contained index.html — f
 
 graft init [dir]                     # pick which agents to wire (prompts on a terminal; writes nothing until you choose)
 graft init --dry-run                 # list every file it would touch, then exit
-graft init --agents cursor kiro      # wire only these agents, no prompt (ids: agents, cursor, gemini, grok, copilot, kiro, windsurf, adal, claude)
+graft init --agents cursor kiro      # wire only these agents, no prompt (ids: agents, cursor, gemini, grok, copilot, kiro, windsurf, adal, claude, pi)
 graft init --yes                     # no prompt; wire every detected agent
 graft init --no-global               # skip writes outside this repo (~/.codex/ config + hooks)
 graft init --no-statusline           # skip Claude Code statusLine (same as GRAFT_NO_STATUSLINE=1)

--- a/src/hosts/registry.ts
+++ b/src/hosts/registry.ts
@@ -121,6 +121,19 @@ export const HOSTS: HostTarget[] = [
     content: windsurfRule,
     detect: (p) => p.dirExists(join(p.home, '.codeium', 'windsurf')) || p.dirExists(join(p.repo, '.windsurf')),
   },
+  {
+    id: 'pi',
+    name: 'Pi (pi coding harness)',
+    kind: 'owned',
+    relPath: join('.pi', 'skills', 'graft', 'SKILL.md'),
+    content: skillTemplate,
+    // pi's global install marker (~/.pi/agent) or a project marker (./.pi):
+    // pi auto-discovers project-local skills from .pi/skills/ once trusted.
+    // (No MCP target: pi ships no built-in MCP client — the CLI is its API.)
+    detect: (p) =>
+      p.dirExists(join(p.home, '.pi', 'agent')) ||
+      p.dirExists(join(p.repo, '.pi')),
+  },
 ];
 
 export function hostIds(): string[] {

--- a/test/hosts-init.test.ts
+++ b/test/hosts-init.test.ts
@@ -34,7 +34,7 @@ test('explicit agents list overrides detection and flags unknown ids', () => {
 test('all writes every host and re-run converges (idempotent)', () => {
   const home = fresh(); const repo = fresh();
   const first = runHostsInit(repo, { home, all: true });
-  assert.equal(first.written.length, 10);
+  assert.equal(first.written.length, 11);
   const second = runHostsInit(repo, { home, all: true });
   assert.ok(second.written.every((w) => w.action === 'unchanged'));
   // `agents` and `antigravity` share AGENTS.md, but the fenced section is written once

--- a/test/hosts-registry.test.ts
+++ b/test/hosts-registry.test.ts
@@ -15,7 +15,7 @@ function probeFor(home: string, repo: string): DetectProbe {
 function fresh(): string { return mkdtempSync(join(tmpdir(), 'graft-registry-')); }
 
 test('registry exposes the known hosts', () => {
-  assert.deepEqual(hostIds().sort(), ['adal', 'agents', 'antigravity', 'copilot', 'cursor', 'gemini', 'grok', 'hermes', 'kiro', 'windsurf']);
+  assert.deepEqual(hostIds().sort(), ['adal', 'agents', 'antigravity', 'copilot', 'cursor', 'gemini', 'grok', 'hermes', 'kiro', 'pi', 'windsurf']);
   for (const h of HOSTS) {
     assert.ok(h.relPath.length > 0);
     assert.ok(h.content().length > 0);
@@ -69,6 +69,21 @@ test('repo-local .grok also lights up the grok host', () => {
   mkdirSync(join(repo, '.grok'));
   const ids = detectHosts(probeFor(home, repo)).map((h) => h.id).sort();
   assert.deepEqual(ids, ['grok']);
+});
+
+test('~/.pi/agent lights up the pi host', () => {
+  const home = fresh(); const repo = fresh();
+  mkdirSync(join(home, '.pi', 'agent'), { recursive: true });
+  const ids = detectHosts(probeFor(home, repo)).map((h) => h.id).sort();
+  assert.deepEqual(ids, ['pi']);
+  assert.ok(HOSTS.find((h) => h.id === 'pi')?.relPath.endsWith(join('.pi', 'skills', 'graft', 'SKILL.md')));
+});
+
+test('repo-local .pi also lights up the pi host', () => {
+  const home = fresh(); const repo = fresh();
+  mkdirSync(join(repo, '.pi'));
+  const ids = detectHosts(probeFor(home, repo)).map((h) => h.id).sort();
+  assert.deepEqual(ids, ['pi']);
 });
 
 test('~/.hermes or AppData/Local/hermes lights up the hermes host', () => {


### PR DESCRIPTION
## What

Teaches `graft init` about [Pi](https://pi.dev) (`npm i -g @earendil-works/pi-coding-agent`) as a first-class `--agents pi` target, writing an owned skill file to `.pi/skills/graft/SKILL.md`.

## Why

Pi auto-loads `AGENTS.md`, so the existing `agents` host already covers its instruction layer — but pi never reads `.claude/skills/` (it discovers skills from `~/.pi/agent/skills/`, `.pi/skills/`, `~/.agents/skills/`, `.agents/skills/`), so without this the skill file never reaches pi sessions.

Detection probes pi's global install marker (`~/.pi/agent`) and the project marker (`./.pi`).

Deliberately **no MCP target**: pi ships no built-in MCP client, so registration has nowhere to land — the CLI (`graft ask --source`, `grep`, `callers`, `skeleton`, `map`, `check`) is its API surface. A community pi extension exposes the same six operations as native pi tools.

## Changes

- `src/hosts/registry.ts` — new `pi` entry (`kind: owned`, `skillTemplate` content). `--agents`, `--list-agents`, the picker, and dry-run pick it up automatically from `HOSTS`.
- `README.md` — `pi` added to the `--agents` ids, the owned-file list, the CLI example, plus one sentence in the MCP section explaining the exception.
- `test/hosts-registry.test.ts` — pinned host list + two detection tests (`~/.pi/agent`, repo-local `.pi`), mirroring the adal/grok tests.
- `test/hosts-init.test.ts` — `--all` write count 10 → 11.

## Verification

- `npm run build` clean
- Host suites (registry, plan, init, picker) → 1222 pass, 0 fail
- E2E: `graft init --dry-run --agents pi` reports `.pi/skills/graft/SKILL.md`; real init writes a valid skill (frontmatter + guidance intact)