### PR TITLE
fix(telemetry): Stop recursive background flush helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Prevent telemetry helpers from repeatedly starting new copies when a sandbox
+  blocks writes to the telemetry state. Internal flush commands skip startup
+  upkeep, and background flushes require a saved timestamp before spawning.
+
 ## 0.18.0
 
 ### Added

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -206,9 +206,9 @@ function parseTabs(raw: string | undefined): VizTab[] | undefined {
 /**
  * Commands that own the upgrade story themselves (`version`, `upgrade`) or must
  * not editorialize on stderr at startup (`mcp` runs its own upkeep at boot, and
- * `_update-check` IS the fetch).
+ * internal helpers must not schedule another copy of themselves).
  */
-const UPKEEP_SKIP = new Set(["version", "upgrade", "_update-check", "_brain-refresh", "mcp"]);
+const UPKEEP_SKIP = new Set(["version", "upgrade", "_update-check", "_telemetry-flush", "_brain-refresh", "mcp"]);
 
 /**
  * Every other command: top up the cached registry answer in the background and,

--- a/src/telemetry/flush.ts
+++ b/src/telemetry/flush.ts
@@ -40,6 +40,8 @@ export function maybeFlushInBackground(home?: string, now = Date.now()): boolean
     if (!queueHasEvents(home)) return false;
     if (!needsFlush(readState(home)?.flushedAt, now)) return false;
     patchState({ flushedAt: now }, home); // before the spawn, so a dying child costs one attempt
+    // patchState tolerates write failures; only spawn if the daily limit was saved.
+    if (readState(home)?.flushedAt !== now) return false;
     const child = spawn(process.execPath, [graftCliPath(), '_telemetry-flush'], {
       detached: true,
       stdio: 'ignore',

--- a/test/telemetry-flush.test.ts
+++ b/test/telemetry-flush.test.ts
@@ -1,0 +1,114 @@
+import { test, beforeEach, afterEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import childProcess, { spawnSync, type ChildProcess } from 'node:child_process';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { syncBuiltinESMExports } from 'node:module';
+import { join } from 'node:path';
+import { FLUSH_TTL_MS, maybeFlushInBackground } from '../src/telemetry/flush.js';
+import { CI_ENV_VARS } from '../src/telemetry/gate.js';
+import { readState, statePath } from '../src/telemetry/identity.js';
+import { peek, queuePath } from '../src/telemetry/queue.js';
+import { homeEnv, tmpRepo } from './helpers.js';
+
+const EVENT = { event: 'query', properties: { command: 'ask' }, distinct_id: 'test-install' };
+const ENV_KEYS = ['GRAFT_POSTHOG_KEY', 'DO_NOT_TRACK', ...CI_ENV_VARS];
+let savedEnv: Record<string, string | undefined>;
+let homes: string[];
+
+beforeEach(() => {
+  savedEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+  for (const key of ENV_KEYS) delete process.env[key];
+  process.env.GRAFT_POSTHOG_KEY = 'phc_test_key';
+  homes = [];
+});
+
+afterEach(() => {
+  mock.restoreAll();
+  syncBuiltinESMExports();
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key]; else process.env[key] = value;
+  }
+  for (const home of homes) rmSync(home, { recursive: true, force: true });
+});
+
+function queuedHome(): string {
+  const home = tmpRepo('telemetry-flush');
+  homes.push(home);
+  mkdirSync(join(home, '.graft'));
+  writeFileSync(statePath(home), JSON.stringify({
+    installId: 'test-install', enabled: true, flushedAt: 0,
+    firstRunAt: '2026-01-01', noticeShownAt: '2026-01-01',
+  }));
+  writeFileSync(queuePath(home), JSON.stringify(EVENT) + '\n');
+  return home;
+}
+
+function interceptSpawn() {
+  const spawn = mock.method(childProcess, 'spawn', () => ({ unref() {} }) as ChildProcess);
+  syncBuiltinESMExports();
+  return spawn;
+}
+
+test('a failed timestamp write leaves the queue intact and starts no helper', () => {
+  const home = queuedHome();
+  const state = readFileSync(statePath(home), 'utf8');
+  const queue = readFileSync(queuePath(home), 'utf8');
+  // A directory blocks the atomic scratch-file write on Windows and as root too.
+  mkdirSync(`${statePath(home)}.${process.pid}.tmp`);
+  const spawn = interceptSpawn();
+
+  assert.equal(maybeFlushInBackground(home, FLUSH_TTL_MS), false);
+  assert.equal(spawn.mock.callCount(), 0);
+  assert.equal(readFileSync(statePath(home), 'utf8'), state);
+  assert.equal(readFileSync(queuePath(home), 'utf8'), queue);
+});
+
+test('a saved timestamp permits one helper and suppresses another before expiry', () => {
+  const home = queuedHome();
+  const spawn = interceptSpawn();
+  const now = FLUSH_TTL_MS;
+
+  assert.equal(maybeFlushInBackground(home, now), true);
+  assert.equal(readState(home)?.flushedAt, now);
+  assert.equal(maybeFlushInBackground(home, now + FLUSH_TTL_MS - 1), false);
+  assert.equal(spawn.mock.callCount(), 1);
+  assert.equal(spawn.mock.calls[0].arguments[1]?.[1], '_telemetry-flush');
+  assert.deepEqual(peek(home), [EVENT]);
+});
+
+test('the flush command sends its queue without starting upkeep or another flush', () => {
+  const home = queuedHome();
+  const state = readFileSync(statePath(home), 'utf8');
+  // Stub before importing the real CLI, so even the broken code cannot recurse
+  // or send data. Run in a child to isolate Commander and its process arguments.
+  const script = `
+    import childProcess from 'node:child_process';
+    import { syncBuiltinESMExports } from 'node:module';
+    const spawns = [], batches = [];
+    childProcess.spawn = (_file, args) => {
+      spawns.push(args);
+      return { unref() {} };
+    };
+    syncBuiltinESMExports();
+    globalThis.fetch = async (_url, options) => {
+      batches.push(JSON.parse(options.body).batch);
+      return { ok: true, status: 200 };
+    };
+    // Commander detects --eval, which has no script path in argv.
+    process.argv = [process.execPath, '_telemetry-flush'];
+    process.once('beforeExit', () => console.log(JSON.stringify({ spawns, batches })));
+    await import(${JSON.stringify(new URL('../src/cli.ts', import.meta.url).href)});
+  `;
+  const result = spawnSync(process.execPath, ['--import', 'tsx', '--input-type=module', '--eval', script], {
+    env: homeEnv(home), encoding: 'utf8', timeout: 30_000,
+  });
+
+  assert.equal(result.status, 0, result.stderr || String(result.error));
+  const { spawns, batches } = JSON.parse(result.stdout.trim());
+  assert.deepEqual(spawns, []);
+  assert.equal(batches.length, 1);
+  assert.equal(batches[0].length, 1);
+  assert.equal(batches[0][0].event, EVENT.event);
+  assert.deepEqual(peek(home), []);
+  assert.equal(readFileSync(statePath(home), 'utf8'), state);
+});


### PR DESCRIPTION
Fix a repeating chain of detached `_telemetry-flush` helpers when writes to the user's telemetry state are denied, such as inside a macOS agent sandbox. This was observed in published 0.16.0 and is still present on current main (0.18.0): 332 different helpers appeared in 15 seconds, with about 40 running together. System logs showed denied writes to `~/.graft/telemetry.json.<pid>.tmp` and denied removal of the queue file.

The internal flush command runs the global startup hook, which schedules another flush before processing its own queue. `patchState()` deliberately tolerates write failures, so the stored timestamp stays stale and each child can start a successor. Skip startup upkeep for `_telemetry-flush` and require the timestamp to be read back from disk before scheduling a background flush. The shared guard covers both CLI calls and MCP startup without changing `patchState()` or discarding queued events.

Three regression tests cover a denied timestamp write, normal daily throttling, and the real internal CLI command. Child creation and network requests are intercepted, so running the tests against the old code cannot start another process chain. Both regression cases fail before the fix and all three tests pass after it. `npm run build` also passes.

The full suite passes: **1,223 tests, zero failures or skips** on Node 25.2.1 and macOS. It ran with a temporary home and a separate copy of the same Node binary so global Graft installations could not override the installation-version fixtures.

Applying the same two guards to the affected 0.16.0 installation stopped the helpers without restarting agents. Four consecutive checks found zero helpers, and total CPU usage fell from about 99% to 27%.
