### PR TITLE
fix(claude): derive the post-edit child budget and keep a hand-raised timeout

### DIFF
--- a/src/claude/hooks.ts
+++ b/src/claude/hooks.ts
@@ -63,6 +63,29 @@ export function promptAskTimeout(dir: string): number {
 }
 
 /**
+ * The same derivation for the other hook that spawns a child: how long post-edit may
+ * let `graft check` run.
+ *
+ * It had no equivalent, so the child kept the flat {@link CHILD_TIMEOUT_MS}. On a repo
+ * wired before the post-edit budget was raised, `PostToolUse` is still `8000` — the
+ * same number — so the child could consume the entire hook budget and leave nothing
+ * for `readWiring()` and `formatBlastRadius()`, which is the failure
+ * {@link promptAskTimeout} exists to prevent, one hook over: the kill takes `emit()`
+ * with it, so the edit gets no blast radius and the stats write never lands
+ * (issue #366).
+ *
+ * `PostToolUse` carries two graft entries (post-edit and tool-savings) and
+ * {@link installedHookTimeout} is matcher-blind by design, so this reads the smaller
+ * of them. That is the conservative direction it documents: guessing high gets the
+ * hook killed, guessing low only shortens one `graft check`.
+ */
+export function postEditCheckTimeout(dir: string): number {
+  const installed = installedHookTimeout(dir, 'PostToolUse');
+  if (installed === null) return CHILD_TIMEOUT_MS - HOOK_OVERHEAD_MS;
+  return Math.max(MIN_CHILD_TIMEOUT_MS, installed - HOOK_OVERHEAD_MS);
+}
+
+/**
  * Every settings file Claude Code merges hook definitions from, for a session
  * rooted at `dir`. The per-repo file is not the only place graft's hooks can be
  * installed: declaring them once at the user level wires every repo on the
@@ -84,14 +107,21 @@ function hookTimeoutIn(file: string, event: string): number | null {
     const settings = JSON.parse(readFileSync(file, 'utf8')) as any;
     const blocks = settings?.hooks?.[event];
     if (!Array.isArray(blocks)) return null;
+    // Smallest within the file, for the same reason {@link installedHookTimeout}
+    // takes the smallest across files: one event can carry several graft entries
+    // (`PostToolUse` carries post-edit and tool-savings) and nothing here can tell
+    // which matcher launched this process. Returning the first one found made the
+    // answer depend on the order the template happens to write them in.
+    let smallest: number | null = null;
     for (const block of blocks) {
       for (const h of block?.hooks ?? []) {
-        if (typeof h?.command === 'string' && h.command.includes('graft-hooks.cjs') && typeof h.timeout === 'number') {
-          return h.timeout;
+        if (typeof h?.command === 'string' && h.command.includes('graft-hooks.cjs')
+          && typeof h.timeout === 'number' && Number.isFinite(h.timeout)) {
+          if (smallest === null || h.timeout < smallest) smallest = h.timeout;
         }
       }
     }
-    return null;
+    return smallest;
   } catch {
     return null;
   }
@@ -150,7 +180,7 @@ function graftJson(dir: string, args: string[], timeout: number = CHILD_TIMEOUT_
   }
 }
 function checkStaleCount(dir: string): number {
-  const r = graftJson(dir, withContextDirArg(dir, ['check', '.', '--json']));
+  const r = graftJson(dir, withContextDirArg(dir, ['check', '.', '--json']), postEditCheckTimeout(dir));
   const g = r?.graph ?? {};
   return (g.changed?.length ?? 0) + (g.added?.length ?? 0) + (g.removed?.length ?? 0);
 }

--- a/src/claude/settings-merge.ts
+++ b/src/claude/settings-merge.ts
@@ -111,6 +111,71 @@ function applyStatusline(
   warnings.push(foreignWarning);
 }
 
+/**
+ * The hook a graft command runs (`post-edit`, `prompt`, …), or null for anything
+ * that is not one. The command also carries the helpers path, which differs between
+ * the repo-level and user-level installs and has changed between versions, so the
+ * hook name rather than the whole command is what identifies an entry across a
+ * rewrite.
+ */
+function graftHookName(command: unknown): string | null {
+  if (typeof command !== 'string' || !command.includes('graft-hooks.cjs')) return null;
+  const last = command.trim().split(/\s+/).pop() ?? '';
+  return last && !last.includes('graft-hooks.cjs') ? last : null;
+}
+
+/**
+ * The largest timeout each prior graft entry declared, keyed by hook name.
+ *
+ * Raising a budget by hand in `.claude/settings.json` is the only way to say "this
+ * repo's graph needs longer than the template assumes", and it could not survive:
+ * the merge below drops graft's own entries whole and rewrites them from the
+ * template, and `reconcileWiring()` fires that rewrite on every version bump, so the
+ * raise reverted unattended (issue #366). Keyed per hook because `PostToolUse`
+ * declares two entries and a raise belongs to the one it was made on.
+ */
+function priorGraftTimeouts(prior: Json[]): Map<string, number> {
+  const timeouts = new Map<string, number>();
+  for (const entry of prior) {
+    if (!isGraftEntry(entry)) continue;
+    const hooks = Array.isArray((entry as any)?.hooks) ? (entry as any).hooks : [];
+    for (const hook of hooks) {
+      const name = graftHookName(hook?.command);
+      const timeout = hook?.timeout;
+      if (name === null || typeof timeout !== 'number' || !Number.isFinite(timeout)) continue;
+      timeouts.set(name, Math.max(timeouts.get(name) ?? 0, timeout));
+    }
+  }
+  return timeouts;
+}
+
+/**
+ * One event's entries after a merge: foreign ones kept untouched, graft's replaced by
+ * the current template — except that a timeout raised above the template is carried
+ * forward.
+ *
+ * Raise-only in both directions: a template can still lift the floor for every repo,
+ * and a hand-raised budget is not lowered back to it. Still exactly one graft entry
+ * per template block, so re-running `graft init` converges rather than stacking.
+ */
+function mergeHookEntries(prior: Json[], blocks: Json[]): Json[] {
+  const raised = priorGraftTimeouts(prior);
+  const current = blocks.map((block: Json) => {
+    const hooks = Array.isArray((block as any)?.hooks) ? (block as any).hooks : [];
+    return {
+      ...(block as any),
+      hooks: hooks.map((hook: any) => {
+        const name = graftHookName(hook?.command);
+        const previous = name === null ? undefined : raised.get(name);
+        return previous !== undefined && previous > (hook?.timeout ?? 0)
+          ? { ...hook, timeout: previous }
+          : hook;
+      }),
+    };
+  });
+  return [...prior.filter((e: Json) => !isGraftEntry(e)), ...current];
+}
+
 export function mergeGraftSettings(
   existing: Json,
   opts: { statusline?: boolean } = {},
@@ -131,8 +196,7 @@ export function mergeGraftSettings(
   merged.hooks = { ...(merged.hooks ?? {}) };
   for (const [event, blocks] of Object.entries(graftBlocks())) {
     const prior = Array.isArray(merged.hooks[event]) ? merged.hooks[event] : [];
-    const foreign = prior.filter((e: Json) => !isGraftEntry(e)); // drop old Graft entries → idempotent
-    merged.hooks[event] = [...foreign, ...blocks];
+    merged.hooks[event] = mergeHookEntries(prior, blocks);
   }
 
   // Drop graft's own prior regex before re-adding, so a change to FOOTER replaces
@@ -172,8 +236,7 @@ export function mergeGraftHooks(existing: Json, helpers: string): { merged: Json
   merged.hooks = { ...(merged.hooks ?? {}) };
   for (const [event, blocks] of Object.entries(graftBlocks(helpers))) {
     const prior = Array.isArray(merged.hooks[event]) ? merged.hooks[event] : [];
-    const foreign = prior.filter((e: Json) => !isGraftEntry(e));
-    merged.hooks[event] = [...foreign, ...blocks];
+    merged.hooks[event] = mergeHookEntries(prior, blocks);
   }
   return { merged };
 }

--- a/test/claude-hooks.test.ts
+++ b/test/claude-hooks.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { existsSync, mkdtempSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { underGraft, main, lastFileScopeHint, promptAskTimeout } from '../src/claude/hooks.js';
+import { underGraft, main, lastFileScopeHint, promptAskTimeout, postEditCheckTimeout } from '../src/claude/hooks.js';
 import { readStats, readSession } from '../src/claude/state.js';
 import { runSync } from '../src/claude/sync-run.js';
 import { savingsLine } from '../src/context/savings.js';
@@ -750,4 +750,76 @@ test('session-start reads INDEX.md from a GRAFT_DIR-relocated context dir', asyn
     delete process.env.GRAFT_DIR;
   }
   assert.match(chunks.join(''), /repo map \(relocated\)/, 'orientation was built from the relocated INDEX.md');
+});
+
+/**
+ * The post-edit hook's `graft check` child had a flat 8s cap while the event it runs
+ * under can carry any budget. On a repo wired before post-edit's budget was raised,
+ * `PostToolUse` is still 8000 — the same number — so the child could eat the whole
+ * hook and `emit()`/`patchStats()` never ran: no blast radius for the edit and no
+ * stats write, silently (issue #366).
+ */
+function withPostToolUse(entries: unknown): string {
+  const d = mkdtempSync(join(tmpdir(), 'graft-postedit-'));
+  mkdirSync(join(d, '.claude'), { recursive: true });
+  const hooks = entries === undefined ? {} : { PostToolUse: entries };
+  writeFileSync(join(d, '.claude', 'settings.json'), JSON.stringify({ hooks }));
+  return d;
+}
+
+function postEditEntry(timeout: unknown) {
+  return { matcher: 'Write|Edit|MultiEdit', hooks: [{ type: 'command', command: 'node ".claude/helpers/graft-hooks.cjs" post-edit', timeout }] };
+}
+function savingsEntry(timeout: unknown) {
+  return { matcher: 'Bash|mcp__graft__|Read|Grep|Glob', hooks: [{ type: 'command', command: 'node ".claude/helpers/graft-hooks.cjs" tool-savings', timeout }] };
+}
+
+test('postEditCheckTimeout is derived from the installed hook budget', () => {
+  const previous = process.env.CLAUDE_CONFIG_DIR;
+  process.env.CLAUDE_CONFIG_DIR = mkdtempSync(join(tmpdir(), 'graft-nouser-'));
+  try {
+    // A repo wired before post-edit's budget was raised: 8000 for both entries, so
+    // the old flat 8000 child had the whole budget and left nothing after it.
+    assert.equal(postEditCheckTimeout(withPostToolUse([postEditEntry(8000), savingsEntry(8000)])), 6000);
+
+    // The current template. `installedHookTimeout` is matcher-blind by design and
+    // takes the smallest, which is the conservative direction: guessing high gets
+    // the hook killed, guessing low only shortens one `graft check`.
+    assert.equal(postEditCheckTimeout(withPostToolUse([postEditEntry(10000), savingsEntry(8000)])), 6000);
+
+    // A repo that raised both by hand gets the longer child it asked for.
+    assert.equal(postEditCheckTimeout(withPostToolUse([postEditEntry(20000), savingsEntry(20000)])), 18000);
+
+    // Never so small the child has no chance.
+    assert.equal(postEditCheckTimeout(withPostToolUse([postEditEntry(1000)])), 4000);
+
+    // Nothing readable: the conservative 8s budget the other hooks carry.
+    assert.equal(postEditCheckTimeout(withPostToolUse(undefined)), 6000);
+    assert.equal(postEditCheckTimeout(withPostToolUse([postEditEntry('nonsense')])), 6000);
+    assert.equal(postEditCheckTimeout(mkdtempSync(join(tmpdir(), 'graft-nosettings-'))), 6000);
+  } finally {
+    if (previous === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = previous;
+  }
+});
+
+test('postEditCheckTimeout reads its own event, not the prompt hook budget', () => {
+  const previous = process.env.CLAUDE_CONFIG_DIR;
+  process.env.CLAUDE_CONFIG_DIR = mkdtempSync(join(tmpdir(), 'graft-nouser-'));
+  try {
+    const d = mkdtempSync(join(tmpdir(), 'graft-bothevents-'));
+    mkdirSync(join(d, '.claude'), { recursive: true });
+    writeFileSync(join(d, '.claude', 'settings.json'), JSON.stringify({
+      hooks: {
+        PostToolUse: [postEditEntry(20000)],
+        UserPromptSubmit: [{ hooks: [{ type: 'command', command: 'node ".claude/helpers/graft-hooks.cjs" prompt', timeout: 8000 }] }],
+      },
+    }));
+    // The two hooks run under separate budgets; neither may cap the other.
+    assert.equal(postEditCheckTimeout(d), 18000);
+    assert.equal(promptAskTimeout(d), 6000);
+  } finally {
+    if (previous === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = previous;
+  }
 });

--- a/test/claude-settings-merge.test.ts
+++ b/test/claude-settings-merge.test.ts
@@ -137,3 +137,112 @@ test('permissions object with no allow key gets one added; other keys preserved'
   assert.deepEqual(merged.permissions.deny, ['Bash(rm:*)']);
   assert.deepEqual(merged.permissions.allow, ['Bash(graft:*)', 'Bash(npx graft:*)', 'Bash(graft-dev:*)', 'Bash(node dist/cli.js:*)']);
 });
+
+/**
+ * A budget raised by hand in `.claude/settings.json` is the only way to say "this
+ * repo's graph needs longer than the template assumes". It could not survive: the
+ * merge dropped graft's own entries whole and rewrote them from the template, and
+ * `reconcileWiring()` fires that rewrite on every version bump, so the raise reverted
+ * unattended with only the one-line "refreshed this repo's agent wiring" notice as a
+ * trace (issue #366).
+ */
+const POST_EDIT = 'node "${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-hooks.cjs" post-edit';
+const SAVINGS = 'node "${CLAUDE_PROJECT_DIR:-.}/.claude/helpers/graft-hooks.cjs" tool-savings';
+
+function postToolUse(merged: any) {
+  const byName: Record<string, any> = {};
+  for (const entry of merged.hooks.PostToolUse) {
+    for (const hook of entry.hooks ?? []) byName[String(hook.command).split(/\s+/).pop()!] = hook;
+  }
+  return byName;
+}
+
+test('a hand-raised hook timeout survives a refresh', () => {
+  const { merged } = mergeGraftSettings({
+    hooks: {
+      PostToolUse: [
+        { matcher: 'Write|Edit|MultiEdit', hooks: [{ type: 'command', command: POST_EDIT, timeout: 20000 }] },
+        { matcher: 'Bash|mcp__graft__|Read|Grep|Glob', hooks: [{ type: 'command', command: SAVINGS, timeout: 8000 }] },
+      ],
+    },
+  });
+
+  const hooks = postToolUse(merged);
+  assert.equal(hooks['post-edit'].timeout, 20000, 'the raise is carried forward');
+  // Per hook, not per event: the raise belongs to the entry it was made on.
+  assert.equal(hooks['tool-savings'].timeout, 8000);
+  // Still one entry per template block, so a refresh converges instead of stacking.
+  assert.equal(merged.hooks.PostToolUse.length, 2);
+  assert.equal(merged.hooks.PostToolUse[0].matcher, 'Write|Edit|MultiEdit');
+});
+
+test('the template can still raise the floor for a repo below it', () => {
+  const { merged } = mergeGraftSettings({
+    hooks: {
+      PostToolUse: [
+        { matcher: 'Write|Edit|MultiEdit', hooks: [{ type: 'command', command: POST_EDIT, timeout: 5000 }] },
+      ],
+    },
+  });
+  // Raise-only in both directions: a prior value below the template does not hold it
+  // down, so a repo wired before a bump still gets the longer budget.
+  assert.equal(postToolUse(merged)['post-edit'].timeout, 10000);
+});
+
+test('a raise is matched by hook name, not by the whole command', () => {
+  // The helpers path differs between the repo-level and user-level installs and has
+  // changed between versions, so an entry written by an older graft still has to be
+  // recognised as the same hook.
+  const { merged } = mergeGraftSettings({
+    hooks: {
+      PostToolUse: [
+        { matcher: 'Write|Edit|MultiEdit', hooks: [{ type: 'command', command: 'node .claude/helpers/graft-hooks.cjs post-edit', timeout: 30000 }] },
+      ],
+      UserPromptSubmit: [
+        { hooks: [{ type: 'command', command: 'node "$HOME/.claude/helpers/graft-hooks.cjs" prompt', timeout: 25000 }] },
+      ],
+    },
+  });
+  assert.equal(postToolUse(merged)['post-edit'].timeout, 30000);
+  assert.equal(merged.hooks.UserPromptSubmit[0].hooks[0].timeout, 25000);
+});
+
+test('a garbage prior timeout is ignored rather than carried', () => {
+  for (const timeout of ['20000', null, undefined, NaN, Infinity]) {
+    const { merged } = mergeGraftSettings({
+      hooks: {
+        PostToolUse: [
+          { matcher: 'Write|Edit|MultiEdit', hooks: [{ type: 'command', command: POST_EDIT, timeout }] },
+        ],
+      },
+    });
+    assert.equal(postToolUse(merged)['post-edit'].timeout, 10000, `timeout=${String(timeout)}`);
+  }
+});
+
+test('a foreign hook on the same event keeps its own timeout', () => {
+  const { merged } = mergeGraftSettings({
+    hooks: {
+      PostToolUse: [
+        { matcher: 'Write', hooks: [{ type: 'command', command: 'my-linter.sh', timeout: 1 }] },
+        { matcher: 'Write|Edit|MultiEdit', hooks: [{ type: 'command', command: POST_EDIT, timeout: 20000 }] },
+      ],
+    },
+  });
+  const foreign = merged.hooks.PostToolUse.find((e: any) => e.hooks[0].command === 'my-linter.sh');
+  assert.equal(foreign.hooks[0].timeout, 1);
+  assert.equal(postToolUse(merged)['post-edit'].timeout, 20000);
+});
+
+test('re-running after a raise is idempotent', () => {
+  const raised = {
+    hooks: {
+      PostToolUse: [
+        { matcher: 'Write|Edit|MultiEdit', hooks: [{ type: 'command', command: POST_EDIT, timeout: 20000 }] },
+      ],
+    },
+  };
+  const once = mergeGraftSettings(raised).merged;
+  const twice = mergeGraftSettings(once).merged;
+  assert.deepEqual(twice, once);
+});


### PR DESCRIPTION
Fixes #366. Both halves, since they are the same wiring and the workaround in the issue exists only because neither side alone was enough.

## 1. The post-edit child now tracks the installed budget

`promptAskTimeout` has derived its cap from the budget actually installed in the repo since the prompt hook hit exactly this; `checkStaleCount` had no equivalent and kept the flat `CHILD_TIMEOUT_MS`. `postEditCheckTimeout` is the same three lines against `PostToolUse`.

The sharp case is a repo wired **before** post-edit's budget was raised: `PostToolUse` is still `8000` there, the same number as the child, so the child could consume the entire hook budget and leave nothing for `readWiring()` + `formatBlastRadius()`. The SIGKILL takes `emit()` and `patchStats()` with it — no blast radius for the edit, no stats write, silently. That is the failure `promptAskTimeout`'s own docstring describes, one hook over.

**One thing the suggestion in the issue needed to work.** `hookTimeoutIn` returned the *first* graft timeout it found in an event, not the smallest. For `UserPromptSubmit` that is the same thing (one entry). `PostToolUse` declares two — post-edit `10000` and tool-savings `8000` — so a straight `installedHookTimeout(dir, 'PostToolUse')` read back `10000`, derived `8000`, and the change would have been a **no-op at the current template**: still an 8s child inside a 10s budget, still ~2s for everything after it.

So `hookTimeoutIn` now takes the smallest within a file, which is what `installedHookTimeout` already does across files and for the reason it documents — nothing in the hook can tell which matcher launched it, guessing high gets the hook killed, guessing low only shortens one `graft check`. With that, the post-edit child is `6000` under the current template instead of `8000`, which is the headroom the issue asks for. `promptAskTimeout` is unchanged unless a repo declares two `UserPromptSubmit` graft entries, where it also becomes conservative.

I did **not** touch `HOOK_OVERHEAD_MS`. Whether 2s is the right allowance after a `graft check` on a 568-card graph is a judgement your measurements support and mine do not — happy to follow up if you want a larger allowance for this hook specifically.

## 2. A hand-raised timeout survives a refresh

Both merge sites go through one `mergeHookEntries`, which keeps foreign entries untouched, replaces graft's from the template, and carries forward a timeout raised above it:

```ts
const previous = name === null ? undefined : raised.get(name);
return previous !== undefined && previous > (hook?.timeout ?? 0)
  ? { ...hook, timeout: previous }
  : hook;
```

Raise-only in both directions: a template can still lift the floor for every repo, and a deliberate raise is not pulled back down. Still exactly one graft entry per template block, so `graft init` converges rather than stacking — the property the `// drop old Graft entries → idempotent` comment was protecting, which turns out not to require discarding the value.

Matched by **hook name** rather than by the whole command, one step beyond the `Math.max` sketch in the issue. The command carries the helpers path, which differs between the repo-level and user-level installs, and `settings-merge.ts:146` notes that the invocation form has changed before — so keying on the command would silently lose the raise on exactly the version bump that triggers the rewrite. Keying per hook also matters because `PostToolUse` has two entries and a raise belongs to the one it was made on.

## Testing

`test/claude-hooks.test.ts` — `postEditCheckTimeout`, in the idiom of the `promptAskTimeout` cases next to it: a repo wired at `8000` → `6000`; the current template (`10000` + `8000`) → `6000`; both raised to `20000` → `18000`; the `MIN_CHILD_TIMEOUT_MS` floor; unreadable/absent/non-numeric → `6000`. Plus one asserting the two hooks read separate events, so neither can cap the other.

`test/claude-settings-merge.test.ts` — the carry-forward: a raise survives while its sibling entry keeps the template value; the template still raises a repo below it; a raise written by an older graft (different helpers path) is still recognised; `'20000'`/`null`/`undefined`/`NaN`/`Infinity` are ignored rather than carried; a foreign hook on the same event keeps its own timeout; merging twice is byte-identical.

```
node scripts/run-tests.mjs    1229 passed, 0 failed
tsc -p tsconfig.json --noEmit  clean
```

(`LC_ALL=en_US.UTF-8` — on a German locale `tool-savings counts a REAL savings line` fails on a clean checkout too, because it matches `~100,000` against a `toLocaleString` that renders `~100.000`. Unrelated to this branch; mentioning it in case it is worth pinning the locale in that assertion.)

Negative controls, each isolating one piece: reverting `hookTimeoutIn` to first-found reddens the derivation case and nothing else; removing the carry-forward reddens 3 of the merge cases.

To be straightforward about one gap: reverting `checkStaleCount` to the default cap reddens **nothing**. The derived number is unit-tested, but the wiring of it into that one call is only observable through a real timeout — a stub `graft check` sleeping several seconds — and I would rather not put a multi-second timing test into a 1229-test suite unless you want it. The change itself is the single argument on `hooks.ts:176`.
