### PR TITLE
Add Pi extension package support

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "context",
     "codebase",
     "llm",
-    "graft"
+    "graft",
+    "pi-package"
   ],
   "license": "MIT",
   "repository": {
@@ -101,5 +102,10 @@
     "tree-sitter-swift": {
       "tree-sitter": "$tree-sitter"
     }
+  },
+  "pi": {
+    "extensions": [
+      "./dist/pi/extension.js"
+    ]
   }
 }

--- a/src/pi/extension.ts
+++ b/src/pi/extension.ts
@@ -1,0 +1,106 @@
+import { mainWorktreeRoot } from '../graph/seed.js';
+import { hasGraftIndex } from '../graph/root.js';
+import { callTool, TOOLS } from '../mcp/tools.js';
+
+interface PiToolResult {
+  content: Array<{ type: 'text'; text: string }>;
+  details?: unknown;
+}
+
+interface MinimalPiContext {
+  cwd: string;
+  signal?: AbortSignal;
+  ui: { notify(message: string, level?: 'info' | 'warning' | 'error'): void };
+}
+
+interface MinimalPi {
+  registerTool(tool: {
+    name: string;
+    label?: string;
+    description: string;
+    parameters: object;
+    execute(toolCallId: string, params: Record<string, unknown>, signal?: AbortSignal, onUpdate?: unknown, ctx?: MinimalPiContext): Promise<PiToolResult>;
+  }): void;
+  registerCommand(name: string, command: { description: string; handler(args: string, ctx: MinimalPiContext): Promise<void> | void }): void;
+  on(event: 'before_agent_start', handler: (event: unknown, ctx: MinimalPiContext) => Promise<unknown> | unknown): void;
+  exec?(command: string, args: string[], options?: { signal?: AbortSignal; timeout?: number }): Promise<{ stdout?: string; stderr?: string; code?: number }>;
+}
+
+function labelFor(name: string): string {
+  return name
+    .split('_')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function graphAvailable(cwd: string): boolean {
+  if (hasGraftIndex(cwd)) return true;
+  const main = mainWorktreeRoot(cwd);
+  return !!main && hasGraftIndex(main);
+}
+
+function graftGuidance(): string {
+  return [
+    '[GRAFT CONTEXT]',
+    'This repo has a Graft graph. For code orientation, locating behavior, tracing callers, finding usages, or scoping refactors, use graft_find_code, graft_find_all, graft_file_api, graft_trace_calls, or graft_repo_map before raw grep/read exploration.',
+    'Use graft_check_freshness when the user asks whether the graph is stale.',
+  ].join('\n');
+}
+
+function textOf(result: { stdout?: string; stderr?: string; code?: number }): string {
+  const stdout = result.stdout?.trimEnd() ?? '';
+  const stderr = result.stderr?.trimEnd() ?? '';
+  if (stdout && stderr) return `${stdout}\n\n[stderr]\n${stderr}`;
+  return stdout || stderr || `graft exited with code ${result.code ?? 'unknown'}`;
+}
+
+export default function graftPiExtension(pi: MinimalPi): void {
+  for (const tool of TOOLS) {
+    pi.registerTool({
+      name: tool.name,
+      label: labelFor(tool.name),
+      description: tool.description,
+      parameters: tool.inputSchema,
+      async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+        const cwd = ctx?.cwd ?? process.cwd();
+        const result = await callTool(cwd, tool.name, params ?? {});
+        if (result.isError) throw new Error(result.text);
+        return {
+          content: [{ type: 'text', text: result.text }],
+          details: { tool: tool.name },
+        };
+      },
+    });
+  }
+
+  pi.registerCommand('graft', {
+    description: 'Show Graft graph status for the current repo',
+    handler: async (_args, ctx) => {
+      const result = await callTool(ctx.cwd, 'graft_check_freshness', {});
+      ctx.ui.notify(result.text, result.isError ? 'error' : 'info');
+    },
+  });
+
+  pi.registerCommand('graft-init-dry-run', {
+    description: 'Preview what `graft init` would write in this repo',
+    handler: async (_args, ctx) => {
+      if (!pi.exec) {
+        ctx.ui.notify('This Pi host does not expose command execution to extensions. Run `graft init --dry-run` in a terminal.', 'warning');
+        return;
+      }
+      const result = await pi.exec('graft', ['init', '--dry-run'], { signal: ctx.signal, timeout: 120000 });
+      ctx.ui.notify(textOf(result), result.code === 0 ? 'info' : 'warning');
+    },
+  });
+
+  pi.on('before_agent_start', async (_event, ctx) => {
+    if (!graphAvailable(ctx.cwd)) return undefined;
+    return {
+      message: {
+        customType: 'graft-context',
+        content: graftGuidance(),
+        display: false,
+      },
+    };
+  });
+}

--- a/test/pi-extension.test.ts
+++ b/test/pi-extension.test.ts
@@ -1,0 +1,76 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import graftPiExtension from '../src/pi/extension.js';
+
+interface RegisteredTool {
+  name: string;
+  parameters: object;
+  execute(toolCallId: string, params: Record<string, unknown>, signal?: AbortSignal, onUpdate?: unknown, ctx?: { cwd: string; ui: { notify(message: string, level?: string): void } }): Promise<{ content: Array<{ type: 'text'; text: string }> }>;
+}
+
+function builtRepo(): string {
+  const d = mkdtempSync(join(tmpdir(), 'graft-pi-extension-'));
+  mkdirSync(join(d, 'src'), { recursive: true });
+  writeFileSync(join(d, 'src', 'math.ts'), 'export function add(a: number, b: number): number {\n  return a + b;\n}\n');
+  execFileSync(process.execPath, ['--import', 'tsx', 'src/cli.ts', 'build', d], { stdio: 'pipe' });
+  return d;
+}
+
+function loadExtension() {
+  const tools = new Map<string, RegisteredTool>();
+  const commands = new Map<string, { description: string; handler(args: string, ctx: any): Promise<void> | void }>();
+  const handlers = new Map<string, (event: unknown, ctx: any) => Promise<unknown> | unknown>();
+  graftPiExtension({
+    registerTool(tool: RegisteredTool) {
+      tools.set(tool.name, tool);
+    },
+    registerCommand(name: string, command: { description: string; handler(args: string, ctx: any): Promise<void> | void }) {
+      commands.set(name, command);
+    },
+    on(event: 'before_agent_start', handler: (event: unknown, ctx: any) => Promise<unknown> | unknown) {
+      handlers.set(event, handler);
+    },
+  });
+  return { tools, commands, handlers };
+}
+
+test('Pi extension registers Graft tools and commands', () => {
+  const { tools, commands, handlers } = loadExtension();
+  assert.deepEqual([...tools.keys()], [
+    'graft_find_code',
+    'graft_file_api',
+    'graft_check_freshness',
+    'graft_trace_calls',
+    'graft_find_all',
+    'graft_repo_map',
+  ]);
+  assert.ok(commands.has('graft'));
+  assert.ok(commands.has('graft-init-dry-run'));
+  assert.ok(handlers.has('before_agent_start'));
+});
+
+test('Pi extension tools dispatch through the Graft engine', async () => {
+  const repo = builtRepo();
+  const { tools } = loadExtension();
+  const result = await tools.get('graft_repo_map')!.execute('tool-call', { max_dirs: 2 }, undefined, undefined, {
+    cwd: repo,
+    ui: { notify() {} },
+  });
+  assert.match(result.content[0].text, /repo map/);
+  assert.match(result.content[0].text, /src\//);
+});
+
+test('Pi extension injects guidance only when a graph is available', async () => {
+  const repo = builtRepo();
+  const empty = mkdtempSync(join(tmpdir(), 'graft-pi-extension-empty-'));
+  const { handlers } = loadExtension();
+  const handler = handlers.get('before_agent_start')!;
+
+  assert.equal(await handler({}, { cwd: empty }), undefined);
+  const injected = await handler({}, { cwd: repo });
+  assert.match(JSON.stringify(injected), /GRAFT CONTEXT/);
+});


### PR DESCRIPTION
## Summary
- add a Pi package manifest that exposes Graft as a Pi extension
- register the existing Graft graph tools directly from the package
- inject graph guidance when a repo has a local or parent-worktree Graft graph
- add extension registration and dispatch tests

## Tests
- npm run build
- npm test