### PR TITLE
test(mcp): report why the server did not answer, instead of hanging on it (#350)

### DIFF
--- a/test/mcp-server.test.ts
+++ b/test/mcp-server.test.ts
@@ -7,10 +7,39 @@ import { join } from 'node:path';
 import { once } from 'node:events';
 import { buildGraph } from '../src/graph/build.js';
 
+/**
+ * How long to wait for the server's replies. Generous on purpose: the loop below
+ * leaves the moment the replies are in — or the moment the child quits — so this
+ * is only ever paid by a server that is up and genuinely silent.
+ */
+const RPC_TIMEOUT_MS = 60_000;
+
+/**
+ * Drive the MCP server over stdio and return its replies.
+ *
+ * Throws rather than returning short. Returning the partial array meant every
+ * caller dereferenced into `undefined` — `Cannot read properties of undefined
+ * (reading 'result')` — which named neither the timeout nor the request, and
+ * read the same whether the server had been slow, had crashed on startup, or had
+ * answered something unparseable. The child's stderr is kept for the same
+ * reason: it is the only place a crash says why, and it was being piped and then
+ * dropped.
+ *
+ * A crashed server used to be worse than badly reported, it hung the run: with
+ * the child already gone, `await once(child, 'exit')` waits for an event that
+ * has fired and will not fire again. The `close` promise below is created while
+ * the child is still alive, so it settles whenever the child ends, whether that
+ * is a crash of its own or the kill at the end.
+ */
 async function rpc(messages: object[], dir: string, expected: number): Promise<any[]> {
   const child = spawn(process.execPath, ['--import', 'tsx', 'src/cli.ts', 'mcp', dir], { stdio: ['pipe', 'pipe', 'pipe'] });
+  const closed = once(child, 'close');
   const responses: any[] = [];
   let buf = '';
+  let stderr = '';
+  // `close`, not `exit`: it fires once the child's stdio is drained, so a server
+  // that answers and then quits is not read as having quit without answering.
+  let died: string | null = null;
   child.stdout.on('data', (d) => {
     buf += d.toString();
     let i;
@@ -20,11 +49,25 @@ async function rpc(messages: object[], dir: string, expected: number): Promise<a
       if (line) responses.push(JSON.parse(line));
     }
   });
+  child.stderr.on('data', (d) => (stderr += d.toString()));
+  child.on('close', (code, signal) => (died ??= `exit code ${code}, signal ${signal}`));
   for (const m of messages) child.stdin.write(`${JSON.stringify(m)}\n`);
-  const deadline = Date.now() + 15000;
-  while (responses.length < expected && Date.now() < deadline) await new Promise((r) => setTimeout(r, 50));
+  const started = Date.now();
+  const deadline = started + RPC_TIMEOUT_MS;
+  while (responses.length < expected && died === null && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  const waited = ((Date.now() - started) / 1000).toFixed(1);
+  const quitFirst = died;
   child.kill();
-  await once(child, 'exit').catch(() => {});
+  await closed.catch(() => {});
+  if (responses.length < expected) {
+    throw new Error(
+      `mcp server answered ${responses.length} of ${expected} in ${waited}s — ` +
+        (quitFirst ? `it quit first (${quitFirst})` : 'it was still running') +
+        (stderr.trim() ? `\n--- its stderr ---\n${stderr.trim()}` : '\nIt wrote nothing to stderr.'),
+    );
+  }
   return responses;
 }
 


### PR DESCRIPTION
Fixes #350.

`rpc()` gave up after a fixed 15s, returned whatever had arrived, and dropped the child's stderr. Callers then dereferenced into `undefined`, so a slow server and a crashed one produced the same `Cannot read properties of undefined (reading 'result')`.

Chasing that turned up something worse than the bad message, which is why this PR is a little larger than the issue implies.

## A crashed server did not fail the run — it hung it

The last two lines of the helper were:

```ts
  child.kill();
  await once(child, 'exit').catch(() => {});
```

That works only while the child is still alive when `kill()` is called. If the server has already died on its own — a bad import, a missing native build, a throw during startup — `exit` has fired and will not fire again, so the `await` never settles. Isolated, without any of graft in the way:

```console
$ node --input-type=module -e "
  import { spawn } from 'node:child_process';
  import { once } from 'node:events';
  const c = spawn(process.execPath, ['-e', 'process.exit(3)']);
  await new Promise(r => setTimeout(r, 300));   // let it die first
  c.kill();
  await once(c, 'exit').catch(() => {});
  console.log('never printed');
"
Warning: Detected unsettled top-level await
```

End to end, with the server replaced by something that writes to stderr and exits 3:

| | result |
| --- | --- |
| before | still running when I killed it at **120s** — not one of the file's five tests had reported anything |
| after | the whole file finishes in **3s**, the failing test reporting in 0.1s |

## After

```
Error: mcp server answered 0 of 3 in 0.1s — it quit first (exit code 3, signal null)
--- its stderr ---
native build missing
    at rpc (test/mcp-server.test.ts:69:11)
```

and, when the server is up but silent (deadline dropped to 100ms to force it):

```
Error: mcp server answered 0 of 3 in 0.1s — it was still running
It wrote nothing to stderr.
```

Those two are now different sentences, which is the whole point of the issue.

## What changed, in one helper

- **Throws instead of returning short.** How many of how many arrived, and how long it waited.
- **Keeps the child's stderr** and puts it in that error. It was already piped; it was just never read. This is the line that turns "the tool list was empty" into "the native build is missing".
- **Waits on a `close` promise created at spawn time**, so it settles whether the child crashed on its own or was killed at the end. This is the hang.
- **Stops waiting when the child quits.** No point sitting out a deadline nothing can arrive before — and it is what makes the crash case 0.1s rather than a full timeout.
- **The deadline goes 15s → 60s, named.** Only reachable now by a server that is up and silent, and the loop leaves the moment the replies are in, so a generous number costs nothing in the passing path. It is also the number that was actually flaking: ~2s of work against 15s sounds like ample headroom and is not, once the suite is running ~30 files in parallel.

`close` rather than `exit` throughout: it fires once stdio is drained, so a server that answers and then quits is not misread as having quit without answering.

## Verified

- `test/mcp-server.test.ts`: 5 of 5 pass, 1.5–3.7s each.
- Full suite: 1221 tests, 1208 pass, 8 fail, 5 skipped — the same 8 that fail on `upstream/main` on this machine, which are #338 (fixed separately in #345) and have nothing to do with this file. (I measured `main` at 1220/1207/8, but at `de8456e`, which is older than this branch's base. The one extra test here is `the brain build worker …`, added by `270edcc` in between. This PR adds no tests.)
- Both failure paths above were produced by temporarily editing the helper locally (deadline to 100ms; spawn target to a crashing one-liner); neither edit is in the diff.

## Environment

Node v24.16.0, Windows 11 x64, on `f9e6539` (0.18.0 plus the brain commits after it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


