### PR TITLE
feat(ansible): a fourth tier for YAML whose meaning is in its key names

### DIFF
--- a/src/graph/ansible.ts
+++ b/src/graph/ansible.ts
@@ -1,0 +1,617 @@
+/**
+ * Ansible tier — YAML whose meaning is in its KEY NAMES, not its syntax.
+ *
+ * Ansible is the case none of the other three tiers can reach. The depth tier
+ * (extract.ts) and the breadth tier (generic.ts) both ask a grammar "what
+ * definitions does this syntax declare?", and YAML's answer is always the same:
+ * mappings and sequences. A `tags.scm` over tree-sitter-yaml would capture every
+ * key in every YAML file in the repo — Kubernetes manifests, CI workflows, lock
+ * files — and call them definitions, which is worse than not indexing at all.
+ * The container tier (container.ts) does not apply either: there is no embedded
+ * language to hand off, the YAML *is* the program.
+ *
+ * So this tier uses the grammar only as a reader (key/value pairs and their
+ * exact lines) and puts the semantics here, in code: a mapping with `hosts:` is
+ * a play, a sequence item with a module key is a task, `notify:` names a
+ * handler, `include_tasks:` names a file. That is the layer that makes an
+ * Ansible repo navigable, and it is not recoverable from the syntax tree.
+ *
+ * **Detection is the whole risk here.** `.yml` is the most overloaded extension
+ * in a modern repo; claiming it wrongly would flood the graph with nodes for
+ * things that are not Ansible and quietly inflate every coverage number graft
+ * reports. The rule is deliberately narrow, and its load-bearing half is
+ * structural: a *sequence* at the document root whose items are Ansible-shaped
+ * mappings. Kubernetes manifests, Compose files, and GitHub workflows are all
+ * mapping-rooted, so they cannot reach the accept path at all. The one
+ * mapping-rooted Ansible shape — a vars file — is admitted only from a path that
+ * Ansible itself gives meaning to (`group_vars/`, a role's `defaults/`, ...).
+ * A file that fails detection produces ZERO nodes, not an empty file node, so a
+ * repo of non-Ansible YAML is indistinguishable from one graft never walked.
+ *
+ * What it emits:
+ *   - `file`     one per Ansible file
+ *   - `module`   a role, minted at `roles/<name>/tasks/main.yml`
+ *   - `class`    a play (`- hosts: web`)
+ *   - `function` a task or a handler
+ *   - `variable` a var from a vars/defaults file, a `vars:` block, or `set_fact`
+ * wired by `contains`, plus the two edges that make it a graph rather than an
+ * outline: `imports` for `include_tasks`/`import_tasks` (resolved to the file)
+ * and `calls` for `include_role`/`import_role`/`roles:` (to the role module) and
+ * `notify:`/`listen:` (to the handler).
+ *
+ * Variable *references* (`{{ foo }}`) are deliberately NOT edges. resolve.ts
+ * only resolves a bare-name `references` edge for generic-origin nodes, so every
+ * one emitted here would be built and then dropped; and a name-only match across
+ * a repo-wide var namespace is exactly the guess that was measured to halve call
+ * precision elsewhere in this codebase. Definitions are indexed; uses are grep.
+ */
+import { contentHash } from "../util/id.js";
+import { loadWasmLanguage, parseWasm, type TsNode } from "./generic.js";
+import type { ExtractResult, RawEdge } from "./extract.js";
+import type { Kind, NodeV1 } from "./types.js";
+
+/** Extensions this tier claims. Must not collide with the depth/breadth tiers. */
+const EXTS = [".yml", ".yaml"] as const;
+
+export function ansibleExtensions(): string[] {
+  return [...EXTS];
+}
+
+/** True if the path *could* be Ansible. Content still decides — this only avoids
+ * reading and parsing files no extension check could ever admit. */
+export function ansibleClaims(path: string): boolean {
+  const p = path.toLowerCase();
+  return EXTS.some((e) => p.endsWith(e));
+}
+
+let grammar: unknown | null = null;
+let warmed = false;
+
+/** Warm the YAML grammar. Same contract as `warmGenericGrammars`: await once
+ * before the synchronous parse loop; an unavailable grammar is skipped rather
+ * than fatal (Ansible files then extract to nothing, as if the tier were off). */
+export async function warmAnsibleGrammar(): Promise<void> {
+  if (warmed) return;
+  warmed = true;
+  grammar = await loadWasmLanguage("yaml");
+}
+
+export function isAnsibleWarm(): boolean {
+  return grammar !== null;
+}
+
+/** Swap the grammar out in tests (mirrors generic.ts's `swapGrammarForTest`). */
+export function swapAnsibleGrammarForTest(g: unknown | null): unknown | null {
+  const prior = grammar;
+  grammar = g;
+  warmed = true;
+  return prior;
+}
+
+// ---------------------------------------------------------------------------
+// CST helpers. tree-sitter-yaml shape:
+//   stream > document > block_node > block_mapping   > block_mapping_pair(key,value)
+//   stream > document > block_node > block_sequence  > block_sequence_item > block_node
+// Scalars are `flow_node`; nested structures are `block_node`.
+// ---------------------------------------------------------------------------
+
+function named(n: TsNode): TsNode[] {
+  const out: TsNode[] = [];
+  for (let i = 0; i < (n.namedChildCount ?? 0); i++) {
+    const c = n.namedChild?.(i);
+    if (c) out.push(c);
+  }
+  return out;
+}
+
+/** Nodes that carry no meaning of their own and only wrap the real value. */
+const WRAPPERS = new Set(["document", "block_node", "flow_node"]);
+
+/** Named children minus the ones that carry no value. `comment` is a NAMED node
+ * in tree-sitter-yaml and sits as a sibling of the content it precedes, so a
+ * commented playbook's `document` has thirteen comment children before its
+ * `block_node` — an unwrap that took the first named child would take a comment
+ * and conclude the file was not a sequence. */
+function content(n: TsNode): TsNode[] {
+  return named(n).filter((c) => c.type !== "comment");
+}
+
+/**
+ * Strip wrapper nodes to reach the value a node actually holds.
+ *
+ * This walks DOWN THROUGH WRAPPERS ONLY — it must never search the subtree. An
+ * earlier version used a recursive first-descendant-of-type search, and it read
+ * every mapping-rooted data file in the repo as a sequence: `aggregates:\n  -
+ * name: san-hosts` is a MAPPING whose value happens to contain a sequence, and a
+ * recursive search finds that inner sequence and hands it back as if it were the
+ * document root. Eight declarative config files were misdetected as Ansible task
+ * files that way. Structure at *this* level is the entire detection signal, so
+ * the unwrap has to preserve it.
+ */
+function unwrap(n: TsNode | null): TsNode | null {
+  let cur = n;
+  while (cur && WRAPPERS.has(cur.type)) {
+    const kids = content(cur);
+    if (kids.length !== 1) return kids.length ? kids[0] : null;
+    cur = kids[0];
+  }
+  return cur;
+}
+
+const MAPPING = new Set(["block_mapping", "flow_mapping"]);
+const SEQUENCE = new Set(["block_sequence", "flow_sequence"]);
+
+/** The mapping this node directly holds, or null if it holds something else. */
+function asMapping(n: TsNode | null): TsNode | null {
+  const u = unwrap(n);
+  return u && MAPPING.has(u.type) ? u : null;
+}
+
+/** The sequence this node directly holds, or null if it holds something else. */
+function asSequence(n: TsNode | null): TsNode | null {
+  const u = unwrap(n);
+  return u && SEQUENCE.has(u.type) ? u : null;
+}
+
+/** key → value nodes of a mapping, in source order. Duplicate keys keep the first
+ * (Ansible itself warns on them; picking one is better than emitting two nodes). */
+function pairs(mapping: TsNode): Array<{ key: string; value: TsNode | null; pair: TsNode }> {
+  const out: Array<{ key: string; value: TsNode | null; pair: TsNode }> = [];
+  const seen = new Set<string>();
+  for (const c of content(mapping)) {
+    if (c.type !== "block_mapping_pair" && c.type !== "flow_pair") continue;
+    const k = c.childForFieldName?.("key");
+    if (!k) continue;
+    const key = scalar(k);
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    out.push({ key, value: c.childForFieldName?.("value") ?? null, pair: c });
+  }
+  return out;
+}
+
+function keysOf(mapping: TsNode): Set<string> {
+  return new Set(pairs(mapping).map((p) => p.key));
+}
+
+function get(mapping: TsNode, key: string): TsNode | null {
+  return pairs(mapping).find((p) => p.key === key)?.value ?? null;
+}
+
+/** A scalar's text with surrounding quotes and whitespace removed. */
+function scalar(n: TsNode | null): string {
+  if (!n) return "";
+  const t = n.text.trim();
+  if (t.length >= 2 && ((t[0] === '"' && t.endsWith('"')) || (t[0] === "'" && t.endsWith("'")))) {
+    return t.slice(1, -1).trim();
+  }
+  return t;
+}
+
+/** The items of a sequence node, each unwrapped past `block_sequence_item`. */
+function items(seq: TsNode): TsNode[] {
+  const out: TsNode[] = [];
+  for (const c of content(seq)) {
+    if (c.type === "block_sequence_item") {
+      const inner = content(c)[0];
+      if (inner) out.push(inner);
+    } else {
+      out.push(c);
+    }
+  }
+  return out;
+}
+
+/** A scalar-or-sequence-of-scalars value read as a list of strings. `notify:` and
+ * `roles:` are both spelled either way in real playbooks. */
+function stringList(v: TsNode | null): string[] {
+  if (!v) return [];
+  const seq = asSequence(v);
+  if (seq) {
+    return items(seq)
+      .map((i) => {
+        // `- role: common` / `- name: common` (a role entry with params)
+        const m = asMapping(i);
+        if (m) return scalar(get(m, "role") ?? get(m, "name"));
+        return scalar(i);
+      })
+      .filter(Boolean);
+  }
+  const s = scalar(v);
+  return s ? [s] : [];
+}
+
+// ---------------------------------------------------------------------------
+// Detection
+// ---------------------------------------------------------------------------
+
+/** Keys that only a play has. */
+const PLAY_KEYS = new Set(["hosts", "import_playbook", "ansible.builtin.import_playbook"]);
+
+/** Keys that mark a mapping as a task. Directives (always spelled bare) plus the
+ * include/import family — NOT a general module list, which would never be
+ * complete and would drift with every collection release. A task without any of
+ * these but with a `name:` is caught by the module-key heuristic below. */
+const TASK_DIRECTIVES = new Set([
+  "block", "rescue", "always",
+  "include_tasks", "import_tasks", "include_role", "import_role", "include_vars", "include",
+  "when", "register", "notify", "listen", "loop", "with_items", "with_dict", "with_fileglob",
+  "with_nested", "with_subelements", "with_together", "with_sequence", "until", "retries",
+  "delay", "become", "become_user", "delegate_to", "run_once", "changed_when", "failed_when",
+  "ignore_errors", "no_log", "check_mode", "environment", "args", "action", "local_action",
+  "set_fact", "tags", "vars", "loop_control", "any_errors_fatal", "throttle",
+  "remote_user", "connection", "collections", "module_defaults", "diff", "async", "poll",
+  "timeout", "debugger", "port", "become_method", "become_flags", "failed_when_result",
+]);
+
+/** `name:` is a task's label, never its module. It is excluded from the module
+ * scan separately from the directive list because the two uses differ: a
+ * directive disqualifies a mapping from *needing* a module to be a task, whereas
+ * `name` is the very thing that makes the module scan necessary. Leaving it in
+ * TASK_DIRECTIVES would make every `- name: x` mapping in any YAML file a task. */
+const NOT_A_MODULE = new Set(["name"]);
+
+/**
+ * Bare (non-FQCN) module names that may stand alone as evidence of a task.
+ *
+ * A bare lowercase key cannot be accepted on its own shape: `- name: alice` +
+ * `description: an admin` is a roster entry, not a task, and "any lowercase
+ * identifier is a module" reads it as one. Since Ansible has no `description`
+ * module, the discriminator is the module NAME — so bare keys are matched
+ * against this list, while a fully-qualified key (`community.general.ufw`) is
+ * accepted structurally because the FQCN shape is itself unambiguous.
+ *
+ * ansible.builtin plus the collection modules common enough to be written bare
+ * in the wild. The consequence of the list being incomplete is a false NEGATIVE
+ * — a task spelled with an uncommon bare module and no directive is not indexed
+ * — which is the right way round: the FQCN spelling (recommended since 2.10)
+ * and any directive (`when`, `become`, `register`, ...) both still work, and a
+ * missed task costs coverage while a false accept costs trust in every count
+ * graft prints.
+ */
+const BARE_MODULES = new Set([
+  // ansible.builtin
+  "add_host", "apt", "apt_key", "apt_repository", "assemble", "assert", "async_status",
+  "blockinfile", "command", "copy", "cron", "debconf", "debug", "dnf", "dpkg_selections",
+  "expect", "fail", "fetch", "file", "find", "gather_facts", "get_url", "getent", "git",
+  "group", "group_by", "hostname", "iptables", "known_hosts", "lineinfile", "meta", "mount",
+  "package", "package_facts", "pause", "ping", "pip", "raw", "reboot", "replace", "rpm_key",
+  "script", "service", "service_facts", "set_stats", "setup", "shell", "slurp", "stat",
+  "subversion", "systemd", "systemd_service", "sysvinit", "tempfile", "template", "unarchive",
+  "uri", "user", "validate_argument_spec", "wait_for", "wait_for_connection", "yum",
+  "yum_repository",
+  // commonly written bare from collections
+  "acl", "alternatives", "archive", "authorized_key", "docker_container", "docker_image",
+  "docker_network", "docker_volume", "filesystem", "firewalld", "htpasswd", "ini_file",
+  "k8s", "locale_gen", "lvg", "lvol", "make", "modprobe", "mysql_db", "mysql_user", "npm",
+  "openssl_certificate", "pam_limits", "parted", "postgresql_db", "postgresql_user", "seboolean",
+  "sefcontext", "selinux", "snap", "sysctl", "timezone", "ufw", "x509_certificate", "xml",
+]);
+
+/** A key that invokes a module: an FQCN (`ansible.builtin.apt`), whose shape is
+ * unambiguous on its own, or a bare name from {@link BARE_MODULES}. */
+function looksLikeModuleKey(key: string): boolean {
+  if (TASK_DIRECTIVES.has(key) || PLAY_KEYS.has(key) || NOT_A_MODULE.has(key)) return false;
+  if (/^[a-z0-9_]+(\.[a-z0-9_]+){2,}$/.test(key)) return true; // FQCN
+  return BARE_MODULES.has(key);
+}
+
+function isTaskMapping(m: TsNode): boolean {
+  const keys = keysOf(m);
+  for (const k of keys) if (TASK_DIRECTIVES.has(k)) return true;
+  // `- name: x` + a module key. `name` alone is not enough: a list of named
+  // things is the single most common shape in all of YAML.
+  if (keys.has("name")) {
+    for (const k of keys) if (looksLikeModuleKey(k)) return true;
+  }
+  return false;
+}
+
+function isPlayMapping(m: TsNode): boolean {
+  const keys = keysOf(m);
+  for (const k of keys) if (PLAY_KEYS.has(k)) return true;
+  return false;
+}
+
+/** Path shapes Ansible itself assigns meaning to. Anchored on a path SEGMENT so
+ * `my_group_vars/` cannot match. */
+const RE_ROLE_TASKS_MAIN = /(^|\/)roles\/([^/]+)\/tasks\/main\.ya?ml$/;
+const RE_VARS_FILE = /(^|\/)(group_vars|host_vars)\//;
+const RE_ROLE_VARS = /(^|\/)roles\/[^/]+\/(defaults|vars)\//;
+const RE_ROLE_META = /(^|\/)roles\/[^/]+\/meta\/main\.ya?ml$/;
+const RE_ROLE_HANDLERS = /(^|\/)roles\/[^/]+\/handlers\//;
+
+/** Cheap textual veto for formats that are definitely not Ansible, so a large
+ * manifest tree is rejected before the parse. Each pattern is anchored at column
+ * zero: a nested `kind:` inside an Ansible task is not a Kubernetes manifest. */
+function vetoed(source: string): boolean {
+  const head = source.slice(0, 4000);
+  if (/^apiVersion:/m.test(head) && /^kind:/m.test(head)) return true; // Kubernetes
+  if (/^on:/m.test(head) && /^jobs:/m.test(head)) return true; // GitHub Actions
+  if (/^services:/m.test(head) && /^(version|networks|volumes):/m.test(head)) return true; // Compose
+  return false;
+}
+
+export type AnsibleShape = "playbook" | "tasks" | "handlers" | "vars" | "meta";
+
+/** What kind of Ansible file this is, or null if it is not Ansible at all. */
+export function ansibleShape(rel: string, root: TsNode, source: string): AnsibleShape | null {
+  if (vetoed(source)) return null;
+
+  // Structural path: a document whose root is a SEQUENCE of Ansible-shaped
+  // mappings. This is the only way a playbook or tasks file can be spelled, and
+  // no mapping-rooted format can reach it.
+  for (const doc of content(root)) {
+    if (doc.type !== "document") continue;
+    const seq = asSequence(doc);
+    if (seq) {
+      const mappings = items(seq)
+        .map((i) => asMapping(i))
+        .filter((m): m is TsNode => m !== null);
+      if (mappings.length === 0) continue;
+      if (mappings.some(isPlayMapping)) return "playbook";
+      if (mappings.some(isTaskMapping)) {
+        return RE_ROLE_HANDLERS.test(rel) ? "handlers" : "tasks";
+      }
+      continue;
+    }
+    // Mapping-rooted: only admitted from a path Ansible gives meaning to.
+    const map = asMapping(doc);
+    if (!map) continue;
+    if (RE_ROLE_META.test(rel)) return "meta";
+    if (RE_VARS_FILE.test(rel) || RE_ROLE_VARS.test(rel)) return "vars";
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * `L<start>-L<end>`, 1-based, with the trailing-newline row trimmed.
+ *
+ * A YAML block node that runs to the end of its parent swallows the newline that
+ * terminates its last line, so tree-sitter reports `endPosition` as row N+1
+ * column 0 — a line the definition does not occupy, and in a file ending with a
+ * newline, a line that does not exist. Left uncorrected every last-in-parent
+ * play, task and block reads one line too long, which is precisely the
+ * plausible-but-wrong span this tier must not produce.
+ */
+function span(n: TsNode): string {
+  const start = n.startPosition.row;
+  let end = n.endPosition.row;
+  if (n.endPosition.column === 0 && end > start) end -= 1;
+  return `L${start + 1}-L${end + 1}`;
+}
+
+/** Ansible names are free text ("Install the base packages"). They are the only
+ * handle a `notify:` has, so they are kept verbatim as the node name; only the
+ * id is normalised, and only enough to stay a usable id. */
+function idPart(name: string): string {
+  return name.replace(/\s+/g, " ").trim().slice(0, 120);
+}
+
+class Emitter {
+  readonly nodes: NodeV1[] = [];
+  readonly rawEdges: RawEdge[] = [];
+  private minted = new Set<string>();
+
+  constructor(
+    private rel: string,
+    private source: string,
+  ) {
+    this.minted.add(rel);
+    this.nodes.push({
+      id: rel,
+      name: rel.split("/").pop() ?? rel,
+      kind: "file",
+      path: rel,
+      span: `L1-L${Math.max(1, source.split("\n").length)}`,
+      signature: null,
+      exported: true,
+      origin: "ast",
+      body_hash: contentHash(source),
+      chars: Buffer.byteLength(source),
+      summary_state: "pending",
+      summary: null,
+      crux: null,
+    });
+  }
+
+  node(name: string, kind: Kind, n: TsNode, signature: string | null, parent: string): string {
+    const base = `${this.rel}#${idPart(name)}`;
+    let id = base;
+    let k = 2;
+    while (this.minted.has(id)) id = `${base}~${k++}`;
+    this.minted.add(id);
+    const body = this.source.slice(n.startIndex, n.endIndex);
+    this.nodes.push({
+      id,
+      name,
+      kind,
+      path: this.rel,
+      span: span(n),
+      signature,
+      exported: true,
+      origin: "ast",
+      body_hash: contentHash(body),
+      body_text: body.replace(/\s+/g, " ").slice(0, 5000),
+      summary_state: "pending",
+      summary: null,
+      crux: null,
+    });
+    this.rawEdges.push({ source: parent, relation: "contains", targetId: id, file: this.rel });
+    return id;
+  }
+
+  /** A `calls` edge resolved by bare name against `kinds`. */
+  call(source: string, name: string, kinds: Kind[]): void {
+    if (!name || name.includes("{{")) return; // templated target — unknowable statically
+    this.rawEdges.push({ source, relation: "calls", name, kinds, file: this.rel });
+  }
+
+  /** An `imports` edge to another file in the repo, as a file-relative specifier
+   * so resolve.ts's `resolveImport` settles it against the node index. */
+  importPath(source: string, target: string): void {
+    if (!target || target.includes("{{")) return;
+    this.rawEdges.push({ source, relation: "imports", specifier: `./${target}`, file: this.rel });
+  }
+}
+
+/** `include_tasks: setup.yml` names a path relative to the including file (close
+ * enough for both the playbook and the role case, which is why role task files
+ * live beside each other). Strips a leading `./` so the specifier is canonical. */
+function includedPath(v: TsNode | null): string {
+  if (!v) return "";
+  const m = asMapping(v);
+  const raw = m ? scalar(get(m, "file") ?? get(m, "_raw_params")) : scalar(v);
+  return raw.replace(/^\.\//, "");
+}
+
+/** `include_role: {name: common}` / `import_role: {name: common}`. */
+function includedRole(v: TsNode | null): string {
+  if (!v) return "";
+  const m = asMapping(v);
+  return m ? scalar(get(m, "name")) : scalar(v);
+}
+
+/** Emit one task (or handler) and everything it points at. Recurses through
+ * `block:`/`rescue:`/`always:`, which nest tasks arbitrarily deep. */
+function emitTask(e: Emitter, m: TsNode, whole: TsNode, parent: string, kind: Kind): void {
+  const ps = pairs(m);
+  const nameVal = ps.find((p) => p.key === "name")?.value ?? null;
+  const moduleKey = ps.find((p) => looksLikeModuleKey(p.key))?.key ?? null;
+  const name = scalar(nameVal) || moduleKey || "task";
+  const id = e.node(name, kind, whole, moduleKey, parent);
+
+  for (const { key, value } of ps) {
+    switch (key) {
+      case "notify":
+      case "listen":
+        for (const h of stringList(value)) e.call(id, h, ["function"]);
+        break;
+      case "include_tasks":
+      case "import_tasks":
+      case "include":
+        e.importPath(id, includedPath(value));
+        break;
+      case "include_role":
+      case "import_role": {
+        const role = includedRole(value);
+        if (role) e.call(id, role, ["module"]);
+        break;
+      }
+      case "set_fact": {
+        const facts = asMapping(value);
+        if (facts) for (const f of pairs(facts)) e.node(f.key, "variable", f.pair, null, id);
+        break;
+      }
+      case "vars": {
+        const vars = asMapping(value);
+        if (vars) for (const v of pairs(vars)) e.node(v.key, "variable", v.pair, null, id);
+        break;
+      }
+      case "block":
+      case "rescue":
+      case "always": {
+        const seq = asSequence(value);
+        if (seq) {
+          for (const it of items(seq)) {
+            const im = asMapping(it);
+            if (im) emitTask(e, im, it, id, kind);
+          }
+        }
+        break;
+      }
+    }
+  }
+}
+
+function emitTaskList(e: Emitter, v: TsNode | null, parent: string, kind: Kind): void {
+  const seq = asSequence(v);
+  if (!seq) return;
+  for (const it of items(seq)) {
+    const m = asMapping(it);
+    if (m) emitTask(e, m, it, parent, kind);
+  }
+}
+
+/** Extract one Ansible file. Synchronous; needs `warmAnsibleGrammar()` awaited.
+ * Returns zero nodes when the file is not Ansible — see the header note. */
+export function extractAnsible(rel: string, source: string): ExtractResult {
+  const empty: ExtractResult = { nodes: [], rawEdges: [] };
+  if (!grammar) return empty;
+
+  let root: TsNode | null;
+  try {
+    root = parseWasm(grammar, source);
+  } catch (err) {
+    throw new Error(`yaml grammar threw: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  if (!root) return empty;
+
+  const shape = ansibleShape(rel, root, source);
+  if (!shape) return empty;
+
+  const e = new Emitter(rel, source);
+
+  // A role's entry point mints the role itself, so `include_role: name: X` has
+  // something to resolve to. Its tasks hang off the role, not the file — the
+  // same file→class→method shape a class-bearing source file produces.
+  const roleMatch = RE_ROLE_TASKS_MAIN.exec(rel);
+  const roleId = roleMatch
+    ? e.node(roleMatch[2], "module", root, `role ${roleMatch[2]}`, rel)
+    : null;
+  const topParent = roleId ?? rel;
+
+  for (const doc of content(root)) {
+    if (doc.type !== "document") continue;
+
+    if (shape === "vars" || shape === "meta") {
+      const map = asMapping(doc);
+      if (!map) continue;
+      if (shape === "vars") {
+        for (const p of pairs(map)) e.node(p.key, "variable", p.pair, null, rel);
+      } else {
+        // meta/main.yml — `dependencies:` are role→role edges.
+        for (const dep of stringList(get(map, "dependencies"))) e.call(rel, dep, ["module"]);
+      }
+      continue;
+    }
+
+    const seq = asSequence(doc);
+    if (!seq) continue;
+
+    for (const it of items(seq)) {
+      const m = asMapping(it);
+      if (!m) continue;
+
+      if (shape === "playbook" && isPlayMapping(m)) {
+        const hosts = scalar(get(m, "hosts"));
+        const playName = scalar(get(m, "name")) || (hosts ? `play: ${hosts}` : "play");
+        const playId = e.node(playName, "class", it, hosts ? `hosts: ${hosts}` : null, rel);
+
+        // `- import_playbook: other.yml` is a play-shaped include.
+        const ip = get(m, "import_playbook") ?? get(m, "ansible.builtin.import_playbook");
+        if (ip) e.importPath(playId, includedPath(ip));
+
+        for (const role of stringList(get(m, "roles"))) e.call(playId, role, ["module"]);
+        for (const vf of stringList(get(m, "vars_files"))) e.importPath(playId, vf);
+        const vars = asMapping(get(m, "vars"));
+        if (vars) for (const v of pairs(vars)) e.node(v.key, "variable", v.pair, null, playId);
+
+        emitTaskList(e, get(m, "pre_tasks"), playId, "function");
+        emitTaskList(e, get(m, "tasks"), playId, "function");
+        emitTaskList(e, get(m, "post_tasks"), playId, "function");
+        emitTaskList(e, get(m, "handlers"), playId, "function");
+        continue;
+      }
+
+      // A bare tasks/handlers file: every item is a task at the top level.
+      if (isTaskMapping(m)) emitTask(e, m, it, topParent, "function");
+    }
+  }
+
+  return { nodes: e.nodes, rawEdges: e.rawEdges };
+}

--- a/src/graph/build.ts
+++ b/src/graph/build.ts
@@ -19,6 +19,7 @@ import { walkDir } from "../ingest/fs.js";
 import { contextDirFor, ensureGitignored, ensureSearchable } from "../context/node-file.js";
 import { extractFile, languageLabelOf, languageOf, type RawEdge } from "./extract.js";
 import { extractGeneric, genericLangOf, warmGenericGrammars } from "./generic.js";
+import { ansibleClaims, extractAnsible, warmAnsibleGrammar } from "./ansible.js";
 import { containerLangOf, extractContainer, warmContainerGrammars } from "./container.js";
 import { contentHash } from "../util/id.js";
 import { relPosix } from "../util/paths.js";
@@ -201,6 +202,9 @@ export async function buildGraph(
   await warmContainerGrammars(
     new Set(files.map((f) => containerLangOf(f.abs)?.name).filter((n): n is string => !!n)),
   );
+  // Ansible tier: one grammar (yaml) for the whole repo, warmed only if some
+  // file could be Ansible. Same await-before-the-sync-loop contract.
+  if (files.some((f) => ansibleClaims(f.abs))) await warmAnsibleGrammar();
 
   files.forEach((f, i) => {
     const rel = f.rel;
@@ -213,7 +217,10 @@ export async function buildGraph(
     // breadth tier so a future grammar claiming .vue can't shadow it.
     const container = lang ? null : containerLangOf(f.abs);
     const generic = lang || container ? null : genericLangOf(f.abs);
-    const label = languageLabelOf(f.abs) ?? container?.name ?? generic?.name ?? "unknown";
+    // Ansible is last: it claims `.yml`/`.yaml`, which no other tier wants, and
+    // it is the only tier that can decline a file it claimed.
+    const ansible = !lang && !container && !generic && ansibleClaims(f.abs);
+    const label = languageLabelOf(f.abs) ?? container?.name ?? generic?.name ?? (ansible ? "ansible" : "unknown");
     const cached = priorExtract.files[rel];
 
     // Every file is read and hashed, every build — only the *parse* is memoized.
@@ -254,7 +261,10 @@ export async function buildGraph(
       }
       nodes.push(...cached.nodes);
       rawEdges.push(...cached.rawEdges);
-      langs.add(label);
+      // A tier that declined the file contributes no nodes and must not put its
+      // language in the banner — otherwise a repo of Kubernetes YAML would report
+      // `[ansible]` and claim a coverage it does not have.
+      if (cached.nodes.length) langs.add(label);
       return;
     }
 
@@ -264,11 +274,13 @@ export async function buildGraph(
         ? extractFile(rel, source, lang)
         : container
           ? extractContainer(rel, source, container)
-          : extractGeneric(rel, source, generic!.name);
+          : ansible
+            ? extractAnsible(rel, source)
+            : extractGeneric(rel, source, generic!.name);
       nodes.push(...fileNodes);
       rawEdges.push(...fileEdges);
       sources.set(rel, source);
-      langs.add(label);
+      if (fileNodes.length) langs.add(label);
       entries[rel] = { size: f.size, mtimeMs: f.mtimeMs, hash, nodes: fileNodes, rawEdges: fileEdges };
     } catch (err) {
       const message = `${rel}: parse failed — ${err instanceof Error ? err.message : String(err)}`;

--- a/src/graph/check.ts
+++ b/src/graph/check.ts
@@ -22,6 +22,7 @@ import { relPosix } from "../util/paths.js";
 import { contextDirFor } from "../context/node-file.js";
 import { extractFile, languageOf } from "./extract.js";
 import { extractGeneric, genericLangOf, warmGenericGrammars } from "./generic.js";
+import { ansibleClaims, extractAnsible, warmAnsibleGrammar } from "./ansible.js";
 import { containerLangOf, extractContainer, warmContainerGrammars } from "./container.js";
 import { listSourceFiles } from "./build.js";
 import { readGraph, wiringPath } from "./write.js";
@@ -97,15 +98,18 @@ export async function checkGraph(
   await warmContainerGrammars(
     new Set(sourceFiles.map((f) => containerLangOf(f)?.name).filter((n): n is string => !!n)),
   );
+  // Ansible tier: same warmup, same #236 reasoning.
+  if (sourceFiles.some((f) => ansibleClaims(f))) await warmAnsibleGrammar();
   const current = new Map<string, string>(); // id → body_hash
   for (const file of sourceFiles) {
-    // The same three-way branch `buildGraph` uses, in the same order. The two must
+    // The same four-way branch `buildGraph` uses, in the same order. The two must
     // stay in step: a tier the build extracts and the check cannot see reports as
     // `removed` forever, and the `graft build` the check tells you to run can never
     // repair it.
     const lang = languageOf(file);
     const container = lang ? null : containerLangOf(file);
     const generic = lang || container ? null : genericLangOf(file);
+    const ansible = !lang && !container && !generic && ansibleClaims(file);
     let source: string | null;
     try {
       source = readSourceFile(file);
@@ -121,7 +125,9 @@ export async function checkGraph(
           ? extractContainer(rel, source, container)
           : generic
             ? extractGeneric(rel, source, generic.name)
-            : null;
+            : ansible
+              ? extractAnsible(rel, source)
+              : null;
       // No tier claims this file. Spelled out rather than asserted away: the
       // `generic!` that used to stand in this position threw a TypeError on a
       // container-tier file, the catch below swallowed it as a parse failure, and

--- a/src/graph/resolve.ts
+++ b/src/graph/resolve.ts
@@ -17,6 +17,7 @@ import { toPosixPath } from "../util/paths.js";
 import type { EdgeV1, Kind, NodeV1, Relation } from "./types.js";
 import { languageOf, type RawEdge } from "./extract.js";
 import { genericLangOf } from "./generic.js";
+import { ansibleClaims } from "./ansible.js";
 
 const IMPORT_EXTS = [".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs", ".py"];
 /** C/C++ source + header extensions, for resolving `#include` targets. */
@@ -65,7 +66,7 @@ for (const group of FAMILIES) for (const lang of group) FAMILY_OF.set(lang, grou
  * A language of its own is its own family, so the common case needs no entry above.
  */
 function familyOf(path: string): string | null {
-  const lang = languageOf(path) ?? genericLangOf(path)?.name ?? null;
+  const lang = languageOf(path) ?? genericLangOf(path)?.name ?? (ansibleClaims(path) ? "ansible" : null);
   if (!lang) return null;
   return FAMILY_OF.get(lang) ?? lang;
 }

--- a/src/graph/source-files.ts
+++ b/src/graph/source-files.ts
@@ -14,11 +14,12 @@ import { readFollowNestedRepos, readFollowSubmodules, readIncludeDirs } from "..
 import { languageOf, depthExtensions } from "./extract.js";
 import { genericLangOf, genericExtensions } from "./generic.js";
 import { containerLangOf, containerExtensions } from "./container.js";
+import { ansibleClaims, ansibleExtensions } from "./ansible.js";
 
-/** Every extension graft has a parser for (depth + breadth + container), sorted
+/** Every extension graft has a parser for (depth + breadth + container + ansible), sorted
  * and de-duped — the authoritative answer to "what does `-e` actually support". */
 export function supportedExtensions(): string[] {
-  return [...new Set([...depthExtensions(), ...genericExtensions(), ...containerExtensions()])].sort();
+  return [...new Set([...depthExtensions(), ...genericExtensions(), ...containerExtensions(), ...ansibleExtensions()])].sort();
 }
 
 /** Normalize a user-supplied extension: ensure a leading dot, lower-case. */
@@ -71,13 +72,16 @@ export function listSourceFiles(
   onlyDirs?: ReadonlySet<string>,
 ): string[] {
   // A file is a source file if a depth-tier grammar (languageOf), a breadth-tier
-  // grammar (genericLangOf) or a container (containerLangOf) claims its extension.
-  // All three must agree here or `build` and `check` would enumerate different sets.
+  // grammar (genericLangOf), a container (containerLangOf) or the Ansible tier
+  // (ansibleClaims) claims its extension. All four must agree here or `build` and
+  // `check` would enumerate different sets. Ansible claims `.yml`/`.yaml` on the
+  // extension alone and decides for real from the content — a non-Ansible YAML
+  // file is walked, parsed, and then yields zero nodes.
   return filterByOnlyDirs(
     repoFiles.filter(
       (f) =>
         !f.startsWith(outDir) &&
-        (languageOf(f) !== null || genericLangOf(f) !== null || containerLangOf(f) !== null),
+        (languageOf(f) !== null || genericLangOf(f) !== null || containerLangOf(f) !== null || ansibleClaims(f)),
     ),
     root,
     onlyDirs,

--- a/test/ansible-extract.test.ts
+++ b/test/ansible-extract.test.ts
@@ -1,0 +1,362 @@
+/**
+ * The Ansible tier: YAML whose meaning is in its key names.
+ *
+ * Two things are load-bearing here and each has a failure mode that is worse
+ * than not indexing at all.
+ *
+ * DETECTION. `.yml` is the most overloaded extension in a modern repo, so a
+ * false accept does not merely add a wrong node — it inflates every coverage
+ * number graft reports and buries the real Ansible in noise. The negative cases
+ * below are therefore not an afterthought: a mapping-rooted data file that
+ * happens to contain a `- name:` list is the exact shape that broke the first
+ * implementation, and `nested sequence` pins it.
+ *
+ * SPANS. Same rule as the container tier: a `file:line` that is plausible but
+ * wrong sends the reader somewhere else with full confidence. Every fixture is
+ * an array of lines joined, so an expected line number is its index + 1 and can
+ * be read off the source instead of counted by hand.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import {
+  warmAnsibleGrammar,
+  extractAnsible,
+  ansibleClaims,
+  ansibleExtensions,
+  isAnsibleWarm,
+} from "../src/graph/ansible.js";
+import { supportedExtensions } from "../src/graph/source-files.js";
+import { buildGraph } from "../src/graph/build.js";
+import { checkGraph } from "../src/graph/check.js";
+import { readGraph, wiringPath } from "../src/graph/write.js";
+import type { NodeV1 } from "../src/graph/types.js";
+
+await warmAnsibleGrammar();
+
+/** Line N of the fixture is `lines[N - 1]` — that is the whole point. */
+function yml(lines: string[]): string {
+  return lines.join("\n") + "\n";
+}
+
+function names(nodes: { name: string }[]): string[] {
+  return nodes.map((n) => n.name);
+}
+
+function byName(nodes: NodeV1[], name: string): NodeV1 {
+  const hit = nodes.find((n) => n.name === name);
+  assert.ok(hit, `no node named ${name} — got ${JSON.stringify(names(nodes))}`);
+  return hit!;
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+test("the tier is warm and claims the yaml extensions", () => {
+  assert.equal(isAnsibleWarm(), true, "the bundled yaml grammar should load");
+  assert.deepEqual(ansibleExtensions().sort(), [".yaml", ".yml"]);
+  assert.equal(ansibleClaims("playbooks/site.yml"), true);
+  assert.equal(ansibleClaims("env/lab/hosts.YAML"), true);
+  assert.equal(ansibleClaims("src/main.py"), false);
+});
+
+test("supportedExtensions advertises yaml, so `-e` and the walker agree", () => {
+  const exts = supportedExtensions();
+  assert.ok(exts.includes(".yml"), ".yml must be walkable");
+  assert.ok(exts.includes(".yaml"), ".yaml must be walkable");
+});
+
+// ---------------------------------------------------------------------------
+// Detection — the negative cases first, because they are the risk
+// ---------------------------------------------------------------------------
+
+test("declines a Kubernetes manifest", () => {
+  const src = yml(["apiVersion: apps/v1", "kind: Deployment", "metadata:", "  name: web"]);
+  assert.deepEqual(extractAnsible("k8s/deploy.yaml", src).nodes, []);
+});
+
+test("declines a docker-compose file", () => {
+  const src = yml(["version: '3'", "services:", "  web:", "    image: nginx"]);
+  assert.deepEqual(extractAnsible("docker-compose.yml", src).nodes, []);
+});
+
+test("declines a GitHub Actions workflow", () => {
+  const src = yml(["on:", "  push:", "jobs:", "  build:", "    steps:", "      - name: checkout", "        uses: actions/checkout@v4"]);
+  assert.deepEqual(extractAnsible(".github/workflows/ci.yml", src).nodes, []);
+});
+
+test("declines a mapping-rooted data file whose value is a `- name:` sequence", () => {
+  // The regression that motivated the strict unwrap: this is a MAPPING at the
+  // document root. A recursive search for a sequence finds the inner one and
+  // reads the file as a tasks file, which is how eight config files in a real
+  // repo were misdetected.
+  const src = yml([
+    "aggregates:",
+    "  - name: san-hosts",
+    "    metadata:",
+    "      storage: san",
+    "  - name: local-hosts",
+    "    metadata:",
+    "      storage: local",
+  ]);
+  assert.deepEqual(extractAnsible("config/placement.yaml", src).nodes, []);
+});
+
+test("declines a plain list of named things with no module key", () => {
+  const src = yml(["- name: alice", "  description: an admin", "- name: bob", "  description: a user"]);
+  assert.deepEqual(extractAnsible("data/people.yaml", src).nodes, []);
+});
+
+test("a declined file contributes NO file node, not an empty one", () => {
+  const src = yml(["apiVersion: v1", "kind: ConfigMap"]);
+  const { nodes, rawEdges } = extractAnsible("k8s/cm.yaml", src);
+  assert.equal(nodes.length, 0, "a non-Ansible file must be invisible, not an empty shell");
+  assert.equal(rawEdges.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Playbooks
+// ---------------------------------------------------------------------------
+
+const PLAYBOOK = yml([
+  /*  1 */ "---",
+  /*  2 */ "# A comment block, because real playbooks open with one and `comment`",
+  /*  3 */ "# is a NAMED node that sits before the content it describes.",
+  /*  4 */ "- name: configure the computes",
+  /*  5 */ "  hosts: computes",
+  /*  6 */ "  become: true",
+  /*  7 */ "  vars:",
+  /*  8 */ "    pkg_state: present",
+  /*  9 */ "  roles:",
+  /* 10 */ "    - common",
+  /* 11 */ "  tasks:",
+  /* 12 */ "    - name: install nginx",
+  /* 13 */ "      ansible.builtin.apt:",
+  /* 14 */ "        name: nginx",
+  /* 15 */ "        state: present",
+  /* 16 */ "      notify: restart nginx",
+  /* 17 */ "    - name: pull in the storage tasks",
+  /* 18 */ "      include_tasks: storage.yml",
+  /* 19 */ "  handlers:",
+  /* 20 */ "    - name: restart nginx",
+  /* 21 */ "      ansible.builtin.service:",
+  /* 22 */ "        name: nginx",
+  /* 23 */ "        state: restarted",
+]);
+
+test("a play becomes a class carrying its hosts, on the right line", () => {
+  const { nodes } = extractAnsible("playbooks/site.yml", PLAYBOOK);
+  const play = byName(nodes, "configure the computes");
+  assert.equal(play.kind, "class");
+  assert.equal(play.signature, "hosts: computes");
+  assert.equal(play.span, "L4-L23", "the play spans from its `- name:` to the last handler line");
+});
+
+test("a task becomes a function whose signature is its MODULE, not its name key", () => {
+  const { nodes } = extractAnsible("playbooks/site.yml", PLAYBOOK);
+  const task = byName(nodes, "install nginx");
+  assert.equal(task.kind, "function");
+  assert.equal(task.span, "L12-L16");
+  assert.equal(task.signature, "ansible.builtin.apt", "`name` must never be read as the module");
+});
+
+test("comments before the document body do not defeat detection", () => {
+  // Three comment lines precede the sequence. An unwrap that takes the first
+  // named child of `document` takes a comment and concludes "not a sequence".
+  const { nodes } = extractAnsible("playbooks/site.yml", PLAYBOOK);
+  assert.ok(nodes.length > 1, "a commented playbook must still extract");
+});
+
+test("play vars become variable nodes on their own lines", () => {
+  const { nodes } = extractAnsible("playbooks/site.yml", PLAYBOOK);
+  const v = byName(nodes, "pkg_state");
+  assert.equal(v.kind, "variable");
+  assert.equal(v.span, "L8-L8");
+});
+
+test("notify, roles and include_tasks each emit the edge that names them", () => {
+  const { nodes, rawEdges } = extractAnsible("playbooks/site.yml", PLAYBOOK);
+  const task = byName(nodes, "install nginx");
+  const includer = byName(nodes, "pull in the storage tasks");
+  const play = byName(nodes, "configure the computes");
+
+  const notify = rawEdges.find((e) => e.relation === "calls" && e.name === "restart nginx");
+  assert.ok(notify, "notify: must emit a calls edge");
+  assert.equal(notify!.source, task.id);
+
+  const role = rawEdges.find((e) => e.relation === "calls" && e.name === "common");
+  assert.ok(role, "roles: must emit a calls edge");
+  assert.equal(role!.source, play.id);
+  assert.deepEqual(role!.kinds, ["module"], "a role resolves to a module, not a function");
+
+  const inc = rawEdges.find((e) => e.relation === "imports");
+  assert.ok(inc, "include_tasks: must emit an imports edge");
+  assert.equal(inc!.specifier, "./storage.yml", "file-relative so resolveImport settles it");
+  assert.equal(inc!.source, includer.id);
+});
+
+test("a templated target is not guessed at", () => {
+  const src = yml([
+    "- hosts: all",
+    "  tasks:",
+    "    - name: dynamic",
+    "      include_tasks: '{{ step }}.yml'",
+    "      notify: '{{ handler_name }}'",
+  ]);
+  const { rawEdges } = extractAnsible("playbooks/dyn.yml", src);
+  assert.equal(
+    rawEdges.filter((e) => e.relation !== "contains").length,
+    0,
+    "a `{{ }}` target is unknowable statically and must not become an edge",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Roles, handlers, blocks
+// ---------------------------------------------------------------------------
+
+test("a role's tasks/main.yml mints the role itself, and its tasks hang off it", () => {
+  const src = yml([
+    "- name: install the base packages",
+    "  ansible.builtin.package:",
+    "    name: curl",
+  ]);
+  const { nodes, rawEdges } = extractAnsible("roles/common/tasks/main.yml", src);
+  const role = byName(nodes, "common");
+  assert.equal(role.kind, "module");
+  assert.equal(role.signature, "role common");
+
+  const roleId = role.id;
+  const task = byName(nodes, "install the base packages");
+  const contains = rawEdges.find(
+    (e) => e.relation === "contains" && e.targetId === task.id,
+  );
+  assert.equal(contains!.source, roleId, "tasks belong to the role, not directly to the file");
+});
+
+test("a tasks file outside a role has no role node", () => {
+  const src = yml(["- name: a task", "  ansible.builtin.command: true"]);
+  const { nodes } = extractAnsible("playbooks/tasks/extra.yml", src);
+  assert.equal(nodes.filter((n) => n.kind === "module").length, 0);
+});
+
+test("block / rescue / always nest their tasks under the enclosing task", () => {
+  const src = yml([
+    "- name: guarded",
+    "  block:",
+    "    - name: try it",
+    "      ansible.builtin.command: /bin/true",
+    "  rescue:",
+    "    - name: clean up",
+    "      ansible.builtin.command: /bin/false",
+  ]);
+  const { nodes, rawEdges } = extractAnsible("playbooks/tasks/b.yml", src);
+  const outer = byName(nodes, "guarded");
+  for (const child of ["try it", "clean up"]) {
+    const c = byName(nodes, child);
+    const edge = rawEdges.find((e) => e.relation === "contains" && e.targetId === c.id);
+    assert.equal(edge!.source, outer.id, `${child} must nest under the block's task`);
+  }
+  assert.equal(byName(nodes, "try it").span, "L3-L4");
+  assert.equal(byName(nodes, "clean up").span, "L6-L7");
+});
+
+test("set_fact keys become variables owned by the task that sets them", () => {
+  const src = yml([
+    "- name: compute a fact",
+    "  set_fact:",
+    "    lv_size: 110G",
+  ]);
+  const { nodes, rawEdges } = extractAnsible("playbooks/tasks/f.yml", src);
+  const v = byName(nodes, "lv_size");
+  assert.equal(v.kind, "variable");
+  assert.equal(v.span, "L3-L3");
+  const owner = byName(nodes, "compute a fact");
+  const edge = rawEdges.find((e) => e.relation === "contains" && e.targetId === v.id);
+  assert.equal(edge!.source, owner.id);
+});
+
+test("a vars file is admitted only from a path Ansible gives meaning to", () => {
+  const src = yml(["ntp_server: 10.0.0.1", "dns_server: 10.0.0.2"]);
+  assert.equal(extractAnsible("group_vars/all.yml", src).nodes.length, 3, "file + two vars");
+  assert.equal(extractAnsible("roles/common/defaults/main.yml", src).nodes.length, 3);
+  assert.deepEqual(extractAnsible("config/settings.yml", src).nodes, [], "same content, meaningless path");
+});
+
+test("role meta dependencies become role→role edges", () => {
+  const src = yml(["dependencies:", "  - role: base", "  - common"]);
+  const { rawEdges } = extractAnsible("roles/web/meta/main.yml", src);
+  const deps = rawEdges.filter((e) => e.relation === "calls").map((e) => e.name);
+  assert.deepEqual(deps.sort(), ["base", "common"]);
+});
+
+// ---------------------------------------------------------------------------
+// End to end: build + check must agree, or `check` reports permanent drift
+// ---------------------------------------------------------------------------
+
+function scratchRepo(files: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), "graft-ansible-"));
+  for (const [rel, body] of Object.entries(files)) {
+    const abs = join(dir, rel);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, body);
+  }
+  return dir;
+}
+
+test("build resolves notify/roles/include across files, and check sees the same nodes", async () => {
+  const dir = scratchRepo({
+    "site.yml": yml([
+      "- name: the play",
+      "  hosts: all",
+      "  roles:",
+      "    - common",
+    ]),
+    "roles/common/tasks/main.yml": yml([
+      "- name: stage the CA",
+      "  ansible.builtin.copy:",
+      "    src: ca.crt",
+      "    dest: /usr/local/share/ca-certificates/ca.crt",
+      "  notify: update-ca-certificates",
+      "- name: bring in storage",
+      "  include_tasks: storage.yml",
+    ]),
+    "roles/common/tasks/storage.yml": yml(["- name: make a vg", "  ansible.builtin.command: vgcreate"]),
+    "roles/common/handlers/main.yml": yml(["- name: update-ca-certificates", "  ansible.builtin.command: update-ca-certificates"]),
+    "k8s/deploy.yaml": yml(["apiVersion: apps/v1", "kind: Deployment"]),
+  });
+  const outDir = join(dir, "graft");
+  await buildGraph(dir, { reuse: false });
+  const graph = readGraph(wiringPath(outDir))!;
+
+  const id = (name: string) => graph.nodes.find((n) => n.name === name)?.id;
+
+  // The Kubernetes manifest must be absent entirely — not present-but-empty.
+  assert.equal(
+    graph.nodes.some((n) => n.path === "k8s/deploy.yaml"),
+    false,
+    "a declined file must leave no trace in the graph",
+  );
+
+  const edge = (rel: string, from: string, to: string) =>
+    graph.edges.some((e) => e.relation === rel && e.source === from && e.target === to);
+
+  assert.ok(edge("calls", id("the play")!, id("common")!), "roles: → the role module");
+  assert.ok(
+    edge("calls", id("stage the CA")!, id("update-ca-certificates")!),
+    "notify: → the handler in another file",
+  );
+  assert.ok(
+    edge("imports", id("bring in storage")!, "roles/common/tasks/storage.yml"),
+    "include_tasks: → the included file",
+  );
+
+  // #236: a tier the build extracts but `check` cannot see reports every one of
+  // its nodes as `removed`, forever, and the rebuild it advises never repairs it.
+  const drift = await checkGraph(dir, { contextDir: outDir });
+  assert.equal(drift.removed.length, 0, `check must see the ansible tier: ${JSON.stringify(drift.removed)}`);
+  assert.equal(drift.added.length, 0, `check must not invent nodes: ${JSON.stringify(drift.added)}`);
+});


### PR DESCRIPTION
Adds an **Ansible tier**: a fourth extractor for YAML whose meaning is in its key names. No new dependencies — it reuses the `tree-sitter-wasm` yaml grammar already in the tree.

## Why not a `GENERIC_LANGS` row

I tried to make this fit an existing tier first, and none of them can hold it:

- **Depth** (`extract.ts`) and **breadth** (`generic.ts`) both ask a grammar *"what definitions does this syntax declare?"* YAML's answer is always "mappings and sequences". A `tags.scm` over tree-sitter-yaml would capture every key in every Kubernetes manifest, CI workflow and lock file in the repo and call it a definition — worse than not indexing, and it would land squarely in the coverage-honesty problem `EXTENSIONS`' comment already worries about.
- **Container** (`container.ts`) does not apply either: there is no embedded language to hand off. The YAML *is* the program.

Ansible's structure lives in its key names — `hosts:` makes a play, `notify:` names a handler, `include_tasks:` names a file. So this tier uses the grammar only as a reader (key/value pairs and their exact lines) and puts the semantics in `ansible.ts`.

## What it emits

| node | from |
|---|---|
| `file` | one per Ansible file |
| `module` | a role, minted at `roles/<name>/tasks/main.yml` |
| `class` | a play (`- hosts: web`), signature `hosts: …` |
| `function` | a task or handler, signature = its module (`ansible.builtin.apt`) |
| `variable` | a vars/defaults file, a `vars:` block, or `set_fact` |

Wired by `contains`, plus the two edges that make it a graph rather than an outline:

- `imports` — `include_tasks` / `import_tasks` / `vars_files` / `import_playbook`, emitted as a file-relative specifier so **`resolveImport` settles it unchanged**.
- `calls` — `include_role` / `import_role` / `roles:` (carrying `kinds: ["module"]` so it lands on the role) and `notify:` / `listen:` (to the handler).

**No resolver changes.** Everything routes through machinery that already exists.

Variable *references* (`{{ foo }}`) are deliberately **not** edges: `resolve.ts` only resolves a bare-name `references` edge for generic-origin nodes, so every one emitted would be built and dropped — and a name-only match across a repo-wide var namespace is the same guess #35 measured as halving call precision. Definitions are indexed; uses stay grep.

## Detection

This is the risk, so it is narrow and its load-bearing half is structural: **a sequence at the document root whose items are Ansible-shaped mappings.** Kubernetes, Compose and Actions files are all *mapping*-rooted and cannot reach the accept path at all. The one mapping-rooted Ansible shape — a vars file — is admitted only from a path Ansible itself gives meaning to (`group_vars/`, `host_vars/`, a role's `defaults/`/`vars/`).

Two consequences I think matter for this project specifically:

- **A declined file emits zero nodes** — not an empty file node — and does not add its language to the banner. A repo full of non-Ansible YAML therefore looks exactly as it did before this tier existed. (`build.ts` gains a `fileNodes.length` guard on `langs.add(label)` for this; it is a no-op for the other tiers, which always emit at least a file node.)
- **Bare module keys match a curated allowlist**, while an FQCN (`ansible.builtin.apt`) is accepted structurally. "Any lowercase key is a module" read `- name: alice` + `description: an admin` as a task. The failure mode is now a false negative — an uncommon bare module with no directive is missed — which costs coverage rather than trust in the counts.

## Three bugs the verification caught, now pinned by tests

1. **Unwrapping with a recursive descendant search read mapping-rooted data files as sequences.** `aggregates:` + a `- name:` list is a *mapping* whose value contains a sequence; a first-descendant-of-type search returns that inner sequence as if it were the document root. Eight declarative config files in my test repo were misdetected this way. `unwrap()` now passes through wrapper nodes only.
2. **`comment` is a NAMED node** in tree-sitter-yaml and sits as a sibling before the content it describes. A playbook opening with a comment block has 13 comment children before its `block_node`, so taking the first named child concluded "not a sequence" — this rejected nearly every real playbook.
3. **Trailing-newline span inflation.** A block node running to the end of its parent swallows the terminating newline, so tree-sitter reports `endPosition` as row N+1 column 0 and every last-in-parent play/task read one line too long. This is exactly the plausible-but-wrong `file:line` `container.ts`'s header warns about, so `span()` trims it.

## `graft check` parity (#236)

`check.ts` gets the same branch in the same order as `build.ts`. Its existing comment about a tier the build writes and the check cannot see reading as `removed` forever was the most useful thing I read while writing this — the end-to-end test asserts a clean build of an Ansible repo checks as in sync.

## Verification

Measured on a 617-file Ansible-first GitOps repo (not synthetic):

- 44 → **123 files**, 335 → **1,657 nodes** (1,058 tasks, 272 vars, 113 plays, 1 role).
- **79 of 214 YAML files accepted, every one under `playbooks/` or `*/ansible/`**; every decline under those paths is a Kubernetes/ArgoCD manifest that happens to live there.
- **969 of 970 emitted spans confirmed against the actual source line.** The one outlier is a multi-line folded scalar my checker could not match, not a wrong span.
- All 10 non-`contains` edges resolve to real nodes, zero unresolved — spot-checked against grep (`notify: update-ca-certificates` → the handler; `roles: [common]` → the role module; `include_tasks: storage_lvm.yml` → the file).
- `graft blast --base HEAD~1` on a commit touching a playbook previously reported *"1 changed file not in the graph"*; it now names the changed task.

**Tests:** 21 new in `test/ansible-extract.test.ts`, following `container-extract.test.ts`'s fixture-as-line-array convention so expected line numbers are readable off the source. Suite goes 1221 → 1242.

The only failures on my machine are the 4 in `claude-shim-resolve.test.ts`, which I confirmed pre-existing by stashing this change and re-running on a clean tree — they probe the machine's global-install layout.

## Notes for review

- Happy to gate the tier behind a flag if you would rather it be opt-in — claiming `.yml`/`.yaml` repo-wide is the most opinionated thing here, which is why a declined file is invisible rather than empty.
- The bare-module allowlist is the part most likely to need additions from other people's repos.
- `resolve.ts`'s `familyOf` gets `"ansible"` so name resolution is scoped to Ansible files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
