### PR TITLE
feat(graph): index Bash scripts with the bundled grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ compiler-grade layer — all `$0` and deterministic (no model, no key):
   call edges via a generic tree-sitter extractor, one grammar per language:
   **Rust, C, C++, C#, Ruby, Scala, Elixir, Solidity,
   OCaml, Zig, Dart, Clojure, Nix, Lua**.
+  **Bash** (`.sh`, `.bash`) also uses this tier for function symbols;
+  Bash call edges and extensionless shell scripts are not yet supported.
 
 - **Compiler-grade edges (opt-in)** — `graft build --lsp` adds precise
   `lsp_resolved` call edges (member calls the static pass can't type) when a
@@ -219,7 +221,7 @@ compiler-grade layer — all `$0` and deterministic (no model, no key):
   **gopls** (Go), **pyright** (Python), **typescript-language-server** (TS/JS).
   It's best-effort — with no server installed the graph is unchanged.
 
-Twenty-three languages in total. A file whose language isn't listed is skipped, not
+Twenty-four languages in total. A file whose language isn't listed is skipped, not
 indexed. Adding a broad-tier language is a small contribution — see
 [CREDITS.md](CREDITS.md) for the folks who added the current set.
 

--- a/src/graph/generic.ts
+++ b/src/graph/generic.ts
@@ -58,6 +58,7 @@ export const GENERIC_LANGS: readonly GenericLang[] = [
   { name: "clojure", exts: [".clj", ".cljs", ".cljc", ".bb"], wasm: "clojure" },
   { name: "nix", exts: [".nix"], wasm: "nix" },
   { name: "lua", exts: [".lua"], wasm: "lua" },
+  { name: "bash", exts: [".sh", ".bash"], wasm: "bash" },
 ];
 
 const byExt = new Map<string, GenericLang>();

--- a/test/graph-bash.test.ts
+++ b/test/graph-bash.test.ts
@@ -1,0 +1,60 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildGraph } from "../src/graph/build.js";
+import { checkGraph } from "../src/graph/check.js";
+import { extractGeneric, genericLangOf, isWarm, warmGenericGrammars } from "../src/graph/generic.js";
+import { unsupportedExtensions } from "../src/graph/source-files.js";
+import { readGraph, wiringPath } from "../src/graph/write.js";
+
+const BASH = `#!/usr/bin/env bash
+greet() {
+  printf '%s\\n' "hello"
+}
+
+function main {
+  greet
+}
+`;
+
+test("Bash extensions load the bundled grammar and extract both function syntaxes", async () => {
+  for (const file of ["setup.sh", "library.bash", "SETUP.SH"]) {
+    assert.equal(genericLangOf(file)?.name, "bash");
+  }
+  assert.deepEqual(unsupportedExtensions([".sh", ".bash", "SH"]), []);
+  await warmGenericGrammars(["bash"]);
+  assert.ok(isWarm("bash"), "the bundled Bash grammar loads");
+  const { nodes } = extractGeneric("setup.sh", BASH, "bash");
+  assert.deepEqual(
+    nodes.filter((node) => node.kind !== "file").map((node) => [node.name, node.kind, node.span]),
+    [["greet", "function", "L2-L4"], ["main", "function", "L6-L8"]],
+  );
+});
+
+test("buildGraph indexes Bash files and checkGraph reports them in sync", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-bash-"));
+  try {
+    writeFileSync(join(dir, "setup.sh"), BASH);
+    writeFileSync(join(dir, "library.bash"), "helper() { echo ok; }\n");
+    writeFileSync(join(dir, "extensionless"), BASH);
+
+    const result = await buildGraph(dir, { reuse: false });
+    assert.deepEqual(result.languages, ["bash"]);
+    assert.deepEqual(result.errors, []);
+    const graph = readGraph(wiringPath(result.contextDir));
+    assert.ok(graph);
+    assert.deepEqual(
+      graph.nodes.filter((node) => node.kind === "file").map((node) => node.path).sort(),
+      ["library.bash", "setup.sh"],
+    );
+    assert.deepEqual(
+      graph.nodes.filter((node) => node.kind === "function").map((node) => node.name).sort(),
+      ["greet", "helper", "main"],
+    );
+    assert.equal((await checkGraph(dir)).ok, true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #353.

Bash's WASM grammar already ships with Graft, but the generic language registry does not include it. As a result, shell scripts are skipped during graph builds.

This registers Bash for `.sh` and `.bash`, allowing the existing generic extractor to index function symbols without adding a dependency. It also documents the supported scope and adds regression coverage for grammar loading, extension validation, both Bash function declaration forms, graph construction, and the graph sync check.

Validation on Node 24.19.0:
- Both new regression tests fail before the registry change and pass after it.
- 33 tests pass across `graph-bash`, `generic-extract`, `graph-languages`, `graph-cross-language`, and the Node 24 WASM regression suite.
- All build stages pass: the main and viewer TypeScript builds, followed by `scripts/build-viewer.mjs`.
- A compiled CLI smoke test indexes two Bash files and three functions without an unsupported-parser warning.

This covers extension-based function indexing. Bash call edges and extensionless shebang detection remain outside this change.