### PR TITLE
feat(brain): check the checkout against the repo the brain expects before mining

### DIFF
--- a/src/brain/push.ts
+++ b/src/brain/push.ts
@@ -109,6 +109,45 @@ async function isPrivate(owner: string, name: string, token: string | null, fetc
   }
 }
 
+/** What the brain is waiting for, when it is waiting for something. */
+export interface ExpectedRepo {
+  slug: string;
+  status: string;
+  brainName: string;
+}
+
+/**
+ * The repository this brain expects, or null when it expects none.
+ *
+ * The website records it when the user chooses the local route, so this is how
+ * the CLI knows whether the directory it is standing in is the one they asked
+ * for. Mining the wrong repo into a brain is silent and very hard to notice
+ * afterwards — the rules simply describe someone else's codebase — so the round
+ * trip is worth it.
+ *
+ * Null on any failure, which keeps an older brain (or an unreachable one)
+ * working exactly as it did before this check existed.
+ */
+export async function fetchExpectedRepo(link: BrainLink, fetchImpl: typeof fetch = fetch): Promise<ExpectedRepo | null> {
+  try {
+    const res = await fetchImpl(`${baseUrlFor(link)}/api/public/brains/${encodeURIComponent(link.brainId)}/repo`, {
+      headers: { authorization: `Bearer ${link.token}`, accept: "application/json" },
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) return null;
+    const body = (await res.json()) as { repo?: { slug?: string; status?: string } | null; brain_name?: string };
+    if (!body.repo?.slug) return null;
+    return { slug: body.repo.slug, status: String(body.repo.status ?? ""), brainName: String(body.brain_name ?? "") };
+  } catch {
+    return null;
+  }
+}
+
+/** Whether two repo slugs name the same repository. GitHub is case-insensitive. */
+export function sameRepo(a: string, b: string): boolean {
+  return a.trim().toLowerCase() === b.trim().toLowerCase();
+}
+
 /** Build the digest for the checkout at `root`. Reads nothing but text. */
 export async function buildLocalDigest(
   root: string,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,7 +20,7 @@ import { hostIds } from "./hosts/registry.js";
 import { parseBrainArg, connectBrain, pullBrain, brainStatus } from "./brain/connect.js";
 import { rulesForPointers } from "./brain/attach.js";
 import { clearLink, type BrainLink } from "./brain/link.js";
-import { buildLocalDigest, pushDigest } from "./brain/push.js";
+import { buildLocalDigest, fetchExpectedRepo, pushDigest, repoSlugFromGit, sameRepo } from "./brain/push.js";
 import { readLink } from "./brain/link.js";
 import { contextDirFor } from "./context/node-file.js";
 import { loadGraphCached } from "./graph/load.js";
@@ -1257,6 +1257,14 @@ brain
       console.error(`⚠ ${res.warning}`);
       return;
     }
+    if (res.ruleCount === 0) {
+      // The normal case on the local route: the brain exists but nothing has
+      // read the repo yet. Saying "0 rules" without saying why reads as a
+      // failure, and the next step is the whole point.
+      console.error("✓ attached this repo to the brain — it has no rules yet");
+      console.error("· run `graft brain push` to read this repository into it");
+      return;
+    }
     console.error(`✓ pulled ${res.ruleCount} rule(s) from ${parsed.brainId}`);
     for (const w of res.writes) console.error(`✓ ${w.path} (${w.action})`);
   });
@@ -1294,13 +1302,28 @@ brain
       process.exitCode = 1;
       return;
     }
+    // What the website said this brain is for. Checked BEFORE any reading, so
+    // standing in the wrong checkout costs a message rather than a brain full
+    // of another repository's rules — a mistake that is silent afterwards,
+    // because the rules look perfectly plausible, just not about your code.
+    const here = repoSlugFromGit(repo);
+    const expected = await fetchExpectedRepo(link);
+    if (expected && here && !sameRepo(expected.slug, `${here.owner}/${here.name}`)) {
+      console.error(`✗ this brain is for ${expected.slug}, but you are in ${here.owner}/${here.name}`);
+      console.error(`  cd into ${expected.slug} and run this again, or attach a different brain here.`);
+      process.exitCode = 1;
+      return;
+    }
+
     // The graph is what symbol anchors are resolved against, so a rule mined
     // here can later go stale on its own. Without one the ingest still works;
     // its rules simply govern the repo rather than a symbol in it.
     const graph = loadGraphCached(contextDirFor(repo, program.opts<GlobalOpts>().dir));
     if (!graph) console.error("· no graph yet — run `graft build` first so rules can be anchored to symbols");
 
-    console.error("· reading this repository (messages and docs only — no code leaves your machine)…");
+    const label = expected?.slug ?? (here ? `${here.owner}/${here.name}` : "this repository");
+    console.error(`· reading ${label} — commit messages, pull-request discussion and the docs in the tree.`);
+    console.error("  No file contents leave this machine.");
     const built = await buildLocalDigest(repo, graph, { autoApprove: opts.approve !== false });
     if ("error" in built) {
       console.error(`✗ ${built.error}`);
@@ -1319,8 +1342,10 @@ brain
       process.exitCode = 1;
       return;
     }
-    console.error(`✓ sent ${d.owner}/${d.name} to brain ${link.brainId}`);
-    console.error("· the brain is mining it now; `graft brain pull` once it finishes to get the rules back");
+    const brainLabel = expected?.brainName ? `“${expected.brainName}”` : link.brainId;
+    console.error(`✓ sent ${d.owner}/${d.name} to ${brainLabel}`);
+    console.error("· it is being mined into rules now — a few minutes. Watch it finish in your browser.");
+    console.error("  The rules reach this repo on their own; nothing else to run.");
   });
 
 brain


### PR DESCRIPTION
## The bug

`graft brain push` read whatever directory it was run in and took the repo from
that checkout's `origin`. Paste `acme/api` on the website, run the command in a
different checkout, and that other repository gets mined into the brain with
nothing objecting.

It fails silently and stays silent: the rules that come back look perfectly
plausible, they are just about someone else's codebase.

## The fix

The website now records which repository a brain is waiting for the moment the
user chooses the local route (a `brain_repos` row in `pending`). `push` fetches
that first, before reading anything, and refuses when the local `origin`
disagrees — naming both, so the fix is obvious:

```
✗ this brain is for acme/api, but you are in acme/web
  cd into acme/api and run this again, or attach a different brain here.
```

No expectation recorded is a valid answer — an older brain, or one made before
this existed — and the CLI then behaves exactly as it did before.

## Copy

The terminal is half of this flow and was saying almost nothing useful:

- `push` names the repo it is about to read and states plainly that no file
  contents leave the machine.
- On success it says the brain is being mined and the browser will show it,
  rather than telling the user to run another command they do not need.
- `connect` on a brain with no rules yet — the normal case on the local route —
  now says so and points at `push`, instead of reporting "0 rules" as if
  something had gone wrong.

## Verified

`upkeep` and `ask` suites pass (58). Requires the assign side for the recorded
expectation; without it `fetchExpectedRepo` returns null and nothing changes.