### PR TITLE
fix: pin rendered numbers to one locale so graft can read its own savings footer (#338)

### DIFF
--- a/src/ask/ask.ts
+++ b/src/ask/ask.ts
@@ -17,7 +17,7 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import matter from "gray-matter";
 import { contextDirFor } from "../context/node-file.js";
-import { withSavings, savingsFor, savingsTurnNudge, type Savings } from "../context/savings.js";
+import { withSavings, savingsFor, savingsTurnNudge, groupDigits, type Savings } from "../context/savings.js";
 import { loadGraphCached, loadAskIndexCached } from "../graph/load.js";
 import {
   assertPrefixIndexed,
@@ -1561,9 +1561,9 @@ function askSavingsLine(r: AskResult, body: string): string {
   const saved = base - pack;
   const pct = Math.round((saved / base) * 100);
   return (
-    `[graft] tokens saved ≈ ${saved.toLocaleString()} (${pct}%) — this pack ≈ ` +
-    `${pack.toLocaleString()} tok vs reading the ${r.saved.files} source file(s) whole ≈ ` +
-    `${base.toLocaleString()} tok. Estimate (baseline = those files read in full).` +
+    `[graft] tokens saved ≈ ${groupDigits(saved)} (${pct}%) — this pack ≈ ` +
+    `${groupDigits(pack)} tok vs reading the ${r.saved.files} source file(s) whole ≈ ` +
+    `${groupDigits(base)} tok. Estimate (baseline = those files read in full).` +
     savingsTurnNudge(saved)
   );
 }

--- a/src/claude/format.ts
+++ b/src/claude/format.ts
@@ -6,6 +6,7 @@ import type { GraphV1, EdgeV1 } from '../graph/types.js';
 // question in both places, and one set of calibrated numbers beats two.
 import { HIGH_FLOOR, STRONG_FLOOR } from '../ask/fuse.js';
 import { dollarsSaved, formatDollars } from '../context/price.js';
+import { groupDigits } from '../context/savings.js';
 
 const C = {
   indigo: (s: string) => `\x1b[38;2;84;111;255m${s}\x1b[0m`,
@@ -39,7 +40,7 @@ export function renderStatusline(
     // stands alone rather than carrying a rate nobody measured.
     const usd = dollarsSaved(saved, session?.inputCostMicros, session?.inputTokensBilled);
     const money = usd === null ? '' : ` · ~${formatDollars(usd)}`;
-    top.push(C.indigo(`~${saved.toLocaleString()} tok saved${money}`));
+    top.push(C.indigo(`~${groupDigits(saved)} tok saved${money}`));
   }
 
   const bottom: string[] = [];
@@ -133,9 +134,9 @@ export function formatRetrieval(ask: AskJson, cap = 5): string | null {
   const base = tokensOf(ask.saved!.baselineChars);
   const pct = Math.round((saved / base) * 100);
   return (
-    `${body}\n[graft] tokens saved ≈ ${saved.toLocaleString()} (${pct}%); this pack ≈ ` +
-    `${tokensOf(body.length).toLocaleString()} tok vs reading the ${ask.saved!.files} file(s) whole ≈ ` +
-    `${base.toLocaleString()} tok (estimate).`
+    `${body}\n[graft] tokens saved ≈ ${groupDigits(saved)} (${pct}%); this pack ≈ ` +
+    `${groupDigits(tokensOf(body.length))} tok vs reading the ${ask.saved!.files} file(s) whole ≈ ` +
+    `${groupDigits(base)} tok (estimate).`
   );
 }
 

--- a/src/claude/session-metrics.ts
+++ b/src/claude/session-metrics.ts
@@ -31,7 +31,7 @@
  */
 import { statSync } from 'node:fs';
 import { join } from 'node:path';
-import { sumSavingsFooters } from '../context/savings.js';
+import { groupDigits, sumSavingsFooters } from '../context/savings.js';
 import { dollarsSaved, formatDollars } from '../context/price.js';
 import { readSession, writeSession, sessionDir, listSessionIds, type SessionState } from './state.js';
 import type { AgentHost } from '../telemetry/contract.js';
@@ -199,7 +199,7 @@ export function formatSessionStats(s: SessionSummary | null): string {
     `  graft reads:   ${graft}`,
     `  source reads:  ${source}   (Read / Grep / Glob)`,
     `  mix:           ${mix}`,
-    `  tokens saved:  ~${saved.toLocaleString()}`,
+    `  tokens saved:  ~${groupDigits(saved)}`,
   ];
   // Omitted, not zeroed, when no turn has been billed yet: a host whose hooks
   // name no transcript can't know what a token costs here, and a made-up rate

--- a/src/context/savings.ts
+++ b/src/context/savings.ts
@@ -105,6 +105,25 @@ export function savingsTurnNudge(savedTokens: number): string {
   );
 }
 
+/**
+ * Digits grouped for display, pinned to en-US.
+ *
+ * Not a style choice: the `[graft] tokens saved ≈ N` line below is read back by
+ * {@link sumSavingsFooters}, whose regex knows `,` and nothing else. Rendered
+ * with the machine's locale instead, a de-DE or tr-TR box wrote `1.990` and
+ * graft parsed its own footer as `1` — every savings total downstream, and the
+ * dollar value beside it, off by a factor of a thousand (#338). fr-FR and ru-RU
+ * group with a narrow no-break space and lost it the same way.
+ *
+ * Every number graft renders goes through here, not only the parsed one: a
+ * statusline that grouped differently from the footer right above it would be
+ * its own small bug. `src/cli-epilogue.ts` pins the same way, for the same
+ * reason.
+ */
+export function groupDigits(n: number): string {
+  return n.toLocaleString('en-US');
+}
+
 /** The one-line savings estimate for a command's text output, so the agent gets
  * the number for free — no extra tool call. `body` is the exact rendered output
  * the agent reads (the pack). Returns "" when there's nothing honest to claim:
@@ -118,9 +137,9 @@ export function savingsLine(body: string, saved: Savings | undefined): string {
   const delta = base - pack;
   const pct = Math.round((delta / base) * 100);
   return (
-    `[graft] tokens saved ≈ ${delta.toLocaleString()} (${pct}%) — this output ≈ ` +
-    `${pack.toLocaleString()} tok vs reading the ${saved.files} file(s) it covers whole ≈ ` +
-    `${base.toLocaleString()} tok (estimate).` +
+    `[graft] tokens saved ≈ ${groupDigits(delta)} (${pct}%) — this output ≈ ` +
+    `${groupDigits(pack)} tok vs reading the ${saved.files} file(s) it covers whole ≈ ` +
+    `${groupDigits(base)} tok (estimate).` +
     savingsTurnNudge(delta)
   );
 }

--- a/test/ratchet-lazy-grammar-import.test.ts
+++ b/test/ratchet-lazy-grammar-import.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Repo-wide ratchet: a native grammar package must never be a static import.
+ *
+ * #323 — `import kotlin from "tree-sitter-kotlin"` (or any of its siblings) at
+ * the top of a module runs the instant that module is loaded, before argv is
+ * read. On a platform with no prebuild and no compiler, that import throws and
+ * takes the whole CLI down with a node-gyp-build stack trace that never says
+ * "graft" — `--version`, `--help`, and every language other than Kotlin died
+ * with it. #337 replaced the static imports in extract.ts with `createRequire`
+ * calls behind a per-language try/catch; #217 later moved the require itself
+ * behind a `grammarOf()` so the module loads on first *parse*, not at import.
+ *
+ * The regression this guards against is not "someone edits extract.ts wrong" —
+ * it is "someone adds an eighth call site". A grep over one file only proves
+ * the seven names it currently checks; a new file, or a refactor that
+ * re-exports one of these packages under a different name, sails past a scan
+ * scoped like that. So this walks the real TypeScript AST over every file in
+ * `src/`, not a fixed list, and keys on the import target, not the surrounding
+ * text — `import x from "tree-sitter-kotlin"`, `import * as k from "..."`, and
+ * a bare `import "tree-sitter-kotlin"` are the same node to this scan.
+ *
+ * `tree-sitter` itself (the core, JS-only package) is not on the banned list:
+ * it has no prebuild to be missing and loading it cannot reproduce #323.
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import ts from "typescript";
+
+const SRC = join(import.meta.dirname, "..", "src");
+
+// The exact packages GRAMMAR_MODULES in src/graph/extract.ts loads lazily.
+// Kept as a literal list, not an import from extract.ts: importing that module
+// here would defeat the point if it ever regressed back to eager loading.
+const BANNED_GRAMMAR_PACKAGES = [
+  "tree-sitter-typescript",
+  "tree-sitter-python",
+  "tree-sitter-go",
+  "tree-sitter-java",
+  "tree-sitter-kotlin",
+  "tree-sitter-swift",
+  "tree-sitter-php",
+  "tree-sitter-r",
+];
+
+function walk(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((e) =>
+    e.isDirectory() ? walk(join(dir, e.name)) : /\.tsx?$/.test(e.name) ? [join(dir, e.name)] : [],
+  );
+}
+
+/** Every static `import ... from "<banned>"` (or bare `import "<banned>"`) in one file. */
+function staticGrammarImports(path: string, source: string): string[] {
+  const sf = ts.createSourceFile(path, source, ts.ScriptTarget.Latest, false);
+  const hits: string[] = [];
+  const visit = (node: ts.Node) => {
+    if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
+      if (BANNED_GRAMMAR_PACKAGES.includes(node.moduleSpecifier.text)) hits.push(node.moduleSpecifier.text);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return hits;
+}
+
+test("no source file statically imports a native grammar package (#323)", () => {
+  const offenders: string[] = [];
+  for (const path of walk(SRC)) {
+    const hits = staticGrammarImports(path, readFileSync(path, "utf8"));
+    if (hits.length > 0) offenders.push(`${path.slice(SRC.length + 1)}: ${hits.join(", ")}`);
+  }
+  assert.deepEqual(
+    offenders,
+    [],
+    `a native grammar package is imported statically — it must be loaded lazily ` +
+      `(createRequire + try/catch, see src/graph/extract.ts) so a missing prebuild ` +
+      `costs one language, not the whole CLI:\n${offenders.join("\n")}`,
+  );
+});
+
+test("the scanner can actually catch a static grammar import", () => {
+  const fixture = `import kotlin from "tree-sitter-kotlin";\nexport const x = kotlin;\n`;
+  assert.deepEqual(staticGrammarImports("fixture.ts", fixture), ["tree-sitter-kotlin"]);
+});
+
+test("the scanner does not flag the core tree-sitter package or a lazy require", () => {
+  const fixture = `import Parser from "tree-sitter";\nimport { createRequire } from "node:module";\nconst require = createRequire(import.meta.url);\nrequire("tree-sitter-kotlin");\n`;
+  assert.deepEqual(staticGrammarImports("fixture.ts", fixture), []);
+});

--- a/test/savings-locale.test.ts
+++ b/test/savings-locale.test.ts
@@ -14,6 +14,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { savingsLine, sumSavingsFooters } from '../src/context/savings.js';
 import { formatSessionStats } from '../src/claude/session-metrics.js';
+import { formatAsk, type AskResult } from '../src/ask/ask.js';
 
 /** Run `fn` on a machine whose default locale groups thousands with `locale`'s
  *  separator. Restores the real method even if `fn` throws. */
@@ -48,4 +49,19 @@ test('#338: what graft displays groups the same way as what it parses', () => {
     formatSessionStats({ id: 'abc', perAgentQuery: {}, graftReads: 8, sourceReads: 2, savedTokens: 12345 }),
   );
   assert.match(out, /tokens saved:\s+~12,345/);
+});
+
+test('#338: `graft ask` writes a footer its own reader can parse, on a machine that is not en-US', () => {
+  // The third writer of the parsed line, and the one no other test renders: ask.ts
+  // has its own wording of the footer, so a revert there would bring the bug back
+  // for every `graft ask` while the other two writers stayed green.
+  const result: AskResult = {
+    query: 'probe',
+    mode: 'lexical',
+    hits: [{ kind: 'symbol', title: 'probe', pointer: 'src/probe.ts:L1-L2', snippet: '', score: 1 }],
+    saved: { files: 3, baselineChars: 8000 }, // ≈ 2000 tok against a pack of a few dozen
+  };
+  const out = withDefaultLocale('de-DE', () => formatAsk(result));
+  assert.match(out, /tokens saved ≈ \d{1,3},\d{3} /, 'grouped for the reader, not for the machine');
+  assert.ok(sumSavingsFooters(out) >= 1000, `read back whole, not as its first group (got ${sumSavingsFooters(out)})`);
 });

--- a/test/savings-locale.test.ts
+++ b/test/savings-locale.test.ts
@@ -1,0 +1,51 @@
+/**
+ * #338: graft rendered its savings footer with the machine's locale and read it
+ * back with a regex that knows only `,`, so a `de-DE`/`tr-TR` box wrote `1.990`
+ * and parsed it as `1`.
+ *
+ * A process cannot change its own ambient locale — Node takes it from the
+ * environment on posix and from the OS on Windows — so these tests move the
+ * *default* instead: `toLocaleString()` with no argument answers the way a
+ * `.`-grouping locale would, while calls that name a locale are left alone.
+ * That is exactly the difference the fix turns on, and it behaves identically on
+ * an en-US CI runner, which is why CI never caught the original.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { savingsLine, sumSavingsFooters } from '../src/context/savings.js';
+import { formatSessionStats } from '../src/claude/session-metrics.js';
+
+/** Run `fn` on a machine whose default locale groups thousands with `locale`'s
+ *  separator. Restores the real method even if `fn` throws. */
+function withDefaultLocale<T>(locale: string, fn: () => T): T {
+  const real = Number.prototype.toLocaleString;
+  Number.prototype.toLocaleString = function (
+    this: number,
+    locales?: string | string[],
+    options?: Intl.NumberFormatOptions,
+  ): string {
+    return real.call(this, locales ?? locale, options);
+  };
+  try {
+    return fn();
+  } finally {
+    Number.prototype.toLocaleString = real;
+  }
+}
+
+test('#338: the savings footer round-trips on a machine that is not en-US', () => {
+  // Sanity: the stand-in really does change what an unqualified call renders,
+  // or the rest of this file would pass for the wrong reason.
+  assert.equal(withDefaultLocale('de-DE', () => (1990).toLocaleString()), '1.990');
+
+  const line = withDefaultLocale('de-DE', () => savingsLine('x'.repeat(40), { files: 2, baselineChars: 8000 }));
+  assert.match(line, /tokens saved ≈ 1,990/, 'grouped for the reader, not for the machine');
+  assert.equal(sumSavingsFooters(line), 1990, 'and read back whole, not as its first group');
+});
+
+test('#338: what graft displays groups the same way as what it parses', () => {
+  const out = withDefaultLocale('de-DE', () =>
+    formatSessionStats({ id: 'abc', perAgentQuery: {}, graftReads: 8, sourceReads: 2, savedTokens: 12345 }),
+  );
+  assert.match(out, /tokens saved:\s+~12,345/);
+});

--- a/test/savings.test.ts
+++ b/test/savings.test.ts
@@ -4,7 +4,7 @@
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { savingsFor, savingsLine, withSavings, toTokens, setInputRate } from '../src/context/savings.js';
+import { savingsFor, savingsLine, withSavings, toTokens, setInputRate, groupDigits } from '../src/context/savings.js';
 import { hasSavingsTally } from '../src/claude/tally.js';
 import type { GraphV1, NodeV1 } from '../src/graph/types.js';
 
@@ -49,7 +49,10 @@ test('savingsLine: reports saved tokens and percent when the output is smaller',
   assert.match(footer, /tokens saved ≈ [\d,]+ \(\d+%\)/);
   assert.match(footer, /2 file\(s\)/);
   const base = toTokens(8000);
-  assert.ok(footer.includes((base - toTokens(body.length)).toLocaleString()));
+  // Through the same pinned formatter the footer uses: rendered with the test
+  // machine's locale instead, this asserted `1.990` against a footer that says
+  // `1,990` — the mirror image of #338, and just as invisible on an en-US runner.
+  assert.ok(footer.includes(groupDigits(base - toTokens(body.length))));
   // The nudge rides along so the agent reports the turn total without SKILL.md.
   assert.match(footer, /end of your reply/i);
   assert.match(footer, /graft saved ~N tokens this turn/);


### PR DESCRIPTION
Fixes #338.

`savingsLine()` wrote the footer with the machine's locale; `sumSavingsFooters()` read it back with `([\d,]+)`. On a machine that groups thousands with anything but a comma, graft parsed its own footer as the first group — `1.990` came back as `1`, and every savings total downstream went with it.

## The change

One formatter, pinned, next to the reader that has to cope with its output:

```ts
export function groupDigits(n: number): string {
  return n.toLocaleString('en-US');
}
```

Five call sites now go through it. Three of them write the `[graft] tokens saved ≈ N` line that `sumSavingsFooters` parses — `context/savings.ts`, `ask/ask.ts`, `claude/format.ts`, each with its own wording of the same footer — and the other two are the displays that sit beside it, the statusline's `~N tok saved` and `graft stats`.

I pinned the two display sites as well, and that is the one judgement call in here worth flagging. They are never parsed, so locale-aware would be defensible — but graft's output is English throughout, a statusline reading `1.990` directly above a footer reading `1,990` would be its own small bug, and `src/cli-epilogue.ts:50` already pins the same way (`nodes.toLocaleString("en-US")`), which is where I took the precedent from. I left that line alone rather than reach across from an init banner into the savings module; say the word if you would rather have it routed through the same helper, or would rather keep the two displays locale-aware and pin only the parsed line.

The reader is untouched. Widening it instead was the option I would not take: `1.990` is a valid en-US *decimal*, so a reader that strips separators is guessing, and it would have to know about U+202F and U+00A0 too.

## Tests

`test/savings-locale.test.ts`. A process cannot change its own ambient locale — Node reads it from the environment on posix and from the OS on Windows — so the test moves the *default* instead: `toLocaleString()` with no argument answers as a `.`-grouping locale would, while calls that name a locale explicitly are left alone. That is exactly the difference the fix turns on, so the test fails without it and passes with it **on an en-US runner too**, which is the property CI was missing. It asserts the stand-in actually changes an unqualified call first, so the rest cannot pass for the wrong reason.

The third test renders the footer through `formatAsk()`. `ask/ask.ts` has its own wording of the parsed line, and no test rendered it at all — your blast-radius bot flagged it ("no test reaches Ask Token Savings"), and it was right: reverting just that file to `toLocaleString()` brought #338 back for every `graft ask` with the rest of the suite still green. Now it fails.

All three fail on `upstream/main`. The first two:

```
✖ #338: the savings footer round-trips on a machine that is not en-US
  actual: '[graft] tokens saved ≈ 1.990 (100%) — this output ≈ 10 tok …'
  expected: /tokens saved ≈ 1,990/
✖ #338: what graft displays groups the same way as what it parses
  actual: '… tokens saved:  ~12.345'
```

## Verified

The eight tests that fail on `upstream/main` on this machine — the ones I mentioned in #337 — are the eight this fixes. `npm test` on a `tr-TR` box:

| | tests | pass | fail |
| --- | --: | --: | --: |
| `upstream/main` | 1220 | 1207 | 8 |
| this branch | 1223 | 1218 | 0 |

(5 skipped either way.)

Seven of the eight were assertions that assumed `,`, and they now hold because the output does. The eighth, `tool-savings counts a REAL savings line`, was the round trip itself failing `1 !== 1990` — it is the test that should have caught this and could not, because the footer it feeds is rendered in the runner's own locale. It passes here now, which is the end-to-end proof: a real `savingsLine()` through the real hook, on a machine that groups with `.`, recording 1990.

One test needed the same treatment as the source. `test/savings.test.ts:52` built its expected value with `(…).toLocaleString()`, so once the footer was pinned it asserted `1.990` against a footer saying `1,990` — the mirror image of the bug. It now goes through `groupDigits` too.

Re-measured against `de8456e` (0.18.0) after rebasing onto it: same 8, same numbers.

## No CHANGELOG entry

I dropped the one I had. 0.18.0 is already released, so there is no unreleased section to add to, and `de8456e` shows the release commit is what writes them. Happy to add a bullet wherever you want it.

Environment: Node v24.16.0, Windows 11 x64, OS locale `tr-TR`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


