### PR TITLE
feat(graph): index GLSL files in the breadth tier (#293)

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ compiler-grade layer — all `$0` and deterministic (no model, no key):
 - **Broad** — symbols (functions, classes, methods, types, …) plus name-resolved
   call edges via a generic tree-sitter extractor, one grammar per language:
   **Rust, C, C++, C#, Ruby, Scala, Elixir, Solidity,
-  OCaml, Zig, Dart, Clojure, Nix, Lua**.
+  OCaml, Zig, Dart, Clojure, Nix, Lua, GLSL**.
 
 - **Compiler-grade edges (opt-in)** — `graft build --lsp` adds precise
   `lsp_resolved` call edges (member calls the static pass can't type) when a
@@ -219,7 +219,7 @@ compiler-grade layer — all `$0` and deterministic (no model, no key):
   **gopls** (Go), **pyright** (Python), **typescript-language-server** (TS/JS).
   It's best-effort — with no server installed the graph is unchanged.
 
-Twenty-three languages in total. A file whose language isn't listed is skipped, not
+Twenty-four languages in total. A file whose language isn't listed is skipped, not
 indexed. Adding a broad-tier language is a small contribution — see
 [CREDITS.md](CREDITS.md) for the folks who added the current set.
 

--- a/src/graph/generic.ts
+++ b/src/graph/generic.ts
@@ -58,7 +58,8 @@ export const GENERIC_LANGS: readonly GenericLang[] = [
   { name: "clojure", exts: [".clj", ".cljs", ".cljc", ".bb"], wasm: "clojure" },
   { name: "nix", exts: [".nix"], wasm: "nix" },
   { name: "lua", exts: [".lua"], wasm: "lua" },
-];
+  { name: "glsl", exts: [".glsl"], wasm: "glsl" }, // #293; gdscript is #299
+]
 
 const byExt = new Map<string, GenericLang>();
 for (const l of GENERIC_LANGS) for (const e of l.exts) byExt.set(e, l);

--- a/test/generic-extract.test.ts
+++ b/test/generic-extract.test.ts
@@ -348,6 +348,53 @@ test("Dart file-level skeleton lists the API, not function-body locals (#134)", 
   );
 });
 
+// #293 remainder: .glsl is in tree-sitter-wasm; no tags.scm, so the walker
+// fallback must still mint struct/function symbols so skeleton is not empty.
+// .gd is #299 — do not register gdscript here.
+const GLSL = `struct Probe {
+  vec3 origin;
+  float radius;
+};
+
+float march(vec3 p) {
+  return length(p);
+}
+
+void main() {
+  float d = march(vec3(0.0));
+}
+`;
+
+test("genericLangOf routes .glsl to the breadth tier (#293)", () => {
+  assert.equal(genericLangOf("shaders/cell.glsl")?.name, "glsl");
+});
+
+test("GLSL struct and functions become symbols without a tags query (#293)", async () => {
+  await warmGenericGrammars(["glsl"]);
+  assert.ok(isWarm("glsl"), "glsl grammar should warm");
+  const { nodes, rawEdges } = extractGeneric("shaders/cell.glsl", GLSL, "glsl");
+  const symbols = nodes.filter((n) => n.kind !== "file");
+  const byName = new Map(symbols.map((n) => [n.name, n]));
+
+  assert.equal(byName.get("Probe")?.kind, "struct", "Probe is a struct");
+  assert.equal(byName.get("march")?.kind, "function", "march is a function");
+  assert.equal(byName.get("main")?.kind, "function", "main is a function");
+  assert.equal(rawEdges.length, 0, "no tags.scm → symbols only, no call edges");
+});
+
+test("GLSL file-level skeleton lists the shader API (#293)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "graft-glsl-"));
+  mkdirSync(join(dir, "shaders"));
+  writeFileSync(join(dir, "shaders", "cell.glsl"), GLSL);
+
+  await buildGraph(dir, { reuse: false });
+  const r = skeleton(dir, "shaders/cell.glsl");
+  const names = r.entries.map((e) => e.name);
+  for (const want of ["Probe", "march", "main"]) {
+    assert.ok(names.includes(want), `skeleton includes ${want} (got ${names.join(", ")})`);
+  }
+});
+
 // #139: tree-sitter-wasm 1.1.4's PHP grammar throws `memory access out of bounds`
 // on heredoc/nowdoc, and extractGeneric swallows that into a file-only result.
 // PHP is depth-tier now (.php is not claimed by the breadth registry), so this

--- a/test/supported-extensions.test.ts
+++ b/test/supported-extensions.test.ts
@@ -18,7 +18,7 @@ test("supportedExtensions covers both tiers, sorted and de-duped", () => {
   // depth tier
   for (const e of [".ts", ".tsx", ".py", ".go", ".java", ".js", ".php", ".kt", ".kts", ".swift"]) assert.ok(exts.includes(e), `depth ${e}`);
   // breadth tier
-  for (const e of [".rs", ".rb", ".c", ".cpp"]) assert.ok(exts.includes(e), `breadth ${e}`);
+  for (const e of [".rs", ".rb", ".c", ".cpp", ".glsl"]) assert.ok(exts.includes(e), `breadth ${e}`);
   // container tier
   assert.ok(exts.includes(".vue"), "container .vue");
   // de-duped (.java is in BOTH tiers but must appear once) and sorted


### PR DESCRIPTION
## Summary
- `tree-sitter-wasm@1.1.6` already ships a `glsl` grammar. `.glsl` files were skipped because nothing in `GENERIC_LANGS` claimed the extension, so `graft skeleton` reported no definitions (#293).
- One registry row. No tags query: the walker fallback mints struct/function symbols. No call edges, no Godot `res://` imports, no GDScript (that is #299).
- Does not close #293 by itself — `.gd` remains #299.

## Test plan
- [x] `genericLangOf` routes `.glsl`
- [x] Fixture shader: `Probe` / `march` / `main` symbols; skeleton lists them
- [x] `node --import tsx --test test/generic-extract.test.ts test/supported-extensions.test.ts`

Made with [Cursor](https://cursor.com)